### PR TITLE
Remove the removal of newlines

### DIFF
--- a/force-app/main/default/classes/IBMWatsonDynamicModel.cls
+++ b/force-app/main/default/classes/IBMWatsonDynamicModel.cls
@@ -9,11 +9,11 @@ public virtual class IBMWatsonDynamicModel {
    */
   public override String toString() {
     // get JSON string representation
-    String jsonString = JSON.serialize(this, true).remove('\\n');
-    
+    String jsonString = JSON.serialize(this, true);
+
     // call custom serializer to raise additional properties
     jsonString = IBMWatsonJSONUtil.serialize(jsonString);
-    
+
     // pretty print formatting
     jsonString = JSON.serializePretty(JSON.deserializeUntyped(jsonString));
     return jsonString;

--- a/force-app/main/default/classes/IBMWatsonGenericModel.cls
+++ b/force-app/main/default/classes/IBMWatsonGenericModel.cls
@@ -7,11 +7,11 @@ public virtual class IBMWatsonGenericModel {
    */
   public override String toString() {
     // get JSON string representation
-    String jsonString = JSON.serialize(this, true).remove('\\n');
-    
+    String jsonString = JSON.serialize(this, true);
+
     // call custom serializer to raise additional properties
     jsonString = IBMWatsonJSONUtil.serialize(jsonString);
-    
+
     // pretty print formatting
     jsonString = JSON.serializePretty(JSON.deserializeUntyped(jsonString));
     return jsonString;


### PR DESCRIPTION
## Summary

The JSON serialization was removing newlines from the output. This caused issues when there were literal newlines in the JSON string and cause errors with HTML or XML content present in a JSON field value.

## Other Information

Would like to know why this included in the first place as it seems arbitrary to remove on the `toString`


Thanks for contributing to the Watson Developer Cloud!