### PR TITLE
Add classifyCollection endpoint

### DIFF
--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
@@ -48,6 +48,24 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
   }
 
   /**
+   * Classify multiple phrases.
+   *
+   * Returns label information for multiple phrases. The status must be `Available` before you can use the classifier to classify text.  Note that classifying Japanese texts is a beta feature.
+   *
+   * @param classifyCollectionOptions the {@link IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptions} containing the options for the call
+   * @return the {@link IBMNaturalLanguageClassifierV1Models.ClassificationCollection} with the response
+   */
+  public IBMNaturalLanguageClassifierV1Models.ClassificationCollection classifyCollection(IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptions classifyCollectionOptions) {
+    IBMWatsonValidator.notNull(classifyCollectionOptions, 'classifyCollectionOptions cannot be null');
+    IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/classifiers/{0}/classify_collection', new String[]{ classifyCollectionOptions.classifierId() }));
+    final Map<String, Object> contentJson = new Map<String, Object>();
+    contentJson.put('collection', classifyCollectionOptions.collection());
+    builder.bodyJson(JSON.serialize(contentJson, true));
+
+    return (IBMNaturalLanguageClassifierV1Models.ClassificationCollection) createServiceCall(builder.build(), IBMNaturalLanguageClassifierV1Models.ClassificationCollection.class);
+  }
+
+  /**
    * Create classifier.
    *
    * Sends data to create and train a classifier and returns information about the new classifier.

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
@@ -134,6 +134,98 @@ public class IBMNaturalLanguageClassifierV1Models {
   }
 
   /**
+   * Response from the classifier for multiple phrases.
+   */
+  public class ClassificationCollection extends IBMWatsonGenericModel {
+    private String classifier_id_serialized_name;
+    private String url_serialized_name;
+    private List<CollectionItem> collection_serialized_name;
+    /**
+     * Gets the classifier_id_serialized_name.
+     *
+     * Unique identifier for this classifier.
+     *
+     * @return the classifier_id_serialized_name
+     */
+    @AuraEnabled
+    public String getClassifierId() {
+      return classifier_id_serialized_name;
+    }
+    /**
+     * Gets the url_serialized_name.
+     *
+     * Link to the classifier.
+     *
+     * @return the url_serialized_name
+     */
+    @AuraEnabled
+    public String getUrl() {
+      return url_serialized_name;
+    }
+    /**
+     * Gets the collection_serialized_name.
+     *
+     * An array of classifier responses for each submitted phrase.
+     *
+     * @return the collection_serialized_name
+     */
+    @AuraEnabled
+    public List<CollectionItem> getCollection() {
+      return collection_serialized_name;
+    }
+
+    /**
+     * Sets the classifier_id_serialized_name.
+     *
+     * @param classifierId the new classifierId
+     */
+    public void setClassifierId(final String classifierId) {
+      this.classifier_id_serialized_name = classifierId;
+    }
+
+    /**
+     * Sets the url_serialized_name.
+     *
+     * @param url the new url
+     */
+    public void setUrl(final String url) {
+      this.url_serialized_name = url;
+    }
+
+    /**
+     * Sets the collection_serialized_name.
+     *
+     * @param collection the new collection
+     */
+    public void setCollection(final List<CollectionItem> collection) {
+      this.collection_serialized_name = collection;
+    }
+
+    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
+      if (jsonMap == null) {
+        return null;
+      }
+
+      ClassificationCollection ret = (ClassificationCollection) super.deserialize(jsonString, jsonMap, classType);
+
+      // calling custom deserializer for collection_serialized_name
+      List<CollectionItem> newCollection = new List<CollectionItem>();
+      List<CollectionItem> deserializedCollection = ret.getCollection();
+      if (deserializedCollection != null) {
+        for (Integer i = 0; i < deserializedCollection.size(); i++) {
+          CollectionItem currentItem = ret.getCollection().get(i);
+          List<Object> itemInMap = (List<Object>) jsonMap.get('collection_serialized_name');
+          CollectionItem newItem = (CollectionItem) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CollectionItem.class);
+          newCollection.add(newItem);
+        }
+        ret.setCollection(newCollection);
+      }
+
+      return ret;
+    }
+  }
+
+  /**
    * Class and confidence.
    */
   public class ClassifiedClass extends IBMWatsonGenericModel {
@@ -378,6 +470,164 @@ public class IBMNaturalLanguageClassifierV1Models {
   }
 
   /**
+   * The classifyCollection options.
+   */
+  public class ClassifyCollectionOptions {
+    private String classifier_id_serialized_name;
+    private List<ClassifyInput> collection_serialized_name;
+    /**
+     * Gets the classifier_id_serialized_name.
+     *
+     * Classifier ID to use.
+     *
+     * @return the classifier_id_serialized_name
+     */
+    public String classifierId() {
+      return classifier_id_serialized_name;
+    }
+    /**
+     * Gets the collection_serialized_name.
+     *
+     * The submitted phrases.
+     *
+     * @return the collection_serialized_name
+     */
+    public List<ClassifyInput> collection() {
+      return collection_serialized_name;
+    }
+    private ClassifyCollectionOptions(ClassifyCollectionOptionsBuilder builder) {
+      IBMWatsonValidator.notEmpty(builder.classifier_id_serialized_name, 'classifier_id_serialized_name cannot be empty');
+      IBMWatsonValidator.notNull(builder.collection_serialized_name, 'collection_serialized_name cannot be null');
+      classifier_id_serialized_name = builder.classifier_id_serialized_name;
+      collection_serialized_name = builder.collection_serialized_name;
+    }
+
+    /**
+     * New builder.
+     *
+     * @return a ClassifyCollectionOptions builder
+     */
+    public ClassifyCollectionOptionsBuilder newBuilder() {
+      return new ClassifyCollectionOptionsBuilder(this);
+    }
+
+  }
+
+  /**
+   * ClassifyCollectionOptions Builder.
+   */
+  public class ClassifyCollectionOptionsBuilder {
+    private String classifier_id_serialized_name;
+    private List<ClassifyInput> collection_serialized_name;
+
+    private ClassifyCollectionOptionsBuilder(ClassifyCollectionOptions classifyCollectionOptions) {
+      classifier_id_serialized_name = classifyCollectionOptions.classifier_id_serialized_name;
+      collection_serialized_name = classifyCollectionOptions.collection_serialized_name;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public ClassifyCollectionOptionsBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param classifierId the classifierId
+     * @param collection the collection
+     */
+    public ClassifyCollectionOptionsBuilder(String classifierId, List<ClassifyInput> collection) {
+      this.classifier_id_serialized_name = classifierId;
+      this.collection_serialized_name = collection;
+    }
+
+    /**
+     * Builds a ClassifyCollectionOptions.
+     *
+     * @return the classifyCollectionOptions
+     */
+    public ClassifyCollectionOptions build() {
+      return new ClassifyCollectionOptions(this);
+    }
+
+    /**
+     * Adds an collection to collection_serialized_name.
+     *
+     * @param collection the new collection
+     * @return the ClassifyCollectionOptions builder
+     */
+    public ClassifyCollectionOptionsBuilder addCollection(ClassifyInput collection) {
+      IBMWatsonValidator.notNull(collection, 'collection cannot be null');
+      if (this.collection_serialized_name == null) {
+        this.collection_serialized_name = new List<ClassifyInput>();
+      }
+      this.collection_serialized_name.add(collection);
+      return this;
+    }
+
+    /**
+     * Set the classifier_id_serialized_name.
+     *
+     * @param classifierId the classifierId
+     * @return the ClassifyCollectionOptions builder
+     */
+    public ClassifyCollectionOptionsBuilder classifierId(String classifierId) {
+      this.classifier_id_serialized_name = classifierId;
+      return this;
+    }
+
+    /**
+     * Set the collection_serialized_name.
+     * Existing collection_serialized_name will be replaced.
+     *
+     * @param collection the collection
+     * @return the ClassifyCollectionOptions builder
+     */
+    public ClassifyCollectionOptionsBuilder collection(List<ClassifyInput> collection) {
+      this.collection_serialized_name = collection;
+      return this;
+    }
+  }
+
+  /**
+   * Request payload to classify.
+   */
+  public class ClassifyInput extends IBMWatsonGenericModel {
+    private String text_serialized_name;
+    /**
+     * Gets the text_serialized_name.
+     *
+     * The submitted phrase.
+     *
+     * @return the text_serialized_name
+     */
+    @AuraEnabled
+    public String getText() {
+      return text_serialized_name;
+    }
+
+    /**
+     * Sets the text_serialized_name.
+     *
+     * @param text the new text
+     */
+    public void setText(final String text) {
+      this.text_serialized_name = text;
+    }
+
+    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
+      if (jsonMap == null) {
+        return null;
+      }
+
+      ClassifyInput ret = (ClassifyInput) super.deserialize(jsonString, jsonMap, classType);
+
+      return ret;
+    }
+  }
+
+  /**
    * The classify options.
    */
   public class ClassifyOptions {
@@ -483,6 +733,98 @@ public class IBMNaturalLanguageClassifierV1Models {
   }
 
   /**
+   * Response from the classifier for a phrase in a collection.
+   */
+  public class CollectionItem extends IBMWatsonGenericModel {
+    private String text_serialized_name;
+    private String top_class_serialized_name;
+    private List<ClassifiedClass> classes_serialized_name;
+    /**
+     * Gets the text_serialized_name.
+     *
+     * The submitted phrase.
+     *
+     * @return the text_serialized_name
+     */
+    @AuraEnabled
+    public String getText() {
+      return text_serialized_name;
+    }
+    /**
+     * Gets the top_class_serialized_name.
+     *
+     * The class with the highest confidence.
+     *
+     * @return the top_class_serialized_name
+     */
+    @AuraEnabled
+    public String getTopClass() {
+      return top_class_serialized_name;
+    }
+    /**
+     * Gets the classes_serialized_name.
+     *
+     * An array of up to ten class-confidence pairs sorted in descending order of confidence.
+     *
+     * @return the classes_serialized_name
+     */
+    @AuraEnabled
+    public List<ClassifiedClass> getClasses() {
+      return classes_serialized_name;
+    }
+
+    /**
+     * Sets the text_serialized_name.
+     *
+     * @param text the new text
+     */
+    public void setText(final String text) {
+      this.text_serialized_name = text;
+    }
+
+    /**
+     * Sets the top_class_serialized_name.
+     *
+     * @param topClass the new topClass
+     */
+    public void setTopClass(final String topClass) {
+      this.top_class_serialized_name = topClass;
+    }
+
+    /**
+     * Sets the classes_serialized_name.
+     *
+     * @param classes the new classes
+     */
+    public void setClasses(final List<ClassifiedClass> classes) {
+      this.classes_serialized_name = classes;
+    }
+
+    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
+      if (jsonMap == null) {
+        return null;
+      }
+
+      CollectionItem ret = (CollectionItem) super.deserialize(jsonString, jsonMap, classType);
+
+      // calling custom deserializer for classes_serialized_name
+      List<ClassifiedClass> newClasses = new List<ClassifiedClass>();
+      List<ClassifiedClass> deserializedClasses = ret.getClasses();
+      if (deserializedClasses != null) {
+        for (Integer i = 0; i < deserializedClasses.size(); i++) {
+          ClassifiedClass currentItem = ret.getClasses().get(i);
+          List<Object> itemInMap = (List<Object>) jsonMap.get('classes_serialized_name');
+          ClassifiedClass newItem = (ClassifiedClass) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ClassifiedClass.class);
+          newClasses.add(newItem);
+        }
+        ret.setClasses(newClasses);
+      }
+
+      return ret;
+    }
+  }
+
+  /**
    * The createClassifier options.
    */
   public class CreateClassifierOptions {
@@ -493,7 +835,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     /**
      * Gets the training_metadata_serialized_name.
      *
-     * Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the classifier.
+     * Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the classifier. Specify the language with the 2-letter primary language code as assigned in ISO standard 639.  Supported languages are English (`en`), Arabic (`ar`), French (`fr`), German, (`de`), Italian (`it`), Japanese (`ja`), Korean (`ko`), Brazilian Portuguese (`pt`), and Spanish (`es`).
      *
      * @return the training_metadata_serialized_name
      */
@@ -513,7 +855,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     /**
      * Gets the training_data_serialized_name.
      *
-     * Training data in CSV format. Each text value must have at least one class. The data can include up to 15,000 records. For details, see [Using your own data](https://console.bluemix.net/docs/services/natural-language-classifier/using-your-data.html).
+     * Training data in CSV format. Each text value must have at least one class. The data can include up to 20,000 records. For details, see [Data preparation](https://console.bluemix.net/docs/services/natural-language-classifier/using-your-data.html).
      *
      * @return the training_data_serialized_name
      */

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
@@ -41,6 +41,9 @@ private class IBMNaturalLanguageClassifierV1Test {
     Test.stopTest();
   }
 
+  /**
+   * Test classifying multiple phrases at once.
+   */
   static testMethod void testClassifyCollection() {
     String body = IBMWatsonMockResponses.ClassifyCollection();
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
@@ -41,6 +41,39 @@ private class IBMNaturalLanguageClassifierV1Test {
     Test.stopTest();
   }
 
+  static testMethod void testClassifyCollection() {
+    String body = IBMWatsonMockResponses.ClassifyCollection();
+    IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
+    Test.setMock(HttpCalloutMock.class, mockResponse);
+    Test.startTest();
+    IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1();
+    service.setEndPoint('https://gateway.watsonplatform.net/natural-language-classifier/api');
+    service.setUsernameAndPassword('username', 'password');
+    String classifierId = '10D41B-nlc-1';
+    IBMNaturalLanguageClassifierV1Models.ClassifyInput input1 = new IBMNaturalLanguageClassifierV1Models.ClassifyInput();
+    String text1 = 'How hot will it be today?';
+    input1.setText(text1);
+    IBMNaturalLanguageClassifierV1Models.ClassifyInput input2 = new IBMNaturalLanguageClassifierV1Models.ClassifyInput();
+    String text2 = 'Is it hot outside?';
+    input2.setText(text2);
+    List<IBMNaturalLanguageClassifierV1Models.ClassifyInput> inputCollection = new List<IBMNaturalLanguageClassifierV1Models.ClassifyInput> {
+      input1,
+      input2
+    };
+    IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptions classifyOptions = new IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptionsBuilder()
+      .classifierId(classifierId)
+      .collection(inputCollection)
+      .build();
+    IBMNaturalLanguageClassifierV1Models.ClassificationCollection classification = service.classifyCollection(classifyOptions);
+    System.assertEquals(classification.getClassifierId(), classifierId);
+    System.assertEquals(classification.getUrl(), 'https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/' + classifierId);
+    System.assertEquals(classification.getCollection().get(0).getText(), text1);
+    System.assertEquals(classification.getCollection().get(0).getTopClass(), 'temperature');
+    System.assertEquals(classification.getCollection().get(1).getText(), text2);
+    System.assertEquals(classification.getCollection().get(1).getTopClass(), 'temperature');
+    Test.stopTest();
+  }
+
   /**
    *  Test send data to create and train a classifier.
    *

--- a/force-app/main/default/classes/IBMWatsonMockResponses.cls
+++ b/force-app/main/default/classes/IBMWatsonMockResponses.cls
@@ -1212,6 +1212,34 @@ public class IBMWatsonMockResponses {
     '  ]' +
     '}';
   }
+
+  public static String ClassifyCollection() {
+    return '{' +
+    '  "classifier_id" : "10D41B-nlc-1",' +
+    '  "url" : "https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/10D41B-nlc-1",' +
+    '  "collection" : [ {' +
+    '    "text" : "How hot will it be today?",' +
+    '    "top_class" : "temperature",' +
+    '    "classes" : [ {' +
+    '      "class_name" : "temperature",' +
+    '      "confidence" : 0.9930558798985937' +
+    '    }, {' +
+    '      "class_name" : "conditions",' +
+    '      "confidence" : 0.006944120101406304' +
+    '    } ]' +
+    '  }, {' +
+    '    "text" : "Is it hot outside?",' +
+    '    "top_class" : "temperature",' +
+    '    "classes" : [ {' +
+    '      "class_name" : "temperature",' +
+    '      "confidence" : 1' +
+    '    }, {' +
+    '      "class_name" : "conditions",' +
+    '      "confidence" : 0' +
+    '    } ]' +
+    '  } ]' +
+    '}';
+  }
   
   public static String CreateClassifier() {
     return '{' +

--- a/force-app/main/test/IBMNaturalLanguageClassifierV1FTests.cls
+++ b/force-app/main/test/IBMNaturalLanguageClassifierV1FTests.cls
@@ -3,7 +3,8 @@ public without sharing class IBMNaturalLanguageClassifierV1FTests {
   private static String URL = 'https://gateway.watsonplatform.net/natural-language-classifier/api';
   private static String NAMED_CREDENTIALS = 'callout:watson_natural_language_classifier_v1';
   private static String VERSION_2017_05_26 = '2017-05-26';
-  private static String ClassifierText = 'How hot will it be today?';
+  private static final String CLASSIFIER_TEXT_1 = 'How hot will it be today?';
+  private static final String CLASSIFIER_TEXT_2 = 'Is it hot outside?';
 
   public static void runAllTests(String username, String password) {
     String classifierId = testCreateClassifier(username, password).getClassifierId();
@@ -37,10 +38,37 @@ public without sharing class IBMNaturalLanguageClassifierV1FTests {
     IBMNaturalLanguageClassifierV1Models.ClassifyOptions classifyOptions =
       new IBMNaturalLanguageClassifierV1Models.ClassifyOptionsBuilder()
       .classifierId(classifierId)
-      .text(ClassifierText)
+      .text(CLASSIFIER_TEXT_1)
       .build();
 
     IBMNaturalLanguageClassifierV1Models.Classification classification = service.classify(classifyOptions);
+    return classification;
+  }
+
+  /**
+   * Test classifying multiple phrases at once.
+   */
+  public static IBMNaturalLanguageClassifierV1Models.ClassificationCollection textClassifyCollection(String classifierId, String username, String password) {
+    IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1();
+
+    if (username != null && password != null) {
+      service.setEndPoint(URL);
+      service.setUsernameAndPassword(username, password);
+    }
+
+    BMNaturalLanguageClassifierV1Models.ClassifyInput input1 = new IBMNaturalLanguageClassifierV1Models.ClassifyInput();
+    input1.setText(CLASSIFIER_TEXT_1);
+    IBMNaturalLanguageClassifierV1Models.ClassifyInput input2 = new IBMNaturalLanguageClassifierV1Models.ClassifyInput();
+    input2.setText(CLASSIFIER_TEXT_2);
+    List<IBMNaturalLanguageClassifierV1Models.ClassifyInput> inputCollection = new List<IBMNaturalLanguageClassifierV1Models.ClassifyInput> {
+      input1,
+      input2
+    };
+    IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptions classifyOptions = new IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptionsBuilder()
+      .classifierId(classifierId)
+      .collection(inputCollection)
+      .build();
+    IBMNaturalLanguageClassifierV1Models.ClassificationCollection classification = service.classifyCollection(classifyOptions);
     return classification;
   }
 

--- a/force-app/main/test/IBMNaturalLanguageClassifierV1FTests.cls
+++ b/force-app/main/test/IBMNaturalLanguageClassifierV1FTests.cls
@@ -13,6 +13,7 @@ public without sharing class IBMNaturalLanguageClassifierV1FTests {
 
     if (classifierStatus.equalsIgnoreCase('ready')) {
       testClassify(classifierId, username, password);
+      textClassifyCollection(classifierId, username, password);
     }
     testDeleteClassifier(classifierId, username, password);
   }
@@ -56,7 +57,7 @@ public without sharing class IBMNaturalLanguageClassifierV1FTests {
       service.setUsernameAndPassword(username, password);
     }
 
-    BMNaturalLanguageClassifierV1Models.ClassifyInput input1 = new IBMNaturalLanguageClassifierV1Models.ClassifyInput();
+    IBMNaturalLanguageClassifierV1Models.ClassifyInput input1 = new IBMNaturalLanguageClassifierV1Models.ClassifyInput();
     input1.setText(CLASSIFIER_TEXT_1);
     IBMNaturalLanguageClassifierV1Models.ClassifyInput input2 = new IBMNaturalLanguageClassifierV1Models.ClassifyInput();
     input2.setText(CLASSIFIER_TEXT_2);


### PR DESCRIPTION
Recently, the NLC service added a new endpoint: `classifyCollection`. This PR adds that service method, as well as any associated models and accompanying tests.