### PR TITLE
File upload fix

### DIFF
--- a/force-app/main/default/classes/IBMDiscoveryV1.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1.cls
@@ -295,7 +295,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
       multipartBuilder.addFormDataPart('configuration', testConfigurationInEnvironmentOptions.configuration());
     }
     if (testConfigurationInEnvironmentOptions.file() != null) {
-      IBMWatsonRequestBody fileBody = IBMWatsonRequestBody.create(testConfigurationInEnvironmentOptions.file(), IBMWatsonHttpMediaType.APPLICATION_OCTET_STREAM);
+      IBMWatsonRequestBody fileBody = IBMWatsonRequestBody.create(testConfigurationInEnvironmentOptions.file(), testConfigurationInEnvironmentOptions.fileContentType());
       multipartBuilder.addFormDataPart('file', testConfigurationInEnvironmentOptions.filename(), fileBody);
     }
     if (testConfigurationInEnvironmentOptions.metadata() != null) {
@@ -490,7 +490,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
     if (addDocumentOptions.file() != null) {
-      IBMWatsonRequestBody fileBody = IBMWatsonRequestBody.create(addDocumentOptions.file(), IBMWatsonHttpMediaType.APPLICATION_OCTET_STREAM);
+      IBMWatsonRequestBody fileBody = IBMWatsonRequestBody.create(addDocumentOptions.file(), addDocumentOptions.fileContentType());
       multipartBuilder.addFormDataPart('file', addDocumentOptions.filename(), fileBody);
     }
     if (addDocumentOptions.metadata() != null) {
@@ -550,7 +550,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
     if (updateDocumentOptions.file() != null) {
-      IBMWatsonRequestBody fileBody = IBMWatsonRequestBody.create(updateDocumentOptions.file(), IBMWatsonHttpMediaType.APPLICATION_OCTET_STREAM);
+      IBMWatsonRequestBody fileBody = IBMWatsonRequestBody.create(updateDocumentOptions.file(), updateDocumentOptions.fileContentType());
       multipartBuilder.addFormDataPart('file', updateDocumentOptions.filename(), fileBody);
     }
     if (updateDocumentOptions.metadata() != null) {

--- a/force-app/main/default/classes/IBMDiscoveryV1Models.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Models.cls
@@ -72,6 +72,9 @@ public class IBMDiscoveryV1Models {
     private AddDocumentOptions(AddDocumentOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.environment_id_serialized_name, 'environment_id_serialized_name cannot be empty');
       IBMWatsonValidator.notEmpty(builder.collection_id_serialized_name, 'collection_id_serialized_name cannot be empty');
+      IBMWatsonValidator.isTrue((builder.file_serialized_name == null)
+        || (builder.filename_serialized_name != null && builder.file_content_type_serialized_name != null),
+        'filename and content type cannot be null if file is not null');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
       file_serialized_name = builder.file_serialized_name;
@@ -12252,6 +12255,9 @@ public class IBMDiscoveryV1Models {
     }
     private TestConfigurationInEnvironmentOptions(TestConfigurationInEnvironmentOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.environment_id_serialized_name, 'environment_id_serialized_name cannot be empty');
+      IBMWatsonValidator.isTrue((builder.file_serialized_name == null)
+        || (builder.filename_serialized_name != null && builder.file_content_type_serialized_name != null),
+        'filename and content type cannot be null if file is not null');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       configuration_serialized_name = builder.configuration_serialized_name;
       step_serialized_name = builder.step_serialized_name;
@@ -13663,6 +13669,9 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.environment_id_serialized_name, 'environment_id_serialized_name cannot be empty');
       IBMWatsonValidator.notEmpty(builder.collection_id_serialized_name, 'collection_id_serialized_name cannot be empty');
       IBMWatsonValidator.notEmpty(builder.document_id_serialized_name, 'document_id_serialized_name cannot be empty');
+      IBMWatsonValidator.isTrue((builder.file_serialized_name == null)
+        || (builder.filename_serialized_name != null && builder.file_content_type_serialized_name != null),
+        'filename and content type cannot be null if file is not null');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
       document_id_serialized_name = builder.document_id_serialized_name;

--- a/force-app/main/test/IBMDiscoveryV1FTests.cls
+++ b/force-app/main/test/IBMDiscoveryV1FTests.cls
@@ -29,7 +29,7 @@ public with sharing class IBMDiscoveryV1FTests {
     testGetTrainingData(ENVIRONMENT_ID, COLLECTION_ID, QUERY_ID, username, password);
     testListTrainingData(ENVIRONMENT_ID, COLLECTION_ID, username, password);
     testFederatedQueryNotices(ENVIRONMENT_ID, COLLECTION_ID, username, password);
-    testAddAndDeleteDocument(environmentId, collectionId, username, password);
+    testAddAndDeleteDocument(ENVIRONMENT_ID, COLLECTION_ID, username, password);
   }
 
   /**

--- a/force-app/main/test/IBMDiscoveryV1FTests.cls
+++ b/force-app/main/test/IBMDiscoveryV1FTests.cls
@@ -29,6 +29,7 @@ public with sharing class IBMDiscoveryV1FTests {
     testGetTrainingData(ENVIRONMENT_ID, COLLECTION_ID, QUERY_ID, username, password);
     testListTrainingData(ENVIRONMENT_ID, COLLECTION_ID, username, password);
     testFederatedQueryNotices(ENVIRONMENT_ID, COLLECTION_ID, username, password);
+    testAddAndDeleteDocument(environmentId, collectionId, username, password);
   }
 
   /**
@@ -780,11 +781,9 @@ public with sharing class IBMDiscoveryV1FTests {
   }
 
   /**
-   *  Add a document.
-   *
-   * then test using testGetDocumentStatus if document is loaded successfully
+   *  Add and delete a document.
    */
-  public static IBMDiscoveryV1Models.DocumentAccepted testAddDocument(String environmentId, String collectionId, String username, String password) {
+  public static Boolean testAddAndDeleteDocument(String environmentId, String collectionId, String username, String password) {
     IBMDiscoveryV1 discovery = new IBMDiscoveryV1('2017-11-07');
     //discovery.setEndPoint(NAMED_CREDENTIALS);
     if (username != null && password != null) {
@@ -794,19 +793,39 @@ public with sharing class IBMDiscoveryV1FTests {
 
     Attachment att=createFile();
     IBMWatsonFile testfile=new IBMWatsonFile.FileBuilder()
-     .attachment(att)
-     .build();
-    IBMDiscoveryV1Models.AddDocumentOptions options = new
-     IBMDiscoveryV1Models.AddDocumentOptionsBuilder()
-     .environmentId(environmentId)
-     .collectionId(collectionId)
-     .file(testfile)
-     .filename(att.Name)
-     .fileContentType(att.ContentType)
-     .build();
-    IBMDiscoveryV1Models.DocumentAccepted resp = discovery.addDocument(options);
-    System.debug('IBMDiscoveryV1FTests.testAddDocument: ' + resp);
-    return resp;
+      .attachment(att)
+      .build();
+    IBMDiscoveryV1Models.AddDocumentOptions addOptions = new IBMDiscoveryV1Models.AddDocumentOptionsBuilder()
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .file(testfile)
+      .filename(att.Name)
+      .fileContentType(att.ContentType)
+      .build();
+    IBMDiscoveryV1Models.DocumentAccepted resp = discovery.addDocument(addOptions);
+    String documentId = resp.getDocumentId();
+    System.debug('IBMDiscoveryV1FTests.testAddAndDeleteDocument (add): ' + resp);
+
+    IBMDiscoveryV1Models.GetDocumentStatusOptions getOptions = new IBMDiscoveryV1Models.GetDocumentStatusOptionsBuilder()
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .documentId(documentId)
+      .build();
+
+    String status = discovery.getDocumentStatus(getOptions).getStatus();
+    while (!status.equals('available')) {
+      status = discovery.getDocumentStatus(getOptions).getStatus();
+    }
+
+    IBMDiscoveryV1Models.DeleteDocumentOptions options = new IBMDiscoveryV1Models.DeleteDocumentOptionsBuilder()
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .documentId(documentId)
+      .build();
+    discovery.deleteDocument(options);
+
+    System.debug('Document successfully deleted');
+    return true;
   }
 
    public static IBMDiscoveryV1Models.TestDocument testConfigurationInEnvironment(String environmentId, String configurationId, String username, String password) {

--- a/force-app/main/test/IBMVisualRecognitionV3FTest.cls
+++ b/force-app/main/test/IBMVisualRecognitionV3FTest.cls
@@ -72,13 +72,12 @@ public with sharing class IBMVisualRecognitionV3FTest {
     IBMVisualRecognitionV3 service = new IBMVisualRecognitionV3('2016-05-20', API_KEY);
     service.setEndPoint(NAMED_CREDENTIALS);
 
-    IBMVisualRecognitionV3Models.IBMVisualRecognitionV3Models.ListClassifiersOptions listOptions
-      = new IBMVisualRecognitionV3Models.ListClassifiersOptionsBuilder()
+    IBMVisualRecognitionV3Models.ListClassifiersOptions listOptions = new IBMVisualRecognitionV3Models.ListClassifiersOptionsBuilder()
       .verbose(true)
       .build();
     IBMVisualRecognitionV3Models.Classifiers classifiers = service.listClassifiers(listOptions);
 
-    for (IBMVisualRecognitionV3Models.Classifier classifier : classifiers) {
+    for (IBMVisualRecognitionV3Models.Classifier classifier : classifiers.getClassifiers()) {
       if (classifier.getCoreMlEnabled()) {
         IBMVisualRecognitionV3Models.GetCoreMlModelOptions getOptions = new IBMVisualRecognitionV3Models.GetCoreMlModelOptionsBuilder()
           .classifierId(classifier.getClassifierId())
@@ -87,5 +86,7 @@ public with sharing class IBMVisualRecognitionV3FTest {
         return modelFile;
       }
     }
+
+    return null;
   }
 }


### PR DESCRIPTION
Fixes #101 

This PR should fix issues with using the file upload methods in the Discovery service: `addDocument()`, `testConfigurationInEnvironment()`, and `updateDocument()`.

Part of the issue was that the service was expecting filenames and file content types, but this wasn't enforced. Validators have been added to the appropriate options classes to warn users before getting errors back from the service.

The other problem was that we were using `application/octet-stream` for all file uploads. That has been changed to pull the content type from the options model like we do in the other SDKs.

Finally, a functional test to add and delete a document has been added to hopefully catch issues in the future.