### PR TITLE
Revert addition of JSON util method to replace empty string values

### DIFF
--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -23,18 +23,6 @@ public class IBMWatsonJSONUtil {
         'using', 'virtual', 'webservice', 'when', 'where', 'while', 'yesterday'
     };
   }
-  /**
-   * Replaces any empty string values with 'null'. This will cause that property to be left out of the
-   * string reprentation of the object and will prevent any deserialization issues with empty
-   * strings being returned.
-   *
-   * @param jsonString String representation of the JSON response
-   *
-   * @return String representing our modified JSON response object
-   */
-  public static String replaceEmptyStrings(String jsonString) {
-    return jsonString.replace('""', 'null');
-  }
 
   /**
    * Removes '_serialized_name' suffix to match API spec and modifies JSON request string

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -59,8 +59,7 @@ public abstract class IBMWatsonService {
       else{
         String responseText = response.getBody();
         if (String.isNotBlank(responseText)) {
-          String responseTextWithNulls = IBMWatsonJSONUtil.replaceEmptyStrings(responseText);
-          Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(responseTextWithNulls);
+          Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(responseText);
           Map<String, Object> safeJsonMap = IBMWatsonJSONUtil.prepareResponse(jsonMap);
           Object targetObject = targetType.newInstance();
           String jsonString = JSON.serialize(safeJsonMap);


### PR DESCRIPTION
In my last PR to fix deserialization issues, I added back the utility method in `IBMWatsonJSONUtil` to replace empty JSON string values with `null`.

It turns out that addition shouldn't have been made, as I ran into issues parsing some calls due to that method. A particular example was trying to parse the response of a `listDialogNodes()` call with Discovery.

This PR removes that method and clears up that issue.