### PR TITLE
Enable "additionalProperty" visibility through Javascript

### DIFF
--- a/force-app/main/default/classes/IBMConversationV1Models.cls
+++ b/force-app/main/default/classes/IBMConversationV1Models.cls
@@ -5,6 +5,7 @@ public class IBMConversationV1Models {
   public class Context extends IBMWatsonDynamicModel {
     private String conversation_id_serialized_name;
     private SystemResponse system_serialized_name;
+    private Map<String, Object> additional_properties_serialized_name;
 
     /**
      * Gets the conversation_id_serialized_name.
@@ -24,6 +25,16 @@ public class IBMConversationV1Models {
     @AuraEnabled
     public SystemResponse getSystem() {
       return system_serialized_name;
+    }
+
+    /**
+     * Gets the dynamic properties attached to Context.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
     }
 
     /**
@@ -8589,6 +8600,7 @@ public class IBMConversationV1Models {
   public class LogMessage extends IBMWatsonDynamicModel {
     private String level_serialized_name;
     private String msg_serialized_name;
+    private Map<String, Object> additional_properties_serialized_name;
 
     /**
      * Gets the level_serialized_name.
@@ -8608,6 +8620,16 @@ public class IBMConversationV1Models {
     @AuraEnabled
     public String getMsg() {
       return msg_serialized_name;
+    }
+
+    /**
+     * Gets the dynamic properties attached to LogMessage.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
     }
 
     /**
@@ -9187,6 +9209,7 @@ public class IBMConversationV1Models {
     private Boolean alternate_intents_serialized_name;
     private Context context_serialized_name;
     private OutputData output_serialized_name;
+    private Map<String, Object> additional_properties_serialized_name;
 
     /**
      * Gets the input_serialized_name.
@@ -9246,6 +9269,16 @@ public class IBMConversationV1Models {
     @AuraEnabled
     public OutputData getOutput() {
       return output_serialized_name;
+    }
+
+    /**
+     * Gets the dynamic properties attached to MessageResponse.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
     }
 
     /**
@@ -9366,6 +9399,7 @@ public class IBMConversationV1Models {
     private List<LogMessage> log_messages_serialized_name;
     private List<String> text_serialized_name;
     private List<String> nodes_visited_serialized_name;
+    private Map<String, Object> additional_properties_serialized_name;
 
     /**
      * Gets the log_messages_serialized_name.
@@ -9395,6 +9429,16 @@ public class IBMConversationV1Models {
     @AuraEnabled
     public List<String> getNodesVisited() {
       return nodes_visited_serialized_name;
+    }
+
+    /**
+     * Gets the dynamic properties attached to OutputData.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
     }
 
     /**
@@ -9565,6 +9609,7 @@ public class IBMConversationV1Models {
     private String value_serialized_name;
     private Double confidence_serialized_name;
     private IBMWatsonMapModel metadata_serialized_name;
+    private Map<String, Object> additional_properties_serialized_name;
 
     /**
      * Gets the entity_serialized_name.
@@ -9614,6 +9659,16 @@ public class IBMConversationV1Models {
     @AuraEnabled
     public IBMWatsonMapModel getMetadata() {
       return metadata_serialized_name;
+    }
+
+    /**
+     * Gets the dynamic properties attached to RuntimeEntity.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
     }
 
     /**
@@ -9690,6 +9745,7 @@ public class IBMConversationV1Models {
   public class RuntimeIntent extends IBMWatsonDynamicModel {
     private String intent_serialized_name;
     private Double confidence_serialized_name;
+    private Map<String, Object> additional_properties_serialized_name;
 
     /**
      * Gets the intent_serialized_name.
@@ -9709,6 +9765,16 @@ public class IBMConversationV1Models {
     @AuraEnabled
     public Double getConfidence() {
       return confidence_serialized_name;
+    }
+
+    /**
+     * Gets the dynamic properties attached to RuntimeIntent.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
     }
 
     /**
@@ -9888,6 +9954,17 @@ public class IBMConversationV1Models {
    * For internal use only.
    */
   public class SystemResponse extends IBMWatsonDynamicModel {
+    private Map<String, Object> additional_properties_serialized_name;
+
+    /**
+     * Gets the dynamic properties attached to SystemResponse.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
+    }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
       if (jsonMap == null) {

--- a/force-app/main/default/classes/IBMDiscoveryV1.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1.cls
@@ -300,11 +300,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     }
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
+    IBMWatsonRequestBody fileBody;
     if (testConfigurationInEnvironmentOptions.configuration() != null) {
       multipartBuilder.addFormDataPart('configuration', testConfigurationInEnvironmentOptions.configuration());
     }
     if (testConfigurationInEnvironmentOptions.file() != null) {
-      IBMWatsonRequestBody fileBody = IBMWatsonRequestBody.create(testConfigurationInEnvironmentOptions.file(), testConfigurationInEnvironmentOptions.fileContentType());
+      fileBody = IBMWatsonRequestBody.create(testConfigurationInEnvironmentOptions.file(), testConfigurationInEnvironmentOptions.fileContentType());
       multipartBuilder.addFormDataPart('file', testConfigurationInEnvironmentOptions.filename(), fileBody);
     }
     if (testConfigurationInEnvironmentOptions.metadata() != null) {
@@ -445,8 +446,9 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     builder.query('version', versionDate);
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
+    IBMWatsonRequestBody fileBody;
     if (addDocumentOptions.file() != null) {
-      IBMWatsonRequestBody fileBody = IBMWatsonRequestBody.create(addDocumentOptions.file(), addDocumentOptions.fileContentType());
+      fileBody = IBMWatsonRequestBody.create(addDocumentOptions.file(), addDocumentOptions.fileContentType());
       multipartBuilder.addFormDataPart('file', addDocumentOptions.filename(), fileBody);
     }
     if (addDocumentOptions.metadata() != null) {
@@ -505,8 +507,9 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     builder.query('version', versionDate);
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
+    IBMWatsonRequestBody fileBody;
     if (updateDocumentOptions.file() != null) {
-      IBMWatsonRequestBody fileBody = IBMWatsonRequestBody.create(updateDocumentOptions.file(), updateDocumentOptions.fileContentType());
+      fileBody = IBMWatsonRequestBody.create(updateDocumentOptions.file(), updateDocumentOptions.fileContentType());
       multipartBuilder.addFormDataPart('file', updateDocumentOptions.filename(), fileBody);
     }
     if (updateDocumentOptions.metadata() != null) {

--- a/force-app/main/default/classes/IBMDiscoveryV1Models.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Models.cls
@@ -7611,6 +7611,7 @@ public class IBMDiscoveryV1Models {
     private Double score_serialized_name;
     private IBMWatsonMapModel metadata_serialized_name;
     private String collection_id_serialized_name;
+    private Map<String, Object> additional_properties_serialized_name;
 
     /**
      * Gets the id_serialized_name.
@@ -7650,6 +7651,16 @@ public class IBMDiscoveryV1Models {
     @AuraEnabled
     public String getCollectionId() {
       return collection_id_serialized_name;
+    }
+
+    /**
+     * Gets the dynamic properties attached to QueryNoticesResult.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
     }
 
     /**
@@ -8539,6 +8550,7 @@ public class IBMDiscoveryV1Models {
     private Double score_serialized_name;
     private IBMWatsonMapModel metadata_serialized_name;
     private String collection_id_serialized_name;
+    private Map<String, Object> additional_properties_serialized_name;
 
     /**
      * Gets the id_serialized_name.
@@ -8578,6 +8590,16 @@ public class IBMDiscoveryV1Models {
     @AuraEnabled
     public String getCollectionId() {
       return collection_id_serialized_name;
+    }
+
+    /**
+     * Gets the dynamic properties attached to QueryResult.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
     }
 
     /**

--- a/force-app/main/default/classes/IBMWatsonDynamicModel.cls
+++ b/force-app/main/default/classes/IBMWatsonDynamicModel.cls
@@ -8,7 +8,15 @@ public virtual class IBMWatsonDynamicModel {
    * @return serialized String form of this
    */
   public override String toString() {
-    return JSON.serializePretty(this, true).remove('_serialized_name');
+    // get JSON string representation
+    String jsonString = JSON.serialize(this, true).remove('\\n');
+    
+    // call custom serializer to raise additional properties
+    jsonString = IBMWatsonJSONUtil.serialize(jsonString);
+    
+    // pretty print formatting
+    jsonString = JSON.serializePretty(JSON.deserializeUntyped(jsonString));
+    return jsonString;
   }
 
   /**

--- a/force-app/main/default/classes/IBMWatsonDynamicModel.cls
+++ b/force-app/main/default/classes/IBMWatsonDynamicModel.cls
@@ -32,7 +32,7 @@ public virtual class IBMWatsonDynamicModel {
     if (additional_properties == null) {
       additional_properties = new Map<String, Object>();
     }
-    return additional_properties.get(key + '_serialized_name');
+    return additional_properties.get(key);
   }
 
   public void put(String key, Object val) {
@@ -40,12 +40,8 @@ public virtual class IBMWatsonDynamicModel {
       additional_properties = new Map<String, Object>();
     }
 
-    // dynamic properties coming from the service will already have this, but users won't add this extension
-    if (!key.endsWith('_serialized_name')) {
-      key += '_serialized_name';
-    }
-
-    additional_properties.put(key, val);
+    String valJson = JSON.serialize(val).remove('_serialized_name');
+    additional_properties.put(key.removeEnd('_serialized_name'), JSON.deserializeUntyped(valJson));
   }
 
   public virtual Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -58,6 +54,10 @@ public virtual class IBMWatsonDynamicModel {
     }
 
     return ret;
+  }
+
+  public Map<String, Object> getDynamicProperties() {
+    return this.additional_properties;
   }
 
 }

--- a/force-app/main/default/classes/IBMWatsonGenericModel.cls
+++ b/force-app/main/default/classes/IBMWatsonGenericModel.cls
@@ -6,7 +6,15 @@ public virtual class IBMWatsonGenericModel {
    * @return serialized String form of this
    */
   public override String toString() {
-    return JSON.serializePretty(this, true).remove('_serialized_name');
+    // get JSON string representation
+    String jsonString = JSON.serialize(this, true).remove('\\n');
+    
+    // call custom serializer to raise additional properties
+    jsonString = IBMWatsonJSONUtil.serialize(jsonString);
+    
+    // pretty print formatting
+    jsonString = JSON.serializePretty(JSON.deserializeUntyped(jsonString));
+    return jsonString;
   }
 
   /**

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -39,7 +39,7 @@ public class IBMWatsonJSONUtil {
   }
 
   /**
-   * Adds 'serialized_name' suffix to any properties which are reserved words in Apex.
+   * Adds 'serialized_name' suffix to all property keys.
    *
    * @param jsonString String representation of the JSON response
    *

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -102,6 +102,9 @@ public class IBMWatsonJSONUtil {
           // looping until we find the end of the additional_properties object
           while (lastToken != JSONToken.END_OBJECT || braceCount > 0) {
             String replacementString = parser.getText();
+            
+            // getText above will remove any escape characters
+            replacementString = replacementString.replace('"', '\\"');
 
             if (current == JSONToken.START_OBJECT) {
               braceCount++;
@@ -110,16 +113,22 @@ public class IBMWatsonJSONUtil {
               braceCount--;
               Integer lastIndex = replacementList.size() - 1;
               String lastVal = replacementList.get(lastIndex);
-
-              lastVal = lastVal.substring(0, lastVal.length() - 1);
-              replacementList.set(lastIndex, lastVal);
+              
+              // only want to remove trailing commas
+              if (!lastVal.equals('{')) {
+                lastVal = lastVal.substring(0, lastVal.length() - 1);
+                replacementList.set(lastIndex, lastVal);
+              }
             }
             else if (current == JSONToken.END_ARRAY) {
               Integer lastIndex = replacementList.size() - 1;
               String lastVal = replacementList.get(lastIndex);
 
-              lastVal = lastVal.substring(0, lastVal.length() - 1);
-              replacementList.set(lastIndex, lastVal);
+              // only want to remove trailing commas
+              if (!lastVal.equals('[')) {
+                lastVal = lastVal.substring(0, lastVal.length() - 1);
+                replacementList.set(lastIndex, lastVal);
+              }
             }
 
             if (current == JSONToken.FIELD_NAME) {
@@ -129,6 +138,7 @@ public class IBMWatsonJSONUtil {
               replacementString = '"' + replacementString + '",';
             }
             else if (current == JSONToken.VALUE_NUMBER_INT
+                || current == JSONToken.VALUE_NUMBER_FLOAT
                 || current == JSONToken.VALUE_TRUE
                 || current == JSONToken.VALUE_FALSE
                 || current == JSONToken.VALUE_NULL
@@ -155,8 +165,6 @@ public class IBMWatsonJSONUtil {
           replacementList.remove(0);
           replacementList.remove(replacementList.size() - 1);
           String replacementString = String.join(replacementList, '');
-
-          Integer replacementIndex = jsonString.indexOf(stringToReplace);
           jsonString = jsonString.replace(stringToReplace, replacementString);
         }
 


### PR DESCRIPTION
Fixes #9 

Dynamic properties located in the `additionalProperties` map are now exposed with the `@AuraEnabled` annotation, allowing access from Javascript.

Objects which may have additional properties will have an `additionalProperties` field, which can be treated like a normal object in Javascript. An example of getting the `text` property of the following response object is shown below:

`QueryResponse` JSON representation (simplified):
```
{
  "matching_results": 2,
  "results": [
    {
      "id": "my_id",
      "score": 1.0,
      "collection_id": "my_collection_id",
      "additional_properties": {
        "enriched_text": {
          "concepts": [
            {
              "text": "my text"
            }
          ]
        }
      }
    },
    // next result
  ]
}
```

Access using Javascript:
```javascript
action.setCallback(this, function(response) {
  var resp = response.getReturnValue();
  console.log(resp.results[0].additionalProperties["enriched_text"]["concepts"][0]["text"]);
});
$A.enqueueAction(action);
```