### PR TITLE
Add IAM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ To access your Watson services through Apex, you'll need to authenticate with yo
 
 ### Using `Named Credentials`
 
+`Named Credentials` are the preferred way of authentication, since they allow you to keep sensitive information out of your code. However, they only work when using a **username and password**, so if you'd like to authenticate with an API key or IAM, you'll need to [set that up in your Apex code](#specifying-credentials-in-the-apex-code).
+
 When creating a service instance like with `new Discovery()`, each service loads the credentials from `Named Credentials`. The SDK will use the service name and API version to build the `Named Credentials` name.
 
 For example
@@ -142,15 +144,90 @@ In order to create **Named credentials**:
 
 ### Specifying credentials in the Apex code
 
-Storing credentials in the Apex code is not recommended. If possible, use **Named Credentials**.
+Setting credentials in the code is always an option, and in fact, it's the only option if you're authenticating with an API key (in the case of the Visual Recognition service) or with IAM.
 
-However, if you choose to, here's an example of setting the credentials in your code:
+You can always set these values directly in the constructor or with a method call after instantiating your service.
+
+_Note: You must set the service endpoint manually when setting your credentials this way. Otherwise, the SDK will default to searching for `Named Credentials` that you won't have set up._
+
+#### Username and Password
 
 ```java
+// in the constructor
+IBMDiscoveryV1 discovery = new IBMDiscoveryV1('2017-11-07', 'USERNAME', 'PASSWORD');
+discovery.setEndPoint('URL');
+```
+
+```java
+// after instantiation
 IBMDiscoveryV1 discovery = new IBMDiscoveryV1('2017-11-07');
 discovery.setEndPoint('URL');
 discovery.setUsernameAndPassword('USERNAME', 'PASSWORD');
 ```
+
+#### API Key
+
+```java
+// in the constructor
+IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', 'API_KEY');
+visualRecognition.setEndPoint('URL');
+```
+
+```java
+// after instantiation
+IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20');
+visualRecognition.setEndPoint('URL');
+visualRecognition.setApiKey('API_KEY');
+```
+
+#### Using IAM
+
+When authenticating with IAM, you have the option of passing in:
+  - the IAM API key and, optionally, the IAM service URL
+  - an IAM access token
+
+**Be aware that passing in an access token means that you're assuming responsibility for maintaining that token's lifecycle.** If you instead pass in an IAM API key, the SDK will manage it for you.
+
+```java
+// in the constructor, letting the SDK manage the IAM token
+IBMWatsonIAMOptions options = new IBMWatsonIAMOptions.Builder()
+  .apiKey('IAM_API_KEY')
+  .url('IAM_URL') // optional - the default value is https://iam.ng.bluemix.net/identity/token
+  .build();
+IBMDiscoveryV1 service = new IBMDiscoveryV1('2017-11-07', options);
+service.setEndPoint('SERVICE_URL');
+```
+
+```java
+// after instantiation, letting the SDK manage the IAM token
+IBMDiscoveryV1 service = new IBMDiscoveryV1('2017-11-07', options);
+IBMWatsonIAMOptions options = new IBMWatsonIAMOptions.Builder()
+  .apiKey('IAM_API_KEY')
+  .build();
+service.setIamCredentials(options);
+service.setEndPoint('SERVICE_URL');
+```
+
+```java
+// in the constructor, assuming control of managing IAM token
+IBMWatsonIAMOptions options = new IBMWatsonIAMOptions.Builder()
+  .accessToken('ACCESS_TOKEN')
+  .build();
+IBMDiscoveryV1 service = new IBMDiscoveryV1('2017-11-07', options);
+service.setEndPoint('SERVICE_URL');
+```
+
+```java
+// after instantiation, assuming control of managing IAM token
+IBMDiscoveryV1 service = new IBMDiscoveryV1('2017-11-07');
+IBMWatsonIAMOptions options = new IBMWatsonIAMOptions.Builder()
+  .accessToken('ACCESS_TOKEN')
+  .build();
+service.setIamCredentials(options);
+service.setEndPoint('SERVICE_URL');
+```
+
+If at any time you would like to let the SDK take over managing your IAM token, simply override your stored IAM credentials with an IAM API key by calling the `setIamCredentials()` method again.
 
 ### Setting Remote Site Settings
 
@@ -161,6 +238,8 @@ The final piece of setup to access Watson services from your Salesforce environm
 1. Click _New Remote Site_
 1. Add whatever name you desire, with the following URL: `https://gateway.watsonplatform.net/`
 1. Click _Save_
+
+If you're authenticating with IAM, you'll also need to add your IAM URL in your remote site settings. The default URL is `https://iam.ng.bluemix.net`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ service.setEndPoint('SERVICE_URL');
 
 ```java
 // after instantiation, letting the SDK manage the IAM token
-IBMDiscoveryV1 service = new IBMDiscoveryV1('2017-11-07', options);
+IBMDiscoveryV1 service = new IBMDiscoveryV1('2017-11-07');
 IBMWatsonIAMOptions options = new IBMWatsonIAMOptions.Builder()
   .apiKey('IAM_API_KEY')
   .build();

--- a/force-app/main/default/classes/IBMAssistantV1.cls
+++ b/force-app/main/default/classes/IBMAssistantV1.cls
@@ -40,6 +40,21 @@ public class IBMAssistantV1 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMAssistantV1` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *        calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMAssistantV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Get response to user input.
    *
    * Get a response to a user's input.    There is no rate limit for this operation.

--- a/force-app/main/default/classes/IBMAssistantV1Test.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Test.cls
@@ -145,8 +145,10 @@ private class IBMAssistantV1Test {
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
 
-    IBMAssistantV1 assistant = new IBMAssistantV1('2018-02-16');
-    assistant.setUsernameAndPassword('username', 'password');
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMAssistantV1 assistant = new IBMAssistantV1('2018-02-16', iamOptions);
     IBMAssistantV1Models.CreateCounterexample counterexample = new IBMAssistantV1Models.CreateCounterexampleBuilder('text')
       .text(counterexampleText)
       .build();

--- a/force-app/main/default/classes/IBMConversationV1.cls
+++ b/force-app/main/default/classes/IBMConversationV1.cls
@@ -40,6 +40,21 @@ public class IBMConversationV1 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMConversationV1` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *        calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMConversationV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Get response to user input.
    *
    * Get a response to a user's input.    There is no rate limit for this operation.

--- a/force-app/main/default/classes/IBMConversationV1Test.cls
+++ b/force-app/main/default/classes/IBMConversationV1Test.cls
@@ -1461,8 +1461,10 @@ private class IBMConversationV1Test {
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
 
-    IBMConversationV1 conversation = new IBMConversationV1('2018-02-16');
-    conversation.setUsernameAndPassword('username', 'password');
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMConversationV1 conversation = new IBMConversationV1('2018-02-16', iamOptions);
 
     IBMConversationV1Models.CreateCounterexampleOptions createOptions = new IBMConversationV1Models.CreateCounterexampleOptionsBuilder()
       .workspaceId(workspaceId)

--- a/force-app/main/default/classes/IBMDiscoveryV1.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1.cls
@@ -42,6 +42,21 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMDiscoveryV1` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *        calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMDiscoveryV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Add an environment.
    *
    * Creates a new environment.  You can create only one environment per service instance. An attempt to create another environment results in an error.

--- a/force-app/main/default/classes/IBMDiscoveryV1Test.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Test.cls
@@ -10,9 +10,11 @@ private class IBMDiscoveryV1Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMDiscoveryV1 discovery = new IBMDiscoveryV1('2017-11-07');
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMDiscoveryV1 discovery = new IBMDiscoveryV1('2017-11-07', iamOptions);
     discovery.setEndPoint('https://gateway.watsonplatform.net/discovery/api');
-    discovery.setUsernameAndPassword('username', 'password');
     String text = 'test_environment';
     IBMDiscoveryV1Models.CreateEnvironmentOptions options = new IBMDiscoveryV1Models.CreateEnvironmentOptionsBuilder()
       .name(text)

--- a/force-app/main/default/classes/IBMLanguageTranslatorV2.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV2.cls
@@ -31,6 +31,19 @@ public class IBMLanguageTranslatorV2 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMLanguageTranslatorV2` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMLanguageTranslatorV2(IBMWatsonIAMOptions iamOptions) {
+    this();
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Translate.
    *
    * Translates the input text from the source language to the target language.

--- a/force-app/main/default/classes/IBMLanguageTranslatorV2Test.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV2Test.cls
@@ -9,7 +9,10 @@ private class IBMLanguageTranslatorV2Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMLanguageTranslatorV2 service = new IBMLanguageTranslatorV2('username', 'password');
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMLanguageTranslatorV2 service = new IBMLanguageTranslatorV2(iamOptions);
     String modelId = '3e7dfdbe-f757-4150-afee-458e71eb93fb';
     String source = 'en';
     String target = 'es';

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
@@ -30,6 +30,19 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMNaturalLanguageClassifierV1` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMNaturalLanguageClassifierV1(IBMWatsonIAMOptions iamOptions) {
+    this();
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Classify a phrase.
    *
    * Returns label information for the input. The status must be `Available` before you can use the classifier to classify text.

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
@@ -10,9 +10,11 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1();
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1(iamOptions);
     service.setEndPoint('https://gateway.watsonplatform.net/natural-language-classifier/api');
-    service.setUsernameAndPassword('username', 'password');
     String classifier_id_serialized_name = '10D41B-nlc-1';
     String text_serialized_name = 'How hot will it be today?';
     // this would be the expected top class as defined on the mock response

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
@@ -78,6 +78,21 @@ public class IBMNaturalLanguageUnderstandingV1 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMNaturalLanguageUnderstandingV1` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *        calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMNaturalLanguageUnderstandingV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Analyze text, HTML, or a public webpage.
    *
    * Analyzes text, HTML, or a public webpage with one or more text analysis features.

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Test.cls
@@ -9,9 +9,11 @@ private class IBMNaturalLanguageUnderstandingV1Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMNaturalLanguageUnderstandingV1 naturalLanguageUnderstanding = new IBMNaturalLanguageUnderstandingV1('2017-02-27');
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMNaturalLanguageUnderstandingV1 naturalLanguageUnderstanding = new IBMNaturalLanguageUnderstandingV1('2017-02-27', iamOptions);
     naturalLanguageUnderstanding.setEndPoint('https://gateway.watsonplatform.net/natural-language-understanding/api');
-    naturalLanguageUnderstanding.setUsernameAndPassword('username', 'password');
     IBMNaturalLanguageUnderstandingV1Models.ConceptsOptions concepts = new IBMNaturalLanguageUnderstandingV1Models.ConceptsOptionsBuilder()
       .limitField(40)
       .build();

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3.cls
@@ -68,6 +68,21 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMPersonalityInsightsV3` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *        calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMPersonalityInsightsV3(String versionDate, IBMWatsonIAMOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Generates a personality profile based on input text.
    *
    * Derives personality insights for up to 20 MB of input content written by an author, though the service requires much less text to produce an accurate profile; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). Accepts input in Arabic, English, Japanese, Korean, or Spanish and produces output in one of eleven languages. Provide plain text, HTML, or JSON content, and receive results in JSON or CSV format.

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3Test.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3Test.cls
@@ -9,10 +9,12 @@ private class IBMPersonalityInsightsV3Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMPersonalityInsightsV3 personalityInsights = new IBMPersonalityInsightsV3('2017-09-01', 'username', 'password');
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMPersonalityInsightsV3 personalityInsights = new IBMPersonalityInsightsV3('2017-09-01', iamOptions);
     //or use
     personalityInsights = new IBMPersonalityInsightsV3('2017-09-01');
-    personalityInsights.setUsernameAndPassword('username', 'password');
     personalityInsights.setEndPoint('https://gateway.watsonplatform.net/personality-insights/api');
     IBMPersonalityInsightsV3Models.ContentItem contentItem=new IBMPersonalityInsightsV3Models.ContentItemBuilder()
       .content('text/plain')

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3Test.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3Test.cls
@@ -13,8 +13,6 @@ private class IBMPersonalityInsightsV3Test {
       .apiKey('apikey')
       .build();
     IBMPersonalityInsightsV3 personalityInsights = new IBMPersonalityInsightsV3('2017-09-01', iamOptions);
-    //or use
-    personalityInsights = new IBMPersonalityInsightsV3('2017-09-01');
     personalityInsights.setEndPoint('https://gateway.watsonplatform.net/personality-insights/api');
     IBMPersonalityInsightsV3Models.ContentItem contentItem=new IBMPersonalityInsightsV3Models.ContentItemBuilder()
       .content('text/plain')

--- a/force-app/main/default/classes/IBMSpeechToTextV1.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1.cls
@@ -30,6 +30,19 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMSpeechToTextV1` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMSpeechToTextV1(IBMWatsonIAMOptions iamOptions) {
+    this();
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Retrieves information about the model.
    *
    * Returns information about a single specified language model that is available for use with the service. The information includes the name of the model and its minimum sampling rate in Hertz, among other things.

--- a/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
@@ -45,11 +45,11 @@ private class IBMSpeechToTextV1Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMSpeechToTextV1 speechToText = new IBMSpeechToTextV1();
-    if (username != null && password != null) {
-      speechToText.setEndPoint(URL);
-      speechToText.setUsernameAndPassword(username, password);
-    }
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMSpeechToTextV1 speechToText = new IBMSpeechToTextV1(iamOptions);
+    speechToText.setEndPoint(URL);
     IBMSpeechToTextV1Models.GetModelOptions getModelOptions = new IBMSpeechToTextV1Models.GetModelOptionsBuilder('en-US_NarrowbandModel')
       .modelId('en-US_NarrowbandModel')
       .build();

--- a/force-app/main/default/classes/IBMTextToSpeechV1.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1.cls
@@ -103,6 +103,19 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMTextToSpeechV1` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMTextToSpeechV1(IBMWatsonIAMOptions iamOptions) {
+    this();
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Retrieves a specific voice available for speech synthesis.
    *
    * Lists information about the voice specified with the `voice` path parameter. Specify the `customization_id` query parameter to obtain information for that custom voice model of the specified voice. Use the `GET /v1/voices` method to see a list of all available voices.

--- a/force-app/main/default/classes/IBMTextToSpeechV1Test.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1Test.cls
@@ -12,11 +12,11 @@ private class IBMTextToSpeechV1Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMTextToSpeechV1 textToSpeech = new IBMTextToSpeechV1();
-    if (username != null && password != null) {
-      textToSpeech.setEndPoint(URL);
-      textToSpeech.setUsernameAndPassword(username, password);
-    }
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMTextToSpeechV1 textToSpeech = new IBMTextToSpeechV1(iamOptions);
+    textToSpeech.setEndPoint(URL);
     IBMTextToSpeechV1Models.CreateVoiceModelOptions options = new IBMTextToSpeechV1Models.CreateVoiceModelOptionsBuilder()
       .name('I love Apples not oranges')
       .language('de-DE')

--- a/force-app/main/default/classes/IBMToneAnalyzerV3.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3.cls
@@ -43,6 +43,21 @@ public class IBMToneAnalyzerV3 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMToneAnalyzerV3` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *        calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMToneAnalyzerV3(String versionDate, IBMWatsonIAMOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Analyze general tone.
    *
    * Use the general purpose endpoint to analyze the tone of your input content. The service analyzes the content for emotional and language tones. The method always analyzes the tone of the full document; by default, it also analyzes the tone of each individual sentence of the content.   You can submit no more than 128 KB of total input content and no more than 1000 individual sentences in JSON, plain text, or HTML format. The service analyzes the first 1000 sentences for document-level analysis and only the first 100 sentences for sentence-level analysis.   Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the service removes HTML tags and analyzes only the textual content.

--- a/force-app/main/default/classes/IBMToneAnalyzerV3Test.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3Test.cls
@@ -9,10 +9,11 @@ private class IBMToneAnalyzerV3Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMToneAnalyzerV3 toneAnalyzer = new IBMToneAnalyzerV3('2017-09-21');
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMToneAnalyzerV3 toneAnalyzer = new IBMToneAnalyzerV3('2017-09-21', iamOptions);
     toneAnalyzer.setEndPoint('https://gateway.watsonplatform.net/tone-analyzer/api');
-    //username and password Not needed if you are providing named credentials in place of url
-    toneAnalyzer.setUsernameAndPassword('username', 'password');
     IBMToneAnalyzerV3Models.ToneInput toneInput = new IBMToneAnalyzerV3Models.ToneInputBuilder()
       .text('We have a better product. We can do better selling by having more campaigns')
       .build();

--- a/force-app/main/default/classes/IBMVisualRecognitionV3.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3.cls
@@ -62,6 +62,21 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMVisualRecognitionV3` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *        calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMVisualRecognitionV3(String versionDate, IBMWatsonIAMOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
+  }
+
+  /**
    * Classify images.
    *
    * Classify images with built-in or custom classifiers.

--- a/force-app/main/default/classes/IBMVisualRecognitionV3.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3.cls
@@ -9,6 +9,7 @@
 public class IBMVisualRecognitionV3 extends IBMWatsonService {
 
   private static final String URL = 'https://gateway-a.watsonplatform.net/visual-recognition/api';
+  private static final String DUMMY_API_KEY = '00000';
 
   private String versionDate;
 
@@ -47,22 +48,32 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
 
   /*
    * Override authentication mechanism for this endpoint
-   *
    */
   protected override void setAuthentication(IBMWatsonRequest.Builder builder) {
-    if (!isTokenManagerSet() && getApiKey() == null) {
+    if (isTokenManagerSet()) {
+      // add dummy API key as a query parameter for backwards-compatibility until it's not required by the service
+      addApiKeyQueryParameter(builder, DUMMY_API_KEY);
+      super.setAuthentication(builder);
+    } else if (getApiKey() != null) {
+      addApiKeyQueryParameter(builder, getApiKey());
+    } else {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('Credentials need to be specified. Use setApiKey() or setIamCredentials().');
     }
-    if (getApiKey() != null) {
-      Url url = builder.build().getUrl();
-      if (String.isBlank(url.getQuery())) {
-        builder.url(builder.build().getUrl().toExternalForm() + '?api_key=' + getApiKey());
-      } else {
-        builder.url(builder.build().getUrl().toExternalForm() + '&api_key=' + getApiKey());
-      }
-    }
-    if (isTokenManagerSet()) {
-      super.setAuthentication(builder);
+  }
+
+  /**
+   * Adds the API key as a query parameter to the request URL.
+   *
+   * @param builder builder for the current request
+   * @param apiKey API key to be added
+   */
+  private void addApiKeyQueryParameter(IBMWatsonRequest.Builder builder, String apiKey) {
+    Url url = builder.build().getUrl();
+
+    if (String.isBlank(url.getQuery())) {
+      builder.url(builder.build().getUrl().toExternalForm() + '?api_key=' + apiKey);
+    } else {
+      builder.url(builder.build().getUrl().toExternalForm() + '&api_key=' + apiKey);
     }
   }
 

--- a/force-app/main/default/classes/IBMVisualRecognitionV3.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3.cls
@@ -50,14 +50,17 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
    *
    */
   protected override void setAuthentication(IBMWatsonRequest.Builder builder) {
-    if (getApiKey() == null) {
-      throw new IBMWatsonServiceExceptions.IllegalArgumentException('api_key needs to be specified. Use setApiKey()');
-    }
-    Url url = builder.build().getUrl();
-    if (String.isBlank(url.getQuery())) {
-      builder.url(builder.build().getUrl().toExternalForm() + '?api_key=' + getApiKey());
+    if (isTokenManagerSet()) {
+      super.setAuthentication(builder);
+    } else if (getApiKey() != null) {
+      Url url = builder.build().getUrl();
+      if (String.isBlank(url.getQuery())) {
+        builder.url(builder.build().getUrl().toExternalForm() + '?api_key=' + getApiKey());
+      } else {
+        builder.url(builder.build().getUrl().toExternalForm() + '&api_key=' + getApiKey());
+      }
     } else {
-      builder.url(builder.build().getUrl().toExternalForm() + '&api_key=' + getApiKey());
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('Credentials need to be specified. Use setApiKey() or setIamCredentials().');
     }
   }
 

--- a/force-app/main/default/classes/IBMVisualRecognitionV3.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3.cls
@@ -50,17 +50,19 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
    *
    */
   protected override void setAuthentication(IBMWatsonRequest.Builder builder) {
-    if (isTokenManagerSet()) {
-      super.setAuthentication(builder);
-    } else if (getApiKey() != null) {
+    if (!isTokenManagerSet() && getApiKey() == null) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('Credentials need to be specified. Use setApiKey() or setIamCredentials().');
+    }
+    if (getApiKey() != null) {
       Url url = builder.build().getUrl();
       if (String.isBlank(url.getQuery())) {
         builder.url(builder.build().getUrl().toExternalForm() + '?api_key=' + getApiKey());
       } else {
         builder.url(builder.build().getUrl().toExternalForm() + '&api_key=' + getApiKey());
       }
-    } else {
-      throw new IBMWatsonServiceExceptions.IllegalArgumentException('Credentials need to be specified. Use setApiKey() or setIamCredentials().');
+    }
+    if (isTokenManagerSet()) {
+      super.setAuthentication(builder);
     }
   }
 

--- a/force-app/main/default/classes/IBMVisualRecognitionV3Test.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3Test.cls
@@ -8,9 +8,11 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', API_KEY);
+    IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+      .apiKey('apikey')
+      .build();
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
     visualRecognition.setEndPoint('https://gateway-a.watsonplatform.net/visual-recognition/api');
-    visualRecognition.setApiKey('80bc2e663293e8d13564c260cdb4cbf891b606c0');
     IBMVisualRecognitionV3Models.ClassifyOptions options = new IBMVisualRecognitionV3Models.ClassifyOptionsBuilder()
       .url('http://www.indya101.com/gallery/Actors_TV/Sumeet_Sachdev/2011/12/27/Sumeet_Sachdevjpg_3_arnem.jpg')
       .build();

--- a/force-app/main/default/classes/IBMWatsonFormBody.cls
+++ b/force-app/main/default/classes/IBMWatsonFormBody.cls
@@ -1,0 +1,41 @@
+public class IBMWatsonFormBody extends IBMWatsonRequestBody {
+
+  private static final String ENCODING_SCHEME = 'UTF-8';
+  private static final String CONTENT_TYPE = 'application/x-www-form-urlencoded';
+
+  private List<String> names;
+  private List<String> values;
+
+  private IBMWatsonFormBody(Builder builder) {
+    this.names = builder.names;
+    this.values = builder.values;
+    this.contentType = IBMWatsonMediaType.parse(CONTENT_TYPE);
+    writeContent();
+  }
+
+  private void writeContent() {
+    this.content = '';
+    for (Integer i = 0; i < names.size(); i++) {
+      if (i > 0) {
+      	content += '&';
+      }
+      this.content += names.get(i) + '=' + values.get(i);
+    }
+  }
+
+  public class Builder {
+    private List<String> names = new List<String>();
+    private List<String> values = new List<String>();
+
+    public Builder add(String name, String value) {
+      names.add(EncodingUtil.urlEncode(name, ENCODING_SCHEME));
+      values.add(EncodingUtil.urlEncode(value, ENCODING_SCHEME));
+      return this;
+    }
+
+    public IBMWatsonFormBody build() {
+      return new IBMWatsonFormBody(this);
+    }
+  }
+
+}

--- a/force-app/main/default/classes/IBMWatsonFormBody.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonFormBody.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonIAMOptions.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMOptions.cls
@@ -1,0 +1,51 @@
+/**
+ * Options for authenticating using IAM.
+ */
+public class IBMWatsonIAMOptions {
+  private String apiKey;
+  private String accessToken;
+  private String url;
+
+  public String getApiKey() {
+    return apiKey;
+  }
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public class Builder {
+    private String apiKey;
+    private String accessToken;
+    private String url;
+
+    public IBMWatsonIAMOptions build() {
+      return new IBMWatsonIAMOptions(this);
+    }
+
+    public Builder apiKey(String apiKey) {
+      this.apiKey = apiKey;
+      return this;
+    }
+
+    public Builder accessToken(String accessToken) {
+      this.accessToken = accessToken;
+      return this;
+    }
+
+    public Builder url(String url) {
+      this.url = url;
+      return this;
+    }
+  }
+
+  private IBMWatsonIAMOptions(Builder builder) {
+    this.apiKey = builder.apiKey;
+    this.accessToken = builder.accessToken;
+    this.url = builder.url;
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonIAMOptions.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonIAMOptions.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonIAMToken.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMToken.cls
@@ -1,0 +1,30 @@
+/**
+ * Represents response from IAM API.
+ */
+public class IBMWatsonIAMToken extends IBMWatsonGenericModel {
+  private String access_token;
+  private String refresh_token;
+  private String token_type;
+  private Long expires_in;
+  private Long expiration;
+
+  public String getAccessToken() {
+    return access_token;
+  }
+
+  public String getRefreshToken() {
+    return refresh_token;
+  }
+
+  public String getTokenType() {
+    return token_type;
+  }
+
+  public Long getExpiresIn() {
+    return expires_in;
+  }
+
+  public Long getExpiration() {
+    return expiration;
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonIAMToken.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMToken.cls
@@ -2,29 +2,29 @@
  * Represents response from IAM API.
  */
 public class IBMWatsonIAMToken extends IBMWatsonGenericModel {
-  private String access_token;
-  private String refresh_token;
-  private String token_type;
-  private Long expires_in;
-  private Long expiration;
+  private String access_token_serialized_name;
+  private String refresh_token_serialized_name;
+  private String token_type_serialized_name;
+  private Long expires_in_serialized_name;
+  private Long expiration_serialized_name;
 
   public String getAccessToken() {
-    return access_token;
+    return access_token_serialized_name;
   }
 
   public String getRefreshToken() {
-    return refresh_token;
+    return refresh_token_serialized_name;
   }
 
   public String getTokenType() {
-    return token_type;
+    return token_type_serialized_name;
   }
 
   public Long getExpiresIn() {
-    return expires_in;
+    return expires_in_serialized_name;
   }
 
   public Long getExpiration() {
-    return expiration;
+    return expiration_serialized_name;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonIAMToken.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonIAMToken.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
@@ -69,10 +69,10 @@ public class IBMWatsonIAMTokenManager {
     builder.addHeader(IBMWatsonHttpHeaders.CONTENT_TYPE, IBMWatsonHttpMediaType.APPLICATION_FORM_URLENCODED);
     builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
 
-    IBMWatsonMultipartBody formBody = new IBMWatsonMultipartBody.Builder()
-      .addFormDataPart(GRANT_TYPE, REQUEST_GRANT_TYPE)
-      .addFormDataPart(API_KEY, apiKey)
-      .addFormDataPart(RESPONSE_TYPE, CLOUD_IAM)
+    IBMWatsonFormBody formBody = new IBMWatsonFormBody.Builder()
+      .add(GRANT_TYPE, REQUEST_GRANT_TYPE)
+      .add(API_KEY, apiKey)
+      .add(RESPONSE_TYPE, CLOUD_IAM)
       .build();
     builder.body(formBody);
 
@@ -91,9 +91,9 @@ public class IBMWatsonIAMTokenManager {
     builder.addHeader(IBMWatsonHttpHeaders.CONTENT_TYPE, IBMWatsonHttpMediaType.APPLICATION_FORM_URLENCODED);
     builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
 
-    IBMWatsonMultipartBody formBody = new IBMWatsonMultipartBody.Builder()
-      .addFormDataPart(GRANT_TYPE, REFRESH_GRANT_TYPE)
-      .addFormDataPart(REFRESH_TOKEN, tokenData.getRefreshToken())
+    IBMWatsonFormBody formBody = new IBMWatsonFormBody.Builder()
+      .add(GRANT_TYPE, REFRESH_GRANT_TYPE)
+      .add(REFRESH_TOKEN, tokenData.getRefreshToken())
       .build();
     builder.body(formBody);
 

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
@@ -1,0 +1,167 @@
+/**
+ * Retrieves, stores, and refreshes IAM tokens.
+ */
+public class IBMWatsonIAMTokenManager {
+  private String userManagedAccessToken;
+  private String apiKey;
+  private String url;
+  private IBMWatsonIAMToken tokenData;
+
+  private static final String DEFAULT_AUTHORIZATION = 'Basic Yng6Yng=';
+  private static final String DEFAULT_IAM_URL = 'https://iam.ng.bluemix.net/identity/token';
+  private static final String GRANT_TYPE = 'grant_type';
+  private static final String REQUEST_GRANT_TYPE = 'urn:ibm:params:oauth:grant-type:apikey';
+  private static final String REFRESH_GRANT_TYPE = 'refresh_token';
+  private static final String API_KEY = 'apikey';
+  private static final String RESPONSE_TYPE = 'response_type';
+  private static final String CLOUD_IAM = 'cloud_iam';
+  private static final String REFRESH_TOKEN = 'refresh_token';
+
+  public IBMWatsonIAMTokenManager(IBMWatsonIAMOptions options) {
+    this.apiKey = options.getApiKey();
+    if (options.getUrl() != null) {
+      this.url = options.getUrl();
+    } else {
+      this.url = DEFAULT_IAM_URL;
+    }
+    this.userManagedAccessToken = options.getAccessToken();
+    tokenData = new IBMWatsonIAMToken();
+  }
+
+  /**
+   * This function returns an access token. The source of the token is determined by the following logic:
+   * 1. If user provides their own managed access token, assume it is valid and send it
+   * 2. If this class is managing tokens and does not yet have one, or the refresh token is expired, make a request
+   * for one
+   * 3. If this class is managing tokens and the token has expired, refresh it
+   * 4. If this class is managing tokens and has a valid token stored, send it
+   *
+   * @return the valid access token
+   */
+  public String getToken() {
+    String token;
+
+    if (userManagedAccessToken != null) {
+      // use user-managed access token
+      token = userManagedAccessToken;
+    } else if (tokenData.getAccessToken() == null || isRefreshTokenExpired()) {
+      // request new token
+      token = requestToken();
+    } else if (isAccessTokenExpired()) {
+      // refresh current token
+      token = refreshToken();
+    } else {
+      // use valid managed token
+      token = tokenData.getAccessToken();
+    }
+
+    return token;
+  }
+
+  /**
+   * Request an IAM token using an API key. Also updates internal managed IAM token information.
+   *
+   * @return the new access token
+   */
+  private String requestToken() {
+    IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(url);
+
+    builder.addHeader(IBMWatsonHttpHeaders.CONTENT_TYPE, IBMWatsonHttpMediaType.APPLICATION_FORM_URLENCODED);
+    builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
+
+    IBMWatsonMultipartBody formBody = new IBMWatsonMultipartBody.Builder()
+      .addFormDataPart(GRANT_TYPE, REQUEST_GRANT_TYPE)
+      .addFormDataPart(API_KEY, apiKey)
+      .addFormDataPart(RESPONSE_TYPE, CLOUD_IAM)
+      .build();
+    builder.body(formBody);
+
+    tokenData = callIamApi(builder.build());
+    return tokenData.getAccessToken();
+  }
+
+  /**
+   * Refresh an IAM token using a refresh token. Also updates internal managed IAM token information.
+   *
+   * @return the new access token
+   */
+  private String refreshToken() {
+    IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(url);
+
+    builder.addHeader(IBMWatsonHttpHeaders.CONTENT_TYPE, IBMWatsonHttpMediaType.APPLICATION_FORM_URLENCODED);
+    builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
+
+    IBMWatsonMultipartBody formBody = new IBMWatsonMultipartBody.Builder()
+      .addFormDataPart(GRANT_TYPE, REFRESH_GRANT_TYPE)
+      .addFormDataPart(REFRESH_TOKEN, tokenData.getRefreshToken())
+      .build();
+    builder.body(formBody);
+
+    tokenData = callIamApi(builder.build());
+    return tokenData.getAccessToken();
+  }
+
+  /**
+   * Check if currently stored access token is expired.
+   *
+   * Using a buffer to prevent the edge case of the
+   * token expiring before the request could be made.
+   *
+   * The buffer will be a fraction of the total TTL. Using 80%.
+   *
+   * @return whether the current managed access token is expired or not
+   */
+  private boolean isAccessTokenExpired() {
+    if (tokenData.getExpiresIn() == null || tokenData.getExpiration() == null) {
+      return true;
+    }
+
+    Double fractionOfTimeToLive = 0.8;
+    Long timeToLive = tokenData.getExpiresIn();
+    Long expirationTime = tokenData.getExpiration();
+    Double refreshTime = expirationTime - (timeToLive * (1.0 - fractionOfTimeToLive));
+    Double currentTime = Math.floor(System.now().getTime() / 1000);
+
+    return refreshTime < currentTime;
+  }
+
+  /**
+   * Used as a fail-safe to prevent the condition of a refresh token expiring,
+   * which could happen after around 30 days. This function will return true
+   * if it has been at least 7 days and 1 hour since the last token was
+   * retrieved.
+   *
+   * @returns whether the current managed refresh token is expired or not
+   */
+  private boolean isRefreshTokenExpired() {
+    if (tokenData.getExpiration() == null) {
+      return true;
+    }
+
+    Integer sevenDays = 7 * 24 * 3600;
+    Double currentTime = Math.floor(System.now().getTime() / 1000);
+    Long newTokenTime = tokenData.getExpiration() + sevenDays;
+    return newTokenTime < currentTime;
+  }
+
+  /**
+   * Executes call to IAM API and returns IBMWatsonIAMToken object representing the response.
+   *
+   * @param request the request for the IAM API
+   * @return object containing requested IAM token information
+   */
+  private IBMWatsonIAMToken callIamApi(IBMWatsonRequest request) {
+    IBMWatsonResponse response = IBMWatsonClient.executeRequest(request);
+
+    if (response.isSuccessful() && String.isNotBlank(response.getBody())) {
+      Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
+      Map<String, Object> safeJsonMap = IBMWatsonJSONUtil.prepareResponse(jsonMap);
+      String jsonString = JSON.serialize(safeJsonMap);
+      return (IBMWatsonIAMToken) ((IBMWatsonGenericModel) IBMWatsonIAMToken.class.newInstance()).deserialize(jsonString, safeJsonMap, IBMWatsonIAMToken.class);
+    } else {
+      String error = response.getBody();
+      Integer statusCode = response.getStatusCode();
+      throw new IBMWatsonServiceExceptions.ResponseException(statusCode, error, response);
+    }
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls
@@ -52,12 +52,13 @@ private class IBMWatsonIAMTokenManagerTest {
    * Tests that if the stored access token is expired, it can be refreshed properly.
    */
   static testMethod void getTokenAfterRefresh() {
+    Double currentTime = Math.floor(System.now().getTime() / 1000);
     String expiredTokenDataBody = '{' +
       '"access_token": "wxyz-9876",' +
       '"refresh_token": "00000000",' +
       '"token_type": "Bearer",' +
       '"expires_in": 3600,' +
-      '"expiration": ' + Math.floor(System.now().getTime() / 1000) +
+      '"expiration": ' + String.valueOf(currentTime) +
     '}';
 
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls
@@ -1,0 +1,86 @@
+@isTest
+private class IBMWatsonIAMTokenManagerTest {
+  private String url;
+
+  private static final String USER_ACCESS_TOKEN = 'abcd-1234';
+  private static final String VALID_ACCESS_TOKEN = 'aaaa-1111';
+  private static final String API_KEY = '123456789';
+  private static final String URL = 'https://test.url';
+
+  /**
+   * Tests that if a user passes in an access token during initial IAM setup, that access token is passed back
+   * during later retrieval.
+   */
+  static testMethod void getUserManagedTokenFromConstructor() {
+    Test.startTest();
+    IBMWatsonIAMOptions options = new IBMWatsonIAMOptions.Builder()
+      .accessToken(USER_ACCESS_TOKEN)
+      .url(URL)
+      .build();
+    IBMWatsonIAMTokenManager manager = new IBMWatsonIAMTokenManager(options);
+
+    String token = manager.getToken();
+    System.assertEquals(USER_ACCESS_TOKEN, token);
+    Test.stopTest();
+  }
+
+  /**
+   * Tests that if only an API key is stored, the user can get back a valid access token.
+   */
+  static testMethod void getTokenFromApiKey() {
+    String body = IBMWatsonMockResponses.validTokenData();
+    IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(
+      200,
+      'Success',
+      body,
+      null);
+    Test.setMock(HttpCalloutMock.class, mockResponse);
+    Test.startTest();
+
+    IBMWatsonIAMOptions options = new IBMWatsonIAMOptions.Builder()
+      .apiKey(API_KEY)
+      .url(URL)
+      .build();
+    IBMWatsonIAMTokenManager manager = new IBMWatsonIAMTokenManager(options);
+
+    String token = manager.getToken();
+    System.assertEquals(VALID_ACCESS_TOKEN, token);
+    Test.stopTest();
+  }
+
+  /**
+   * Tests that if the stored access token is expired, it can be refreshed properly.
+   */
+  static testMethod void getTokenAfterRefresh() {
+    String body = IBMWatsonMockResponses.expiredTokenData();
+    IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(
+      200,
+      'Success',
+      body,
+      null);
+    Test.setMock(HttpCalloutMock.class, mockResponse);
+    Test.startTest();
+
+    IBMWatsonIAMOptions options = new IBMWatsonIAMOptions.Builder()
+      .apiKey(API_KEY)
+      .url(URL)
+      .build();
+    IBMWatsonIAMTokenManager manager = new IBMWatsonIAMTokenManager(options);
+
+    // setting expired token
+    manager.getToken();
+
+    // getting valid token
+    String newBody = IBMWatsonMockResponses.validTokenData();
+    IBMWatsonMockHttpResponse newMockResponse = new IBMWatsonMockHttpResponse(
+      200,
+      'Success',
+      newBody,
+      null);
+    Test.setMock(HttpCalloutMock.class, newMockResponse);
+    String newToken = manager.getToken();
+
+    System.assertEquals(VALID_ACCESS_TOKEN, newToken);
+    Test.stopTest();
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls
@@ -70,7 +70,6 @@ private class IBMWatsonIAMTokenManagerTest {
 
     IBMWatsonIAMOptions options = new IBMWatsonIAMOptions.Builder()
       .apiKey(API_KEY)
-      .url(URL)
       .build();
     IBMWatsonIAMTokenManager manager = new IBMWatsonIAMTokenManager(options);
 

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls
@@ -52,11 +52,18 @@ private class IBMWatsonIAMTokenManagerTest {
    * Tests that if the stored access token is expired, it can be refreshed properly.
    */
   static testMethod void getTokenAfterRefresh() {
-    String body = IBMWatsonMockResponses.expiredTokenData();
+    String expiredTokenDataBody = '{' +
+      '"access_token": "wxyz-9876",' +
+      '"refresh_token": "00000000",' +
+      '"token_type": "Bearer",' +
+      '"expires_in": 3600,' +
+      '"expiration": ' + Math.floor(System.now().getTime() / 1000) +
+    '}';
+
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(
       200,
       'Success',
-      body,
+      expiredTokenDataBody,
       null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManagerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonMockResponses.cls
+++ b/force-app/main/default/classes/IBMWatsonMockResponses.cls
@@ -2489,14 +2489,4 @@ public class IBMWatsonMockResponses {
       '"expiration": 999999999999999999' +
     '}';
   }
-
-  public static String expiredTokenData() {
-    return '{' +
-      '"access_token": "wxyz-9876",' +
-      '"refresh_token": "00000000",' +
-      '"token_type": "Bearer",' +
-      '"expires_in": 3600,' +
-      '"expiration": 1522788645' +
-    '}';
-  }
 }

--- a/force-app/main/default/classes/IBMWatsonMockResponses.cls
+++ b/force-app/main/default/classes/IBMWatsonMockResponses.cls
@@ -2479,4 +2479,24 @@ public class IBMWatsonMockResponses {
       ']' +
     '}';
   }
+
+  public static String validTokenData() {
+    return '{' +
+      '"access_token": "aaaa-1111",' +
+      '"refresh_token": "99999999",' +
+      '"token_type": "Bearer",' +
+      '"expires_in": 3600,' +
+      '"expiration": 999999999999999999' +
+    '}';
+  }
+
+  public static String expiredTokenData() {
+    return '{' +
+      '"access_token": "wxyz-9876",' +
+      '"refresh_token": "00000000",' +
+      '"token_type": "Bearer",' +
+      '"expires_in": 3600,' +
+      '"expiration": 1522788645' +
+    '}';
+  }
 }

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -12,7 +12,6 @@ public abstract class IBMWatsonService {
 
   private static final String URL = 'url';
   private static final String PATH_AUTHORIZATION_V1_TOKEN = '/v1/token';
-  private static final String AUTHORIZATION = 'authorization';
   private static final String CALLOUT = 'callout:';
   private static final String BASIC = 'Basic ';
   private static final String BEARER = 'Bearer ';
@@ -257,5 +256,14 @@ public abstract class IBMWatsonService {
    */
   protected String getApiKey() {
     return apiKey;
+  }
+
+  /**
+   * Checks the status of the tokenManager.
+   *
+   * @return true if the tokenManager has been set
+   */
+  protected Boolean isTokenManagerSet() {
+    return tokenManager != null;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -6,6 +6,7 @@ public abstract class IBMWatsonService {
   private String endPoint;
   private String userAgent;
   private String name;
+  private IBMWatsonIAMTokenManager tokenManager;
   private boolean skipAuthentication = false;
   private Map<String, String> defaultHeaders = null;
 
@@ -14,6 +15,7 @@ public abstract class IBMWatsonService {
   private static final String AUTHORIZATION = 'authorization';
   private static final String CALLOUT = 'callout:';
   private static final String BASIC = 'Basic ';
+  private static final String BEARER = 'Bearer ';
   private static final String VERSION = 'version';
   private static final String USER_AGENT_FORMAT = 'watson-apis-salesforce-sdk/{0}/({1})';
   private static final String SDK_VERSION = '1.2.1';
@@ -177,13 +179,17 @@ public abstract class IBMWatsonService {
    * @param builder the new authentication
    */
   protected virtual void setAuthentication(IBMWatsonRequest.Builder builder) {
-    if (getApiKey() == null) {
+    if (tokenManager != null) {
+      String accessToken = tokenManager.getToken();
+      builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, BEARER + accessToken);
+    } else if (getApiKey() == null) {
       if (skipAuthentication) {
         return; // chosen to skip authentication with the service
       }
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('apiKey or username and password were not specified');
+    } else {
+      builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, apiKey.startsWith(BASIC) ? apiKey : BASIC + apiKey);
     }
-    builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, apiKey.startsWith(BASIC) ? apiKey : BASIC + apiKey);
   }
 
   /**
@@ -218,6 +224,19 @@ public abstract class IBMWatsonService {
     if (String.isNotBlank(apiKey)) {
       this.apiKey = apiKey;
     }
+  }
+
+  /**
+   * Sets IAM information.
+   *
+   * Be aware that if you pass in an access token using this method, you accept responsibility for managing the access
+   * token yourself. You must set a new access token before this one expires. Failing to do so will result in
+   * authentication errors after this token expires.
+   *
+   * @param iamOptions object containing values to be used for authenticating with IAM
+   */
+  public void setIamCredentials(IBMWatsonIAMOptions iamOptions) {
+    this.tokenManager = new IBMWatsonIAMTokenManager(iamOptions);
   }
 
   /**


### PR DESCRIPTION
This PR adds support for IAM authentication. The changes necessary for this new functionality include:

  - New IAM-related classes (`IBMWatsonIAMOptions`, `IBMWatsonIAMToken`, `IBMWatsonIAMTokenManager`)
  - New core class for sending `x-www-form-urlencoded` data
  - Constructors using the `IBMWatsonIAMOptions` in each of the service classes
  - Specifically for Visual Recognition, changes to `setAuthentication()` to handle authentication with IAM

Tests were also added for all of the above, and the README was updated to instruct users on how to use the new authentication method.