### PR TITLE
Add support for request and response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,29 @@ System.debug(intent);
 
 The manner of instantiating and using services should be consistent no matter which you decide to use, which should make it easy to explore the many capabilities Watson services have to offer.
 
+## Request and Response Headers
+
+The SDK supports sending custom headers with any request as well as parsing headers that are returned by the service.
+
+To send request headers, simply add them as a property when building up your `Options` model. Here's an example in the Discovery service:
+
+```java
+IBMDiscoveryV1Models.QueryOptions options = new
+  IBMDiscoveryV1Models.QueryOptionsBuilder()
+  .environmentId('<environment_id>')
+  .collectionId('<collection_id>')
+  .naturalLanguageQuery('Articles about the Boston Celtics')
+  .addHeader('Custon-Header', 'custom_value') // custom header added here
+  .build();
+```
+
+To get headers returned by the service, call the `getHeaders()` method on a response model. This is what it looks like to get the headers returned after making the above call:
+
+```java
+IBMDiscoveryV1Models.QueryResponse response = discovery.query(options);
+Map<String, String> responseHeaders = response.getHeaders();
+```
+
 ## Using the SDK with Lightning
 
 The Watson Salesforce SDK models are Lightning-ready, meaning that you can access model properties through Javascript for your Lightning apps. Everything should work as expected, but it's important to note that there are two ways to go about dealing with dynamic models through Javascript. These models are ones which may have properties unknown until runtime and which extend `IBMWatsonDynamicModel`.

--- a/force-app/main/default/classes/IBMAssistantV1.cls
+++ b/force-app/main/default/classes/IBMAssistantV1.cls
@@ -27,6 +27,20 @@ public class IBMAssistantV1 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMAssistantV1` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *        calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMAssistantV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
+  }
+  /**
    * Instantiates a new `IBMAssistantV1` with username and password.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
@@ -65,6 +79,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.MessageResponse message(IBMAssistantV1Models.MessageOptions messageOptions) {
     IBMWatsonValidator.notNull(messageOptions, 'messageOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/message', new String[]{ messageOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (messageOptions != null) ? messageOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (messageOptions.nodesVisitedDetails() != null) {
       builder.query('nodes_visited_details', String.valueOf(messageOptions.nodesVisitedDetails()));
@@ -103,6 +123,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
    */
   public IBMAssistantV1Models.Workspace createWorkspace(IBMAssistantV1Models.CreateWorkspaceOptions createWorkspaceOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/workspaces');
+    Map<String, String> requestHeaders = (createWorkspaceOptions != null) ? createWorkspaceOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (createWorkspaceOptions.name() != null) {
@@ -148,6 +174,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public void deleteWorkspace(IBMAssistantV1Models.DeleteWorkspaceOptions deleteWorkspaceOptions) {
     IBMWatsonValidator.notNull(deleteWorkspaceOptions, 'deleteWorkspaceOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}', new String[]{ deleteWorkspaceOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (deleteWorkspaceOptions != null) ? deleteWorkspaceOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -164,6 +196,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.WorkspaceExport getWorkspace(IBMAssistantV1Models.GetWorkspaceOptions getWorkspaceOptions) {
     IBMWatsonValidator.notNull(getWorkspaceOptions, 'getWorkspaceOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}', new String[]{ getWorkspaceOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (getWorkspaceOptions != null) ? getWorkspaceOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getWorkspaceOptions.exportField() != null) {
       builder.query('export', String.valueOf(getWorkspaceOptions.exportField()));
@@ -185,6 +223,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
    */
   public IBMAssistantV1Models.WorkspaceCollection listWorkspaces(IBMAssistantV1Models.ListWorkspacesOptions listWorkspacesOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/workspaces');
+    Map<String, String> requestHeaders = (listWorkspacesOptions != null) ? listWorkspacesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listWorkspacesOptions != null && listWorkspacesOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listWorkspacesOptions.pageLimit()));
@@ -216,6 +260,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Workspace updateWorkspace(IBMAssistantV1Models.UpdateWorkspaceOptions updateWorkspaceOptions) {
     IBMWatsonValidator.notNull(updateWorkspaceOptions, 'updateWorkspaceOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}', new String[]{ updateWorkspaceOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (updateWorkspaceOptions != null) ? updateWorkspaceOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (updateWorkspaceOptions.append() != null) {
       builder.query('append', String.valueOf(updateWorkspaceOptions.append()));
@@ -264,6 +314,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Intent createIntent(IBMAssistantV1Models.CreateIntentOptions createIntentOptions) {
     IBMWatsonValidator.notNull(createIntentOptions, 'createIntentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/intents', new String[]{ createIntentOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (createIntentOptions != null) ? createIntentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('intent', createIntentOptions.intent());
@@ -289,6 +345,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public void deleteIntent(IBMAssistantV1Models.DeleteIntentOptions deleteIntentOptions) {
     IBMWatsonValidator.notNull(deleteIntentOptions, 'deleteIntentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}', new String[]{ deleteIntentOptions.workspaceId(), deleteIntentOptions.intent() }));
+    Map<String, String> requestHeaders = (deleteIntentOptions != null) ? deleteIntentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -305,6 +367,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.IntentExport getIntent(IBMAssistantV1Models.GetIntentOptions getIntentOptions) {
     IBMWatsonValidator.notNull(getIntentOptions, 'getIntentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}', new String[]{ getIntentOptions.workspaceId(), getIntentOptions.intent() }));
+    Map<String, String> requestHeaders = (getIntentOptions != null) ? getIntentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getIntentOptions.exportField() != null) {
       builder.query('export', String.valueOf(getIntentOptions.exportField()));
@@ -327,6 +395,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.IntentCollection listIntents(IBMAssistantV1Models.ListIntentsOptions listIntentsOptions) {
     IBMWatsonValidator.notNull(listIntentsOptions, 'listIntentsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/intents', new String[]{ listIntentsOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listIntentsOptions != null) ? listIntentsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listIntentsOptions.exportField() != null) {
       builder.query('export', String.valueOf(listIntentsOptions.exportField()));
@@ -361,6 +435,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Intent updateIntent(IBMAssistantV1Models.UpdateIntentOptions updateIntentOptions) {
     IBMWatsonValidator.notNull(updateIntentOptions, 'updateIntentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}', new String[]{ updateIntentOptions.workspaceId(), updateIntentOptions.intent() }));
+    Map<String, String> requestHeaders = (updateIntentOptions != null) ? updateIntentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateIntentOptions.newIntent() != null) {
@@ -388,6 +468,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Example createExample(IBMAssistantV1Models.CreateExampleOptions createExampleOptions) {
     IBMWatsonValidator.notNull(createExampleOptions, 'createExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples', new String[]{ createExampleOptions.workspaceId(), createExampleOptions.intent() }));
+    Map<String, String> requestHeaders = (createExampleOptions != null) ? createExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('text', createExampleOptions.text());
@@ -407,6 +493,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public void deleteExample(IBMAssistantV1Models.DeleteExampleOptions deleteExampleOptions) {
     IBMWatsonValidator.notNull(deleteExampleOptions, 'deleteExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples/{2}', new String[]{ deleteExampleOptions.workspaceId(), deleteExampleOptions.intent(), deleteExampleOptions.text() }));
+    Map<String, String> requestHeaders = (deleteExampleOptions != null) ? deleteExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -423,6 +515,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Example getExample(IBMAssistantV1Models.GetExampleOptions getExampleOptions) {
     IBMWatsonValidator.notNull(getExampleOptions, 'getExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples/{2}', new String[]{ getExampleOptions.workspaceId(), getExampleOptions.intent(), getExampleOptions.text() }));
+    Map<String, String> requestHeaders = (getExampleOptions != null) ? getExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getExampleOptions.includeAudit() != null) {
       builder.query('include_audit', String.valueOf(getExampleOptions.includeAudit()));
@@ -442,6 +540,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.ExampleCollection listExamples(IBMAssistantV1Models.ListExamplesOptions listExamplesOptions) {
     IBMWatsonValidator.notNull(listExamplesOptions, 'listExamplesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples', new String[]{ listExamplesOptions.workspaceId(), listExamplesOptions.intent() }));
+    Map<String, String> requestHeaders = (listExamplesOptions != null) ? listExamplesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listExamplesOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listExamplesOptions.pageLimit()));
@@ -473,6 +577,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Example updateExample(IBMAssistantV1Models.UpdateExampleOptions updateExampleOptions) {
     IBMWatsonValidator.notNull(updateExampleOptions, 'updateExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples/{2}', new String[]{ updateExampleOptions.workspaceId(), updateExampleOptions.intent(), updateExampleOptions.text() }));
+    Map<String, String> requestHeaders = (updateExampleOptions != null) ? updateExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateExampleOptions.newText() != null) {
@@ -494,6 +604,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Counterexample createCounterexample(IBMAssistantV1Models.CreateCounterexampleOptions createCounterexampleOptions) {
     IBMWatsonValidator.notNull(createCounterexampleOptions, 'createCounterexampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples', new String[]{ createCounterexampleOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (createCounterexampleOptions != null) ? createCounterexampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('text', createCounterexampleOptions.text());
@@ -513,6 +629,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public void deleteCounterexample(IBMAssistantV1Models.DeleteCounterexampleOptions deleteCounterexampleOptions) {
     IBMWatsonValidator.notNull(deleteCounterexampleOptions, 'deleteCounterexampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples/{1}', new String[]{ deleteCounterexampleOptions.workspaceId(), deleteCounterexampleOptions.text() }));
+    Map<String, String> requestHeaders = (deleteCounterexampleOptions != null) ? deleteCounterexampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -529,6 +651,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Counterexample getCounterexample(IBMAssistantV1Models.GetCounterexampleOptions getCounterexampleOptions) {
     IBMWatsonValidator.notNull(getCounterexampleOptions, 'getCounterexampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples/{1}', new String[]{ getCounterexampleOptions.workspaceId(), getCounterexampleOptions.text() }));
+    Map<String, String> requestHeaders = (getCounterexampleOptions != null) ? getCounterexampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getCounterexampleOptions.includeAudit() != null) {
       builder.query('include_audit', String.valueOf(getCounterexampleOptions.includeAudit()));
@@ -548,6 +676,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.CounterexampleCollection listCounterexamples(IBMAssistantV1Models.ListCounterexamplesOptions listCounterexamplesOptions) {
     IBMWatsonValidator.notNull(listCounterexamplesOptions, 'listCounterexamplesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples', new String[]{ listCounterexamplesOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listCounterexamplesOptions != null) ? listCounterexamplesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listCounterexamplesOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listCounterexamplesOptions.pageLimit()));
@@ -579,6 +713,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Counterexample updateCounterexample(IBMAssistantV1Models.UpdateCounterexampleOptions updateCounterexampleOptions) {
     IBMWatsonValidator.notNull(updateCounterexampleOptions, 'updateCounterexampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples/{1}', new String[]{ updateCounterexampleOptions.workspaceId(), updateCounterexampleOptions.text() }));
+    Map<String, String> requestHeaders = (updateCounterexampleOptions != null) ? updateCounterexampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateCounterexampleOptions.newText() != null) {
@@ -600,6 +740,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Entity createEntity(IBMAssistantV1Models.CreateEntityOptions createEntityOptions) {
     IBMWatsonValidator.notNull(createEntityOptions, 'createEntityOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities', new String[]{ createEntityOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (createEntityOptions != null) ? createEntityOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('entity', createEntityOptions.entity());
@@ -631,6 +777,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public void deleteEntity(IBMAssistantV1Models.DeleteEntityOptions deleteEntityOptions) {
     IBMWatsonValidator.notNull(deleteEntityOptions, 'deleteEntityOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}', new String[]{ deleteEntityOptions.workspaceId(), deleteEntityOptions.entity() }));
+    Map<String, String> requestHeaders = (deleteEntityOptions != null) ? deleteEntityOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -647,6 +799,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.EntityExport getEntity(IBMAssistantV1Models.GetEntityOptions getEntityOptions) {
     IBMWatsonValidator.notNull(getEntityOptions, 'getEntityOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}', new String[]{ getEntityOptions.workspaceId(), getEntityOptions.entity() }));
+    Map<String, String> requestHeaders = (getEntityOptions != null) ? getEntityOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getEntityOptions.exportField() != null) {
       builder.query('export', String.valueOf(getEntityOptions.exportField()));
@@ -669,6 +827,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.EntityCollection listEntities(IBMAssistantV1Models.ListEntitiesOptions listEntitiesOptions) {
     IBMWatsonValidator.notNull(listEntitiesOptions, 'listEntitiesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities', new String[]{ listEntitiesOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listEntitiesOptions != null) ? listEntitiesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listEntitiesOptions.exportField() != null) {
       builder.query('export', String.valueOf(listEntitiesOptions.exportField()));
@@ -703,6 +867,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Entity updateEntity(IBMAssistantV1Models.UpdateEntityOptions updateEntityOptions) {
     IBMWatsonValidator.notNull(updateEntityOptions, 'updateEntityOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}', new String[]{ updateEntityOptions.workspaceId(), updateEntityOptions.entity() }));
+    Map<String, String> requestHeaders = (updateEntityOptions != null) ? updateEntityOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateEntityOptions.newFuzzyMatch() != null) {
@@ -736,6 +906,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Value createValue(IBMAssistantV1Models.CreateValueOptions createValueOptions) {
     IBMWatsonValidator.notNull(createValueOptions, 'createValueOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values', new String[]{ createValueOptions.workspaceId(), createValueOptions.entity() }));
+    Map<String, String> requestHeaders = (createValueOptions != null) ? createValueOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('value', createValueOptions.value());
@@ -767,6 +943,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public void deleteValue(IBMAssistantV1Models.DeleteValueOptions deleteValueOptions) {
     IBMWatsonValidator.notNull(deleteValueOptions, 'deleteValueOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}', new String[]{ deleteValueOptions.workspaceId(), deleteValueOptions.entity(), deleteValueOptions.value() }));
+    Map<String, String> requestHeaders = (deleteValueOptions != null) ? deleteValueOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -783,6 +965,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.ValueExport getValue(IBMAssistantV1Models.GetValueOptions getValueOptions) {
     IBMWatsonValidator.notNull(getValueOptions, 'getValueOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}', new String[]{ getValueOptions.workspaceId(), getValueOptions.entity(), getValueOptions.value() }));
+    Map<String, String> requestHeaders = (getValueOptions != null) ? getValueOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getValueOptions.exportField() != null) {
       builder.query('export', String.valueOf(getValueOptions.exportField()));
@@ -805,6 +993,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.ValueCollection listValues(IBMAssistantV1Models.ListValuesOptions listValuesOptions) {
     IBMWatsonValidator.notNull(listValuesOptions, 'listValuesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values', new String[]{ listValuesOptions.workspaceId(), listValuesOptions.entity() }));
+    Map<String, String> requestHeaders = (listValuesOptions != null) ? listValuesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listValuesOptions.exportField() != null) {
       builder.query('export', String.valueOf(listValuesOptions.exportField()));
@@ -839,6 +1033,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Value updateValue(IBMAssistantV1Models.UpdateValueOptions updateValueOptions) {
     IBMWatsonValidator.notNull(updateValueOptions, 'updateValueOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}', new String[]{ updateValueOptions.workspaceId(), updateValueOptions.entity(), updateValueOptions.value() }));
+    Map<String, String> requestHeaders = (updateValueOptions != null) ? updateValueOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateValueOptions.newSynonyms() != null) {
@@ -872,6 +1072,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Synonym createSynonym(IBMAssistantV1Models.CreateSynonymOptions createSynonymOptions) {
     IBMWatsonValidator.notNull(createSynonymOptions, 'createSynonymOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms', new String[]{ createSynonymOptions.workspaceId(), createSynonymOptions.entity(), createSynonymOptions.value() }));
+    Map<String, String> requestHeaders = (createSynonymOptions != null) ? createSynonymOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('synonym', createSynonymOptions.synonym());
@@ -891,6 +1097,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public void deleteSynonym(IBMAssistantV1Models.DeleteSynonymOptions deleteSynonymOptions) {
     IBMWatsonValidator.notNull(deleteSynonymOptions, 'deleteSynonymOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}', new String[]{ deleteSynonymOptions.workspaceId(), deleteSynonymOptions.entity(), deleteSynonymOptions.value(), deleteSynonymOptions.synonym() }));
+    Map<String, String> requestHeaders = (deleteSynonymOptions != null) ? deleteSynonymOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -907,6 +1119,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Synonym getSynonym(IBMAssistantV1Models.GetSynonymOptions getSynonymOptions) {
     IBMWatsonValidator.notNull(getSynonymOptions, 'getSynonymOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}', new String[]{ getSynonymOptions.workspaceId(), getSynonymOptions.entity(), getSynonymOptions.value(), getSynonymOptions.synonym() }));
+    Map<String, String> requestHeaders = (getSynonymOptions != null) ? getSynonymOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getSynonymOptions.includeAudit() != null) {
       builder.query('include_audit', String.valueOf(getSynonymOptions.includeAudit()));
@@ -926,6 +1144,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.SynonymCollection listSynonyms(IBMAssistantV1Models.ListSynonymsOptions listSynonymsOptions) {
     IBMWatsonValidator.notNull(listSynonymsOptions, 'listSynonymsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms', new String[]{ listSynonymsOptions.workspaceId(), listSynonymsOptions.entity(), listSynonymsOptions.value() }));
+    Map<String, String> requestHeaders = (listSynonymsOptions != null) ? listSynonymsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listSynonymsOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listSynonymsOptions.pageLimit()));
@@ -957,6 +1181,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.Synonym updateSynonym(IBMAssistantV1Models.UpdateSynonymOptions updateSynonymOptions) {
     IBMWatsonValidator.notNull(updateSynonymOptions, 'updateSynonymOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}', new String[]{ updateSynonymOptions.workspaceId(), updateSynonymOptions.entity(), updateSynonymOptions.value(), updateSynonymOptions.synonym() }));
+    Map<String, String> requestHeaders = (updateSynonymOptions != null) ? updateSynonymOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateSynonymOptions.newSynonym() != null) {
@@ -978,6 +1208,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.DialogNode createDialogNode(IBMAssistantV1Models.CreateDialogNodeOptions createDialogNodeOptions) {
     IBMWatsonValidator.notNull(createDialogNodeOptions, 'createDialogNodeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes', new String[]{ createDialogNodeOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (createDialogNodeOptions != null) ? createDialogNodeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('dialog_node', createDialogNodeOptions.dialogNode());
@@ -1045,6 +1281,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public void deleteDialogNode(IBMAssistantV1Models.DeleteDialogNodeOptions deleteDialogNodeOptions) {
     IBMWatsonValidator.notNull(deleteDialogNodeOptions, 'deleteDialogNodeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes/{1}', new String[]{ deleteDialogNodeOptions.workspaceId(), deleteDialogNodeOptions.dialogNode() }));
+    Map<String, String> requestHeaders = (deleteDialogNodeOptions != null) ? deleteDialogNodeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -1061,6 +1303,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.DialogNode getDialogNode(IBMAssistantV1Models.GetDialogNodeOptions getDialogNodeOptions) {
     IBMWatsonValidator.notNull(getDialogNodeOptions, 'getDialogNodeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes/{1}', new String[]{ getDialogNodeOptions.workspaceId(), getDialogNodeOptions.dialogNode() }));
+    Map<String, String> requestHeaders = (getDialogNodeOptions != null) ? getDialogNodeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getDialogNodeOptions.includeAudit() != null) {
       builder.query('include_audit', String.valueOf(getDialogNodeOptions.includeAudit()));
@@ -1080,6 +1328,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.DialogNodeCollection listDialogNodes(IBMAssistantV1Models.ListDialogNodesOptions listDialogNodesOptions) {
     IBMWatsonValidator.notNull(listDialogNodesOptions, 'listDialogNodesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes', new String[]{ listDialogNodesOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listDialogNodesOptions != null) ? listDialogNodesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listDialogNodesOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listDialogNodesOptions.pageLimit()));
@@ -1111,6 +1365,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.DialogNode updateDialogNode(IBMAssistantV1Models.UpdateDialogNodeOptions updateDialogNodeOptions) {
     IBMWatsonValidator.notNull(updateDialogNodeOptions, 'updateDialogNodeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes/{1}', new String[]{ updateDialogNodeOptions.workspaceId(), updateDialogNodeOptions.dialogNode() }));
+    Map<String, String> requestHeaders = (updateDialogNodeOptions != null) ? updateDialogNodeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateDialogNodeOptions.newType() != null) {
@@ -1180,6 +1440,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.LogCollection listAllLogs(IBMAssistantV1Models.ListAllLogsOptions listAllLogsOptions) {
     IBMWatsonValidator.notNull(listAllLogsOptions, 'listAllLogsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/logs');
+    Map<String, String> requestHeaders = (listAllLogsOptions != null) ? listAllLogsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listAllLogsOptions.filter() != null) {
       builder.query('filter', listAllLogsOptions.filter());
@@ -1208,6 +1474,12 @@ public class IBMAssistantV1 extends IBMWatsonService {
   public IBMAssistantV1Models.LogCollection listLogs(IBMAssistantV1Models.ListLogsOptions listLogsOptions) {
     IBMWatsonValidator.notNull(listLogsOptions, 'listLogsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/logs', new String[]{ listLogsOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listLogsOptions != null) ? listLogsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listLogsOptions.sortField() != null) {
       builder.query('sort', listLogsOptions.sortField());

--- a/force-app/main/default/classes/IBMAssistantV1.cls
+++ b/force-app/main/default/classes/IBMAssistantV1.cls
@@ -54,21 +54,6 @@ public class IBMAssistantV1 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMAssistantV1` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
-   *
-   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
-   *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
-   */
-  public IBMAssistantV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
-    this(versionDate);
-    setIamCredentials(iamOptions);
-  }
-
-  /**
    * Get response to user input.
    *
    * Get a response to a user's input.    There is no rate limit for this operation.

--- a/force-app/main/default/classes/IBMAssistantV1Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Models.cls
@@ -139,7 +139,7 @@ public class IBMAssistantV1Models {
   /**
    * Counterexample.
    */
-  public class Counterexample extends IBMWatsonGenericModel {
+  public class Counterexample extends IBMWatsonResponseModel {
     private String text_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -200,7 +200,7 @@ public class IBMAssistantV1Models {
   /**
    * CounterexampleCollection.
    */
-  public class CounterexampleCollection extends IBMWatsonGenericModel {
+  public class CounterexampleCollection extends IBMWatsonResponseModel {
     private List<Counterexample> counterexamples_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -352,7 +352,7 @@ public class IBMAssistantV1Models {
   /**
    * The createCounterexample options.
    */
-  public class CreateCounterexampleOptions {
+  public class CreateCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     /**
@@ -380,6 +380,7 @@ public class IBMAssistantV1Models {
       IBMWatsonValidator.notNull(builder.text_serialized_name, 'text_serialized_name cannot be null');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -396,7 +397,7 @@ public class IBMAssistantV1Models {
   /**
    * CreateCounterexampleOptions Builder.
    */
-  public class CreateCounterexampleOptionsBuilder {
+  public class CreateCounterexampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
 
@@ -450,6 +451,18 @@ public class IBMAssistantV1Models {
      */
     public CreateCounterexampleOptionsBuilder text(String text) {
       this.text_serialized_name = text;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateCounterexampleOptions builder
+     */
+    public CreateCounterexampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -950,7 +963,7 @@ public class IBMAssistantV1Models {
   /**
    * The createDialogNode options.
    */
-  public class CreateDialogNodeOptions {
+  public class CreateDialogNodeOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private String description_serialized_name;
@@ -1170,6 +1183,7 @@ public class IBMAssistantV1Models {
       digress_in_serialized_name = builder.digress_in_serialized_name;
       digress_out_serialized_name = builder.digress_out_serialized_name;
       digress_out_slots_serialized_name = builder.digress_out_slots_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1186,7 +1200,7 @@ public class IBMAssistantV1Models {
   /**
    * CreateDialogNodeOptions Builder.
    */
-  public class CreateDialogNodeOptionsBuilder {
+  public class CreateDialogNodeOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private String description_serialized_name;
@@ -1466,6 +1480,18 @@ public class IBMAssistantV1Models {
       this.digress_out_slots_serialized_name = digressOutSlots;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateDialogNodeOptions builder
+     */
+    public CreateDialogNodeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
@@ -1664,7 +1690,7 @@ public class IBMAssistantV1Models {
   /**
    * The createEntity options.
    */
-  public class CreateEntityOptions {
+  public class CreateEntityOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String description_serialized_name;
@@ -1740,6 +1766,7 @@ public class IBMAssistantV1Models {
       metadata_serialized_name = builder.metadata_serialized_name;
       values_serialized_name = builder.values_serialized_name;
       fuzzy_match_serialized_name = builder.fuzzy_match_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1756,7 +1783,7 @@ public class IBMAssistantV1Models {
   /**
    * CreateEntityOptions Builder.
    */
-  public class CreateEntityOptionsBuilder {
+  public class CreateEntityOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String description_serialized_name;
@@ -1880,6 +1907,18 @@ public class IBMAssistantV1Models {
       this.fuzzy_match_serialized_name = fuzzyMatch;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateEntityOptions builder
+     */
+    public CreateEntityOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
@@ -1962,7 +2001,7 @@ public class IBMAssistantV1Models {
   /**
    * The createExample options.
    */
-  public class CreateExampleOptions {
+  public class CreateExampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -2003,6 +2042,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       intent_serialized_name = builder.intent_serialized_name;
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2019,7 +2059,7 @@ public class IBMAssistantV1Models {
   /**
    * CreateExampleOptions Builder.
    */
-  public class CreateExampleOptionsBuilder {
+  public class CreateExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -2088,6 +2128,18 @@ public class IBMAssistantV1Models {
      */
     public CreateExampleOptionsBuilder text(String text) {
       this.text_serialized_name = text;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateExampleOptions builder
+     */
+    public CreateExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -2238,7 +2290,7 @@ public class IBMAssistantV1Models {
   /**
    * The createIntent options.
    */
-  public class CreateIntentOptions {
+  public class CreateIntentOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String description_serialized_name;
@@ -2290,6 +2342,7 @@ public class IBMAssistantV1Models {
       intent_serialized_name = builder.intent_serialized_name;
       description_serialized_name = builder.description_serialized_name;
       examples_serialized_name = builder.examples_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2306,7 +2359,7 @@ public class IBMAssistantV1Models {
   /**
    * CreateIntentOptions Builder.
    */
-  public class CreateIntentOptionsBuilder {
+  public class CreateIntentOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String description_serialized_name;
@@ -2404,12 +2457,24 @@ public class IBMAssistantV1Models {
       this.examples_serialized_name = examples;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateIntentOptions builder
+     */
+    public CreateIntentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The createSynonym options.
    */
-  public class CreateSynonymOptions {
+  public class CreateSynonymOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -2463,6 +2528,7 @@ public class IBMAssistantV1Models {
       entity_serialized_name = builder.entity_serialized_name;
       value_serialized_name = builder.value_serialized_name;
       synonym_serialized_name = builder.synonym_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2479,7 +2545,7 @@ public class IBMAssistantV1Models {
   /**
    * CreateSynonymOptions Builder.
    */
-  public class CreateSynonymOptionsBuilder {
+  public class CreateSynonymOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -2563,6 +2629,18 @@ public class IBMAssistantV1Models {
      */
     public CreateSynonymOptionsBuilder synonym(String synonym) {
       this.synonym_serialized_name = synonym;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateSynonymOptions builder
+     */
+    public CreateSynonymOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -2779,7 +2857,7 @@ public class IBMAssistantV1Models {
   /**
    * The createValue options.
    */
-  public class CreateValueOptions {
+  public class CreateValueOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -2868,6 +2946,7 @@ public class IBMAssistantV1Models {
       synonyms_serialized_name = builder.synonyms_serialized_name;
       patterns_serialized_name = builder.patterns_serialized_name;
       type_serialized_name = builder.type_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2884,7 +2963,7 @@ public class IBMAssistantV1Models {
   /**
    * CreateValueOptions Builder.
    */
-  public class CreateValueOptionsBuilder {
+  public class CreateValueOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -3039,12 +3118,24 @@ public class IBMAssistantV1Models {
       this.type_serialized_name = typeVar;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateValueOptions builder
+     */
+    public CreateValueOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The createWorkspace options.
    */
-  public class CreateWorkspaceOptions {
+  public class CreateWorkspaceOptions extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String description_serialized_name;
     private String language_serialized_name;
@@ -3154,6 +3245,7 @@ public class IBMAssistantV1Models {
       counterexamples_serialized_name = builder.counterexamples_serialized_name;
       metadata_serialized_name = builder.metadata_serialized_name;
       learning_opt_out_serialized_name = builder.learning_opt_out_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3170,7 +3262,7 @@ public class IBMAssistantV1Models {
   /**
    * CreateWorkspaceOptions Builder.
    */
-  public class CreateWorkspaceOptionsBuilder {
+  public class CreateWorkspaceOptionsBuilder extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String description_serialized_name;
     private String language_serialized_name;
@@ -3370,12 +3462,24 @@ public class IBMAssistantV1Models {
       this.learning_opt_out_serialized_name = learningOptOut;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateWorkspaceOptions builder
+     */
+    public CreateWorkspaceOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteCounterexample options.
    */
-  public class DeleteCounterexampleOptions {
+  public class DeleteCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     /**
@@ -3403,6 +3507,7 @@ public class IBMAssistantV1Models {
       IBMWatsonValidator.notEmpty(builder.text_serialized_name, 'text_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3419,7 +3524,7 @@ public class IBMAssistantV1Models {
   /**
    * DeleteCounterexampleOptions Builder.
    */
-  public class DeleteCounterexampleOptionsBuilder {
+  public class DeleteCounterexampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
 
@@ -3475,12 +3580,24 @@ public class IBMAssistantV1Models {
       this.text_serialized_name = text;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteCounterexampleOptions builder
+     */
+    public DeleteCounterexampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteDialogNode options.
    */
-  public class DeleteDialogNodeOptions {
+  public class DeleteDialogNodeOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     /**
@@ -3508,6 +3625,7 @@ public class IBMAssistantV1Models {
       IBMWatsonValidator.notEmpty(builder.dialog_node_serialized_name, 'dialog_node_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       dialog_node_serialized_name = builder.dialog_node_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3524,7 +3642,7 @@ public class IBMAssistantV1Models {
   /**
    * DeleteDialogNodeOptions Builder.
    */
-  public class DeleteDialogNodeOptionsBuilder {
+  public class DeleteDialogNodeOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
 
@@ -3580,12 +3698,24 @@ public class IBMAssistantV1Models {
       this.dialog_node_serialized_name = dialogNode;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteDialogNodeOptions builder
+     */
+    public DeleteDialogNodeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteEntity options.
    */
-  public class DeleteEntityOptions {
+  public class DeleteEntityOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     /**
@@ -3613,6 +3743,7 @@ public class IBMAssistantV1Models {
       IBMWatsonValidator.notEmpty(builder.entity_serialized_name, 'entity_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       entity_serialized_name = builder.entity_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3629,7 +3760,7 @@ public class IBMAssistantV1Models {
   /**
    * DeleteEntityOptions Builder.
    */
-  public class DeleteEntityOptionsBuilder {
+  public class DeleteEntityOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
 
@@ -3685,12 +3816,24 @@ public class IBMAssistantV1Models {
       this.entity_serialized_name = entity;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteEntityOptions builder
+     */
+    public DeleteEntityOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteExample options.
    */
-  public class DeleteExampleOptions {
+  public class DeleteExampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -3731,6 +3874,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       intent_serialized_name = builder.intent_serialized_name;
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3747,7 +3891,7 @@ public class IBMAssistantV1Models {
   /**
    * DeleteExampleOptions Builder.
    */
-  public class DeleteExampleOptionsBuilder {
+  public class DeleteExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -3818,12 +3962,24 @@ public class IBMAssistantV1Models {
       this.text_serialized_name = text;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteExampleOptions builder
+     */
+    public DeleteExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteIntent options.
    */
-  public class DeleteIntentOptions {
+  public class DeleteIntentOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     /**
@@ -3851,6 +4007,7 @@ public class IBMAssistantV1Models {
       IBMWatsonValidator.notEmpty(builder.intent_serialized_name, 'intent_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       intent_serialized_name = builder.intent_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3867,7 +4024,7 @@ public class IBMAssistantV1Models {
   /**
    * DeleteIntentOptions Builder.
    */
-  public class DeleteIntentOptionsBuilder {
+  public class DeleteIntentOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
 
@@ -3923,12 +4080,24 @@ public class IBMAssistantV1Models {
       this.intent_serialized_name = intent;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteIntentOptions builder
+     */
+    public DeleteIntentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteSynonym options.
    */
-  public class DeleteSynonymOptions {
+  public class DeleteSynonymOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -3982,6 +4151,7 @@ public class IBMAssistantV1Models {
       entity_serialized_name = builder.entity_serialized_name;
       value_serialized_name = builder.value_serialized_name;
       synonym_serialized_name = builder.synonym_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3998,7 +4168,7 @@ public class IBMAssistantV1Models {
   /**
    * DeleteSynonymOptions Builder.
    */
-  public class DeleteSynonymOptionsBuilder {
+  public class DeleteSynonymOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -4084,12 +4254,24 @@ public class IBMAssistantV1Models {
       this.synonym_serialized_name = synonym;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteSynonymOptions builder
+     */
+    public DeleteSynonymOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteValue options.
    */
-  public class DeleteValueOptions {
+  public class DeleteValueOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -4130,6 +4312,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       entity_serialized_name = builder.entity_serialized_name;
       value_serialized_name = builder.value_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4146,7 +4329,7 @@ public class IBMAssistantV1Models {
   /**
    * DeleteValueOptions Builder.
    */
-  public class DeleteValueOptionsBuilder {
+  public class DeleteValueOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -4217,12 +4400,24 @@ public class IBMAssistantV1Models {
       this.value_serialized_name = value;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteValueOptions builder
+     */
+    public DeleteValueOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteWorkspace options.
    */
-  public class DeleteWorkspaceOptions {
+  public class DeleteWorkspaceOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     /**
      * Gets the workspace_id_serialized_name.
@@ -4237,6 +4432,7 @@ public class IBMAssistantV1Models {
     private DeleteWorkspaceOptions(DeleteWorkspaceOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.workspace_id_serialized_name, 'workspace_id_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4253,7 +4449,7 @@ public class IBMAssistantV1Models {
   /**
    * DeleteWorkspaceOptions Builder.
    */
-  public class DeleteWorkspaceOptionsBuilder {
+  public class DeleteWorkspaceOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
 
     private DeleteWorkspaceOptionsBuilder(DeleteWorkspaceOptions deleteWorkspaceOptions) {
@@ -4294,12 +4490,24 @@ public class IBMAssistantV1Models {
       this.workspace_id_serialized_name = workspaceId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteWorkspaceOptions builder
+     */
+    public DeleteWorkspaceOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * DialogNode.
    */
-  public class DialogNode extends IBMWatsonGenericModel {
+  public class DialogNode extends IBMWatsonResponseModel {
     private String dialog_node_serialized_name;
     private String description_serialized_name;
     private String conditions_serialized_name;
@@ -4850,7 +5058,7 @@ public class IBMAssistantV1Models {
   /**
    * An array of dialog nodes.
    */
-  public class DialogNodeCollection extends IBMWatsonGenericModel {
+  public class DialogNodeCollection extends IBMWatsonResponseModel {
     private List<DialogNode> dialog_nodes_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -5083,7 +5291,7 @@ public class IBMAssistantV1Models {
   /**
    * Entity.
    */
-  public class Entity extends IBMWatsonGenericModel {
+  public class Entity extends IBMWatsonResponseModel {
     private String entity_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -5211,7 +5419,7 @@ public class IBMAssistantV1Models {
   /**
    * An array of entities.
    */
-  public class EntityCollection extends IBMWatsonGenericModel {
+  public class EntityCollection extends IBMWatsonResponseModel {
     private List<EntityExport> entities_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -5286,7 +5494,7 @@ public class IBMAssistantV1Models {
   /**
    * EntityExport.
    */
-  public class EntityExport extends IBMWatsonGenericModel {
+  public class EntityExport extends IBMWatsonResponseModel {
     private String entity_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -5448,7 +5656,7 @@ public class IBMAssistantV1Models {
   /**
    * Example.
    */
-  public class Example extends IBMWatsonGenericModel {
+  public class Example extends IBMWatsonResponseModel {
     private String text_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -5509,7 +5717,7 @@ public class IBMAssistantV1Models {
   /**
    * ExampleCollection.
    */
-  public class ExampleCollection extends IBMWatsonGenericModel {
+  public class ExampleCollection extends IBMWatsonResponseModel {
     private List<Example> examples_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -5584,7 +5792,7 @@ public class IBMAssistantV1Models {
   /**
    * The getCounterexample options.
    */
-  public class GetCounterexampleOptions {
+  public class GetCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -5624,6 +5832,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       text_serialized_name = builder.text_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5640,7 +5849,7 @@ public class IBMAssistantV1Models {
   /**
    * GetCounterexampleOptions Builder.
    */
-  public class GetCounterexampleOptionsBuilder {
+  public class GetCounterexampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -5709,12 +5918,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetCounterexampleOptions builder
+     */
+    public GetCounterexampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getDialogNode options.
    */
-  public class GetDialogNodeOptions {
+  public class GetDialogNodeOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -5754,6 +5975,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       dialog_node_serialized_name = builder.dialog_node_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5770,7 +5992,7 @@ public class IBMAssistantV1Models {
   /**
    * GetDialogNodeOptions Builder.
    */
-  public class GetDialogNodeOptionsBuilder {
+  public class GetDialogNodeOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -5839,12 +6061,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetDialogNodeOptions builder
+     */
+    public GetDialogNodeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getEntity options.
    */
-  public class GetEntityOptions {
+  public class GetEntityOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean export_serialized_name;
@@ -5896,6 +6130,7 @@ public class IBMAssistantV1Models {
       entity_serialized_name = builder.entity_serialized_name;
       export_serialized_name = builder.export_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5912,7 +6147,7 @@ public class IBMAssistantV1Models {
   /**
    * GetEntityOptions Builder.
    */
-  public class GetEntityOptionsBuilder {
+  public class GetEntityOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean export_serialized_name;
@@ -5994,12 +6229,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetEntityOptions builder
+     */
+    public GetEntityOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getExample options.
    */
-  public class GetExampleOptions {
+  public class GetExampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -6052,6 +6299,7 @@ public class IBMAssistantV1Models {
       intent_serialized_name = builder.intent_serialized_name;
       text_serialized_name = builder.text_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6068,7 +6316,7 @@ public class IBMAssistantV1Models {
   /**
    * GetExampleOptions Builder.
    */
-  public class GetExampleOptionsBuilder {
+  public class GetExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -6152,12 +6400,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetExampleOptions builder
+     */
+    public GetExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getIntent options.
    */
-  public class GetIntentOptions {
+  public class GetIntentOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private Boolean export_serialized_name;
@@ -6209,6 +6469,7 @@ public class IBMAssistantV1Models {
       intent_serialized_name = builder.intent_serialized_name;
       export_serialized_name = builder.export_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6225,7 +6486,7 @@ public class IBMAssistantV1Models {
   /**
    * GetIntentOptions Builder.
    */
-  public class GetIntentOptionsBuilder {
+  public class GetIntentOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private Boolean export_serialized_name;
@@ -6307,12 +6568,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetIntentOptions builder
+     */
+    public GetIntentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getSynonym options.
    */
-  public class GetSynonymOptions {
+  public class GetSynonymOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -6378,6 +6651,7 @@ public class IBMAssistantV1Models {
       value_serialized_name = builder.value_serialized_name;
       synonym_serialized_name = builder.synonym_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6394,7 +6668,7 @@ public class IBMAssistantV1Models {
   /**
    * GetSynonymOptions Builder.
    */
-  public class GetSynonymOptionsBuilder {
+  public class GetSynonymOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -6493,12 +6767,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetSynonymOptions builder
+     */
+    public GetSynonymOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getValue options.
    */
-  public class GetValueOptions {
+  public class GetValueOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -6563,6 +6849,7 @@ public class IBMAssistantV1Models {
       value_serialized_name = builder.value_serialized_name;
       export_serialized_name = builder.export_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6579,7 +6866,7 @@ public class IBMAssistantV1Models {
   /**
    * GetValueOptions Builder.
    */
-  public class GetValueOptionsBuilder {
+  public class GetValueOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -6676,12 +6963,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetValueOptions builder
+     */
+    public GetValueOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getWorkspace options.
    */
-  public class GetWorkspaceOptions {
+  public class GetWorkspaceOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -6720,6 +7019,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       export_serialized_name = builder.export_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6736,7 +7036,7 @@ public class IBMAssistantV1Models {
   /**
    * GetWorkspaceOptions Builder.
    */
-  public class GetWorkspaceOptionsBuilder {
+  public class GetWorkspaceOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -6803,12 +7103,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetWorkspaceOptions builder
+     */
+    public GetWorkspaceOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The user input.
    */
-  public class InputData {
+  public class InputData extends IBMWatsonGenericModel {
     private String text_serialized_name;
     /**
      * Gets the text_serialized_name.
@@ -6833,7 +7145,6 @@ public class IBMAssistantV1Models {
     public InputDataBuilder newBuilder() {
       return new InputDataBuilder(this);
     }
-
   }
 
   /**
@@ -6885,7 +7196,7 @@ public class IBMAssistantV1Models {
   /**
    * Intent.
    */
-  public class Intent extends IBMWatsonGenericModel {
+  public class Intent extends IBMWatsonResponseModel {
     private String intent_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -6967,7 +7278,7 @@ public class IBMAssistantV1Models {
   /**
    * IntentCollection.
    */
-  public class IntentCollection extends IBMWatsonGenericModel {
+  public class IntentCollection extends IBMWatsonResponseModel {
     private List<IntentExport> intents_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -7042,7 +7353,7 @@ public class IBMAssistantV1Models {
   /**
    * IntentExport.
    */
-  public class IntentExport extends IBMWatsonGenericModel {
+  public class IntentExport extends IBMWatsonResponseModel {
     private String intent_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -7158,7 +7469,7 @@ public class IBMAssistantV1Models {
   /**
    * The listAllLogs options.
    */
-  public class ListAllLogsOptions {
+  public class ListAllLogsOptions extends IBMWatsonOptionsModel {
     private String filter_serialized_name;
     private String sort_serialized_name;
     private Long page_limit_serialized_name;
@@ -7209,6 +7520,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       page_limit_serialized_name = builder.page_limit_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7225,7 +7537,7 @@ public class IBMAssistantV1Models {
   /**
    * ListAllLogsOptions Builder.
    */
-  public class ListAllLogsOptionsBuilder {
+  public class ListAllLogsOptionsBuilder extends IBMWatsonOptionsModel {
     private String filter_serialized_name;
     private String sort_serialized_name;
     private Long page_limit_serialized_name;
@@ -7305,12 +7617,24 @@ public class IBMAssistantV1Models {
       this.cursor_serialized_name = cursor;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListAllLogsOptions builder
+     */
+    public ListAllLogsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listCounterexamples options.
    */
-  public class ListCounterexamplesOptions {
+  public class ListCounterexamplesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
@@ -7385,6 +7709,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7401,7 +7726,7 @@ public class IBMAssistantV1Models {
   /**
    * ListCounterexamplesOptions Builder.
    */
-  public class ListCounterexamplesOptionsBuilder {
+  public class ListCounterexamplesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
@@ -7507,12 +7832,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListCounterexamplesOptions builder
+     */
+    public ListCounterexamplesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listDialogNodes options.
    */
-  public class ListDialogNodesOptions {
+  public class ListDialogNodesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
@@ -7587,6 +7924,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7603,7 +7941,7 @@ public class IBMAssistantV1Models {
   /**
    * ListDialogNodesOptions Builder.
    */
-  public class ListDialogNodesOptionsBuilder {
+  public class ListDialogNodesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
@@ -7709,12 +8047,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListDialogNodesOptions builder
+     */
+    public ListDialogNodesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listEntities options.
    */
-  public class ListEntitiesOptions {
+  public class ListEntitiesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Long page_limit_serialized_name;
@@ -7801,6 +8151,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7817,7 +8168,7 @@ public class IBMAssistantV1Models {
   /**
    * ListEntitiesOptions Builder.
    */
-  public class ListEntitiesOptionsBuilder {
+  public class ListEntitiesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Long page_limit_serialized_name;
@@ -7936,12 +8287,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListEntitiesOptions builder
+     */
+    public ListEntitiesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listExamples options.
    */
-  public class ListExamplesOptions {
+  public class ListExamplesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private Long page_limit_serialized_name;
@@ -8029,6 +8392,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8045,7 +8409,7 @@ public class IBMAssistantV1Models {
   /**
    * ListExamplesOptions Builder.
    */
-  public class ListExamplesOptionsBuilder {
+  public class ListExamplesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private Long page_limit_serialized_name;
@@ -8166,12 +8530,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListExamplesOptions builder
+     */
+    public ListExamplesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listIntents options.
    */
-  public class ListIntentsOptions {
+  public class ListIntentsOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Long page_limit_serialized_name;
@@ -8258,6 +8634,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8274,7 +8651,7 @@ public class IBMAssistantV1Models {
   /**
    * ListIntentsOptions Builder.
    */
-  public class ListIntentsOptionsBuilder {
+  public class ListIntentsOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Long page_limit_serialized_name;
@@ -8393,12 +8770,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListIntentsOptions builder
+     */
+    public ListIntentsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listLogs options.
    */
-  public class ListLogsOptions {
+  public class ListLogsOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String sort_serialized_name;
     private String filter_serialized_name;
@@ -8461,6 +8850,7 @@ public class IBMAssistantV1Models {
       filter_serialized_name = builder.filter_serialized_name;
       page_limit_serialized_name = builder.page_limit_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8477,7 +8867,7 @@ public class IBMAssistantV1Models {
   /**
    * ListLogsOptions Builder.
    */
-  public class ListLogsOptionsBuilder {
+  public class ListLogsOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String sort_serialized_name;
     private String filter_serialized_name;
@@ -8570,12 +8960,24 @@ public class IBMAssistantV1Models {
       this.cursor_serialized_name = cursor;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListLogsOptions builder
+     */
+    public ListLogsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listSynonyms options.
    */
-  public class ListSynonymsOptions {
+  public class ListSynonymsOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -8676,6 +9078,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8692,7 +9095,7 @@ public class IBMAssistantV1Models {
   /**
    * ListSynonymsOptions Builder.
    */
-  public class ListSynonymsOptionsBuilder {
+  public class ListSynonymsOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -8828,12 +9231,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListSynonymsOptions builder
+     */
+    public ListSynonymsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listValues options.
    */
-  public class ListValuesOptions {
+  public class ListValuesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean export_serialized_name;
@@ -8933,6 +9348,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8949,7 +9365,7 @@ public class IBMAssistantV1Models {
   /**
    * ListValuesOptions Builder.
    */
-  public class ListValuesOptionsBuilder {
+  public class ListValuesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean export_serialized_name;
@@ -9083,12 +9499,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListValuesOptions builder
+     */
+    public ListValuesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listWorkspaces options.
    */
-  public class ListWorkspacesOptions {
+  public class ListWorkspacesOptions extends IBMWatsonOptionsModel {
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
     private String sort_serialized_name;
@@ -9150,6 +9578,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -9166,7 +9595,7 @@ public class IBMAssistantV1Models {
   /**
    * ListWorkspacesOptions Builder.
    */
-  public class ListWorkspacesOptionsBuilder {
+  public class ListWorkspacesOptionsBuilder extends IBMWatsonOptionsModel {
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
     private String sort_serialized_name;
@@ -9250,12 +9679,24 @@ public class IBMAssistantV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListWorkspacesOptions builder
+     */
+    public ListWorkspacesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * LogCollection.
    */
-  public class LogCollection extends IBMWatsonGenericModel {
+  public class LogCollection extends IBMWatsonResponseModel {
     private List<LogExport> logs_serialized_name;
     private LogPagination pagination_serialized_name;
     /**
@@ -9692,7 +10133,7 @@ public class IBMAssistantV1Models {
   /**
    * The message options.
    */
-  public class MessageOptions {
+  public class MessageOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private InputData input_serialized_name;
     private Boolean alternate_intents_serialized_name;
@@ -9791,6 +10232,7 @@ public class IBMAssistantV1Models {
       intents_serialized_name = builder.intents_serialized_name;
       output_serialized_name = builder.output_serialized_name;
       nodes_visited_details_serialized_name = builder.nodes_visited_details_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -9807,7 +10249,7 @@ public class IBMAssistantV1Models {
   /**
    * MessageOptions Builder.
    */
-  public class MessageOptionsBuilder {
+  public class MessageOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private InputData input_serialized_name;
     private Boolean alternate_intents_serialized_name;
@@ -9985,6 +10427,18 @@ public class IBMAssistantV1Models {
       this.entities_serialized_name = messageRequest.getEntities();
       this.intents_serialized_name = messageRequest.getIntents();
       this.output_serialized_name = messageRequest.getOutput();
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the MessageOptions builder
+     */
+    public MessageOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -10168,7 +10622,7 @@ public class IBMAssistantV1Models {
   /**
    * A response from the Watson Assistant service.
    */
-  public class MessageResponse extends IBMWatsonDynamicModel {
+  public class MessageResponse extends IBMWatsonDynamicResponseModel {
     private MessageInput input_serialized_name;
     private List<RuntimeIntent> intents_serialized_name;
     private List<RuntimeEntity> entities_serialized_name;
@@ -10891,7 +11345,7 @@ public class IBMAssistantV1Models {
   /**
    * Synonym.
    */
-  public class Synonym extends IBMWatsonGenericModel {
+  public class Synonym extends IBMWatsonResponseModel {
     private String synonym_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -10952,7 +11406,7 @@ public class IBMAssistantV1Models {
   /**
    * SynonymCollection.
    */
-  public class SynonymCollection extends IBMWatsonGenericModel {
+  public class SynonymCollection extends IBMWatsonResponseModel {
     private List<Synonym> synonyms_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -11062,7 +11516,7 @@ public class IBMAssistantV1Models {
   /**
    * The updateCounterexample options.
    */
-  public class UpdateCounterexampleOptions {
+  public class UpdateCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     private String new_text_serialized_name;
@@ -11102,6 +11556,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       text_serialized_name = builder.text_serialized_name;
       new_text_serialized_name = builder.new_text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -11118,7 +11573,7 @@ public class IBMAssistantV1Models {
   /**
    * UpdateCounterexampleOptions Builder.
    */
-  public class UpdateCounterexampleOptionsBuilder {
+  public class UpdateCounterexampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     private String new_text_serialized_name;
@@ -11187,12 +11642,24 @@ public class IBMAssistantV1Models {
       this.new_text_serialized_name = newText;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateCounterexampleOptions builder
+     */
+    public UpdateCounterexampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The UpdateDialogNode options.
    */
-  public class UpdateDialogNodeOptions {
+  public class UpdateDialogNodeOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private String new_type_serialized_name;
@@ -11424,6 +11891,7 @@ public class IBMAssistantV1Models {
       new_output_serialized_name = builder.new_output_serialized_name;
       new_parent_serialized_name = builder.new_parent_serialized_name;
       new_dialog_node_serialized_name = builder.new_dialog_node_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -11440,7 +11908,7 @@ public class IBMAssistantV1Models {
   /**
    * UpdateDialogNodeOptions Builder.
    */
-  public class UpdateDialogNodeOptionsBuilder {
+  public class UpdateDialogNodeOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private String new_type_serialized_name;
@@ -11733,12 +12201,24 @@ public class IBMAssistantV1Models {
       this.new_dialog_node_serialized_name = newDialogNode;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateDialogNodeOptions builder
+     */
+    public UpdateDialogNodeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateEntity options.
    */
-  public class UpdateEntityOptions {
+  public class UpdateEntityOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean new_fuzzy_match_serialized_name;
@@ -11826,6 +12306,7 @@ public class IBMAssistantV1Models {
       new_metadata_serialized_name = builder.new_metadata_serialized_name;
       new_values_serialized_name = builder.new_values_serialized_name;
       new_description_serialized_name = builder.new_description_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -11842,7 +12323,7 @@ public class IBMAssistantV1Models {
   /**
    * UpdateEntityOptions Builder.
    */
-  public class UpdateEntityOptionsBuilder {
+  public class UpdateEntityOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean new_fuzzy_match_serialized_name;
@@ -11979,12 +12460,24 @@ public class IBMAssistantV1Models {
       this.new_description_serialized_name = newDescription;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateEntityOptions builder
+     */
+    public UpdateEntityOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateExample options.
    */
-  public class UpdateExampleOptions {
+  public class UpdateExampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -12037,6 +12530,7 @@ public class IBMAssistantV1Models {
       intent_serialized_name = builder.intent_serialized_name;
       text_serialized_name = builder.text_serialized_name;
       new_text_serialized_name = builder.new_text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12053,7 +12547,7 @@ public class IBMAssistantV1Models {
   /**
    * UpdateExampleOptions Builder.
    */
-  public class UpdateExampleOptionsBuilder {
+  public class UpdateExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -12137,12 +12631,24 @@ public class IBMAssistantV1Models {
       this.new_text_serialized_name = newText;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateExampleOptions builder
+     */
+    public UpdateExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateIntent options.
    */
-  public class UpdateIntentOptions {
+  public class UpdateIntentOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String new_intent_serialized_name;
@@ -12206,6 +12712,7 @@ public class IBMAssistantV1Models {
       new_intent_serialized_name = builder.new_intent_serialized_name;
       new_examples_serialized_name = builder.new_examples_serialized_name;
       new_description_serialized_name = builder.new_description_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12222,7 +12729,7 @@ public class IBMAssistantV1Models {
   /**
    * UpdateIntentOptions Builder.
    */
-  public class UpdateIntentOptionsBuilder {
+  public class UpdateIntentOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String new_intent_serialized_name;
@@ -12333,12 +12840,24 @@ public class IBMAssistantV1Models {
       this.new_description_serialized_name = newDescription;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateIntentOptions builder
+     */
+    public UpdateIntentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateSynonym options.
    */
-  public class UpdateSynonymOptions {
+  public class UpdateSynonymOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -12404,6 +12923,7 @@ public class IBMAssistantV1Models {
       value_serialized_name = builder.value_serialized_name;
       synonym_serialized_name = builder.synonym_serialized_name;
       new_synonym_serialized_name = builder.new_synonym_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12420,7 +12940,7 @@ public class IBMAssistantV1Models {
   /**
    * UpdateSynonymOptions Builder.
    */
-  public class UpdateSynonymOptionsBuilder {
+  public class UpdateSynonymOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -12519,12 +13039,24 @@ public class IBMAssistantV1Models {
       this.new_synonym_serialized_name = newSynonym;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateSynonymOptions builder
+     */
+    public UpdateSynonymOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateValue options.
    */
-  public class UpdateValueOptions {
+  public class UpdateValueOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -12625,6 +13157,7 @@ public class IBMAssistantV1Models {
       new_metadata_serialized_name = builder.new_metadata_serialized_name;
       new_patterns_serialized_name = builder.new_patterns_serialized_name;
       new_value_serialized_name = builder.new_value_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12641,7 +13174,7 @@ public class IBMAssistantV1Models {
   /**
    * UpdateValueOptions Builder.
    */
-  public class UpdateValueOptionsBuilder {
+  public class UpdateValueOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -12809,12 +13342,24 @@ public class IBMAssistantV1Models {
       this.new_value_serialized_name = newValue;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateValueOptions builder
+     */
+    public UpdateValueOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateWorkspace options.
    */
-  public class UpdateWorkspaceOptions {
+  public class UpdateWorkspaceOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -12949,6 +13494,7 @@ public class IBMAssistantV1Models {
       metadata_serialized_name = builder.metadata_serialized_name;
       learning_opt_out_serialized_name = builder.learning_opt_out_serialized_name;
       append_serialized_name = builder.append_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12965,7 +13511,7 @@ public class IBMAssistantV1Models {
   /**
    * UpdateWorkspaceOptions Builder.
    */
-  public class UpdateWorkspaceOptionsBuilder {
+  public class UpdateWorkspaceOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -13200,12 +13746,24 @@ public class IBMAssistantV1Models {
       this.append_serialized_name = append;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateWorkspaceOptions builder
+     */
+    public UpdateWorkspaceOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * Value.
    */
-  public class Value extends IBMWatsonGenericModel {
+  public class Value extends IBMWatsonResponseModel {
     private String value_serialized_name;
     private IBMWatsonMapModel metadata_serialized_name;
     private Datetime created_serialized_name;
@@ -13354,7 +13912,7 @@ public class IBMAssistantV1Models {
   /**
    * ValueCollection.
    */
-  public class ValueCollection extends IBMWatsonGenericModel {
+  public class ValueCollection extends IBMWatsonResponseModel {
     private List<ValueExport> values_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -13429,7 +13987,7 @@ public class IBMAssistantV1Models {
   /**
    * ValueExport.
    */
-  public class ValueExport extends IBMWatsonGenericModel {
+  public class ValueExport extends IBMWatsonResponseModel {
     private String value_serialized_name;
     private IBMWatsonMapModel metadata_serialized_name;
     private Datetime created_serialized_name;
@@ -13578,7 +14136,7 @@ public class IBMAssistantV1Models {
   /**
    * Workspace.
    */
-  public class Workspace extends IBMWatsonGenericModel {
+  public class Workspace extends IBMWatsonResponseModel {
     private String name_serialized_name;
     private String language_serialized_name;
     private Datetime created_serialized_name;
@@ -13739,7 +14297,7 @@ public class IBMAssistantV1Models {
   /**
    * WorkspaceCollection.
    */
-  public class WorkspaceCollection extends IBMWatsonGenericModel {
+  public class WorkspaceCollection extends IBMWatsonResponseModel {
     private List<Workspace> workspaces_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -13814,7 +14372,7 @@ public class IBMAssistantV1Models {
   /**
    * WorkspaceExport.
    */
-  public class WorkspaceExport extends IBMWatsonGenericModel {
+  public class WorkspaceExport extends IBMWatsonResponseModel {
     private String name_serialized_name;
     private String description_serialized_name;
     private String language_serialized_name;

--- a/force-app/main/default/classes/IBMAssistantV1Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Models.cls
@@ -7122,6 +7122,13 @@ public class IBMAssistantV1Models {
    */
   public class InputData extends IBMWatsonGenericModel {
     private String text_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public InputData() { }
+
     /**
      * Gets the text_serialized_name.
      *
@@ -7129,7 +7136,8 @@ public class IBMAssistantV1Models {
      *
      * @return the text_serialized_name
      */
-    public String text() {
+    @AuraEnabled
+    public String getText() {
       return text_serialized_name;
     }
     private InputData(InputDataBuilder builder) {
@@ -7144,6 +7152,16 @@ public class IBMAssistantV1Models {
      */
     public InputDataBuilder newBuilder() {
       return new InputDataBuilder(this);
+    }
+
+    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
+      if (jsonMap == null) {
+        return null;
+      }
+
+      InputData ret = (InputData) super.deserialize(jsonString, jsonMap, classType);
+
+      return ret;
     }
   }
 
@@ -10580,6 +10598,10 @@ public class IBMAssistantV1Models {
       }
 
       MessageRequest ret = (MessageRequest) super.deserialize(jsonString, jsonMap, classType);
+
+      // calling custom deserializer for input_serialized_name
+      InputData newInput = (InputData) new InputData().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input_serialized_name'), InputData.class);
+      ret.setInput(newInput);
 
       // calling custom deserializer for context_serialized_name
       Context newContext = (Context) new Context().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context_serialized_name'), Context.class);

--- a/force-app/main/default/classes/IBMAssistantV1Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Models.cls
@@ -404,6 +404,7 @@ public class IBMAssistantV1Models {
     private CreateCounterexampleOptionsBuilder(CreateCounterexampleOptions createCounterexampleOptions) {
       workspace_id_serialized_name = createCounterexampleOptions.workspace_id_serialized_name;
       text_serialized_name = createCounterexampleOptions.text_serialized_name;
+      this.requestHeaders.putAll(createCounterexampleOptions.requestHeaders());
     }
 
     /**
@@ -1239,6 +1240,7 @@ public class IBMAssistantV1Models {
       digress_in_serialized_name = createDialogNodeOptions.digress_in_serialized_name;
       digress_out_serialized_name = createDialogNodeOptions.digress_out_serialized_name;
       digress_out_slots_serialized_name = createDialogNodeOptions.digress_out_slots_serialized_name;
+      this.requestHeaders.putAll(createDialogNodeOptions.requestHeaders());
     }
 
     /**
@@ -1798,6 +1800,7 @@ public class IBMAssistantV1Models {
       metadata_serialized_name = createEntityOptions.metadata_serialized_name;
       values_serialized_name = createEntityOptions.values_serialized_name;
       fuzzy_match_serialized_name = createEntityOptions.fuzzy_match_serialized_name;
+      this.requestHeaders.putAll(createEntityOptions.requestHeaders());
     }
 
     /**
@@ -2068,6 +2071,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = createExampleOptions.workspace_id_serialized_name;
       intent_serialized_name = createExampleOptions.intent_serialized_name;
       text_serialized_name = createExampleOptions.text_serialized_name;
+      this.requestHeaders.putAll(createExampleOptions.requestHeaders());
     }
 
     /**
@@ -2370,6 +2374,7 @@ public class IBMAssistantV1Models {
       intent_serialized_name = createIntentOptions.intent_serialized_name;
       description_serialized_name = createIntentOptions.description_serialized_name;
       examples_serialized_name = createIntentOptions.examples_serialized_name;
+      this.requestHeaders.putAll(createIntentOptions.requestHeaders());
     }
 
     /**
@@ -2556,6 +2561,7 @@ public class IBMAssistantV1Models {
       entity_serialized_name = createSynonymOptions.entity_serialized_name;
       value_serialized_name = createSynonymOptions.value_serialized_name;
       synonym_serialized_name = createSynonymOptions.synonym_serialized_name;
+      this.requestHeaders.putAll(createSynonymOptions.requestHeaders());
     }
 
     /**
@@ -2980,6 +2986,7 @@ public class IBMAssistantV1Models {
       synonyms_serialized_name = createValueOptions.synonyms_serialized_name;
       patterns_serialized_name = createValueOptions.patterns_serialized_name;
       type_serialized_name = createValueOptions.type_serialized_name;
+      this.requestHeaders.putAll(createValueOptions.requestHeaders());
     }
 
     /**
@@ -3283,6 +3290,7 @@ public class IBMAssistantV1Models {
       counterexamples_serialized_name = createWorkspaceOptions.counterexamples_serialized_name;
       metadata_serialized_name = createWorkspaceOptions.metadata_serialized_name;
       learning_opt_out_serialized_name = createWorkspaceOptions.learning_opt_out_serialized_name;
+      this.requestHeaders.putAll(createWorkspaceOptions.requestHeaders());
     }
 
     /**
@@ -3531,6 +3539,7 @@ public class IBMAssistantV1Models {
     private DeleteCounterexampleOptionsBuilder(DeleteCounterexampleOptions deleteCounterexampleOptions) {
       workspace_id_serialized_name = deleteCounterexampleOptions.workspace_id_serialized_name;
       text_serialized_name = deleteCounterexampleOptions.text_serialized_name;
+      this.requestHeaders.putAll(deleteCounterexampleOptions.requestHeaders());
     }
 
     /**
@@ -3649,6 +3658,7 @@ public class IBMAssistantV1Models {
     private DeleteDialogNodeOptionsBuilder(DeleteDialogNodeOptions deleteDialogNodeOptions) {
       workspace_id_serialized_name = deleteDialogNodeOptions.workspace_id_serialized_name;
       dialog_node_serialized_name = deleteDialogNodeOptions.dialog_node_serialized_name;
+      this.requestHeaders.putAll(deleteDialogNodeOptions.requestHeaders());
     }
 
     /**
@@ -3767,6 +3777,7 @@ public class IBMAssistantV1Models {
     private DeleteEntityOptionsBuilder(DeleteEntityOptions deleteEntityOptions) {
       workspace_id_serialized_name = deleteEntityOptions.workspace_id_serialized_name;
       entity_serialized_name = deleteEntityOptions.entity_serialized_name;
+      this.requestHeaders.putAll(deleteEntityOptions.requestHeaders());
     }
 
     /**
@@ -3900,6 +3911,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = deleteExampleOptions.workspace_id_serialized_name;
       intent_serialized_name = deleteExampleOptions.intent_serialized_name;
       text_serialized_name = deleteExampleOptions.text_serialized_name;
+      this.requestHeaders.putAll(deleteExampleOptions.requestHeaders());
     }
 
     /**
@@ -4031,6 +4043,7 @@ public class IBMAssistantV1Models {
     private DeleteIntentOptionsBuilder(DeleteIntentOptions deleteIntentOptions) {
       workspace_id_serialized_name = deleteIntentOptions.workspace_id_serialized_name;
       intent_serialized_name = deleteIntentOptions.intent_serialized_name;
+      this.requestHeaders.putAll(deleteIntentOptions.requestHeaders());
     }
 
     /**
@@ -4179,6 +4192,7 @@ public class IBMAssistantV1Models {
       entity_serialized_name = deleteSynonymOptions.entity_serialized_name;
       value_serialized_name = deleteSynonymOptions.value_serialized_name;
       synonym_serialized_name = deleteSynonymOptions.synonym_serialized_name;
+      this.requestHeaders.putAll(deleteSynonymOptions.requestHeaders());
     }
 
     /**
@@ -4338,6 +4352,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = deleteValueOptions.workspace_id_serialized_name;
       entity_serialized_name = deleteValueOptions.entity_serialized_name;
       value_serialized_name = deleteValueOptions.value_serialized_name;
+      this.requestHeaders.putAll(deleteValueOptions.requestHeaders());
     }
 
     /**
@@ -4454,6 +4469,7 @@ public class IBMAssistantV1Models {
 
     private DeleteWorkspaceOptionsBuilder(DeleteWorkspaceOptions deleteWorkspaceOptions) {
       workspace_id_serialized_name = deleteWorkspaceOptions.workspace_id_serialized_name;
+      this.requestHeaders.putAll(deleteWorkspaceOptions.requestHeaders());
     }
 
     /**
@@ -5858,6 +5874,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = getCounterexampleOptions.workspace_id_serialized_name;
       text_serialized_name = getCounterexampleOptions.text_serialized_name;
       include_audit_serialized_name = getCounterexampleOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getCounterexampleOptions.requestHeaders());
     }
 
     /**
@@ -6001,6 +6018,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = getDialogNodeOptions.workspace_id_serialized_name;
       dialog_node_serialized_name = getDialogNodeOptions.dialog_node_serialized_name;
       include_audit_serialized_name = getDialogNodeOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getDialogNodeOptions.requestHeaders());
     }
 
     /**
@@ -6158,6 +6176,7 @@ public class IBMAssistantV1Models {
       entity_serialized_name = getEntityOptions.entity_serialized_name;
       export_serialized_name = getEntityOptions.export_serialized_name;
       include_audit_serialized_name = getEntityOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getEntityOptions.requestHeaders());
     }
 
     /**
@@ -6327,6 +6346,7 @@ public class IBMAssistantV1Models {
       intent_serialized_name = getExampleOptions.intent_serialized_name;
       text_serialized_name = getExampleOptions.text_serialized_name;
       include_audit_serialized_name = getExampleOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getExampleOptions.requestHeaders());
     }
 
     /**
@@ -6497,6 +6517,7 @@ public class IBMAssistantV1Models {
       intent_serialized_name = getIntentOptions.intent_serialized_name;
       export_serialized_name = getIntentOptions.export_serialized_name;
       include_audit_serialized_name = getIntentOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getIntentOptions.requestHeaders());
     }
 
     /**
@@ -6681,6 +6702,7 @@ public class IBMAssistantV1Models {
       value_serialized_name = getSynonymOptions.value_serialized_name;
       synonym_serialized_name = getSynonymOptions.synonym_serialized_name;
       include_audit_serialized_name = getSynonymOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getSynonymOptions.requestHeaders());
     }
 
     /**
@@ -6879,6 +6901,7 @@ public class IBMAssistantV1Models {
       value_serialized_name = getValueOptions.value_serialized_name;
       export_serialized_name = getValueOptions.export_serialized_name;
       include_audit_serialized_name = getValueOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getValueOptions.requestHeaders());
     }
 
     /**
@@ -7045,6 +7068,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = getWorkspaceOptions.workspace_id_serialized_name;
       export_serialized_name = getWorkspaceOptions.export_serialized_name;
       include_audit_serialized_name = getWorkspaceOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getWorkspaceOptions.requestHeaders());
     }
 
     /**
@@ -7567,6 +7591,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = listAllLogsOptions.sort_serialized_name;
       page_limit_serialized_name = listAllLogsOptions.page_limit_serialized_name;
       cursor_serialized_name = listAllLogsOptions.cursor_serialized_name;
+      this.requestHeaders.putAll(listAllLogsOptions.requestHeaders());
     }
 
     /**
@@ -7760,6 +7785,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = listCounterexamplesOptions.sort_serialized_name;
       cursor_serialized_name = listCounterexamplesOptions.cursor_serialized_name;
       include_audit_serialized_name = listCounterexamplesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listCounterexamplesOptions.requestHeaders());
     }
 
     /**
@@ -7975,6 +8001,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = listDialogNodesOptions.sort_serialized_name;
       cursor_serialized_name = listDialogNodesOptions.cursor_serialized_name;
       include_audit_serialized_name = listDialogNodesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listDialogNodesOptions.requestHeaders());
     }
 
     /**
@@ -8204,6 +8231,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = listEntitiesOptions.sort_serialized_name;
       cursor_serialized_name = listEntitiesOptions.cursor_serialized_name;
       include_audit_serialized_name = listEntitiesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listEntitiesOptions.requestHeaders());
     }
 
     /**
@@ -8445,6 +8473,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = listExamplesOptions.sort_serialized_name;
       cursor_serialized_name = listExamplesOptions.cursor_serialized_name;
       include_audit_serialized_name = listExamplesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listExamplesOptions.requestHeaders());
     }
 
     /**
@@ -8687,6 +8716,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = listIntentsOptions.sort_serialized_name;
       cursor_serialized_name = listIntentsOptions.cursor_serialized_name;
       include_audit_serialized_name = listIntentsOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listIntentsOptions.requestHeaders());
     }
 
     /**
@@ -8899,6 +8929,7 @@ public class IBMAssistantV1Models {
       filter_serialized_name = listLogsOptions.filter_serialized_name;
       page_limit_serialized_name = listLogsOptions.page_limit_serialized_name;
       cursor_serialized_name = listLogsOptions.cursor_serialized_name;
+      this.requestHeaders.putAll(listLogsOptions.requestHeaders());
     }
 
     /**
@@ -9133,6 +9164,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = listSynonymsOptions.sort_serialized_name;
       cursor_serialized_name = listSynonymsOptions.cursor_serialized_name;
       include_audit_serialized_name = listSynonymsOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listSynonymsOptions.requestHeaders());
     }
 
     /**
@@ -9403,6 +9435,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = listValuesOptions.sort_serialized_name;
       cursor_serialized_name = listValuesOptions.cursor_serialized_name;
       include_audit_serialized_name = listValuesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listValuesOptions.requestHeaders());
     }
 
     /**
@@ -9627,6 +9660,7 @@ public class IBMAssistantV1Models {
       sort_serialized_name = listWorkspacesOptions.sort_serialized_name;
       cursor_serialized_name = listWorkspacesOptions.cursor_serialized_name;
       include_audit_serialized_name = listWorkspacesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listWorkspacesOptions.requestHeaders());
     }
 
     /**
@@ -10287,6 +10321,7 @@ public class IBMAssistantV1Models {
       intents_serialized_name = messageOptions.intents_serialized_name;
       output_serialized_name = messageOptions.output_serialized_name;
       nodes_visited_details_serialized_name = messageOptions.nodes_visited_details_serialized_name;
+      this.requestHeaders.putAll(messageOptions.requestHeaders());
     }
 
     /**
@@ -11605,6 +11640,7 @@ public class IBMAssistantV1Models {
       workspace_id_serialized_name = updateCounterexampleOptions.workspace_id_serialized_name;
       text_serialized_name = updateCounterexampleOptions.text_serialized_name;
       new_text_serialized_name = updateCounterexampleOptions.new_text_serialized_name;
+      this.requestHeaders.putAll(updateCounterexampleOptions.requestHeaders());
     }
 
     /**
@@ -11972,6 +12008,7 @@ public class IBMAssistantV1Models {
       new_output_serialized_name = updateDialogNodeOptions.new_output_serialized_name;
       new_parent_serialized_name = updateDialogNodeOptions.new_parent_serialized_name;
       new_dialog_node_serialized_name = updateDialogNodeOptions.new_dialog_node_serialized_name;
+      this.requestHeaders.putAll(updateDialogNodeOptions.requestHeaders());
     }
 
     /**
@@ -12363,6 +12400,7 @@ public class IBMAssistantV1Models {
       new_metadata_serialized_name = updateEntityOptions.new_metadata_serialized_name;
       new_values_serialized_name = updateEntityOptions.new_values_serialized_name;
       new_description_serialized_name = updateEntityOptions.new_description_serialized_name;
+      this.requestHeaders.putAll(updateEntityOptions.requestHeaders());
     }
 
     /**
@@ -12581,6 +12619,7 @@ public class IBMAssistantV1Models {
       intent_serialized_name = updateExampleOptions.intent_serialized_name;
       text_serialized_name = updateExampleOptions.text_serialized_name;
       new_text_serialized_name = updateExampleOptions.new_text_serialized_name;
+      this.requestHeaders.putAll(updateExampleOptions.requestHeaders());
     }
 
     /**
@@ -12765,6 +12804,7 @@ public class IBMAssistantV1Models {
       new_intent_serialized_name = updateIntentOptions.new_intent_serialized_name;
       new_examples_serialized_name = updateIntentOptions.new_examples_serialized_name;
       new_description_serialized_name = updateIntentOptions.new_description_serialized_name;
+      this.requestHeaders.putAll(updateIntentOptions.requestHeaders());
     }
 
     /**
@@ -12976,6 +13016,7 @@ public class IBMAssistantV1Models {
       value_serialized_name = updateSynonymOptions.value_serialized_name;
       synonym_serialized_name = updateSynonymOptions.synonym_serialized_name;
       new_synonym_serialized_name = updateSynonymOptions.new_synonym_serialized_name;
+      this.requestHeaders.putAll(updateSynonymOptions.requestHeaders());
     }
 
     /**
@@ -13216,6 +13257,7 @@ public class IBMAssistantV1Models {
       new_metadata_serialized_name = updateValueOptions.new_metadata_serialized_name;
       new_patterns_serialized_name = updateValueOptions.new_patterns_serialized_name;
       new_value_serialized_name = updateValueOptions.new_value_serialized_name;
+      this.requestHeaders.putAll(updateValueOptions.requestHeaders());
     }
 
     /**
@@ -13559,6 +13601,7 @@ public class IBMAssistantV1Models {
       metadata_serialized_name = updateWorkspaceOptions.metadata_serialized_name;
       learning_opt_out_serialized_name = updateWorkspaceOptions.learning_opt_out_serialized_name;
       append_serialized_name = updateWorkspaceOptions.append_serialized_name;
+      this.requestHeaders.putAll(updateWorkspaceOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMAssistantV1Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Models.cls
@@ -7160,8 +7160,9 @@ public class IBMAssistantV1Models {
       }
 
       InputData ret = (InputData) super.deserialize(jsonString, jsonMap, classType);
+      InputDataBuilder retBuilder = ret.newBuilder();
 
-      return ret;
+      return retBuilder.build();
     }
   }
 

--- a/force-app/main/default/classes/IBMAssistantV1Test.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Test.cls
@@ -220,9 +220,10 @@ private class IBMAssistantV1Test {
       .addentities(createEntity)
       .entities(new List<IBMAssistantV1Models.CreateEntity>{createEntity})
       .language(workspaceLanguage)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
-     createWorkspaceOptions = createWorkspaceOptions.newBuilder().build();
+    createWorkspaceOptions = createWorkspaceOptions.newBuilder().build();
     IBMAssistantV1Models.Workspace response = assistant.createWorkspace(createWorkspaceOptions);
 
     System.assertEquals(response.getName(), workspaceName);
@@ -251,6 +252,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.DeleteWorkspaceOptions deleteOptions = new IBMAssistantV1Models.DeleteWorkspaceOptionsBuilder()
       .workspaceId(workspaceId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -274,6 +276,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.GetWorkspaceOptions getOptions = new IBMAssistantV1Models.GetWorkspaceOptionsBuilder()
       .workspaceId(workspaceId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -312,6 +315,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.UpdateWorkspaceOptions updateOptions = new IBMAssistantV1Models.UpdateWorkspaceOptionsBuilder()
       .workspaceId(workspaceId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -342,6 +346,7 @@ private class IBMAssistantV1Test {
     assistant.setUsernameAndPassword('username', 'password');
 
     IBMAssistantV1Models.ListWorkspacesOptions listOptions = new IBMAssistantV1Models.ListWorkspacesOptionsBuilder()
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -381,6 +386,7 @@ private class IBMAssistantV1Test {
       .metadata(metadata)
       .addPatterns(valuePattern)
       .addSynonyms(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -412,6 +418,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .value(valueName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -438,6 +445,7 @@ private class IBMAssistantV1Test {
       .entity(entityName)
       .value(valueName)
       .exportField(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -472,6 +480,7 @@ private class IBMAssistantV1Test {
       .newMetadata(metadata)
       .addNewPatterns(valuePattern)
       .addNewSynonyms(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -502,6 +511,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.ListValuesOptions listOptions = new IBMAssistantV1Models.ListValuesOptionsBuilder()
       .workspaceId(workspaceId)
       .entity(entityName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -542,6 +552,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .input(input)
       .alternateIntents(alternateIntents)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     messageOptions = messageOptions.newBuilder().build();
@@ -584,6 +595,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .description(intentDescription)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -612,6 +624,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.DeleteIntentOptions deleteOptions = new IBMAssistantV1Models.DeleteIntentOptionsBuilder()
       .workspaceId(workspaceId)
       .intent(intentName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -637,6 +650,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .exportField(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -668,6 +682,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.ListIntentsOptions listOptions = new IBMAssistantV1Models.ListIntentsOptionsBuilder()
       .workspaceId(workspaceId)
       .exportField(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -706,6 +721,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .newDescription(intentDescription)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -735,6 +751,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .text(exampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -763,6 +780,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .text('example A')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -788,6 +806,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .text(exampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -815,6 +834,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.ListExamplesOptions listOptions = new IBMAssistantV1Models.ListExamplesOptionsBuilder()
       .workspaceId(workspaceId)
       .intent(intentName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -848,6 +868,7 @@ private class IBMAssistantV1Test {
       .intent(intentName)
       .text(exampleText)
       .newText(exampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -876,6 +897,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .description(entityDescription)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -906,6 +928,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.DeleteEntityOptions deleteOptions = new IBMAssistantV1Models.DeleteEntityOptionsBuilder()
       .workspaceId(workspaceId)
       .entity(entityName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -931,6 +954,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .exportField(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -967,6 +991,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.ListEntitiesOptions listOptions = new IBMAssistantV1Models.ListEntitiesOptionsBuilder()
       .workspaceId(workspaceId)
       .exportField(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1008,6 +1033,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .newDescription(entityDescription)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1040,6 +1066,7 @@ private class IBMAssistantV1Test {
       .entity(entityName)
       .value(valueName)
       .synonym(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1069,6 +1096,7 @@ private class IBMAssistantV1Test {
       .entity(entityName)
       .value(valueName)
       .synonym(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1095,6 +1123,7 @@ private class IBMAssistantV1Test {
       .entity(entityName)
       .value(valueName)
       .synonym(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1123,6 +1152,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .value(valueName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1157,6 +1187,7 @@ private class IBMAssistantV1Test {
       .value(valueName)
       .synonym(valueSynonym)
       .newSynonym(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1187,6 +1218,7 @@ private class IBMAssistantV1Test {
       .digressIn(dialogNodeDigressIn)
       .digressOut(dialogNodeDigressOut)
       .digressOutSlots(dialogNodeDigressOutSlots)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1236,6 +1268,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.DeleteDialogNodeOptions deleteOptions = new IBMAssistantV1Models.DeleteDialogNodeOptionsBuilder()
       .workspaceId(workspaceId)
       .dialogNode(dialogNodeName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1260,6 +1293,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.GetDialogNodeOptions getOptions = new IBMAssistantV1Models.GetDialogNodeOptionsBuilder()
       .workspaceId(workspaceId)
       .dialogNode(dialogNodeName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1305,6 +1339,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.ListDialogNodesOptions listOptions = new IBMAssistantV1Models.ListDialogNodesOptionsBuilder()
       .workspaceId(workspaceId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1358,6 +1393,7 @@ private class IBMAssistantV1Test {
       .newDigressIn(dialogNodeDigressIn)
       .newDigressOut(dialogNodeDigressOut)
       .newDigressOutSlots(dialogNodeDigressOutSlots)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1404,6 +1440,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.ListLogsOptions listOptions = new IBMAssistantV1Models.ListLogsOptionsBuilder()
       .workspaceId(workspaceId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1451,6 +1488,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.CreateCounterexampleOptions createOptions = new IBMAssistantV1Models.CreateCounterexampleOptionsBuilder()
       .workspaceId(workspaceId)
       .text(counterexampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1476,6 +1514,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.CreateCounterexampleOptions createOptions =
       new IBMAssistantV1Models.CreateCounterexampleOptionsBuilder(workspaceId,counterexampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1503,6 +1542,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.DeleteCounterexampleOptions deleteOptions = new IBMAssistantV1Models.DeleteCounterexampleOptionsBuilder()
       .workspaceId(workspaceId)
       .text(counterexampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1527,6 +1567,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.GetCounterexampleOptions getOptions = new IBMAssistantV1Models.GetCounterexampleOptionsBuilder()
       .workspaceId(workspaceId)
       .text(counterexampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1553,6 +1594,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.ListCounterexamplesOptions listOptions = new IBMAssistantV1Models.ListCounterexamplesOptionsBuilder()
       .workspaceId(workspaceId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1585,6 +1627,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .text(counterexampleText)
       .newText(counterexampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();

--- a/force-app/main/default/classes/IBMAssistantV1Test.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Test.cls
@@ -1409,7 +1409,7 @@ private class IBMAssistantV1Test {
     listOptions = listOptions.newBuilder().build();
     IBMAssistantV1Models.LogCollection response = assistant.listLogs(listOptions);
 
-    System.assertEquals(response.getLogs().get(0).getRequest().getInput().text(), messageInput);
+    System.assertEquals(response.getLogs().get(0).getRequest().getInput().getText(), messageInput);
     System.assertEquals(response.getLogs().get(0).getResponse().getIntents().get(0).getIntent(), intentName);
     System.assertEquals(response.getLogs().get(0).getResponse().getIntents().get(0).getConfidence(), confidence);
     System.assertEquals(response.getLogs().get(0).getResponse().getEntities().get(0).getEntity(), entityName);

--- a/force-app/main/default/classes/IBMConversationV1.cls
+++ b/force-app/main/default/classes/IBMConversationV1.cls
@@ -27,6 +27,20 @@ public class IBMConversationV1 extends IBMWatsonService {
   }
 
   /**
+   * Instantiates a new `IBMConversationV1` with IAM. Note that if the access token is specified in the
+   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
+   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
+   *        calls from failing when the service introduces breaking changes.
+   * @param iamOptions the options for authenticating through IAM
+   */
+  public IBMConversationV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+    this(versionDate);
+    setIamCredentials(iamOptions);
+  }
+  /**
    * Instantiates a new `IBMConversationV1` with username and password.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
@@ -65,6 +79,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.MessageResponse message(IBMConversationV1Models.MessageOptions messageOptions) {
     IBMWatsonValidator.notNull(messageOptions, 'messageOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/message', new String[]{ messageOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (messageOptions != null) ? messageOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (messageOptions.nodesVisitedDetails() != null) {
       builder.query('nodes_visited_details', String.valueOf(messageOptions.nodesVisitedDetails()));
@@ -103,6 +123,12 @@ public class IBMConversationV1 extends IBMWatsonService {
    */
   public IBMConversationV1Models.Workspace createWorkspace(IBMConversationV1Models.CreateWorkspaceOptions createWorkspaceOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/workspaces');
+    Map<String, String> requestHeaders = (createWorkspaceOptions != null) ? createWorkspaceOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (createWorkspaceOptions.name() != null) {
@@ -148,6 +174,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public void deleteWorkspace(IBMConversationV1Models.DeleteWorkspaceOptions deleteWorkspaceOptions) {
     IBMWatsonValidator.notNull(deleteWorkspaceOptions, 'deleteWorkspaceOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}', new String[]{ deleteWorkspaceOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (deleteWorkspaceOptions != null) ? deleteWorkspaceOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -164,6 +196,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.WorkspaceExport getWorkspace(IBMConversationV1Models.GetWorkspaceOptions getWorkspaceOptions) {
     IBMWatsonValidator.notNull(getWorkspaceOptions, 'getWorkspaceOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}', new String[]{ getWorkspaceOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (getWorkspaceOptions != null) ? getWorkspaceOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getWorkspaceOptions.exportField() != null) {
       builder.query('export', String.valueOf(getWorkspaceOptions.exportField()));
@@ -185,6 +223,12 @@ public class IBMConversationV1 extends IBMWatsonService {
    */
   public IBMConversationV1Models.WorkspaceCollection listWorkspaces(IBMConversationV1Models.ListWorkspacesOptions listWorkspacesOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/workspaces');
+    Map<String, String> requestHeaders = (listWorkspacesOptions != null) ? listWorkspacesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listWorkspacesOptions != null && listWorkspacesOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listWorkspacesOptions.pageLimit()));
@@ -216,6 +260,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Workspace updateWorkspace(IBMConversationV1Models.UpdateWorkspaceOptions updateWorkspaceOptions) {
     IBMWatsonValidator.notNull(updateWorkspaceOptions, 'updateWorkspaceOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}', new String[]{ updateWorkspaceOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (updateWorkspaceOptions != null) ? updateWorkspaceOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (updateWorkspaceOptions.append() != null) {
       builder.query('append', String.valueOf(updateWorkspaceOptions.append()));
@@ -264,6 +314,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Intent createIntent(IBMConversationV1Models.CreateIntentOptions createIntentOptions) {
     IBMWatsonValidator.notNull(createIntentOptions, 'createIntentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/intents', new String[]{ createIntentOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (createIntentOptions != null) ? createIntentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('intent', createIntentOptions.intent());
@@ -289,6 +345,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public void deleteIntent(IBMConversationV1Models.DeleteIntentOptions deleteIntentOptions) {
     IBMWatsonValidator.notNull(deleteIntentOptions, 'deleteIntentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}', new String[]{ deleteIntentOptions.workspaceId(), deleteIntentOptions.intent() }));
+    Map<String, String> requestHeaders = (deleteIntentOptions != null) ? deleteIntentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -305,6 +367,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.IntentExport getIntent(IBMConversationV1Models.GetIntentOptions getIntentOptions) {
     IBMWatsonValidator.notNull(getIntentOptions, 'getIntentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}', new String[]{ getIntentOptions.workspaceId(), getIntentOptions.intent() }));
+    Map<String, String> requestHeaders = (getIntentOptions != null) ? getIntentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getIntentOptions.exportField() != null) {
       builder.query('export', String.valueOf(getIntentOptions.exportField()));
@@ -327,6 +395,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.IntentCollection listIntents(IBMConversationV1Models.ListIntentsOptions listIntentsOptions) {
     IBMWatsonValidator.notNull(listIntentsOptions, 'listIntentsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/intents', new String[]{ listIntentsOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listIntentsOptions != null) ? listIntentsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listIntentsOptions.exportField() != null) {
       builder.query('export', String.valueOf(listIntentsOptions.exportField()));
@@ -361,6 +435,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Intent updateIntent(IBMConversationV1Models.UpdateIntentOptions updateIntentOptions) {
     IBMWatsonValidator.notNull(updateIntentOptions, 'updateIntentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}', new String[]{ updateIntentOptions.workspaceId(), updateIntentOptions.intent() }));
+    Map<String, String> requestHeaders = (updateIntentOptions != null) ? updateIntentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateIntentOptions.newIntent() != null) {
@@ -388,6 +468,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Example createExample(IBMConversationV1Models.CreateExampleOptions createExampleOptions) {
     IBMWatsonValidator.notNull(createExampleOptions, 'createExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples', new String[]{ createExampleOptions.workspaceId(), createExampleOptions.intent() }));
+    Map<String, String> requestHeaders = (createExampleOptions != null) ? createExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('text', createExampleOptions.text());
@@ -407,6 +493,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public void deleteExample(IBMConversationV1Models.DeleteExampleOptions deleteExampleOptions) {
     IBMWatsonValidator.notNull(deleteExampleOptions, 'deleteExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples/{2}', new String[]{ deleteExampleOptions.workspaceId(), deleteExampleOptions.intent(), deleteExampleOptions.text() }));
+    Map<String, String> requestHeaders = (deleteExampleOptions != null) ? deleteExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -423,6 +515,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Example getExample(IBMConversationV1Models.GetExampleOptions getExampleOptions) {
     IBMWatsonValidator.notNull(getExampleOptions, 'getExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples/{2}', new String[]{ getExampleOptions.workspaceId(), getExampleOptions.intent(), getExampleOptions.text() }));
+    Map<String, String> requestHeaders = (getExampleOptions != null) ? getExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getExampleOptions.includeAudit() != null) {
       builder.query('include_audit', String.valueOf(getExampleOptions.includeAudit()));
@@ -442,6 +540,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.ExampleCollection listExamples(IBMConversationV1Models.ListExamplesOptions listExamplesOptions) {
     IBMWatsonValidator.notNull(listExamplesOptions, 'listExamplesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples', new String[]{ listExamplesOptions.workspaceId(), listExamplesOptions.intent() }));
+    Map<String, String> requestHeaders = (listExamplesOptions != null) ? listExamplesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listExamplesOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listExamplesOptions.pageLimit()));
@@ -473,6 +577,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Example updateExample(IBMConversationV1Models.UpdateExampleOptions updateExampleOptions) {
     IBMWatsonValidator.notNull(updateExampleOptions, 'updateExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/intents/{1}/examples/{2}', new String[]{ updateExampleOptions.workspaceId(), updateExampleOptions.intent(), updateExampleOptions.text() }));
+    Map<String, String> requestHeaders = (updateExampleOptions != null) ? updateExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateExampleOptions.newText() != null) {
@@ -494,6 +604,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Counterexample createCounterexample(IBMConversationV1Models.CreateCounterexampleOptions createCounterexampleOptions) {
     IBMWatsonValidator.notNull(createCounterexampleOptions, 'createCounterexampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples', new String[]{ createCounterexampleOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (createCounterexampleOptions != null) ? createCounterexampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('text', createCounterexampleOptions.text());
@@ -513,6 +629,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public void deleteCounterexample(IBMConversationV1Models.DeleteCounterexampleOptions deleteCounterexampleOptions) {
     IBMWatsonValidator.notNull(deleteCounterexampleOptions, 'deleteCounterexampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples/{1}', new String[]{ deleteCounterexampleOptions.workspaceId(), deleteCounterexampleOptions.text() }));
+    Map<String, String> requestHeaders = (deleteCounterexampleOptions != null) ? deleteCounterexampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -529,6 +651,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Counterexample getCounterexample(IBMConversationV1Models.GetCounterexampleOptions getCounterexampleOptions) {
     IBMWatsonValidator.notNull(getCounterexampleOptions, 'getCounterexampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples/{1}', new String[]{ getCounterexampleOptions.workspaceId(), getCounterexampleOptions.text() }));
+    Map<String, String> requestHeaders = (getCounterexampleOptions != null) ? getCounterexampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getCounterexampleOptions.includeAudit() != null) {
       builder.query('include_audit', String.valueOf(getCounterexampleOptions.includeAudit()));
@@ -548,6 +676,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.CounterexampleCollection listCounterexamples(IBMConversationV1Models.ListCounterexamplesOptions listCounterexamplesOptions) {
     IBMWatsonValidator.notNull(listCounterexamplesOptions, 'listCounterexamplesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples', new String[]{ listCounterexamplesOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listCounterexamplesOptions != null) ? listCounterexamplesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listCounterexamplesOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listCounterexamplesOptions.pageLimit()));
@@ -579,6 +713,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Counterexample updateCounterexample(IBMConversationV1Models.UpdateCounterexampleOptions updateCounterexampleOptions) {
     IBMWatsonValidator.notNull(updateCounterexampleOptions, 'updateCounterexampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/counterexamples/{1}', new String[]{ updateCounterexampleOptions.workspaceId(), updateCounterexampleOptions.text() }));
+    Map<String, String> requestHeaders = (updateCounterexampleOptions != null) ? updateCounterexampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateCounterexampleOptions.newText() != null) {
@@ -600,6 +740,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Entity createEntity(IBMConversationV1Models.CreateEntityOptions createEntityOptions) {
     IBMWatsonValidator.notNull(createEntityOptions, 'createEntityOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities', new String[]{ createEntityOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (createEntityOptions != null) ? createEntityOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('entity', createEntityOptions.entity());
@@ -631,6 +777,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public void deleteEntity(IBMConversationV1Models.DeleteEntityOptions deleteEntityOptions) {
     IBMWatsonValidator.notNull(deleteEntityOptions, 'deleteEntityOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}', new String[]{ deleteEntityOptions.workspaceId(), deleteEntityOptions.entity() }));
+    Map<String, String> requestHeaders = (deleteEntityOptions != null) ? deleteEntityOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -647,6 +799,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.EntityExport getEntity(IBMConversationV1Models.GetEntityOptions getEntityOptions) {
     IBMWatsonValidator.notNull(getEntityOptions, 'getEntityOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}', new String[]{ getEntityOptions.workspaceId(), getEntityOptions.entity() }));
+    Map<String, String> requestHeaders = (getEntityOptions != null) ? getEntityOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getEntityOptions.exportField() != null) {
       builder.query('export', String.valueOf(getEntityOptions.exportField()));
@@ -669,6 +827,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.EntityCollection listEntities(IBMConversationV1Models.ListEntitiesOptions listEntitiesOptions) {
     IBMWatsonValidator.notNull(listEntitiesOptions, 'listEntitiesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities', new String[]{ listEntitiesOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listEntitiesOptions != null) ? listEntitiesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listEntitiesOptions.exportField() != null) {
       builder.query('export', String.valueOf(listEntitiesOptions.exportField()));
@@ -703,6 +867,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Entity updateEntity(IBMConversationV1Models.UpdateEntityOptions updateEntityOptions) {
     IBMWatsonValidator.notNull(updateEntityOptions, 'updateEntityOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}', new String[]{ updateEntityOptions.workspaceId(), updateEntityOptions.entity() }));
+    Map<String, String> requestHeaders = (updateEntityOptions != null) ? updateEntityOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateEntityOptions.newFuzzyMatch() != null) {
@@ -736,6 +906,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Value createValue(IBMConversationV1Models.CreateValueOptions createValueOptions) {
     IBMWatsonValidator.notNull(createValueOptions, 'createValueOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values', new String[]{ createValueOptions.workspaceId(), createValueOptions.entity() }));
+    Map<String, String> requestHeaders = (createValueOptions != null) ? createValueOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('value', createValueOptions.value());
@@ -767,6 +943,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public void deleteValue(IBMConversationV1Models.DeleteValueOptions deleteValueOptions) {
     IBMWatsonValidator.notNull(deleteValueOptions, 'deleteValueOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}', new String[]{ deleteValueOptions.workspaceId(), deleteValueOptions.entity(), deleteValueOptions.value() }));
+    Map<String, String> requestHeaders = (deleteValueOptions != null) ? deleteValueOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -783,6 +965,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.ValueExport getValue(IBMConversationV1Models.GetValueOptions getValueOptions) {
     IBMWatsonValidator.notNull(getValueOptions, 'getValueOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}', new String[]{ getValueOptions.workspaceId(), getValueOptions.entity(), getValueOptions.value() }));
+    Map<String, String> requestHeaders = (getValueOptions != null) ? getValueOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getValueOptions.exportField() != null) {
       builder.query('export', String.valueOf(getValueOptions.exportField()));
@@ -805,6 +993,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.ValueCollection listValues(IBMConversationV1Models.ListValuesOptions listValuesOptions) {
     IBMWatsonValidator.notNull(listValuesOptions, 'listValuesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values', new String[]{ listValuesOptions.workspaceId(), listValuesOptions.entity() }));
+    Map<String, String> requestHeaders = (listValuesOptions != null) ? listValuesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listValuesOptions.exportField() != null) {
       builder.query('export', String.valueOf(listValuesOptions.exportField()));
@@ -839,6 +1033,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Value updateValue(IBMConversationV1Models.UpdateValueOptions updateValueOptions) {
     IBMWatsonValidator.notNull(updateValueOptions, 'updateValueOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}', new String[]{ updateValueOptions.workspaceId(), updateValueOptions.entity(), updateValueOptions.value() }));
+    Map<String, String> requestHeaders = (updateValueOptions != null) ? updateValueOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateValueOptions.newSynonyms() != null) {
@@ -872,6 +1072,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Synonym createSynonym(IBMConversationV1Models.CreateSynonymOptions createSynonymOptions) {
     IBMWatsonValidator.notNull(createSynonymOptions, 'createSynonymOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms', new String[]{ createSynonymOptions.workspaceId(), createSynonymOptions.entity(), createSynonymOptions.value() }));
+    Map<String, String> requestHeaders = (createSynonymOptions != null) ? createSynonymOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('synonym', createSynonymOptions.synonym());
@@ -891,6 +1097,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public void deleteSynonym(IBMConversationV1Models.DeleteSynonymOptions deleteSynonymOptions) {
     IBMWatsonValidator.notNull(deleteSynonymOptions, 'deleteSynonymOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}', new String[]{ deleteSynonymOptions.workspaceId(), deleteSynonymOptions.entity(), deleteSynonymOptions.value(), deleteSynonymOptions.synonym() }));
+    Map<String, String> requestHeaders = (deleteSynonymOptions != null) ? deleteSynonymOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -907,6 +1119,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Synonym getSynonym(IBMConversationV1Models.GetSynonymOptions getSynonymOptions) {
     IBMWatsonValidator.notNull(getSynonymOptions, 'getSynonymOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}', new String[]{ getSynonymOptions.workspaceId(), getSynonymOptions.entity(), getSynonymOptions.value(), getSynonymOptions.synonym() }));
+    Map<String, String> requestHeaders = (getSynonymOptions != null) ? getSynonymOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getSynonymOptions.includeAudit() != null) {
       builder.query('include_audit', String.valueOf(getSynonymOptions.includeAudit()));
@@ -926,6 +1144,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.SynonymCollection listSynonyms(IBMConversationV1Models.ListSynonymsOptions listSynonymsOptions) {
     IBMWatsonValidator.notNull(listSynonymsOptions, 'listSynonymsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms', new String[]{ listSynonymsOptions.workspaceId(), listSynonymsOptions.entity(), listSynonymsOptions.value() }));
+    Map<String, String> requestHeaders = (listSynonymsOptions != null) ? listSynonymsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listSynonymsOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listSynonymsOptions.pageLimit()));
@@ -957,6 +1181,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.Synonym updateSynonym(IBMConversationV1Models.UpdateSynonymOptions updateSynonymOptions) {
     IBMWatsonValidator.notNull(updateSynonymOptions, 'updateSynonymOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/entities/{1}/values/{2}/synonyms/{3}', new String[]{ updateSynonymOptions.workspaceId(), updateSynonymOptions.entity(), updateSynonymOptions.value(), updateSynonymOptions.synonym() }));
+    Map<String, String> requestHeaders = (updateSynonymOptions != null) ? updateSynonymOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateSynonymOptions.newSynonym() != null) {
@@ -978,6 +1208,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.DialogNode createDialogNode(IBMConversationV1Models.CreateDialogNodeOptions createDialogNodeOptions) {
     IBMWatsonValidator.notNull(createDialogNodeOptions, 'createDialogNodeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes', new String[]{ createDialogNodeOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (createDialogNodeOptions != null) ? createDialogNodeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('dialog_node', createDialogNodeOptions.dialogNode());
@@ -1045,6 +1281,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public void deleteDialogNode(IBMConversationV1Models.DeleteDialogNodeOptions deleteDialogNodeOptions) {
     IBMWatsonValidator.notNull(deleteDialogNodeOptions, 'deleteDialogNodeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes/{1}', new String[]{ deleteDialogNodeOptions.workspaceId(), deleteDialogNodeOptions.dialogNode() }));
+    Map<String, String> requestHeaders = (deleteDialogNodeOptions != null) ? deleteDialogNodeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -1061,6 +1303,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.DialogNode getDialogNode(IBMConversationV1Models.GetDialogNodeOptions getDialogNodeOptions) {
     IBMWatsonValidator.notNull(getDialogNodeOptions, 'getDialogNodeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes/{1}', new String[]{ getDialogNodeOptions.workspaceId(), getDialogNodeOptions.dialogNode() }));
+    Map<String, String> requestHeaders = (getDialogNodeOptions != null) ? getDialogNodeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (getDialogNodeOptions.includeAudit() != null) {
       builder.query('include_audit', String.valueOf(getDialogNodeOptions.includeAudit()));
@@ -1080,6 +1328,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.DialogNodeCollection listDialogNodes(IBMConversationV1Models.ListDialogNodesOptions listDialogNodesOptions) {
     IBMWatsonValidator.notNull(listDialogNodesOptions, 'listDialogNodesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes', new String[]{ listDialogNodesOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listDialogNodesOptions != null) ? listDialogNodesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listDialogNodesOptions.pageLimit() != null) {
       builder.query('page_limit', String.valueOf(listDialogNodesOptions.pageLimit()));
@@ -1111,6 +1365,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.DialogNode updateDialogNode(IBMConversationV1Models.UpdateDialogNodeOptions updateDialogNodeOptions) {
     IBMWatsonValidator.notNull(updateDialogNodeOptions, 'updateDialogNodeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/workspaces/{0}/dialog_nodes/{1}', new String[]{ updateDialogNodeOptions.workspaceId(), updateDialogNodeOptions.dialogNode() }));
+    Map<String, String> requestHeaders = (updateDialogNodeOptions != null) ? updateDialogNodeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateDialogNodeOptions.newType() != null) {
@@ -1180,6 +1440,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.LogCollection listAllLogs(IBMConversationV1Models.ListAllLogsOptions listAllLogsOptions) {
     IBMWatsonValidator.notNull(listAllLogsOptions, 'listAllLogsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/logs');
+    Map<String, String> requestHeaders = (listAllLogsOptions != null) ? listAllLogsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listAllLogsOptions.filter() != null) {
       builder.query('filter', listAllLogsOptions.filter());
@@ -1208,6 +1474,12 @@ public class IBMConversationV1 extends IBMWatsonService {
   public IBMConversationV1Models.LogCollection listLogs(IBMConversationV1Models.ListLogsOptions listLogsOptions) {
     IBMWatsonValidator.notNull(listLogsOptions, 'listLogsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/workspaces/{0}/logs', new String[]{ listLogsOptions.workspaceId() }));
+    Map<String, String> requestHeaders = (listLogsOptions != null) ? listLogsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listLogsOptions.sortField() != null) {
       builder.query('sort', listLogsOptions.sortField());

--- a/force-app/main/default/classes/IBMConversationV1.cls
+++ b/force-app/main/default/classes/IBMConversationV1.cls
@@ -27,20 +27,6 @@ public class IBMConversationV1 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMConversationV1` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
-   *
-   * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
-   *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
-   */
-  public IBMConversationV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
-    this(versionDate);
-    setIamCredentials(iamOptions);
-  }
-  /**
    * Instantiates a new `IBMConversationV1` with username and password.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API

--- a/force-app/main/default/classes/IBMConversationV1Models.cls
+++ b/force-app/main/default/classes/IBMConversationV1Models.cls
@@ -7122,6 +7122,13 @@ public class IBMConversationV1Models {
    */
   public class InputData extends IBMWatsonGenericModel {
     private String text_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public InputData() { }
+
     /**
      * Gets the text_serialized_name.
      *
@@ -7129,7 +7136,8 @@ public class IBMConversationV1Models {
      *
      * @return the text_serialized_name
      */
-    public String text() {
+    @AuraEnabled
+    public String getText() {
       return text_serialized_name;
     }
     private InputData(InputDataBuilder builder) {
@@ -7144,6 +7152,16 @@ public class IBMConversationV1Models {
      */
     public InputDataBuilder newBuilder() {
       return new InputDataBuilder(this);
+    }
+
+    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
+      if (jsonMap == null) {
+        return null;
+      }
+
+      InputData ret = (InputData) super.deserialize(jsonString, jsonMap, classType);
+
+      return ret;
     }
   }
 
@@ -10580,6 +10598,10 @@ public class IBMConversationV1Models {
       }
 
       MessageRequest ret = (MessageRequest) super.deserialize(jsonString, jsonMap, classType);
+
+      // calling custom deserializer for input_serialized_name
+      InputData newInput = (InputData) new InputData().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input_serialized_name'), InputData.class);
+      ret.setInput(newInput);
 
       // calling custom deserializer for context_serialized_name
       Context newContext = (Context) new Context().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context_serialized_name'), Context.class);

--- a/force-app/main/default/classes/IBMConversationV1Models.cls
+++ b/force-app/main/default/classes/IBMConversationV1Models.cls
@@ -139,7 +139,7 @@ public class IBMConversationV1Models {
   /**
    * Counterexample.
    */
-  public class Counterexample extends IBMWatsonGenericModel {
+  public class Counterexample extends IBMWatsonResponseModel {
     private String text_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -200,7 +200,7 @@ public class IBMConversationV1Models {
   /**
    * CounterexampleCollection.
    */
-  public class CounterexampleCollection extends IBMWatsonGenericModel {
+  public class CounterexampleCollection extends IBMWatsonResponseModel {
     private List<Counterexample> counterexamples_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -352,7 +352,7 @@ public class IBMConversationV1Models {
   /**
    * The createCounterexample options.
    */
-  public class CreateCounterexampleOptions {
+  public class CreateCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     /**
@@ -380,6 +380,7 @@ public class IBMConversationV1Models {
       IBMWatsonValidator.notNull(builder.text_serialized_name, 'text_serialized_name cannot be null');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -396,7 +397,7 @@ public class IBMConversationV1Models {
   /**
    * CreateCounterexampleOptions Builder.
    */
-  public class CreateCounterexampleOptionsBuilder {
+  public class CreateCounterexampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
 
@@ -450,6 +451,18 @@ public class IBMConversationV1Models {
      */
     public CreateCounterexampleOptionsBuilder text(String text) {
       this.text_serialized_name = text;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateCounterexampleOptions builder
+     */
+    public CreateCounterexampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -950,7 +963,7 @@ public class IBMConversationV1Models {
   /**
    * The createDialogNode options.
    */
-  public class CreateDialogNodeOptions {
+  public class CreateDialogNodeOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private String description_serialized_name;
@@ -1170,6 +1183,7 @@ public class IBMConversationV1Models {
       digress_in_serialized_name = builder.digress_in_serialized_name;
       digress_out_serialized_name = builder.digress_out_serialized_name;
       digress_out_slots_serialized_name = builder.digress_out_slots_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1186,7 +1200,7 @@ public class IBMConversationV1Models {
   /**
    * CreateDialogNodeOptions Builder.
    */
-  public class CreateDialogNodeOptionsBuilder {
+  public class CreateDialogNodeOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private String description_serialized_name;
@@ -1466,6 +1480,18 @@ public class IBMConversationV1Models {
       this.digress_out_slots_serialized_name = digressOutSlots;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateDialogNodeOptions builder
+     */
+    public CreateDialogNodeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
@@ -1664,7 +1690,7 @@ public class IBMConversationV1Models {
   /**
    * The createEntity options.
    */
-  public class CreateEntityOptions {
+  public class CreateEntityOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String description_serialized_name;
@@ -1740,6 +1766,7 @@ public class IBMConversationV1Models {
       metadata_serialized_name = builder.metadata_serialized_name;
       values_serialized_name = builder.values_serialized_name;
       fuzzy_match_serialized_name = builder.fuzzy_match_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1756,7 +1783,7 @@ public class IBMConversationV1Models {
   /**
    * CreateEntityOptions Builder.
    */
-  public class CreateEntityOptionsBuilder {
+  public class CreateEntityOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String description_serialized_name;
@@ -1880,6 +1907,18 @@ public class IBMConversationV1Models {
       this.fuzzy_match_serialized_name = fuzzyMatch;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateEntityOptions builder
+     */
+    public CreateEntityOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
@@ -1962,7 +2001,7 @@ public class IBMConversationV1Models {
   /**
    * The createExample options.
    */
-  public class CreateExampleOptions {
+  public class CreateExampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -2003,6 +2042,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       intent_serialized_name = builder.intent_serialized_name;
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2019,7 +2059,7 @@ public class IBMConversationV1Models {
   /**
    * CreateExampleOptions Builder.
    */
-  public class CreateExampleOptionsBuilder {
+  public class CreateExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -2088,6 +2128,18 @@ public class IBMConversationV1Models {
      */
     public CreateExampleOptionsBuilder text(String text) {
       this.text_serialized_name = text;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateExampleOptions builder
+     */
+    public CreateExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -2238,7 +2290,7 @@ public class IBMConversationV1Models {
   /**
    * The createIntent options.
    */
-  public class CreateIntentOptions {
+  public class CreateIntentOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String description_serialized_name;
@@ -2290,6 +2342,7 @@ public class IBMConversationV1Models {
       intent_serialized_name = builder.intent_serialized_name;
       description_serialized_name = builder.description_serialized_name;
       examples_serialized_name = builder.examples_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2306,7 +2359,7 @@ public class IBMConversationV1Models {
   /**
    * CreateIntentOptions Builder.
    */
-  public class CreateIntentOptionsBuilder {
+  public class CreateIntentOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String description_serialized_name;
@@ -2404,12 +2457,24 @@ public class IBMConversationV1Models {
       this.examples_serialized_name = examples;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateIntentOptions builder
+     */
+    public CreateIntentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The createSynonym options.
    */
-  public class CreateSynonymOptions {
+  public class CreateSynonymOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -2463,6 +2528,7 @@ public class IBMConversationV1Models {
       entity_serialized_name = builder.entity_serialized_name;
       value_serialized_name = builder.value_serialized_name;
       synonym_serialized_name = builder.synonym_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2479,7 +2545,7 @@ public class IBMConversationV1Models {
   /**
    * CreateSynonymOptions Builder.
    */
-  public class CreateSynonymOptionsBuilder {
+  public class CreateSynonymOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -2563,6 +2629,18 @@ public class IBMConversationV1Models {
      */
     public CreateSynonymOptionsBuilder synonym(String synonym) {
       this.synonym_serialized_name = synonym;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateSynonymOptions builder
+     */
+    public CreateSynonymOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -2779,7 +2857,7 @@ public class IBMConversationV1Models {
   /**
    * The createValue options.
    */
-  public class CreateValueOptions {
+  public class CreateValueOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -2868,6 +2946,7 @@ public class IBMConversationV1Models {
       synonyms_serialized_name = builder.synonyms_serialized_name;
       patterns_serialized_name = builder.patterns_serialized_name;
       type_serialized_name = builder.type_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2884,7 +2963,7 @@ public class IBMConversationV1Models {
   /**
    * CreateValueOptions Builder.
    */
-  public class CreateValueOptionsBuilder {
+  public class CreateValueOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -3039,12 +3118,24 @@ public class IBMConversationV1Models {
       this.type_serialized_name = typeVar;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateValueOptions builder
+     */
+    public CreateValueOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The createWorkspace options.
    */
-  public class CreateWorkspaceOptions {
+  public class CreateWorkspaceOptions extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String description_serialized_name;
     private String language_serialized_name;
@@ -3154,6 +3245,7 @@ public class IBMConversationV1Models {
       counterexamples_serialized_name = builder.counterexamples_serialized_name;
       metadata_serialized_name = builder.metadata_serialized_name;
       learning_opt_out_serialized_name = builder.learning_opt_out_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3170,7 +3262,7 @@ public class IBMConversationV1Models {
   /**
    * CreateWorkspaceOptions Builder.
    */
-  public class CreateWorkspaceOptionsBuilder {
+  public class CreateWorkspaceOptionsBuilder extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String description_serialized_name;
     private String language_serialized_name;
@@ -3370,12 +3462,24 @@ public class IBMConversationV1Models {
       this.learning_opt_out_serialized_name = learningOptOut;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateWorkspaceOptions builder
+     */
+    public CreateWorkspaceOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteCounterexample options.
    */
-  public class DeleteCounterexampleOptions {
+  public class DeleteCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     /**
@@ -3403,6 +3507,7 @@ public class IBMConversationV1Models {
       IBMWatsonValidator.notEmpty(builder.text_serialized_name, 'text_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3419,7 +3524,7 @@ public class IBMConversationV1Models {
   /**
    * DeleteCounterexampleOptions Builder.
    */
-  public class DeleteCounterexampleOptionsBuilder {
+  public class DeleteCounterexampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
 
@@ -3475,12 +3580,24 @@ public class IBMConversationV1Models {
       this.text_serialized_name = text;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteCounterexampleOptions builder
+     */
+    public DeleteCounterexampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteDialogNode options.
    */
-  public class DeleteDialogNodeOptions {
+  public class DeleteDialogNodeOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     /**
@@ -3508,6 +3625,7 @@ public class IBMConversationV1Models {
       IBMWatsonValidator.notEmpty(builder.dialog_node_serialized_name, 'dialog_node_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       dialog_node_serialized_name = builder.dialog_node_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3524,7 +3642,7 @@ public class IBMConversationV1Models {
   /**
    * DeleteDialogNodeOptions Builder.
    */
-  public class DeleteDialogNodeOptionsBuilder {
+  public class DeleteDialogNodeOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
 
@@ -3580,12 +3698,24 @@ public class IBMConversationV1Models {
       this.dialog_node_serialized_name = dialogNode;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteDialogNodeOptions builder
+     */
+    public DeleteDialogNodeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteEntity options.
    */
-  public class DeleteEntityOptions {
+  public class DeleteEntityOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     /**
@@ -3613,6 +3743,7 @@ public class IBMConversationV1Models {
       IBMWatsonValidator.notEmpty(builder.entity_serialized_name, 'entity_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       entity_serialized_name = builder.entity_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3629,7 +3760,7 @@ public class IBMConversationV1Models {
   /**
    * DeleteEntityOptions Builder.
    */
-  public class DeleteEntityOptionsBuilder {
+  public class DeleteEntityOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
 
@@ -3685,12 +3816,24 @@ public class IBMConversationV1Models {
       this.entity_serialized_name = entity;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteEntityOptions builder
+     */
+    public DeleteEntityOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteExample options.
    */
-  public class DeleteExampleOptions {
+  public class DeleteExampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -3731,6 +3874,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       intent_serialized_name = builder.intent_serialized_name;
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3747,7 +3891,7 @@ public class IBMConversationV1Models {
   /**
    * DeleteExampleOptions Builder.
    */
-  public class DeleteExampleOptionsBuilder {
+  public class DeleteExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -3818,12 +3962,24 @@ public class IBMConversationV1Models {
       this.text_serialized_name = text;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteExampleOptions builder
+     */
+    public DeleteExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteIntent options.
    */
-  public class DeleteIntentOptions {
+  public class DeleteIntentOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     /**
@@ -3851,6 +4007,7 @@ public class IBMConversationV1Models {
       IBMWatsonValidator.notEmpty(builder.intent_serialized_name, 'intent_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       intent_serialized_name = builder.intent_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3867,7 +4024,7 @@ public class IBMConversationV1Models {
   /**
    * DeleteIntentOptions Builder.
    */
-  public class DeleteIntentOptionsBuilder {
+  public class DeleteIntentOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
 
@@ -3923,12 +4080,24 @@ public class IBMConversationV1Models {
       this.intent_serialized_name = intent;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteIntentOptions builder
+     */
+    public DeleteIntentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteSynonym options.
    */
-  public class DeleteSynonymOptions {
+  public class DeleteSynonymOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -3982,6 +4151,7 @@ public class IBMConversationV1Models {
       entity_serialized_name = builder.entity_serialized_name;
       value_serialized_name = builder.value_serialized_name;
       synonym_serialized_name = builder.synonym_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3998,7 +4168,7 @@ public class IBMConversationV1Models {
   /**
    * DeleteSynonymOptions Builder.
    */
-  public class DeleteSynonymOptionsBuilder {
+  public class DeleteSynonymOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -4084,12 +4254,24 @@ public class IBMConversationV1Models {
       this.synonym_serialized_name = synonym;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteSynonymOptions builder
+     */
+    public DeleteSynonymOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteValue options.
    */
-  public class DeleteValueOptions {
+  public class DeleteValueOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -4130,6 +4312,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       entity_serialized_name = builder.entity_serialized_name;
       value_serialized_name = builder.value_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4146,7 +4329,7 @@ public class IBMConversationV1Models {
   /**
    * DeleteValueOptions Builder.
    */
-  public class DeleteValueOptionsBuilder {
+  public class DeleteValueOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -4217,12 +4400,24 @@ public class IBMConversationV1Models {
       this.value_serialized_name = value;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteValueOptions builder
+     */
+    public DeleteValueOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteWorkspace options.
    */
-  public class DeleteWorkspaceOptions {
+  public class DeleteWorkspaceOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     /**
      * Gets the workspace_id_serialized_name.
@@ -4237,6 +4432,7 @@ public class IBMConversationV1Models {
     private DeleteWorkspaceOptions(DeleteWorkspaceOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.workspace_id_serialized_name, 'workspace_id_serialized_name cannot be empty');
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4253,7 +4449,7 @@ public class IBMConversationV1Models {
   /**
    * DeleteWorkspaceOptions Builder.
    */
-  public class DeleteWorkspaceOptionsBuilder {
+  public class DeleteWorkspaceOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
 
     private DeleteWorkspaceOptionsBuilder(DeleteWorkspaceOptions deleteWorkspaceOptions) {
@@ -4294,12 +4490,24 @@ public class IBMConversationV1Models {
       this.workspace_id_serialized_name = workspaceId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteWorkspaceOptions builder
+     */
+    public DeleteWorkspaceOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * DialogNode.
    */
-  public class DialogNode extends IBMWatsonGenericModel {
+  public class DialogNode extends IBMWatsonResponseModel {
     private String dialog_node_serialized_name;
     private String description_serialized_name;
     private String conditions_serialized_name;
@@ -4850,7 +5058,7 @@ public class IBMConversationV1Models {
   /**
    * An array of dialog nodes.
    */
-  public class DialogNodeCollection extends IBMWatsonGenericModel {
+  public class DialogNodeCollection extends IBMWatsonResponseModel {
     private List<DialogNode> dialog_nodes_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -5083,7 +5291,7 @@ public class IBMConversationV1Models {
   /**
    * Entity.
    */
-  public class Entity extends IBMWatsonGenericModel {
+  public class Entity extends IBMWatsonResponseModel {
     private String entity_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -5211,7 +5419,7 @@ public class IBMConversationV1Models {
   /**
    * An array of entities.
    */
-  public class EntityCollection extends IBMWatsonGenericModel {
+  public class EntityCollection extends IBMWatsonResponseModel {
     private List<EntityExport> entities_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -5286,7 +5494,7 @@ public class IBMConversationV1Models {
   /**
    * EntityExport.
    */
-  public class EntityExport extends IBMWatsonGenericModel {
+  public class EntityExport extends IBMWatsonResponseModel {
     private String entity_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -5448,7 +5656,7 @@ public class IBMConversationV1Models {
   /**
    * Example.
    */
-  public class Example extends IBMWatsonGenericModel {
+  public class Example extends IBMWatsonResponseModel {
     private String text_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -5509,7 +5717,7 @@ public class IBMConversationV1Models {
   /**
    * ExampleCollection.
    */
-  public class ExampleCollection extends IBMWatsonGenericModel {
+  public class ExampleCollection extends IBMWatsonResponseModel {
     private List<Example> examples_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -5584,7 +5792,7 @@ public class IBMConversationV1Models {
   /**
    * The getCounterexample options.
    */
-  public class GetCounterexampleOptions {
+  public class GetCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -5624,6 +5832,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       text_serialized_name = builder.text_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5640,7 +5849,7 @@ public class IBMConversationV1Models {
   /**
    * GetCounterexampleOptions Builder.
    */
-  public class GetCounterexampleOptionsBuilder {
+  public class GetCounterexampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -5709,12 +5918,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetCounterexampleOptions builder
+     */
+    public GetCounterexampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getDialogNode options.
    */
-  public class GetDialogNodeOptions {
+  public class GetDialogNodeOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -5754,6 +5975,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       dialog_node_serialized_name = builder.dialog_node_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5770,7 +5992,7 @@ public class IBMConversationV1Models {
   /**
    * GetDialogNodeOptions Builder.
    */
-  public class GetDialogNodeOptionsBuilder {
+  public class GetDialogNodeOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -5839,12 +6061,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetDialogNodeOptions builder
+     */
+    public GetDialogNodeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getEntity options.
    */
-  public class GetEntityOptions {
+  public class GetEntityOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean export_serialized_name;
@@ -5896,6 +6130,7 @@ public class IBMConversationV1Models {
       entity_serialized_name = builder.entity_serialized_name;
       export_serialized_name = builder.export_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5912,7 +6147,7 @@ public class IBMConversationV1Models {
   /**
    * GetEntityOptions Builder.
    */
-  public class GetEntityOptionsBuilder {
+  public class GetEntityOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean export_serialized_name;
@@ -5994,12 +6229,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetEntityOptions builder
+     */
+    public GetEntityOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getExample options.
    */
-  public class GetExampleOptions {
+  public class GetExampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -6052,6 +6299,7 @@ public class IBMConversationV1Models {
       intent_serialized_name = builder.intent_serialized_name;
       text_serialized_name = builder.text_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6068,7 +6316,7 @@ public class IBMConversationV1Models {
   /**
    * GetExampleOptions Builder.
    */
-  public class GetExampleOptionsBuilder {
+  public class GetExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -6152,12 +6400,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetExampleOptions builder
+     */
+    public GetExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getIntent options.
    */
-  public class GetIntentOptions {
+  public class GetIntentOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private Boolean export_serialized_name;
@@ -6209,6 +6469,7 @@ public class IBMConversationV1Models {
       intent_serialized_name = builder.intent_serialized_name;
       export_serialized_name = builder.export_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6225,7 +6486,7 @@ public class IBMConversationV1Models {
   /**
    * GetIntentOptions Builder.
    */
-  public class GetIntentOptionsBuilder {
+  public class GetIntentOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private Boolean export_serialized_name;
@@ -6307,12 +6568,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetIntentOptions builder
+     */
+    public GetIntentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getSynonym options.
    */
-  public class GetSynonymOptions {
+  public class GetSynonymOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -6378,6 +6651,7 @@ public class IBMConversationV1Models {
       value_serialized_name = builder.value_serialized_name;
       synonym_serialized_name = builder.synonym_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6394,7 +6668,7 @@ public class IBMConversationV1Models {
   /**
    * GetSynonymOptions Builder.
    */
-  public class GetSynonymOptionsBuilder {
+  public class GetSynonymOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -6493,12 +6767,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetSynonymOptions builder
+     */
+    public GetSynonymOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getValue options.
    */
-  public class GetValueOptions {
+  public class GetValueOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -6563,6 +6849,7 @@ public class IBMConversationV1Models {
       value_serialized_name = builder.value_serialized_name;
       export_serialized_name = builder.export_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6579,7 +6866,7 @@ public class IBMConversationV1Models {
   /**
    * GetValueOptions Builder.
    */
-  public class GetValueOptionsBuilder {
+  public class GetValueOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -6676,12 +6963,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetValueOptions builder
+     */
+    public GetValueOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getWorkspace options.
    */
-  public class GetWorkspaceOptions {
+  public class GetWorkspaceOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -6720,6 +7019,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       export_serialized_name = builder.export_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6736,7 +7036,7 @@ public class IBMConversationV1Models {
   /**
    * GetWorkspaceOptions Builder.
    */
-  public class GetWorkspaceOptionsBuilder {
+  public class GetWorkspaceOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Boolean include_audit_serialized_name;
@@ -6803,12 +7103,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetWorkspaceOptions builder
+     */
+    public GetWorkspaceOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The user input.
    */
-  public class InputData {
+  public class InputData extends IBMWatsonGenericModel {
     private String text_serialized_name;
     /**
      * Gets the text_serialized_name.
@@ -6833,7 +7145,6 @@ public class IBMConversationV1Models {
     public InputDataBuilder newBuilder() {
       return new InputDataBuilder(this);
     }
-
   }
 
   /**
@@ -6885,7 +7196,7 @@ public class IBMConversationV1Models {
   /**
    * Intent.
    */
-  public class Intent extends IBMWatsonGenericModel {
+  public class Intent extends IBMWatsonResponseModel {
     private String intent_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -6967,7 +7278,7 @@ public class IBMConversationV1Models {
   /**
    * IntentCollection.
    */
-  public class IntentCollection extends IBMWatsonGenericModel {
+  public class IntentCollection extends IBMWatsonResponseModel {
     private List<IntentExport> intents_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -7042,7 +7353,7 @@ public class IBMConversationV1Models {
   /**
    * IntentExport.
    */
-  public class IntentExport extends IBMWatsonGenericModel {
+  public class IntentExport extends IBMWatsonResponseModel {
     private String intent_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -7158,7 +7469,7 @@ public class IBMConversationV1Models {
   /**
    * The listAllLogs options.
    */
-  public class ListAllLogsOptions {
+  public class ListAllLogsOptions extends IBMWatsonOptionsModel {
     private String filter_serialized_name;
     private String sort_serialized_name;
     private Long page_limit_serialized_name;
@@ -7209,6 +7520,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       page_limit_serialized_name = builder.page_limit_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7225,7 +7537,7 @@ public class IBMConversationV1Models {
   /**
    * ListAllLogsOptions Builder.
    */
-  public class ListAllLogsOptionsBuilder {
+  public class ListAllLogsOptionsBuilder extends IBMWatsonOptionsModel {
     private String filter_serialized_name;
     private String sort_serialized_name;
     private Long page_limit_serialized_name;
@@ -7305,12 +7617,24 @@ public class IBMConversationV1Models {
       this.cursor_serialized_name = cursor;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListAllLogsOptions builder
+     */
+    public ListAllLogsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listCounterexamples options.
    */
-  public class ListCounterexamplesOptions {
+  public class ListCounterexamplesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
@@ -7385,6 +7709,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7401,7 +7726,7 @@ public class IBMConversationV1Models {
   /**
    * ListCounterexamplesOptions Builder.
    */
-  public class ListCounterexamplesOptionsBuilder {
+  public class ListCounterexamplesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
@@ -7507,12 +7832,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListCounterexamplesOptions builder
+     */
+    public ListCounterexamplesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listDialogNodes options.
    */
-  public class ListDialogNodesOptions {
+  public class ListDialogNodesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
@@ -7587,6 +7924,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7603,7 +7941,7 @@ public class IBMConversationV1Models {
   /**
    * ListDialogNodesOptions Builder.
    */
-  public class ListDialogNodesOptionsBuilder {
+  public class ListDialogNodesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
@@ -7709,12 +8047,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListDialogNodesOptions builder
+     */
+    public ListDialogNodesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listEntities options.
    */
-  public class ListEntitiesOptions {
+  public class ListEntitiesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Long page_limit_serialized_name;
@@ -7801,6 +8151,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7817,7 +8168,7 @@ public class IBMConversationV1Models {
   /**
    * ListEntitiesOptions Builder.
    */
-  public class ListEntitiesOptionsBuilder {
+  public class ListEntitiesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Long page_limit_serialized_name;
@@ -7936,12 +8287,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListEntitiesOptions builder
+     */
+    public ListEntitiesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listExamples options.
    */
-  public class ListExamplesOptions {
+  public class ListExamplesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private Long page_limit_serialized_name;
@@ -8029,6 +8392,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8045,7 +8409,7 @@ public class IBMConversationV1Models {
   /**
    * ListExamplesOptions Builder.
    */
-  public class ListExamplesOptionsBuilder {
+  public class ListExamplesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private Long page_limit_serialized_name;
@@ -8166,12 +8530,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListExamplesOptions builder
+     */
+    public ListExamplesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listIntents options.
    */
-  public class ListIntentsOptions {
+  public class ListIntentsOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Long page_limit_serialized_name;
@@ -8258,6 +8634,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8274,7 +8651,7 @@ public class IBMConversationV1Models {
   /**
    * ListIntentsOptions Builder.
    */
-  public class ListIntentsOptionsBuilder {
+  public class ListIntentsOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private Boolean export_serialized_name;
     private Long page_limit_serialized_name;
@@ -8393,12 +8770,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListIntentsOptions builder
+     */
+    public ListIntentsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listLogs options.
    */
-  public class ListLogsOptions {
+  public class ListLogsOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String sort_serialized_name;
     private String filter_serialized_name;
@@ -8461,6 +8850,7 @@ public class IBMConversationV1Models {
       filter_serialized_name = builder.filter_serialized_name;
       page_limit_serialized_name = builder.page_limit_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8477,7 +8867,7 @@ public class IBMConversationV1Models {
   /**
    * ListLogsOptions Builder.
    */
-  public class ListLogsOptionsBuilder {
+  public class ListLogsOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String sort_serialized_name;
     private String filter_serialized_name;
@@ -8570,12 +8960,24 @@ public class IBMConversationV1Models {
       this.cursor_serialized_name = cursor;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListLogsOptions builder
+     */
+    public ListLogsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listSynonyms options.
    */
-  public class ListSynonymsOptions {
+  public class ListSynonymsOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -8676,6 +9078,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8692,7 +9095,7 @@ public class IBMConversationV1Models {
   /**
    * ListSynonymsOptions Builder.
    */
-  public class ListSynonymsOptionsBuilder {
+  public class ListSynonymsOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -8828,12 +9231,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListSynonymsOptions builder
+     */
+    public ListSynonymsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listValues options.
    */
-  public class ListValuesOptions {
+  public class ListValuesOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean export_serialized_name;
@@ -8933,6 +9348,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8949,7 +9365,7 @@ public class IBMConversationV1Models {
   /**
    * ListValuesOptions Builder.
    */
-  public class ListValuesOptionsBuilder {
+  public class ListValuesOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean export_serialized_name;
@@ -9083,12 +9499,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListValuesOptions builder
+     */
+    public ListValuesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listWorkspaces options.
    */
-  public class ListWorkspacesOptions {
+  public class ListWorkspacesOptions extends IBMWatsonOptionsModel {
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
     private String sort_serialized_name;
@@ -9150,6 +9578,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = builder.sort_serialized_name;
       cursor_serialized_name = builder.cursor_serialized_name;
       include_audit_serialized_name = builder.include_audit_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -9166,7 +9595,7 @@ public class IBMConversationV1Models {
   /**
    * ListWorkspacesOptions Builder.
    */
-  public class ListWorkspacesOptionsBuilder {
+  public class ListWorkspacesOptionsBuilder extends IBMWatsonOptionsModel {
     private Long page_limit_serialized_name;
     private Boolean include_count_serialized_name;
     private String sort_serialized_name;
@@ -9250,12 +9679,24 @@ public class IBMConversationV1Models {
       this.include_audit_serialized_name = includeAudit;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListWorkspacesOptions builder
+     */
+    public ListWorkspacesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * LogCollection.
    */
-  public class LogCollection extends IBMWatsonGenericModel {
+  public class LogCollection extends IBMWatsonResponseModel {
     private List<LogExport> logs_serialized_name;
     private LogPagination pagination_serialized_name;
     /**
@@ -9692,7 +10133,7 @@ public class IBMConversationV1Models {
   /**
    * The message options.
    */
-  public class MessageOptions {
+  public class MessageOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private InputData input_serialized_name;
     private Boolean alternate_intents_serialized_name;
@@ -9791,6 +10232,7 @@ public class IBMConversationV1Models {
       intents_serialized_name = builder.intents_serialized_name;
       output_serialized_name = builder.output_serialized_name;
       nodes_visited_details_serialized_name = builder.nodes_visited_details_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -9807,7 +10249,7 @@ public class IBMConversationV1Models {
   /**
    * MessageOptions Builder.
    */
-  public class MessageOptionsBuilder {
+  public class MessageOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private InputData input_serialized_name;
     private Boolean alternate_intents_serialized_name;
@@ -9985,6 +10427,18 @@ public class IBMConversationV1Models {
       this.entities_serialized_name = messageRequest.getEntities();
       this.intents_serialized_name = messageRequest.getIntents();
       this.output_serialized_name = messageRequest.getOutput();
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the MessageOptions builder
+     */
+    public MessageOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -10168,7 +10622,7 @@ public class IBMConversationV1Models {
   /**
    * A response from the Conversation service.
    */
-  public class MessageResponse extends IBMWatsonDynamicModel {
+  public class MessageResponse extends IBMWatsonDynamicResponseModel {
     private MessageInput input_serialized_name;
     private List<RuntimeIntent> intents_serialized_name;
     private List<RuntimeEntity> entities_serialized_name;
@@ -10891,7 +11345,7 @@ public class IBMConversationV1Models {
   /**
    * Synonym.
    */
-  public class Synonym extends IBMWatsonGenericModel {
+  public class Synonym extends IBMWatsonResponseModel {
     private String synonym_serialized_name;
     private Datetime created_serialized_name;
     private Datetime updated_serialized_name;
@@ -10952,7 +11406,7 @@ public class IBMConversationV1Models {
   /**
    * SynonymCollection.
    */
-  public class SynonymCollection extends IBMWatsonGenericModel {
+  public class SynonymCollection extends IBMWatsonResponseModel {
     private List<Synonym> synonyms_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -11062,7 +11516,7 @@ public class IBMConversationV1Models {
   /**
    * The updateCounterexample options.
    */
-  public class UpdateCounterexampleOptions {
+  public class UpdateCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     private String new_text_serialized_name;
@@ -11102,6 +11556,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = builder.workspace_id_serialized_name;
       text_serialized_name = builder.text_serialized_name;
       new_text_serialized_name = builder.new_text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -11118,7 +11573,7 @@ public class IBMConversationV1Models {
   /**
    * UpdateCounterexampleOptions Builder.
    */
-  public class UpdateCounterexampleOptionsBuilder {
+  public class UpdateCounterexampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String text_serialized_name;
     private String new_text_serialized_name;
@@ -11187,12 +11642,24 @@ public class IBMConversationV1Models {
       this.new_text_serialized_name = newText;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateCounterexampleOptions builder
+     */
+    public UpdateCounterexampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The UpdateDialogNode options.
    */
-  public class UpdateDialogNodeOptions {
+  public class UpdateDialogNodeOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private String new_type_serialized_name;
@@ -11424,6 +11891,7 @@ public class IBMConversationV1Models {
       new_output_serialized_name = builder.new_output_serialized_name;
       new_parent_serialized_name = builder.new_parent_serialized_name;
       new_dialog_node_serialized_name = builder.new_dialog_node_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -11440,7 +11908,7 @@ public class IBMConversationV1Models {
   /**
    * UpdateDialogNodeOptions Builder.
    */
-  public class UpdateDialogNodeOptionsBuilder {
+  public class UpdateDialogNodeOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String dialog_node_serialized_name;
     private String new_type_serialized_name;
@@ -11733,12 +12201,24 @@ public class IBMConversationV1Models {
       this.new_dialog_node_serialized_name = newDialogNode;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateDialogNodeOptions builder
+     */
+    public UpdateDialogNodeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateEntity options.
    */
-  public class UpdateEntityOptions {
+  public class UpdateEntityOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean new_fuzzy_match_serialized_name;
@@ -11826,6 +12306,7 @@ public class IBMConversationV1Models {
       new_metadata_serialized_name = builder.new_metadata_serialized_name;
       new_values_serialized_name = builder.new_values_serialized_name;
       new_description_serialized_name = builder.new_description_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -11842,7 +12323,7 @@ public class IBMConversationV1Models {
   /**
    * UpdateEntityOptions Builder.
    */
-  public class UpdateEntityOptionsBuilder {
+  public class UpdateEntityOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private Boolean new_fuzzy_match_serialized_name;
@@ -11979,12 +12460,24 @@ public class IBMConversationV1Models {
       this.new_description_serialized_name = newDescription;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateEntityOptions builder
+     */
+    public UpdateEntityOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateExample options.
    */
-  public class UpdateExampleOptions {
+  public class UpdateExampleOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -12037,6 +12530,7 @@ public class IBMConversationV1Models {
       intent_serialized_name = builder.intent_serialized_name;
       text_serialized_name = builder.text_serialized_name;
       new_text_serialized_name = builder.new_text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12053,7 +12547,7 @@ public class IBMConversationV1Models {
   /**
    * UpdateExampleOptions Builder.
    */
-  public class UpdateExampleOptionsBuilder {
+  public class UpdateExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String text_serialized_name;
@@ -12137,12 +12631,24 @@ public class IBMConversationV1Models {
       this.new_text_serialized_name = newText;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateExampleOptions builder
+     */
+    public UpdateExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateIntent options.
    */
-  public class UpdateIntentOptions {
+  public class UpdateIntentOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String new_intent_serialized_name;
@@ -12206,6 +12712,7 @@ public class IBMConversationV1Models {
       new_intent_serialized_name = builder.new_intent_serialized_name;
       new_examples_serialized_name = builder.new_examples_serialized_name;
       new_description_serialized_name = builder.new_description_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12222,7 +12729,7 @@ public class IBMConversationV1Models {
   /**
    * UpdateIntentOptions Builder.
    */
-  public class UpdateIntentOptionsBuilder {
+  public class UpdateIntentOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String intent_serialized_name;
     private String new_intent_serialized_name;
@@ -12333,12 +12840,24 @@ public class IBMConversationV1Models {
       this.new_description_serialized_name = newDescription;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateIntentOptions builder
+     */
+    public UpdateIntentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateSynonym options.
    */
-  public class UpdateSynonymOptions {
+  public class UpdateSynonymOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -12404,6 +12923,7 @@ public class IBMConversationV1Models {
       value_serialized_name = builder.value_serialized_name;
       synonym_serialized_name = builder.synonym_serialized_name;
       new_synonym_serialized_name = builder.new_synonym_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12420,7 +12940,7 @@ public class IBMConversationV1Models {
   /**
    * UpdateSynonymOptions Builder.
    */
-  public class UpdateSynonymOptionsBuilder {
+  public class UpdateSynonymOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -12519,12 +13039,24 @@ public class IBMConversationV1Models {
       this.new_synonym_serialized_name = newSynonym;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateSynonymOptions builder
+     */
+    public UpdateSynonymOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateValue options.
    */
-  public class UpdateValueOptions {
+  public class UpdateValueOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -12625,6 +13157,7 @@ public class IBMConversationV1Models {
       new_metadata_serialized_name = builder.new_metadata_serialized_name;
       new_patterns_serialized_name = builder.new_patterns_serialized_name;
       new_value_serialized_name = builder.new_value_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12641,7 +13174,7 @@ public class IBMConversationV1Models {
   /**
    * UpdateValueOptions Builder.
    */
-  public class UpdateValueOptionsBuilder {
+  public class UpdateValueOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String entity_serialized_name;
     private String value_serialized_name;
@@ -12809,12 +13342,24 @@ public class IBMConversationV1Models {
       this.new_value_serialized_name = newValue;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateValueOptions builder
+     */
+    public UpdateValueOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateWorkspace options.
    */
-  public class UpdateWorkspaceOptions {
+  public class UpdateWorkspaceOptions extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -12949,6 +13494,7 @@ public class IBMConversationV1Models {
       metadata_serialized_name = builder.metadata_serialized_name;
       learning_opt_out_serialized_name = builder.learning_opt_out_serialized_name;
       append_serialized_name = builder.append_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12965,7 +13511,7 @@ public class IBMConversationV1Models {
   /**
    * UpdateWorkspaceOptions Builder.
    */
-  public class UpdateWorkspaceOptionsBuilder {
+  public class UpdateWorkspaceOptionsBuilder extends IBMWatsonOptionsModel {
     private String workspace_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -13200,12 +13746,24 @@ public class IBMConversationV1Models {
       this.append_serialized_name = append;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateWorkspaceOptions builder
+     */
+    public UpdateWorkspaceOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * Value.
    */
-  public class Value extends IBMWatsonGenericModel {
+  public class Value extends IBMWatsonResponseModel {
     private String value_serialized_name;
     private IBMWatsonMapModel metadata_serialized_name;
     private Datetime created_serialized_name;
@@ -13354,7 +13912,7 @@ public class IBMConversationV1Models {
   /**
    * ValueCollection.
    */
-  public class ValueCollection extends IBMWatsonGenericModel {
+  public class ValueCollection extends IBMWatsonResponseModel {
     private List<ValueExport> values_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -13429,7 +13987,7 @@ public class IBMConversationV1Models {
   /**
    * ValueExport.
    */
-  public class ValueExport extends IBMWatsonGenericModel {
+  public class ValueExport extends IBMWatsonResponseModel {
     private String value_serialized_name;
     private IBMWatsonMapModel metadata_serialized_name;
     private Datetime created_serialized_name;
@@ -13578,7 +14136,7 @@ public class IBMConversationV1Models {
   /**
    * Workspace.
    */
-  public class Workspace extends IBMWatsonGenericModel {
+  public class Workspace extends IBMWatsonResponseModel {
     private String name_serialized_name;
     private String language_serialized_name;
     private Datetime created_serialized_name;
@@ -13739,7 +14297,7 @@ public class IBMConversationV1Models {
   /**
    * WorkspaceCollection.
    */
-  public class WorkspaceCollection extends IBMWatsonGenericModel {
+  public class WorkspaceCollection extends IBMWatsonResponseModel {
     private List<Workspace> workspaces_serialized_name;
     private Pagination pagination_serialized_name;
     /**
@@ -13814,7 +14372,7 @@ public class IBMConversationV1Models {
   /**
    * WorkspaceExport.
    */
-  public class WorkspaceExport extends IBMWatsonGenericModel {
+  public class WorkspaceExport extends IBMWatsonResponseModel {
     private String name_serialized_name;
     private String description_serialized_name;
     private String language_serialized_name;

--- a/force-app/main/default/classes/IBMConversationV1Models.cls
+++ b/force-app/main/default/classes/IBMConversationV1Models.cls
@@ -404,6 +404,7 @@ public class IBMConversationV1Models {
     private CreateCounterexampleOptionsBuilder(CreateCounterexampleOptions createCounterexampleOptions) {
       workspace_id_serialized_name = createCounterexampleOptions.workspace_id_serialized_name;
       text_serialized_name = createCounterexampleOptions.text_serialized_name;
+      this.requestHeaders.putAll(createCounterexampleOptions.requestHeaders());
     }
 
     /**
@@ -1239,6 +1240,7 @@ public class IBMConversationV1Models {
       digress_in_serialized_name = createDialogNodeOptions.digress_in_serialized_name;
       digress_out_serialized_name = createDialogNodeOptions.digress_out_serialized_name;
       digress_out_slots_serialized_name = createDialogNodeOptions.digress_out_slots_serialized_name;
+      this.requestHeaders.putAll(createDialogNodeOptions.requestHeaders());
     }
 
     /**
@@ -1798,6 +1800,7 @@ public class IBMConversationV1Models {
       metadata_serialized_name = createEntityOptions.metadata_serialized_name;
       values_serialized_name = createEntityOptions.values_serialized_name;
       fuzzy_match_serialized_name = createEntityOptions.fuzzy_match_serialized_name;
+      this.requestHeaders.putAll(createEntityOptions.requestHeaders());
     }
 
     /**
@@ -2068,6 +2071,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = createExampleOptions.workspace_id_serialized_name;
       intent_serialized_name = createExampleOptions.intent_serialized_name;
       text_serialized_name = createExampleOptions.text_serialized_name;
+      this.requestHeaders.putAll(createExampleOptions.requestHeaders());
     }
 
     /**
@@ -2370,6 +2374,7 @@ public class IBMConversationV1Models {
       intent_serialized_name = createIntentOptions.intent_serialized_name;
       description_serialized_name = createIntentOptions.description_serialized_name;
       examples_serialized_name = createIntentOptions.examples_serialized_name;
+      this.requestHeaders.putAll(createIntentOptions.requestHeaders());
     }
 
     /**
@@ -2556,6 +2561,7 @@ public class IBMConversationV1Models {
       entity_serialized_name = createSynonymOptions.entity_serialized_name;
       value_serialized_name = createSynonymOptions.value_serialized_name;
       synonym_serialized_name = createSynonymOptions.synonym_serialized_name;
+      this.requestHeaders.putAll(createSynonymOptions.requestHeaders());
     }
 
     /**
@@ -2980,6 +2986,7 @@ public class IBMConversationV1Models {
       synonyms_serialized_name = createValueOptions.synonyms_serialized_name;
       patterns_serialized_name = createValueOptions.patterns_serialized_name;
       type_serialized_name = createValueOptions.type_serialized_name;
+      this.requestHeaders.putAll(createValueOptions.requestHeaders());
     }
 
     /**
@@ -3283,6 +3290,7 @@ public class IBMConversationV1Models {
       counterexamples_serialized_name = createWorkspaceOptions.counterexamples_serialized_name;
       metadata_serialized_name = createWorkspaceOptions.metadata_serialized_name;
       learning_opt_out_serialized_name = createWorkspaceOptions.learning_opt_out_serialized_name;
+      this.requestHeaders.putAll(createWorkspaceOptions.requestHeaders());
     }
 
     /**
@@ -3531,6 +3539,7 @@ public class IBMConversationV1Models {
     private DeleteCounterexampleOptionsBuilder(DeleteCounterexampleOptions deleteCounterexampleOptions) {
       workspace_id_serialized_name = deleteCounterexampleOptions.workspace_id_serialized_name;
       text_serialized_name = deleteCounterexampleOptions.text_serialized_name;
+      this.requestHeaders.putAll(deleteCounterexampleOptions.requestHeaders());
     }
 
     /**
@@ -3649,6 +3658,7 @@ public class IBMConversationV1Models {
     private DeleteDialogNodeOptionsBuilder(DeleteDialogNodeOptions deleteDialogNodeOptions) {
       workspace_id_serialized_name = deleteDialogNodeOptions.workspace_id_serialized_name;
       dialog_node_serialized_name = deleteDialogNodeOptions.dialog_node_serialized_name;
+      this.requestHeaders.putAll(deleteDialogNodeOptions.requestHeaders());
     }
 
     /**
@@ -3767,6 +3777,7 @@ public class IBMConversationV1Models {
     private DeleteEntityOptionsBuilder(DeleteEntityOptions deleteEntityOptions) {
       workspace_id_serialized_name = deleteEntityOptions.workspace_id_serialized_name;
       entity_serialized_name = deleteEntityOptions.entity_serialized_name;
+      this.requestHeaders.putAll(deleteEntityOptions.requestHeaders());
     }
 
     /**
@@ -3900,6 +3911,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = deleteExampleOptions.workspace_id_serialized_name;
       intent_serialized_name = deleteExampleOptions.intent_serialized_name;
       text_serialized_name = deleteExampleOptions.text_serialized_name;
+      this.requestHeaders.putAll(deleteExampleOptions.requestHeaders());
     }
 
     /**
@@ -4031,6 +4043,7 @@ public class IBMConversationV1Models {
     private DeleteIntentOptionsBuilder(DeleteIntentOptions deleteIntentOptions) {
       workspace_id_serialized_name = deleteIntentOptions.workspace_id_serialized_name;
       intent_serialized_name = deleteIntentOptions.intent_serialized_name;
+      this.requestHeaders.putAll(deleteIntentOptions.requestHeaders());
     }
 
     /**
@@ -4179,6 +4192,7 @@ public class IBMConversationV1Models {
       entity_serialized_name = deleteSynonymOptions.entity_serialized_name;
       value_serialized_name = deleteSynonymOptions.value_serialized_name;
       synonym_serialized_name = deleteSynonymOptions.synonym_serialized_name;
+      this.requestHeaders.putAll(deleteSynonymOptions.requestHeaders());
     }
 
     /**
@@ -4338,6 +4352,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = deleteValueOptions.workspace_id_serialized_name;
       entity_serialized_name = deleteValueOptions.entity_serialized_name;
       value_serialized_name = deleteValueOptions.value_serialized_name;
+      this.requestHeaders.putAll(deleteValueOptions.requestHeaders());
     }
 
     /**
@@ -4454,6 +4469,7 @@ public class IBMConversationV1Models {
 
     private DeleteWorkspaceOptionsBuilder(DeleteWorkspaceOptions deleteWorkspaceOptions) {
       workspace_id_serialized_name = deleteWorkspaceOptions.workspace_id_serialized_name;
+      this.requestHeaders.putAll(deleteWorkspaceOptions.requestHeaders());
     }
 
     /**
@@ -5858,6 +5874,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = getCounterexampleOptions.workspace_id_serialized_name;
       text_serialized_name = getCounterexampleOptions.text_serialized_name;
       include_audit_serialized_name = getCounterexampleOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getCounterexampleOptions.requestHeaders());
     }
 
     /**
@@ -6001,6 +6018,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = getDialogNodeOptions.workspace_id_serialized_name;
       dialog_node_serialized_name = getDialogNodeOptions.dialog_node_serialized_name;
       include_audit_serialized_name = getDialogNodeOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getDialogNodeOptions.requestHeaders());
     }
 
     /**
@@ -6158,6 +6176,7 @@ public class IBMConversationV1Models {
       entity_serialized_name = getEntityOptions.entity_serialized_name;
       export_serialized_name = getEntityOptions.export_serialized_name;
       include_audit_serialized_name = getEntityOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getEntityOptions.requestHeaders());
     }
 
     /**
@@ -6327,6 +6346,7 @@ public class IBMConversationV1Models {
       intent_serialized_name = getExampleOptions.intent_serialized_name;
       text_serialized_name = getExampleOptions.text_serialized_name;
       include_audit_serialized_name = getExampleOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getExampleOptions.requestHeaders());
     }
 
     /**
@@ -6497,6 +6517,7 @@ public class IBMConversationV1Models {
       intent_serialized_name = getIntentOptions.intent_serialized_name;
       export_serialized_name = getIntentOptions.export_serialized_name;
       include_audit_serialized_name = getIntentOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getIntentOptions.requestHeaders());
     }
 
     /**
@@ -6681,6 +6702,7 @@ public class IBMConversationV1Models {
       value_serialized_name = getSynonymOptions.value_serialized_name;
       synonym_serialized_name = getSynonymOptions.synonym_serialized_name;
       include_audit_serialized_name = getSynonymOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getSynonymOptions.requestHeaders());
     }
 
     /**
@@ -6879,6 +6901,7 @@ public class IBMConversationV1Models {
       value_serialized_name = getValueOptions.value_serialized_name;
       export_serialized_name = getValueOptions.export_serialized_name;
       include_audit_serialized_name = getValueOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getValueOptions.requestHeaders());
     }
 
     /**
@@ -7045,6 +7068,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = getWorkspaceOptions.workspace_id_serialized_name;
       export_serialized_name = getWorkspaceOptions.export_serialized_name;
       include_audit_serialized_name = getWorkspaceOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(getWorkspaceOptions.requestHeaders());
     }
 
     /**
@@ -7567,6 +7591,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = listAllLogsOptions.sort_serialized_name;
       page_limit_serialized_name = listAllLogsOptions.page_limit_serialized_name;
       cursor_serialized_name = listAllLogsOptions.cursor_serialized_name;
+      this.requestHeaders.putAll(listAllLogsOptions.requestHeaders());
     }
 
     /**
@@ -7760,6 +7785,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = listCounterexamplesOptions.sort_serialized_name;
       cursor_serialized_name = listCounterexamplesOptions.cursor_serialized_name;
       include_audit_serialized_name = listCounterexamplesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listCounterexamplesOptions.requestHeaders());
     }
 
     /**
@@ -7975,6 +8001,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = listDialogNodesOptions.sort_serialized_name;
       cursor_serialized_name = listDialogNodesOptions.cursor_serialized_name;
       include_audit_serialized_name = listDialogNodesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listDialogNodesOptions.requestHeaders());
     }
 
     /**
@@ -8204,6 +8231,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = listEntitiesOptions.sort_serialized_name;
       cursor_serialized_name = listEntitiesOptions.cursor_serialized_name;
       include_audit_serialized_name = listEntitiesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listEntitiesOptions.requestHeaders());
     }
 
     /**
@@ -8445,6 +8473,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = listExamplesOptions.sort_serialized_name;
       cursor_serialized_name = listExamplesOptions.cursor_serialized_name;
       include_audit_serialized_name = listExamplesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listExamplesOptions.requestHeaders());
     }
 
     /**
@@ -8687,6 +8716,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = listIntentsOptions.sort_serialized_name;
       cursor_serialized_name = listIntentsOptions.cursor_serialized_name;
       include_audit_serialized_name = listIntentsOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listIntentsOptions.requestHeaders());
     }
 
     /**
@@ -8899,6 +8929,7 @@ public class IBMConversationV1Models {
       filter_serialized_name = listLogsOptions.filter_serialized_name;
       page_limit_serialized_name = listLogsOptions.page_limit_serialized_name;
       cursor_serialized_name = listLogsOptions.cursor_serialized_name;
+      this.requestHeaders.putAll(listLogsOptions.requestHeaders());
     }
 
     /**
@@ -9133,6 +9164,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = listSynonymsOptions.sort_serialized_name;
       cursor_serialized_name = listSynonymsOptions.cursor_serialized_name;
       include_audit_serialized_name = listSynonymsOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listSynonymsOptions.requestHeaders());
     }
 
     /**
@@ -9403,6 +9435,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = listValuesOptions.sort_serialized_name;
       cursor_serialized_name = listValuesOptions.cursor_serialized_name;
       include_audit_serialized_name = listValuesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listValuesOptions.requestHeaders());
     }
 
     /**
@@ -9627,6 +9660,7 @@ public class IBMConversationV1Models {
       sort_serialized_name = listWorkspacesOptions.sort_serialized_name;
       cursor_serialized_name = listWorkspacesOptions.cursor_serialized_name;
       include_audit_serialized_name = listWorkspacesOptions.include_audit_serialized_name;
+      this.requestHeaders.putAll(listWorkspacesOptions.requestHeaders());
     }
 
     /**
@@ -10287,6 +10321,7 @@ public class IBMConversationV1Models {
       intents_serialized_name = messageOptions.intents_serialized_name;
       output_serialized_name = messageOptions.output_serialized_name;
       nodes_visited_details_serialized_name = messageOptions.nodes_visited_details_serialized_name;
+      this.requestHeaders.putAll(messageOptions.requestHeaders());
     }
 
     /**
@@ -11605,6 +11640,7 @@ public class IBMConversationV1Models {
       workspace_id_serialized_name = updateCounterexampleOptions.workspace_id_serialized_name;
       text_serialized_name = updateCounterexampleOptions.text_serialized_name;
       new_text_serialized_name = updateCounterexampleOptions.new_text_serialized_name;
+      this.requestHeaders.putAll(updateCounterexampleOptions.requestHeaders());
     }
 
     /**
@@ -11972,6 +12008,7 @@ public class IBMConversationV1Models {
       new_output_serialized_name = updateDialogNodeOptions.new_output_serialized_name;
       new_parent_serialized_name = updateDialogNodeOptions.new_parent_serialized_name;
       new_dialog_node_serialized_name = updateDialogNodeOptions.new_dialog_node_serialized_name;
+      this.requestHeaders.putAll(updateDialogNodeOptions.requestHeaders());
     }
 
     /**
@@ -12363,6 +12400,7 @@ public class IBMConversationV1Models {
       new_metadata_serialized_name = updateEntityOptions.new_metadata_serialized_name;
       new_values_serialized_name = updateEntityOptions.new_values_serialized_name;
       new_description_serialized_name = updateEntityOptions.new_description_serialized_name;
+      this.requestHeaders.putAll(updateEntityOptions.requestHeaders());
     }
 
     /**
@@ -12581,6 +12619,7 @@ public class IBMConversationV1Models {
       intent_serialized_name = updateExampleOptions.intent_serialized_name;
       text_serialized_name = updateExampleOptions.text_serialized_name;
       new_text_serialized_name = updateExampleOptions.new_text_serialized_name;
+      this.requestHeaders.putAll(updateExampleOptions.requestHeaders());
     }
 
     /**
@@ -12765,6 +12804,7 @@ public class IBMConversationV1Models {
       new_intent_serialized_name = updateIntentOptions.new_intent_serialized_name;
       new_examples_serialized_name = updateIntentOptions.new_examples_serialized_name;
       new_description_serialized_name = updateIntentOptions.new_description_serialized_name;
+      this.requestHeaders.putAll(updateIntentOptions.requestHeaders());
     }
 
     /**
@@ -12976,6 +13016,7 @@ public class IBMConversationV1Models {
       value_serialized_name = updateSynonymOptions.value_serialized_name;
       synonym_serialized_name = updateSynonymOptions.synonym_serialized_name;
       new_synonym_serialized_name = updateSynonymOptions.new_synonym_serialized_name;
+      this.requestHeaders.putAll(updateSynonymOptions.requestHeaders());
     }
 
     /**
@@ -13216,6 +13257,7 @@ public class IBMConversationV1Models {
       new_metadata_serialized_name = updateValueOptions.new_metadata_serialized_name;
       new_patterns_serialized_name = updateValueOptions.new_patterns_serialized_name;
       new_value_serialized_name = updateValueOptions.new_value_serialized_name;
+      this.requestHeaders.putAll(updateValueOptions.requestHeaders());
     }
 
     /**
@@ -13559,6 +13601,7 @@ public class IBMConversationV1Models {
       metadata_serialized_name = updateWorkspaceOptions.metadata_serialized_name;
       learning_opt_out_serialized_name = updateWorkspaceOptions.learning_opt_out_serialized_name;
       append_serialized_name = updateWorkspaceOptions.append_serialized_name;
+      this.requestHeaders.putAll(updateWorkspaceOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMConversationV1Models.cls
+++ b/force-app/main/default/classes/IBMConversationV1Models.cls
@@ -7160,8 +7160,9 @@ public class IBMConversationV1Models {
       }
 
       InputData ret = (InputData) super.deserialize(jsonString, jsonMap, classType);
+      InputDataBuilder retBuilder = ret.newBuilder();
 
-      return ret;
+      return retBuilder.build();
     }
   }
 

--- a/force-app/main/default/classes/IBMConversationV1Test.cls
+++ b/force-app/main/default/classes/IBMConversationV1Test.cls
@@ -1425,7 +1425,7 @@ private class IBMConversationV1Test {
     listOptions = listOptions.newBuilder().build();
     IBMConversationV1Models.LogCollection response = conversation.listLogs(listOptions);
 
-    System.assertEquals(response.getLogs().get(0).getRequest().getInput().text(), messageInput);
+    System.assertEquals(response.getLogs().get(0).getRequest().getInput().getText(), messageInput);
     System.assertEquals(response.getLogs().get(0).getResponse().getIntents().get(0).getIntent(), intentName);
     System.assertEquals(response.getLogs().get(0).getResponse().getIntents().get(0).getConfidence(), confidence);
     System.assertEquals(response.getLogs().get(0).getResponse().getEntities().get(0).getEntity(), entityName);

--- a/force-app/main/default/classes/IBMConversationV1Test.cls
+++ b/force-app/main/default/classes/IBMConversationV1Test.cls
@@ -219,6 +219,7 @@ private class IBMConversationV1Test {
       .addentities(createEntity)
       .entities(new List<IBMConversationV1Models.CreateEntity>{createEntity})
       .language(workspaceLanguage)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
      createWorkspaceOptions = createWorkspaceOptions.newBuilder().build();
@@ -250,6 +251,7 @@ private class IBMConversationV1Test {
 
     IBMConversationV1Models.DeleteWorkspaceOptions deleteOptions = new IBMConversationV1Models.DeleteWorkspaceOptionsBuilder()
       .workspaceId(workspaceId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -274,6 +276,7 @@ private class IBMConversationV1Test {
     IBMConversationV1Models.GetWorkspaceOptions getOptions = new IBMConversationV1Models.GetWorkspaceOptionsBuilder()
       .includeAudit(true)
       .workspaceId(workspaceId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -313,6 +316,7 @@ private class IBMConversationV1Test {
     IBMConversationV1Models.UpdateWorkspaceOptions updateOptions = new IBMConversationV1Models.UpdateWorkspaceOptionsBuilder()
       .workspaceId(workspaceId)
       .append(false)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -344,6 +348,7 @@ private class IBMConversationV1Test {
 
     IBMConversationV1Models.ListWorkspacesOptions listOptions = new IBMConversationV1Models.ListWorkspacesOptionsBuilder()
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -383,6 +388,7 @@ private class IBMConversationV1Test {
       .metadata(metadata)
       .addPatterns(valuePattern)
       .addSynonyms(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -414,6 +420,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .value(valueName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -441,6 +448,7 @@ private class IBMConversationV1Test {
       .value(valueName)
       .exportField(true)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -475,6 +483,7 @@ private class IBMConversationV1Test {
       .newMetadata(metadata)
       .addNewPatterns(valuePattern)
       .addNewSynonyms(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -506,6 +515,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -547,6 +557,7 @@ private class IBMConversationV1Test {
       .input(input)
       .alternateIntents(alternateIntents)
       .nodesVisitedDetails(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     messageOptions = messageOptions.newBuilder().build();
@@ -590,6 +601,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .description(intentDescription)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -618,6 +630,7 @@ private class IBMConversationV1Test {
     IBMConversationV1Models.DeleteIntentOptions deleteOptions = new IBMConversationV1Models.DeleteIntentOptionsBuilder()
       .workspaceId(workspaceId)
       .intent(intentName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -644,6 +657,7 @@ private class IBMConversationV1Test {
       .intent(intentName)
       .exportField(true)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -676,6 +690,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .exportField(true)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -714,6 +729,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .newDescription(intentDescription)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -743,6 +759,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .text(exampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -771,6 +788,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .text('example A')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -797,6 +815,7 @@ private class IBMConversationV1Test {
       .intent(intentName)
       .text(exampleText)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -825,6 +844,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -858,6 +878,7 @@ private class IBMConversationV1Test {
       .intent(intentName)
       .text(exampleText)
       .newText(exampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -886,6 +907,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .description(entityDescription)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -916,6 +938,7 @@ private class IBMConversationV1Test {
     IBMConversationV1Models.DeleteEntityOptions deleteOptions = new IBMConversationV1Models.DeleteEntityOptionsBuilder()
       .workspaceId(workspaceId)
       .entity(entityName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -942,6 +965,7 @@ private class IBMConversationV1Test {
       .entity(entityName)
       .exportField(true)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -979,6 +1003,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .exportField(true)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1020,6 +1045,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .newDescription(entityDescription)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1052,6 +1078,7 @@ private class IBMConversationV1Test {
       .entity(entityName)
       .value(valueName)
       .synonym(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1081,6 +1108,7 @@ private class IBMConversationV1Test {
       .entity(entityName)
       .value(valueName)
       .synonym(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1108,6 +1136,7 @@ private class IBMConversationV1Test {
       .value(valueName)
       .synonym(valueSynonym)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1137,6 +1166,7 @@ private class IBMConversationV1Test {
       .entity(entityName)
       .value(valueName)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1171,6 +1201,7 @@ private class IBMConversationV1Test {
       .value(valueName)
       .synonym(valueSynonym)
       .newSynonym(valueSynonym)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1201,6 +1232,7 @@ private class IBMConversationV1Test {
       .digressIn(dialogNodeDigressIn)
       .digressOut(dialogNodeDigressOut)
       .digressOutSlots(dialogNodeDigressOutSlots)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1250,6 +1282,7 @@ private class IBMConversationV1Test {
     IBMConversationV1Models.DeleteDialogNodeOptions deleteOptions = new IBMConversationV1Models.DeleteDialogNodeOptionsBuilder()
       .workspaceId(workspaceId)
       .dialogNode(dialogNodeName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1275,6 +1308,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .dialogNode(dialogNodeName)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1321,6 +1355,7 @@ private class IBMConversationV1Test {
     IBMConversationV1Models.ListDialogNodesOptions listOptions = new IBMConversationV1Models.ListDialogNodesOptionsBuilder()
       .workspaceId(workspaceId)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1374,6 +1409,7 @@ private class IBMConversationV1Test {
       .newDigressIn(dialogNodeDigressIn)
       .newDigressOut(dialogNodeDigressOut)
       .newDigressOutSlots(dialogNodeDigressOutSlots)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1420,6 +1456,7 @@ private class IBMConversationV1Test {
 
     IBMConversationV1Models.ListLogsOptions listOptions = new IBMConversationV1Models.ListLogsOptionsBuilder()
       .workspaceId(workspaceId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1469,6 +1506,7 @@ private class IBMConversationV1Test {
     IBMConversationV1Models.CreateCounterexampleOptions createOptions = new IBMConversationV1Models.CreateCounterexampleOptionsBuilder()
       .workspaceId(workspaceId)
       .text(counterexampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1494,6 +1532,7 @@ private class IBMConversationV1Test {
 
     IBMConversationV1Models.CreateCounterexampleOptions createOptions =
       new IBMConversationV1Models.CreateCounterexampleOptionsBuilder(workspaceId,counterexampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1521,6 +1560,7 @@ private class IBMConversationV1Test {
     IBMConversationV1Models.DeleteCounterexampleOptions deleteOptions = new IBMConversationV1Models.DeleteCounterexampleOptionsBuilder()
       .workspaceId(workspaceId)
       .text(counterexampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1546,6 +1586,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .text(counterexampleText)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1573,6 +1614,7 @@ private class IBMConversationV1Test {
     IBMConversationV1Models.ListCounterexamplesOptions listOptions = new IBMConversationV1Models.ListCounterexamplesOptionsBuilder()
       .workspaceId(workspaceId)
       .includeAudit(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1605,6 +1647,7 @@ private class IBMConversationV1Test {
       .workspaceId(workspaceId)
       .text(counterexampleText)
       .newText(counterexampleText)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();

--- a/force-app/main/default/classes/IBMDiscoveryV1.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1.cls
@@ -57,7 +57,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
-   * Add an environment.
+   * Create an environment.
    *
    * Creates a new environment.  You can create only one environment per service instance. An attempt to create another environment results in an error.
    *
@@ -67,6 +67,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Environment createEnvironment(IBMDiscoveryV1Models.CreateEnvironmentOptions createEnvironmentOptions) {
     IBMWatsonValidator.notNull(createEnvironmentOptions, 'createEnvironmentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/environments');
+    Map<String, String> requestHeaders = (createEnvironmentOptions != null) ? createEnvironmentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('name', createEnvironmentOptions.name());
@@ -90,6 +96,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public void deleteEnvironment(IBMDiscoveryV1Models.DeleteEnvironmentOptions deleteEnvironmentOptions) {
     IBMWatsonValidator.notNull(deleteEnvironmentOptions, 'deleteEnvironmentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/environments/{0}', new String[]{ deleteEnvironmentOptions.environmentId() }));
+    Map<String, String> requestHeaders = (deleteEnvironmentOptions != null) ? deleteEnvironmentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -104,6 +116,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Environment getEnvironment(IBMDiscoveryV1Models.GetEnvironmentOptions getEnvironmentOptions) {
     IBMWatsonValidator.notNull(getEnvironmentOptions, 'getEnvironmentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}', new String[]{ getEnvironmentOptions.environmentId() }));
+    Map<String, String> requestHeaders = (getEnvironmentOptions != null) ? getEnvironmentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.Environment) createServiceCall(builder.build(), IBMDiscoveryV1Models.Environment.class);
@@ -119,6 +137,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
    */
   public IBMDiscoveryV1Models.ListEnvironmentsResponse listEnvironments(IBMDiscoveryV1Models.ListEnvironmentsOptions listEnvironmentsOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/environments');
+    Map<String, String> requestHeaders = (listEnvironmentsOptions != null) ? listEnvironmentsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listEnvironmentsOptions != null && listEnvironmentsOptions.name() != null) {
       builder.query('name', listEnvironmentsOptions.name());
@@ -128,7 +152,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
-   * List fields in specified collections.
+   * List fields across collections.
    *
    * Gets a list of the unique fields (and their types) stored in the indexes of the specified collections.
    *
@@ -138,6 +162,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.ListCollectionFieldsResponse listFields(IBMDiscoveryV1Models.ListFieldsOptions listFieldsOptions) {
     IBMWatsonValidator.notNull(listFieldsOptions, 'listFieldsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/fields', new String[]{ listFieldsOptions.environmentId() }));
+    Map<String, String> requestHeaders = (listFieldsOptions != null) ? listFieldsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listFieldsOptions.collectionIds() != null) {
       builder.query('collection_ids', String.join(listFieldsOptions.collectionIds(), ','));
@@ -157,6 +187,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Environment updateEnvironment(IBMDiscoveryV1Models.UpdateEnvironmentOptions updateEnvironmentOptions) {
     IBMWatsonValidator.notNull(updateEnvironmentOptions, 'updateEnvironmentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPut(getEndPoint() + String.format('/v1/environments/{0}', new String[]{ updateEnvironmentOptions.environmentId() }));
+    Map<String, String> requestHeaders = (updateEnvironmentOptions != null) ? updateEnvironmentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateEnvironmentOptions.name() != null) {
@@ -181,6 +217,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Configuration createConfiguration(IBMDiscoveryV1Models.CreateConfigurationOptions createConfigurationOptions) {
     IBMWatsonValidator.notNull(createConfigurationOptions, 'createConfigurationOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/configurations', new String[]{ createConfigurationOptions.environmentId() }));
+    Map<String, String> requestHeaders = (createConfigurationOptions != null) ? createConfigurationOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (createConfigurationOptions.name() != null) {
@@ -214,6 +256,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public void deleteConfiguration(IBMDiscoveryV1Models.DeleteConfigurationOptions deleteConfigurationOptions) {
     IBMWatsonValidator.notNull(deleteConfigurationOptions, 'deleteConfigurationOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/environments/{0}/configurations/{1}', new String[]{ deleteConfigurationOptions.environmentId(), deleteConfigurationOptions.configurationId() }));
+    Map<String, String> requestHeaders = (deleteConfigurationOptions != null) ? deleteConfigurationOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -228,6 +276,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Configuration getConfiguration(IBMDiscoveryV1Models.GetConfigurationOptions getConfigurationOptions) {
     IBMWatsonValidator.notNull(getConfigurationOptions, 'getConfigurationOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/configurations/{1}', new String[]{ getConfigurationOptions.environmentId(), getConfigurationOptions.configurationId() }));
+    Map<String, String> requestHeaders = (getConfigurationOptions != null) ? getConfigurationOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.Configuration) createServiceCall(builder.build(), IBMDiscoveryV1Models.Configuration.class);
@@ -244,6 +298,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.ListConfigurationsResponse listConfigurations(IBMDiscoveryV1Models.ListConfigurationsOptions listConfigurationsOptions) {
     IBMWatsonValidator.notNull(listConfigurationsOptions, 'listConfigurationsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/configurations', new String[]{ listConfigurationsOptions.environmentId() }));
+    Map<String, String> requestHeaders = (listConfigurationsOptions != null) ? listConfigurationsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listConfigurationsOptions.name() != null) {
       builder.query('name', listConfigurationsOptions.name());
@@ -263,6 +323,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Configuration updateConfiguration(IBMDiscoveryV1Models.UpdateConfigurationOptions updateConfigurationOptions) {
     IBMWatsonValidator.notNull(updateConfigurationOptions, 'updateConfigurationOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPut(getEndPoint() + String.format('/v1/environments/{0}/configurations/{1}', new String[]{ updateConfigurationOptions.environmentId(), updateConfigurationOptions.configurationId() }));
+    Map<String, String> requestHeaders = (updateConfigurationOptions != null) ? updateConfigurationOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateConfigurationOptions.name() != null) {
@@ -297,6 +363,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     IBMWatsonValidator.notNull(testConfigurationInEnvironmentOptions, 'testConfigurationInEnvironmentOptions cannot be null');
     IBMWatsonValidator.isTrue((testConfigurationInEnvironmentOptions.configuration() != null) || (testConfigurationInEnvironmentOptions.file() != null) || (testConfigurationInEnvironmentOptions.metadata() != null), 'At least one of configuration, file, or metadata must be supplied.');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/preview', new String[]{ testConfigurationInEnvironmentOptions.environmentId() }));
+    Map<String, String> requestHeaders = (testConfigurationInEnvironmentOptions != null) ? testConfigurationInEnvironmentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (testConfigurationInEnvironmentOptions.step() != null) {
       builder.query('step', testConfigurationInEnvironmentOptions.step());
@@ -331,6 +403,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Collection createCollection(IBMDiscoveryV1Models.CreateCollectionOptions createCollectionOptions) {
     IBMWatsonValidator.notNull(createCollectionOptions, 'createCollectionOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/collections', new String[]{ createCollectionOptions.environmentId() }));
+    Map<String, String> requestHeaders = (createCollectionOptions != null) ? createCollectionOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('name', createCollectionOptions.name());
@@ -357,6 +435,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public void deleteCollection(IBMDiscoveryV1Models.DeleteCollectionOptions deleteCollectionOptions) {
     IBMWatsonValidator.notNull(deleteCollectionOptions, 'deleteCollectionOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}', new String[]{ deleteCollectionOptions.environmentId(), deleteCollectionOptions.collectionId() }));
+    Map<String, String> requestHeaders = (deleteCollectionOptions != null) ? deleteCollectionOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -371,13 +455,19 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Collection getCollection(IBMDiscoveryV1Models.GetCollectionOptions getCollectionOptions) {
     IBMWatsonValidator.notNull(getCollectionOptions, 'getCollectionOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}', new String[]{ getCollectionOptions.environmentId(), getCollectionOptions.collectionId() }));
+    Map<String, String> requestHeaders = (getCollectionOptions != null) ? getCollectionOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.Collection) createServiceCall(builder.build(), IBMDiscoveryV1Models.Collection.class);
   }
 
   /**
-   * List unique fields.
+   * List collection fields.
    *
    * Gets a list of the unique fields (and their types) stored in the index.
    *
@@ -387,6 +477,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.ListCollectionFieldsResponse listCollectionFields(IBMDiscoveryV1Models.ListCollectionFieldsOptions listCollectionFieldsOptions) {
     IBMWatsonValidator.notNull(listCollectionFieldsOptions, 'listCollectionFieldsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/fields', new String[]{ listCollectionFieldsOptions.environmentId(), listCollectionFieldsOptions.collectionId() }));
+    Map<String, String> requestHeaders = (listCollectionFieldsOptions != null) ? listCollectionFieldsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.ListCollectionFieldsResponse) createServiceCall(builder.build(), IBMDiscoveryV1Models.ListCollectionFieldsResponse.class);
@@ -403,6 +499,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.ListCollectionsResponse listCollections(IBMDiscoveryV1Models.ListCollectionsOptions listCollectionsOptions) {
     IBMWatsonValidator.notNull(listCollectionsOptions, 'listCollectionsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections', new String[]{ listCollectionsOptions.environmentId() }));
+    Map<String, String> requestHeaders = (listCollectionsOptions != null) ? listCollectionsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listCollectionsOptions.name() != null) {
       builder.query('name', listCollectionsOptions.name());
@@ -420,6 +522,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Collection updateCollection(IBMDiscoveryV1Models.UpdateCollectionOptions updateCollectionOptions) {
     IBMWatsonValidator.notNull(updateCollectionOptions, 'updateCollectionOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPut(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}', new String[]{ updateCollectionOptions.environmentId(), updateCollectionOptions.collectionId() }));
+    Map<String, String> requestHeaders = (updateCollectionOptions != null) ? updateCollectionOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateCollectionOptions.name() != null) {
@@ -437,7 +545,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
-   * Set the expansion list.
+   * Create or update expansion list.
    *
    * Create or replace the Expansion list for this collection. The maximum number of expanded terms per collection is `500`. The current expansion list is replaced with the uploaded content.
    *
@@ -447,6 +555,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Expansions createExpansions(IBMDiscoveryV1Models.CreateExpansionsOptions createExpansionsOptions) {
     IBMWatsonValidator.notNull(createExpansionsOptions, 'createExpansionsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/expansions', new String[]{ createExpansionsOptions.environmentId(), createExpansionsOptions.collectionId() }));
+    Map<String, String> requestHeaders = (createExpansionsOptions != null) ? createExpansionsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (createExpansionsOptions.expansions() != null) {
@@ -458,7 +572,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
-   * Delete the expansions list.
+   * Delete the expansion list.
    *
    * Remove the expansion information for this collection. The expansion list must be deleted to disable query expansion for a collection.
    *
@@ -468,13 +582,19 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public void deleteExpansions(IBMDiscoveryV1Models.DeleteExpansionsOptions deleteExpansionsOptions) {
     IBMWatsonValidator.notNull(deleteExpansionsOptions, 'deleteExpansionsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/expansions', new String[]{ deleteExpansionsOptions.environmentId(), deleteExpansionsOptions.collectionId() }));
+    Map<String, String> requestHeaders = (deleteExpansionsOptions != null) ? deleteExpansionsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * List current expansions.
+   * Get the expansion list.
    *
    * Returns the current expansion list for the specified collection. If an expansion list is not specified, an object with empty expansion arrays is returned.
    *
@@ -484,6 +604,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.Expansions listExpansions(IBMDiscoveryV1Models.ListExpansionsOptions listExpansionsOptions) {
     IBMWatsonValidator.notNull(listExpansionsOptions, 'listExpansionsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/expansions', new String[]{ listExpansionsOptions.environmentId(), listExpansionsOptions.collectionId() }));
+    Map<String, String> requestHeaders = (listExpansionsOptions != null) ? listExpansionsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.Expansions) createServiceCall(builder.build(), IBMDiscoveryV1Models.Expansions.class);
@@ -501,6 +627,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     IBMWatsonValidator.notNull(addDocumentOptions, 'addDocumentOptions cannot be null');
     IBMWatsonValidator.isTrue((addDocumentOptions.file() != null) || (addDocumentOptions.metadata() != null), 'At least one of file or metadata must be supplied.');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/documents', new String[]{ addDocumentOptions.environmentId(), addDocumentOptions.collectionId() }));
+    Map<String, String> requestHeaders = (addDocumentOptions != null) ? addDocumentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
@@ -528,6 +660,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public void deleteDocument(IBMDiscoveryV1Models.DeleteDocumentOptions deleteDocumentOptions) {
     IBMWatsonValidator.notNull(deleteDocumentOptions, 'deleteDocumentOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/documents/{2}', new String[]{ deleteDocumentOptions.environmentId(), deleteDocumentOptions.collectionId(), deleteDocumentOptions.documentId() }));
+    Map<String, String> requestHeaders = (deleteDocumentOptions != null) ? deleteDocumentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -544,6 +682,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.DocumentStatus getDocumentStatus(IBMDiscoveryV1Models.GetDocumentStatusOptions getDocumentStatusOptions) {
     IBMWatsonValidator.notNull(getDocumentStatusOptions, 'getDocumentStatusOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/documents/{2}', new String[]{ getDocumentStatusOptions.environmentId(), getDocumentStatusOptions.collectionId(), getDocumentStatusOptions.documentId() }));
+    Map<String, String> requestHeaders = (getDocumentStatusOptions != null) ? getDocumentStatusOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.DocumentStatus) createServiceCall(builder.build(), IBMDiscoveryV1Models.DocumentStatus.class);
@@ -561,6 +705,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     IBMWatsonValidator.notNull(updateDocumentOptions, 'updateDocumentOptions cannot be null');
     IBMWatsonValidator.isTrue((updateDocumentOptions.file() != null) || (updateDocumentOptions.metadata() != null), 'At least one of file or metadata must be supplied.');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/documents/{2}', new String[]{ updateDocumentOptions.environmentId(), updateDocumentOptions.collectionId(), updateDocumentOptions.documentId() }));
+    Map<String, String> requestHeaders = (updateDocumentOptions != null) ? updateDocumentOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
@@ -588,6 +738,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.QueryResponse federatedQuery(IBMDiscoveryV1Models.FederatedQueryOptions federatedQueryOptions) {
     IBMWatsonValidator.notNull(federatedQueryOptions, 'federatedQueryOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/query', new String[]{ federatedQueryOptions.environmentId() }));
+    Map<String, String> requestHeaders = (federatedQueryOptions != null) ? federatedQueryOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (federatedQueryOptions.collectionIds() != null) {
       builder.query('collection_ids', String.join(federatedQueryOptions.collectionIds(), ','));
@@ -649,6 +805,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.QueryNoticesResponse federatedQueryNotices(IBMDiscoveryV1Models.FederatedQueryNoticesOptions federatedQueryNoticesOptions) {
     IBMWatsonValidator.notNull(federatedQueryNoticesOptions, 'federatedQueryNoticesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/notices', new String[]{ federatedQueryNoticesOptions.environmentId() }));
+    Map<String, String> requestHeaders = (federatedQueryNoticesOptions != null) ? federatedQueryNoticesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (federatedQueryNoticesOptions.collectionIds() != null) {
       builder.query('collection_ids', String.join(federatedQueryNoticesOptions.collectionIds(), ','));
@@ -697,9 +859,9 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
-   * Query documents.
+   * Query your collection.
    *
-   * See the [Discovery service documentation](https://console.bluemix.net/docs/services/discovery/using.html) for more details.
+   * After your content is uploaded and enriched by the Discovery service, you can build queries to search your content. For details, see the [Discovery service documentation](https://console.bluemix.net/docs/services/discovery/using.html).
    *
    * @param queryOptions the {@link IBMDiscoveryV1Models.QueryOptions} containing the options for the call
    * @return the {@link IBMDiscoveryV1Models.QueryResponse} with the response
@@ -707,6 +869,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.QueryResponse query(IBMDiscoveryV1Models.QueryOptions queryOptions) {
     IBMWatsonValidator.notNull(queryOptions, 'queryOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/query', new String[]{ queryOptions.environmentId(), queryOptions.collectionId() }));
+    Map<String, String> requestHeaders = (queryOptions != null) ? queryOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (queryOptions.filter() != null) {
       builder.query('filter', queryOptions.filter());
@@ -777,6 +945,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.QueryEntitiesResponse queryEntities(IBMDiscoveryV1Models.QueryEntitiesOptions queryEntitiesOptions) {
     IBMWatsonValidator.notNull(queryEntitiesOptions, 'queryEntitiesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/query_entities', new String[]{ queryEntitiesOptions.environmentId(), queryEntitiesOptions.collectionId() }));
+    Map<String, String> requestHeaders = (queryEntitiesOptions != null) ? queryEntitiesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (queryEntitiesOptions.feature() != null) {
@@ -810,6 +984,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.QueryNoticesResponse queryNotices(IBMDiscoveryV1Models.QueryNoticesOptions queryNoticesOptions) {
     IBMWatsonValidator.notNull(queryNoticesOptions, 'queryNoticesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/notices', new String[]{ queryNoticesOptions.environmentId(), queryNoticesOptions.collectionId() }));
+    Map<String, String> requestHeaders = (queryNoticesOptions != null) ? queryNoticesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (queryNoticesOptions.filter() != null) {
       builder.query('filter', queryNoticesOptions.filter());
@@ -877,6 +1057,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.QueryRelationsResponse queryRelations(IBMDiscoveryV1Models.QueryRelationsOptions queryRelationsOptions) {
     IBMWatsonValidator.notNull(queryRelationsOptions, 'queryRelationsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/query_relations', new String[]{ queryRelationsOptions.environmentId(), queryRelationsOptions.collectionId() }));
+    Map<String, String> requestHeaders = (queryRelationsOptions != null) ? queryRelationsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (queryRelationsOptions.entities() != null) {
@@ -903,6 +1089,8 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
+   * Add query to training data.
+   *
    * Adds a query to the training data for this collection. The query can contain a filter and natural language query.
    *
    * @param addTrainingDataOptions the {@link IBMDiscoveryV1Models.AddTrainingDataOptions} containing the options for the call
@@ -911,6 +1099,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.TrainingQuery addTrainingData(IBMDiscoveryV1Models.AddTrainingDataOptions addTrainingDataOptions) {
     IBMWatsonValidator.notNull(addTrainingDataOptions, 'addTrainingDataOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data', new String[]{ addTrainingDataOptions.environmentId(), addTrainingDataOptions.collectionId() }));
+    Map<String, String> requestHeaders = (addTrainingDataOptions != null) ? addTrainingDataOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (addTrainingDataOptions.naturalLanguageQuery() != null) {
@@ -928,7 +1122,9 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
-   * Adds a new example to this training data query.
+   * Add example to training data query.
+   *
+   * Adds a example to this training data query.
    *
    * @param createTrainingExampleOptions the {@link IBMDiscoveryV1Models.CreateTrainingExampleOptions} containing the options for the call
    * @return the {@link IBMDiscoveryV1Models.TrainingExample} with the response
@@ -936,6 +1132,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.TrainingExample createTrainingExample(IBMDiscoveryV1Models.CreateTrainingExampleOptions createTrainingExampleOptions) {
     IBMWatsonValidator.notNull(createTrainingExampleOptions, 'createTrainingExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data/{2}/examples', new String[]{ createTrainingExampleOptions.environmentId(), createTrainingExampleOptions.collectionId(), createTrainingExampleOptions.queryId() }));
+    Map<String, String> requestHeaders = (createTrainingExampleOptions != null) ? createTrainingExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (createTrainingExampleOptions.documentId() != null) {
@@ -953,7 +1155,9 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
-   * Clears all training data for this collection.
+   * Delete all training data.
+   *
+   * Deletes all training data from a collection.
    *
    * @param deleteAllTrainingDataOptions the {@link IBMDiscoveryV1Models.DeleteAllTrainingDataOptions} containing the options for the call
    * @return the service call
@@ -961,13 +1165,21 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public void deleteAllTrainingData(IBMDiscoveryV1Models.DeleteAllTrainingDataOptions deleteAllTrainingDataOptions) {
     IBMWatsonValidator.notNull(deleteAllTrainingDataOptions, 'deleteAllTrainingDataOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data', new String[]{ deleteAllTrainingDataOptions.environmentId(), deleteAllTrainingDataOptions.collectionId() }));
+    Map<String, String> requestHeaders = (deleteAllTrainingDataOptions != null) ? deleteAllTrainingDataOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Removes the training data and all associated examples from the training data set.
+   * Delete a training data query.
+   *
+   * Removes the training data query and all associated examples from the training data set.
    *
    * @param deleteTrainingDataOptions the {@link IBMDiscoveryV1Models.DeleteTrainingDataOptions} containing the options for the call
    * @return the service call
@@ -975,13 +1187,21 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public void deleteTrainingData(IBMDiscoveryV1Models.DeleteTrainingDataOptions deleteTrainingDataOptions) {
     IBMWatsonValidator.notNull(deleteTrainingDataOptions, 'deleteTrainingDataOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data/{2}', new String[]{ deleteTrainingDataOptions.environmentId(), deleteTrainingDataOptions.collectionId(), deleteTrainingDataOptions.queryId() }));
+    Map<String, String> requestHeaders = (deleteTrainingDataOptions != null) ? deleteTrainingDataOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Removes the example with the given ID for the training data query.
+   * Delete example for training data query.
+   *
+   * Deletes the example document with the given ID from the training data query.
    *
    * @param deleteTrainingExampleOptions the {@link IBMDiscoveryV1Models.DeleteTrainingExampleOptions} containing the options for the call
    * @return the service call
@@ -989,13 +1209,21 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public void deleteTrainingExample(IBMDiscoveryV1Models.DeleteTrainingExampleOptions deleteTrainingExampleOptions) {
     IBMWatsonValidator.notNull(deleteTrainingExampleOptions, 'deleteTrainingExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data/{2}/examples/{3}', new String[]{ deleteTrainingExampleOptions.environmentId(), deleteTrainingExampleOptions.collectionId(), deleteTrainingExampleOptions.queryId(), deleteTrainingExampleOptions.exampleId() }));
+    Map<String, String> requestHeaders = (deleteTrainingExampleOptions != null) ? deleteTrainingExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Shows details for a specific training data query, including the query string and all examples.
+   * Get details about a query.
+   *
+   * Gets details for a specific training data query, including the query string and all examples.
    *
    * @param getTrainingDataOptions the {@link IBMDiscoveryV1Models.GetTrainingDataOptions} containing the options for the call
    * @return the {@link IBMDiscoveryV1Models.TrainingQuery} with the response
@@ -1003,12 +1231,20 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.TrainingQuery getTrainingData(IBMDiscoveryV1Models.GetTrainingDataOptions getTrainingDataOptions) {
     IBMWatsonValidator.notNull(getTrainingDataOptions, 'getTrainingDataOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data/{2}', new String[]{ getTrainingDataOptions.environmentId(), getTrainingDataOptions.collectionId(), getTrainingDataOptions.queryId() }));
+    Map<String, String> requestHeaders = (getTrainingDataOptions != null) ? getTrainingDataOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.TrainingQuery) createServiceCall(builder.build(), IBMDiscoveryV1Models.TrainingQuery.class);
   }
 
   /**
+   * Get details for training data example.
+   *
    * Gets the details for this training example.
    *
    * @param getTrainingExampleOptions the {@link IBMDiscoveryV1Models.GetTrainingExampleOptions} containing the options for the call
@@ -1017,13 +1253,21 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.TrainingExample getTrainingExample(IBMDiscoveryV1Models.GetTrainingExampleOptions getTrainingExampleOptions) {
     IBMWatsonValidator.notNull(getTrainingExampleOptions, 'getTrainingExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data/{2}/examples/{3}', new String[]{ getTrainingExampleOptions.environmentId(), getTrainingExampleOptions.collectionId(), getTrainingExampleOptions.queryId(), getTrainingExampleOptions.exampleId() }));
+    Map<String, String> requestHeaders = (getTrainingExampleOptions != null) ? getTrainingExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.TrainingExample) createServiceCall(builder.build(), IBMDiscoveryV1Models.TrainingExample.class);
   }
 
   /**
-   * Lists the training data for this collection.
+   * List training data.
+   *
+   * Lists the training data for the specified collection.
    *
    * @param listTrainingDataOptions the {@link IBMDiscoveryV1Models.ListTrainingDataOptions} containing the options for the call
    * @return the {@link IBMDiscoveryV1Models.TrainingDataSet} with the response
@@ -1031,12 +1275,20 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.TrainingDataSet listTrainingData(IBMDiscoveryV1Models.ListTrainingDataOptions listTrainingDataOptions) {
     IBMWatsonValidator.notNull(listTrainingDataOptions, 'listTrainingDataOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data', new String[]{ listTrainingDataOptions.environmentId(), listTrainingDataOptions.collectionId() }));
+    Map<String, String> requestHeaders = (listTrainingDataOptions != null) ? listTrainingDataOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.TrainingDataSet) createServiceCall(builder.build(), IBMDiscoveryV1Models.TrainingDataSet.class);
   }
 
   /**
+   * List examples for a training data query.
+   *
    * List all examples for this training data query.
    *
    * @param listTrainingExamplesOptions the {@link IBMDiscoveryV1Models.ListTrainingExamplesOptions} containing the options for the call
@@ -1045,13 +1297,21 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.TrainingExampleList listTrainingExamples(IBMDiscoveryV1Models.ListTrainingExamplesOptions listTrainingExamplesOptions) {
     IBMWatsonValidator.notNull(listTrainingExamplesOptions, 'listTrainingExamplesOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data/{2}/examples', new String[]{ listTrainingExamplesOptions.environmentId(), listTrainingExamplesOptions.collectionId(), listTrainingExamplesOptions.queryId() }));
+    Map<String, String> requestHeaders = (listTrainingExamplesOptions != null) ? listTrainingExamplesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMDiscoveryV1Models.TrainingExampleList) createServiceCall(builder.build(), IBMDiscoveryV1Models.TrainingExampleList.class);
   }
 
   /**
-   * Changes the label or cross reference query for this training example.
+   * Change label or cross reference for example.
+   *
+   * Changes the label or cross reference query for this training data example.
    *
    * @param updateTrainingExampleOptions the {@link IBMDiscoveryV1Models.UpdateTrainingExampleOptions} containing the options for the call
    * @return the {@link IBMDiscoveryV1Models.TrainingExample} with the response
@@ -1059,6 +1319,12 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   public IBMDiscoveryV1Models.TrainingExample updateTrainingExample(IBMDiscoveryV1Models.UpdateTrainingExampleOptions updateTrainingExampleOptions) {
     IBMWatsonValidator.notNull(updateTrainingExampleOptions, 'updateTrainingExampleOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPut(getEndPoint() + String.format('/v1/environments/{0}/collections/{1}/training_data/{2}/examples/{3}', new String[]{ updateTrainingExampleOptions.environmentId(), updateTrainingExampleOptions.collectionId(), updateTrainingExampleOptions.queryId(), updateTrainingExampleOptions.exampleId() }));
+    Map<String, String> requestHeaders = (updateTrainingExampleOptions != null) ? updateTrainingExampleOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateTrainingExampleOptions.crossReference() != null) {

--- a/force-app/main/default/classes/IBMDiscoveryV1Models.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Models.cls
@@ -2,7 +2,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The addDocument options.
    */
-  public class AddDocumentOptions {
+  public class AddDocumentOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private IBMWatsonFile file_serialized_name;
@@ -81,6 +81,7 @@ public class IBMDiscoveryV1Models {
       filename_serialized_name = builder.filename_serialized_name;
       metadata_serialized_name = builder.metadata_serialized_name;
       file_content_type_serialized_name = builder.file_content_type_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -97,7 +98,7 @@ public class IBMDiscoveryV1Models {
   /**
    * AddDocumentOptions Builder.
    */
-  public class AddDocumentOptionsBuilder {
+  public class AddDocumentOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private IBMWatsonFile file_serialized_name;
@@ -205,12 +206,24 @@ public class IBMDiscoveryV1Models {
       this.file_content_type_serialized_name = fileContentType;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the AddDocumentOptions builder
+     */
+    public AddDocumentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The addTrainingData options.
    */
-  public class AddTrainingDataOptions {
+  public class AddTrainingDataOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String natural_language_query_serialized_name;
@@ -268,6 +281,7 @@ public class IBMDiscoveryV1Models {
       natural_language_query_serialized_name = builder.natural_language_query_serialized_name;
       filter_serialized_name = builder.filter_serialized_name;
       examples_serialized_name = builder.examples_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -284,7 +298,7 @@ public class IBMDiscoveryV1Models {
   /**
    * AddTrainingDataOptions Builder.
    */
-  public class AddTrainingDataOptionsBuilder {
+  public class AddTrainingDataOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String natural_language_query_serialized_name;
@@ -395,6 +409,18 @@ public class IBMDiscoveryV1Models {
       this.examples_serialized_name = examples;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the AddTrainingDataOptions builder
+     */
+    public AddTrainingDataOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
@@ -492,7 +518,7 @@ public class IBMDiscoveryV1Models {
   /**
    * A collection for storing documents.
    */
-  public class Collection extends IBMWatsonGenericModel {
+  public class Collection extends IBMWatsonResponseModel {
     private String collection_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -784,7 +810,7 @@ public class IBMDiscoveryV1Models {
   /**
    * A custom configuration for the environment.
    */
-  public class Configuration extends IBMWatsonGenericModel {
+  public class Configuration extends IBMWatsonResponseModel {
     private String configuration_id_serialized_name;
     private String name_serialized_name;
     private Datetime created_serialized_name;
@@ -1121,7 +1147,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The createCollection options.
    */
-  public class CreateCollectionOptions {
+  public class CreateCollectionOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -1185,6 +1211,7 @@ public class IBMDiscoveryV1Models {
       description_serialized_name = builder.description_serialized_name;
       configuration_id_serialized_name = builder.configuration_id_serialized_name;
       language_serialized_name = builder.language_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1201,7 +1228,7 @@ public class IBMDiscoveryV1Models {
   /**
    * CreateCollectionOptions Builder.
    */
-  public class CreateCollectionOptionsBuilder {
+  public class CreateCollectionOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -1296,12 +1323,24 @@ public class IBMDiscoveryV1Models {
       this.language_serialized_name = language;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateCollectionOptions builder
+     */
+    public CreateCollectionOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The createConfiguration options.
    */
-  public class CreateConfigurationOptions {
+  public class CreateConfigurationOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -1376,6 +1415,7 @@ public class IBMDiscoveryV1Models {
       conversions_serialized_name = builder.conversions_serialized_name;
       enrichments_serialized_name = builder.enrichments_serialized_name;
       normalizations_serialized_name = builder.normalizations_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1392,7 +1432,7 @@ public class IBMDiscoveryV1Models {
   /**
    * CreateConfigurationOptions Builder.
    */
-  public class CreateConfigurationOptionsBuilder {
+  public class CreateConfigurationOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -1545,12 +1585,24 @@ public class IBMDiscoveryV1Models {
       this.normalizations_serialized_name = configuration.getNormalizations();
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateConfigurationOptions builder
+     */
+    public CreateConfigurationOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The createEnvironment options.
    */
-  public class CreateEnvironmentOptions {
+  public class CreateEnvironmentOptions extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String description_serialized_name;
     private Long size_serialized_name;
@@ -1589,6 +1641,7 @@ public class IBMDiscoveryV1Models {
       name_serialized_name = builder.name_serialized_name;
       description_serialized_name = builder.description_serialized_name;
       size_serialized_name = builder.size_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1605,7 +1658,7 @@ public class IBMDiscoveryV1Models {
   /**
    * CreateEnvironmentOptions Builder.
    */
-  public class CreateEnvironmentOptionsBuilder {
+  public class CreateEnvironmentOptionsBuilder extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String description_serialized_name;
     private Long size_serialized_name;
@@ -1672,12 +1725,24 @@ public class IBMDiscoveryV1Models {
       this.size_serialized_name = size;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateEnvironmentOptions builder
+     */
+    public CreateEnvironmentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The createExpansions options.
    */
-  public class CreateExpansionsOptions {
+  public class CreateExpansionsOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private List<Expansion> expansions_serialized_name;
@@ -1717,6 +1782,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
       expansions_serialized_name = builder.expansions_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1733,7 +1799,7 @@ public class IBMDiscoveryV1Models {
   /**
    * CreateExpansionsOptions Builder.
    */
-  public class CreateExpansionsOptionsBuilder {
+  public class CreateExpansionsOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private List<Expansion> expansions_serialized_name;
@@ -1829,12 +1895,24 @@ public class IBMDiscoveryV1Models {
       this.expansions_serialized_name = expansions.getExpansions();
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateExpansionsOptions builder
+     */
+    public CreateExpansionsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The createTrainingExample options.
    */
-  public class CreateTrainingExampleOptions {
+  public class CreateTrainingExampleOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -1905,6 +1983,7 @@ public class IBMDiscoveryV1Models {
       document_id_serialized_name = builder.document_id_serialized_name;
       cross_reference_serialized_name = builder.cross_reference_serialized_name;
       relevance_serialized_name = builder.relevance_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1921,7 +2000,7 @@ public class IBMDiscoveryV1Models {
   /**
    * CreateTrainingExampleOptions Builder.
    */
-  public class CreateTrainingExampleOptionsBuilder {
+  public class CreateTrainingExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -2044,12 +2123,24 @@ public class IBMDiscoveryV1Models {
       this.relevance_serialized_name = trainingExample.getRelevance();
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateTrainingExampleOptions builder
+     */
+    public CreateTrainingExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The deleteAllTrainingData options.
    */
-  public class DeleteAllTrainingDataOptions {
+  public class DeleteAllTrainingDataOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     /**
@@ -2077,6 +2168,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.collection_id_serialized_name, 'collection_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2093,7 +2185,7 @@ public class IBMDiscoveryV1Models {
   /**
    * DeleteAllTrainingDataOptions Builder.
    */
-  public class DeleteAllTrainingDataOptionsBuilder {
+  public class DeleteAllTrainingDataOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
 
@@ -2149,12 +2241,24 @@ public class IBMDiscoveryV1Models {
       this.collection_id_serialized_name = collectionId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteAllTrainingDataOptions builder
+     */
+    public DeleteAllTrainingDataOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The deleteCollection options.
    */
-  public class DeleteCollectionOptions {
+  public class DeleteCollectionOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     /**
@@ -2182,6 +2286,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.collection_id_serialized_name, 'collection_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2198,7 +2303,7 @@ public class IBMDiscoveryV1Models {
   /**
    * DeleteCollectionOptions Builder.
    */
-  public class DeleteCollectionOptionsBuilder {
+  public class DeleteCollectionOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
 
@@ -2254,12 +2359,24 @@ public class IBMDiscoveryV1Models {
       this.collection_id_serialized_name = collectionId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteCollectionOptions builder
+     */
+    public DeleteCollectionOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The deleteConfiguration options.
    */
-  public class DeleteConfigurationOptions {
+  public class DeleteConfigurationOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String configuration_id_serialized_name;
     /**
@@ -2287,6 +2404,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.configuration_id_serialized_name, 'configuration_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       configuration_id_serialized_name = builder.configuration_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2303,7 +2421,7 @@ public class IBMDiscoveryV1Models {
   /**
    * DeleteConfigurationOptions Builder.
    */
-  public class DeleteConfigurationOptionsBuilder {
+  public class DeleteConfigurationOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String configuration_id_serialized_name;
 
@@ -2359,12 +2477,24 @@ public class IBMDiscoveryV1Models {
       this.configuration_id_serialized_name = configurationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteConfigurationOptions builder
+     */
+    public DeleteConfigurationOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The deleteDocument options.
    */
-  public class DeleteDocumentOptions {
+  public class DeleteDocumentOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String document_id_serialized_name;
@@ -2405,6 +2535,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
       document_id_serialized_name = builder.document_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2421,7 +2552,7 @@ public class IBMDiscoveryV1Models {
   /**
    * DeleteDocumentOptions Builder.
    */
-  public class DeleteDocumentOptionsBuilder {
+  public class DeleteDocumentOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String document_id_serialized_name;
@@ -2492,12 +2623,24 @@ public class IBMDiscoveryV1Models {
       this.document_id_serialized_name = documentId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteDocumentOptions builder
+     */
+    public DeleteDocumentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The deleteEnvironment options.
    */
-  public class DeleteEnvironmentOptions {
+  public class DeleteEnvironmentOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     /**
      * Gets the environment_id_serialized_name.
@@ -2512,6 +2655,7 @@ public class IBMDiscoveryV1Models {
     private DeleteEnvironmentOptions(DeleteEnvironmentOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.environment_id_serialized_name, 'environment_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2528,7 +2672,7 @@ public class IBMDiscoveryV1Models {
   /**
    * DeleteEnvironmentOptions Builder.
    */
-  public class DeleteEnvironmentOptionsBuilder {
+  public class DeleteEnvironmentOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
 
     private DeleteEnvironmentOptionsBuilder(DeleteEnvironmentOptions deleteEnvironmentOptions) {
@@ -2569,12 +2713,24 @@ public class IBMDiscoveryV1Models {
       this.environment_id_serialized_name = environmentId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteEnvironmentOptions builder
+     */
+    public DeleteEnvironmentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The deleteExpansions options.
    */
-  public class DeleteExpansionsOptions {
+  public class DeleteExpansionsOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     /**
@@ -2602,6 +2758,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.collection_id_serialized_name, 'collection_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2618,7 +2775,7 @@ public class IBMDiscoveryV1Models {
   /**
    * DeleteExpansionsOptions Builder.
    */
-  public class DeleteExpansionsOptionsBuilder {
+  public class DeleteExpansionsOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
 
@@ -2674,12 +2831,24 @@ public class IBMDiscoveryV1Models {
       this.collection_id_serialized_name = collectionId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteExpansionsOptions builder
+     */
+    public DeleteExpansionsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The deleteTrainingData options.
    */
-  public class DeleteTrainingDataOptions {
+  public class DeleteTrainingDataOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -2720,6 +2889,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
       query_id_serialized_name = builder.query_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2736,7 +2906,7 @@ public class IBMDiscoveryV1Models {
   /**
    * DeleteTrainingDataOptions Builder.
    */
-  public class DeleteTrainingDataOptionsBuilder {
+  public class DeleteTrainingDataOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -2807,12 +2977,24 @@ public class IBMDiscoveryV1Models {
       this.query_id_serialized_name = queryId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteTrainingDataOptions builder
+     */
+    public DeleteTrainingDataOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The deleteTrainingExample options.
    */
-  public class DeleteTrainingExampleOptions {
+  public class DeleteTrainingExampleOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -2866,6 +3048,7 @@ public class IBMDiscoveryV1Models {
       collection_id_serialized_name = builder.collection_id_serialized_name;
       query_id_serialized_name = builder.query_id_serialized_name;
       example_id_serialized_name = builder.example_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2882,7 +3065,7 @@ public class IBMDiscoveryV1Models {
   /**
    * DeleteTrainingExampleOptions Builder.
    */
-  public class DeleteTrainingExampleOptionsBuilder {
+  public class DeleteTrainingExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -2968,6 +3151,18 @@ public class IBMDiscoveryV1Models {
       this.example_id_serialized_name = exampleId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteTrainingExampleOptions builder
+     */
+    public DeleteTrainingExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
@@ -3061,7 +3256,7 @@ public class IBMDiscoveryV1Models {
   /**
    * DocumentAccepted.
    */
-  public class DocumentAccepted extends IBMWatsonGenericModel {
+  public class DocumentAccepted extends IBMWatsonResponseModel {
     private String document_id_serialized_name;
     private String status_serialized_name;
     private List<Notice> notices_serialized_name;
@@ -3263,7 +3458,7 @@ public class IBMDiscoveryV1Models {
   /**
    * Status information about a submitted document.
    */
-  public class DocumentStatus extends IBMWatsonGenericModel {
+  public class DocumentStatus extends IBMWatsonResponseModel {
     private String document_id_serialized_name;
     private String configuration_id_serialized_name;
     private Datetime created_serialized_name;
@@ -3618,6 +3813,13 @@ public class IBMDiscoveryV1Models {
   public class EnrichmentOptions extends IBMWatsonGenericModel {
     private NluEnrichmentFeatures features_serialized_name;
     private String model_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public EnrichmentOptions() { }
+
     /**
      * Gets the features_serialized_name.
      *
@@ -3640,23 +3842,18 @@ public class IBMDiscoveryV1Models {
     public String getModel() {
       return model_serialized_name;
     }
-
-    /**
-     * Sets the features_serialized_name.
-     *
-     * @param features the new features
-     */
-    public void setFeatures(final NluEnrichmentFeatures features) {
-      this.features_serialized_name = features;
+    private EnrichmentOptions(EnrichmentOptionsBuilder builder) {
+      features_serialized_name = builder.features_serialized_name;
+      model_serialized_name = builder.model_serialized_name;
     }
 
     /**
-     * Sets the model_serialized_name.
+     * New builder.
      *
-     * @param model the new model
+     * @return a EnrichmentOptions builder
      */
-    public void setModel(final String model) {
-      this.model_serialized_name = model;
+    public EnrichmentOptionsBuilder newBuilder() {
+      return new EnrichmentOptionsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3665,19 +3862,70 @@ public class IBMDiscoveryV1Models {
       }
 
       EnrichmentOptions ret = (EnrichmentOptions) super.deserialize(jsonString, jsonMap, classType);
+      EnrichmentOptionsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for features_serialized_name
       NluEnrichmentFeatures newFeatures = (NluEnrichmentFeatures) new NluEnrichmentFeatures().deserialize(JSON.serialize(ret.getFeatures()), (Map<String, Object>) jsonMap.get('features_serialized_name'), NluEnrichmentFeatures.class);
-      ret.setFeatures(newFeatures);
+      retBuilder.features(newFeatures);
 
-      return ret;
+      return retBuilder.build();
+    }
+  }
+
+  /**
+   * EnrichmentOptions Builder.
+   */
+  public class EnrichmentOptionsBuilder {
+    private NluEnrichmentFeatures features_serialized_name;
+    private String model_serialized_name;
+
+    private EnrichmentOptionsBuilder(EnrichmentOptions enrichmentOptions) {
+      features_serialized_name = enrichmentOptions.features_serialized_name;
+      model_serialized_name = enrichmentOptions.model_serialized_name;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public EnrichmentOptionsBuilder() {
+    }
+
+    /**
+     * Builds a EnrichmentOptions.
+     *
+     * @return the enrichmentOptions
+     */
+    public EnrichmentOptions build() {
+      return new EnrichmentOptions(this);
+    }
+
+    /**
+     * Set the features_serialized_name.
+     *
+     * @param features the features
+     * @return the EnrichmentOptions builder
+     */
+    public EnrichmentOptionsBuilder features(NluEnrichmentFeatures features) {
+      this.features_serialized_name = features;
+      return this;
+    }
+
+    /**
+     * Set the model_serialized_name.
+     *
+     * @param model the model
+     * @return the EnrichmentOptions builder
+     */
+    public EnrichmentOptionsBuilder model(String model) {
+      this.model_serialized_name = model;
+      return this;
     }
   }
 
   /**
    * Details about an environment.
    */
-  public class Environment extends IBMWatsonGenericModel {
+  public class Environment extends IBMWatsonResponseModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -3939,7 +4187,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The query expansion definitions for the specified collection.
    */
-  public class Expansions extends IBMWatsonGenericModel {
+  public class Expansions extends IBMWatsonResponseModel {
     private List<Expansion> expansions_serialized_name;
     /**
      * Gets the expansions_serialized_name.
@@ -3989,7 +4237,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The federatedQueryNotices options.
    */
-  public class FederatedQueryNoticesOptions {
+  public class FederatedQueryNoticesOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private List<String> collection_ids_serialized_name;
     private String filter_serialized_name;
@@ -4173,6 +4421,7 @@ public class IBMDiscoveryV1Models {
       similar_serialized_name = builder.similar_serialized_name;
       similar_document_ids_serialized_name = builder.similar_document_ids_serialized_name;
       similar_fields_serialized_name = builder.similar_fields_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4189,7 +4438,7 @@ public class IBMDiscoveryV1Models {
   /**
    * FederatedQueryNoticesOptions Builder.
    */
-  public class FederatedQueryNoticesOptionsBuilder {
+  public class FederatedQueryNoticesOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private List<String> collection_ids_serialized_name;
     private String filter_serialized_name;
@@ -4494,12 +4743,24 @@ public class IBMDiscoveryV1Models {
       this.similar_fields_serialized_name = similarFields;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the FederatedQueryNoticesOptions builder
+     */
+    public FederatedQueryNoticesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The federatedQuery options.
    */
-  public class FederatedQueryOptions {
+  public class FederatedQueryOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private List<String> collection_ids_serialized_name;
     private String filter_serialized_name;
@@ -4695,6 +4956,7 @@ public class IBMDiscoveryV1Models {
       similar_serialized_name = builder.similar_serialized_name;
       similar_document_ids_serialized_name = builder.similar_document_ids_serialized_name;
       similar_fields_serialized_name = builder.similar_fields_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4711,7 +4973,7 @@ public class IBMDiscoveryV1Models {
   /**
    * FederatedQueryOptions Builder.
    */
-  public class FederatedQueryOptionsBuilder {
+  public class FederatedQueryOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private List<String> collection_ids_serialized_name;
     private String filter_serialized_name;
@@ -5029,6 +5291,18 @@ public class IBMDiscoveryV1Models {
       this.similar_fields_serialized_name = similarFields;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the FederatedQueryOptions builder
+     */
+    public FederatedQueryOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
@@ -5204,7 +5478,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The getCollection options.
    */
-  public class GetCollectionOptions {
+  public class GetCollectionOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     /**
@@ -5232,6 +5506,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.collection_id_serialized_name, 'collection_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5248,7 +5523,7 @@ public class IBMDiscoveryV1Models {
   /**
    * GetCollectionOptions Builder.
    */
-  public class GetCollectionOptionsBuilder {
+  public class GetCollectionOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
 
@@ -5304,12 +5579,24 @@ public class IBMDiscoveryV1Models {
       this.collection_id_serialized_name = collectionId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetCollectionOptions builder
+     */
+    public GetCollectionOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The getConfiguration options.
    */
-  public class GetConfigurationOptions {
+  public class GetConfigurationOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String configuration_id_serialized_name;
     /**
@@ -5337,6 +5624,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.configuration_id_serialized_name, 'configuration_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       configuration_id_serialized_name = builder.configuration_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5353,7 +5641,7 @@ public class IBMDiscoveryV1Models {
   /**
    * GetConfigurationOptions Builder.
    */
-  public class GetConfigurationOptionsBuilder {
+  public class GetConfigurationOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String configuration_id_serialized_name;
 
@@ -5409,12 +5697,24 @@ public class IBMDiscoveryV1Models {
       this.configuration_id_serialized_name = configurationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetConfigurationOptions builder
+     */
+    public GetConfigurationOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The getDocumentStatus options.
    */
-  public class GetDocumentStatusOptions {
+  public class GetDocumentStatusOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String document_id_serialized_name;
@@ -5455,6 +5755,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
       document_id_serialized_name = builder.document_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5471,7 +5772,7 @@ public class IBMDiscoveryV1Models {
   /**
    * GetDocumentStatusOptions Builder.
    */
-  public class GetDocumentStatusOptionsBuilder {
+  public class GetDocumentStatusOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String document_id_serialized_name;
@@ -5542,12 +5843,24 @@ public class IBMDiscoveryV1Models {
       this.document_id_serialized_name = documentId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetDocumentStatusOptions builder
+     */
+    public GetDocumentStatusOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The getEnvironment options.
    */
-  public class GetEnvironmentOptions {
+  public class GetEnvironmentOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     /**
      * Gets the environment_id_serialized_name.
@@ -5562,6 +5875,7 @@ public class IBMDiscoveryV1Models {
     private GetEnvironmentOptions(GetEnvironmentOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.environment_id_serialized_name, 'environment_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5578,7 +5892,7 @@ public class IBMDiscoveryV1Models {
   /**
    * GetEnvironmentOptions Builder.
    */
-  public class GetEnvironmentOptionsBuilder {
+  public class GetEnvironmentOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
 
     private GetEnvironmentOptionsBuilder(GetEnvironmentOptions getEnvironmentOptions) {
@@ -5619,12 +5933,24 @@ public class IBMDiscoveryV1Models {
       this.environment_id_serialized_name = environmentId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetEnvironmentOptions builder
+     */
+    public GetEnvironmentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The getTrainingData options.
    */
-  public class GetTrainingDataOptions {
+  public class GetTrainingDataOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -5665,6 +5991,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
       query_id_serialized_name = builder.query_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5681,7 +6008,7 @@ public class IBMDiscoveryV1Models {
   /**
    * GetTrainingDataOptions Builder.
    */
-  public class GetTrainingDataOptionsBuilder {
+  public class GetTrainingDataOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -5752,12 +6079,24 @@ public class IBMDiscoveryV1Models {
       this.query_id_serialized_name = queryId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetTrainingDataOptions builder
+     */
+    public GetTrainingDataOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The getTrainingExample options.
    */
-  public class GetTrainingExampleOptions {
+  public class GetTrainingExampleOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -5811,6 +6150,7 @@ public class IBMDiscoveryV1Models {
       collection_id_serialized_name = builder.collection_id_serialized_name;
       query_id_serialized_name = builder.query_id_serialized_name;
       example_id_serialized_name = builder.example_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5827,7 +6167,7 @@ public class IBMDiscoveryV1Models {
   /**
    * GetTrainingExampleOptions Builder.
    */
-  public class GetTrainingExampleOptionsBuilder {
+  public class GetTrainingExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -5913,6 +6253,18 @@ public class IBMDiscoveryV1Models {
       this.example_id_serialized_name = exampleId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetTrainingExampleOptions builder
+     */
+    public GetTrainingExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
@@ -6172,7 +6524,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The listCollectionFields options.
    */
-  public class ListCollectionFieldsOptions {
+  public class ListCollectionFieldsOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     /**
@@ -6200,6 +6552,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.collection_id_serialized_name, 'collection_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6216,7 +6569,7 @@ public class IBMDiscoveryV1Models {
   /**
    * ListCollectionFieldsOptions Builder.
    */
-  public class ListCollectionFieldsOptionsBuilder {
+  public class ListCollectionFieldsOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
 
@@ -6272,12 +6625,24 @@ public class IBMDiscoveryV1Models {
       this.collection_id_serialized_name = collectionId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListCollectionFieldsOptions builder
+     */
+    public ListCollectionFieldsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The list of fetched fields.  The fields are returned using a fully qualified name format, however, the format differs slightly from that used by the query operations.    * Fields which contain nested JSON objects are assigned a type of "nested".    * Fields which belong to a nested object are prefixed with `.properties` (for example, `warnings.properties.severity` means that the `warnings` object has a property called `severity`).    * Fields returned from the News collection are prefixed with `v{N}-fullnews-t3-{YEAR}.mappings` (for example, `v5-fullnews-t3-2016.mappings.text.properties.author`).
    */
-  public class ListCollectionFieldsResponse extends IBMWatsonGenericModel {
+  public class ListCollectionFieldsResponse extends IBMWatsonResponseModel {
     private List<Field> fields_serialized_name;
     /**
      * Gets the fields_serialized_name.
@@ -6327,7 +6692,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The listCollections options.
    */
-  public class ListCollectionsOptions {
+  public class ListCollectionsOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
     /**
@@ -6354,6 +6719,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.environment_id_serialized_name, 'environment_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       name_serialized_name = builder.name_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6370,7 +6736,7 @@ public class IBMDiscoveryV1Models {
   /**
    * ListCollectionsOptions Builder.
    */
-  public class ListCollectionsOptionsBuilder {
+  public class ListCollectionsOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
 
@@ -6424,12 +6790,24 @@ public class IBMDiscoveryV1Models {
       this.name_serialized_name = name;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListCollectionsOptions builder
+     */
+    public ListCollectionsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * ListCollectionsResponse.
    */
-  public class ListCollectionsResponse extends IBMWatsonGenericModel {
+  public class ListCollectionsResponse extends IBMWatsonResponseModel {
     private List<Collection> collections_serialized_name;
     /**
      * Gets the collections_serialized_name.
@@ -6479,7 +6857,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The listConfigurations options.
    */
-  public class ListConfigurationsOptions {
+  public class ListConfigurationsOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
     /**
@@ -6506,6 +6884,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.environment_id_serialized_name, 'environment_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       name_serialized_name = builder.name_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6522,7 +6901,7 @@ public class IBMDiscoveryV1Models {
   /**
    * ListConfigurationsOptions Builder.
    */
-  public class ListConfigurationsOptionsBuilder {
+  public class ListConfigurationsOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
 
@@ -6576,12 +6955,24 @@ public class IBMDiscoveryV1Models {
       this.name_serialized_name = name;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListConfigurationsOptions builder
+     */
+    public ListConfigurationsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * ListConfigurationsResponse.
    */
-  public class ListConfigurationsResponse extends IBMWatsonGenericModel {
+  public class ListConfigurationsResponse extends IBMWatsonResponseModel {
     private List<Configuration> configurations_serialized_name;
     /**
      * Gets the configurations_serialized_name.
@@ -6631,7 +7022,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The listEnvironments options.
    */
-  public class ListEnvironmentsOptions {
+  public class ListEnvironmentsOptions extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     /**
      * Gets the name_serialized_name.
@@ -6645,6 +7036,7 @@ public class IBMDiscoveryV1Models {
     }
     private ListEnvironmentsOptions(ListEnvironmentsOptionsBuilder builder) {
       name_serialized_name = builder.name_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6661,7 +7053,7 @@ public class IBMDiscoveryV1Models {
   /**
    * ListEnvironmentsOptions Builder.
    */
-  public class ListEnvironmentsOptionsBuilder {
+  public class ListEnvironmentsOptionsBuilder extends IBMWatsonOptionsModel {
     private String name_serialized_name;
 
     private ListEnvironmentsOptionsBuilder(ListEnvironmentsOptions listEnvironmentsOptions) {
@@ -6693,12 +7085,24 @@ public class IBMDiscoveryV1Models {
       this.name_serialized_name = name;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListEnvironmentsOptions builder
+     */
+    public ListEnvironmentsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * ListEnvironmentsResponse.
    */
-  public class ListEnvironmentsResponse extends IBMWatsonGenericModel {
+  public class ListEnvironmentsResponse extends IBMWatsonResponseModel {
     private List<Environment> environments_serialized_name;
     /**
      * Gets the environments_serialized_name.
@@ -6748,7 +7152,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The listExpansions options.
    */
-  public class ListExpansionsOptions {
+  public class ListExpansionsOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     /**
@@ -6776,6 +7180,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.collection_id_serialized_name, 'collection_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6792,7 +7197,7 @@ public class IBMDiscoveryV1Models {
   /**
    * ListExpansionsOptions Builder.
    */
-  public class ListExpansionsOptionsBuilder {
+  public class ListExpansionsOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
 
@@ -6848,12 +7253,24 @@ public class IBMDiscoveryV1Models {
       this.collection_id_serialized_name = collectionId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListExpansionsOptions builder
+     */
+    public ListExpansionsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The listFields options.
    */
-  public class ListFieldsOptions {
+  public class ListFieldsOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private List<String> collection_ids_serialized_name;
     /**
@@ -6881,6 +7298,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notNull(builder.collection_ids_serialized_name, 'collection_ids_serialized_name cannot be null');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_ids_serialized_name = builder.collection_ids_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6897,7 +7315,7 @@ public class IBMDiscoveryV1Models {
   /**
    * ListFieldsOptions Builder.
    */
-  public class ListFieldsOptionsBuilder {
+  public class ListFieldsOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private List<String> collection_ids_serialized_name;
 
@@ -6969,12 +7387,24 @@ public class IBMDiscoveryV1Models {
       this.collection_ids_serialized_name = collectionIds;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListFieldsOptions builder
+     */
+    public ListFieldsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The listTrainingData options.
    */
-  public class ListTrainingDataOptions {
+  public class ListTrainingDataOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     /**
@@ -7002,6 +7432,7 @@ public class IBMDiscoveryV1Models {
       IBMWatsonValidator.notEmpty(builder.collection_id_serialized_name, 'collection_id_serialized_name cannot be empty');
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7018,7 +7449,7 @@ public class IBMDiscoveryV1Models {
   /**
    * ListTrainingDataOptions Builder.
    */
-  public class ListTrainingDataOptionsBuilder {
+  public class ListTrainingDataOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
 
@@ -7074,12 +7505,24 @@ public class IBMDiscoveryV1Models {
       this.collection_id_serialized_name = collectionId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListTrainingDataOptions builder
+     */
+    public ListTrainingDataOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * The listTrainingExamples options.
    */
-  public class ListTrainingExamplesOptions {
+  public class ListTrainingExamplesOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -7120,6 +7563,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = builder.environment_id_serialized_name;
       collection_id_serialized_name = builder.collection_id_serialized_name;
       query_id_serialized_name = builder.query_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -7136,7 +7580,7 @@ public class IBMDiscoveryV1Models {
   /**
    * ListTrainingExamplesOptions Builder.
    */
-  public class ListTrainingExamplesOptionsBuilder {
+  public class ListTrainingExamplesOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -7207,6 +7651,18 @@ public class IBMDiscoveryV1Models {
       this.query_id_serialized_name = queryId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListTrainingExamplesOptions builder
+     */
+    public ListTrainingExamplesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
@@ -7326,6 +7782,13 @@ public class IBMDiscoveryV1Models {
   public class NluEnrichmentEmotion extends IBMWatsonGenericModel {
     private Boolean document_serialized_name;
     private List<String> targets_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NluEnrichmentEmotion() { }
+
     /**
      * Gets the document_serialized_name.
      *
@@ -7348,23 +7811,18 @@ public class IBMDiscoveryV1Models {
     public List<String> getTargets() {
       return targets_serialized_name;
     }
-
-    /**
-     * Sets the document_serialized_name.
-     *
-     * @param document the new document
-     */
-    public void setDocument(final Boolean document) {
-      this.document_serialized_name = document;
+    private NluEnrichmentEmotion(NluEnrichmentEmotionBuilder builder) {
+      document_serialized_name = builder.document_serialized_name;
+      targets_serialized_name = builder.targets_serialized_name;
     }
 
     /**
-     * Sets the targets_serialized_name.
+     * New builder.
      *
-     * @param targets the new targets
+     * @return a NluEnrichmentEmotion builder
      */
-    public void setTargets(final List<String> targets) {
-      this.targets_serialized_name = targets;
+    public NluEnrichmentEmotionBuilder newBuilder() {
+      return new NluEnrichmentEmotionBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7379,6 +7837,72 @@ public class IBMDiscoveryV1Models {
   }
 
   /**
+   * NluEnrichmentEmotion Builder.
+   */
+  public class NluEnrichmentEmotionBuilder {
+    private Boolean document_serialized_name;
+    private List<String> targets_serialized_name;
+
+    private NluEnrichmentEmotionBuilder(NluEnrichmentEmotion nluEnrichmentEmotion) {
+      document_serialized_name = nluEnrichmentEmotion.document_serialized_name;
+      targets_serialized_name = nluEnrichmentEmotion.targets_serialized_name;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public NluEnrichmentEmotionBuilder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentEmotion.
+     *
+     * @return the nluEnrichmentEmotion
+     */
+    public NluEnrichmentEmotion build() {
+      return new NluEnrichmentEmotion(this);
+    }
+
+    /**
+     * Adds an targets to targets_serialized_name.
+     *
+     * @param targets the new targets
+     * @return the NluEnrichmentEmotion builder
+     */
+    public NluEnrichmentEmotionBuilder addTargets(String targets) {
+      IBMWatsonValidator.notNull(targets, 'targets cannot be null');
+      if (this.targets_serialized_name == null) {
+        this.targets_serialized_name = new List<String>();
+      }
+      this.targets_serialized_name.add(targets);
+      return this;
+    }
+
+    /**
+     * Set the document_serialized_name.
+     *
+     * @param document the document
+     * @return the NluEnrichmentEmotion builder
+     */
+    public NluEnrichmentEmotionBuilder document(Boolean document) {
+      this.document_serialized_name = document;
+      return this;
+    }
+
+    /**
+     * Set the targets_serialized_name.
+     * Existing targets_serialized_name will be replaced.
+     *
+     * @param targets the targets
+     * @return the NluEnrichmentEmotion builder
+     */
+    public NluEnrichmentEmotionBuilder targets(List<String> targets) {
+      this.targets_serialized_name = targets;
+      return this;
+    }
+  }
+
+  /**
    * An object speficying the Entities enrichment and related parameters.
    */
   public class NluEnrichmentEntities extends IBMWatsonGenericModel {
@@ -7389,6 +7913,13 @@ public class IBMDiscoveryV1Models {
     private Boolean mention_types_serialized_name;
     private Boolean sentence_location_serialized_name;
     private String model_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NluEnrichmentEntities() { }
+
     /**
      * Gets the sentiment_serialized_name.
      *
@@ -7466,68 +7997,23 @@ public class IBMDiscoveryV1Models {
     public String getModel() {
       return model_serialized_name;
     }
-
-    /**
-     * Sets the sentiment_serialized_name.
-     *
-     * @param sentiment the new sentiment
-     */
-    public void setSentiment(final Boolean sentiment) {
-      this.sentiment_serialized_name = sentiment;
+    private NluEnrichmentEntities(NluEnrichmentEntitiesBuilder builder) {
+      sentiment_serialized_name = builder.sentiment_serialized_name;
+      emotion_serialized_name = builder.emotion_serialized_name;
+      limit_serialized_name = builder.limit_serialized_name;
+      mentions_serialized_name = builder.mentions_serialized_name;
+      mention_types_serialized_name = builder.mention_types_serialized_name;
+      sentence_location_serialized_name = builder.sentence_location_serialized_name;
+      model_serialized_name = builder.model_serialized_name;
     }
 
     /**
-     * Sets the emotion_serialized_name.
+     * New builder.
      *
-     * @param emotion the new emotion
+     * @return a NluEnrichmentEntities builder
      */
-    public void setEmotion(final Boolean emotion) {
-      this.emotion_serialized_name = emotion;
-    }
-
-    /**
-     * Sets the limit_serialized_name.
-     *
-     * @param limitVar the new limitVar
-     */
-    public void setLimit(final long limitVar) {
-      this.limit_serialized_name = limitVar;
-    }
-
-    /**
-     * Sets the mentions_serialized_name.
-     *
-     * @param mentions the new mentions
-     */
-    public void setMentions(final Boolean mentions) {
-      this.mentions_serialized_name = mentions;
-    }
-
-    /**
-     * Sets the mention_types_serialized_name.
-     *
-     * @param mentionTypes the new mentionTypes
-     */
-    public void setMentionTypes(final Boolean mentionTypes) {
-      this.mention_types_serialized_name = mentionTypes;
-    }
-
-    /**
-     * Sets the sentence_location_serialized_name.
-     *
-     * @param sentenceLocation the new sentenceLocation
-     */
-    public void setSentenceLocation(final Boolean sentenceLocation) {
-      this.sentence_location_serialized_name = sentenceLocation;
-    }
-
-    /**
-     * Sets the model_serialized_name.
-     *
-     * @param model the new model
-     */
-    public void setModel(final String model) {
-      this.model_serialized_name = model;
+    public NluEnrichmentEntitiesBuilder newBuilder() {
+      return new NluEnrichmentEntitiesBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7542,6 +8028,121 @@ public class IBMDiscoveryV1Models {
   }
 
   /**
+   * NluEnrichmentEntities Builder.
+   */
+  public class NluEnrichmentEntitiesBuilder {
+    private Boolean sentiment_serialized_name;
+    private Boolean emotion_serialized_name;
+    private Long limit_serialized_name;
+    private Boolean mentions_serialized_name;
+    private Boolean mention_types_serialized_name;
+    private Boolean sentence_location_serialized_name;
+    private String model_serialized_name;
+
+    private NluEnrichmentEntitiesBuilder(NluEnrichmentEntities nluEnrichmentEntities) {
+      sentiment_serialized_name = nluEnrichmentEntities.sentiment_serialized_name;
+      emotion_serialized_name = nluEnrichmentEntities.emotion_serialized_name;
+      limit_serialized_name = nluEnrichmentEntities.limit_serialized_name;
+      mentions_serialized_name = nluEnrichmentEntities.mentions_serialized_name;
+      mention_types_serialized_name = nluEnrichmentEntities.mention_types_serialized_name;
+      sentence_location_serialized_name = nluEnrichmentEntities.sentence_location_serialized_name;
+      model_serialized_name = nluEnrichmentEntities.model_serialized_name;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public NluEnrichmentEntitiesBuilder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentEntities.
+     *
+     * @return the nluEnrichmentEntities
+     */
+    public NluEnrichmentEntities build() {
+      return new NluEnrichmentEntities(this);
+    }
+
+    /**
+     * Set the sentiment_serialized_name.
+     *
+     * @param sentiment the sentiment
+     * @return the NluEnrichmentEntities builder
+     */
+    public NluEnrichmentEntitiesBuilder sentiment(Boolean sentiment) {
+      this.sentiment_serialized_name = sentiment;
+      return this;
+    }
+
+    /**
+     * Set the emotion_serialized_name.
+     *
+     * @param emotion the emotion
+     * @return the NluEnrichmentEntities builder
+     */
+    public NluEnrichmentEntitiesBuilder emotion(Boolean emotion) {
+      this.emotion_serialized_name = emotion;
+      return this;
+    }
+
+    /**
+     * Set the limit_serialized_name.
+     *
+     * @param limitVar the limitVar
+     * @return the NluEnrichmentEntities builder
+     */
+    public NluEnrichmentEntitiesBuilder limitField(Long limitVar) {
+      this.limit_serialized_name = limitVar;
+      return this;
+    }
+
+    /**
+     * Set the mentions_serialized_name.
+     *
+     * @param mentions the mentions
+     * @return the NluEnrichmentEntities builder
+     */
+    public NluEnrichmentEntitiesBuilder mentions(Boolean mentions) {
+      this.mentions_serialized_name = mentions;
+      return this;
+    }
+
+    /**
+     * Set the mention_types_serialized_name.
+     *
+     * @param mentionTypes the mentionTypes
+     * @return the NluEnrichmentEntities builder
+     */
+    public NluEnrichmentEntitiesBuilder mentionTypes(Boolean mentionTypes) {
+      this.mention_types_serialized_name = mentionTypes;
+      return this;
+    }
+
+    /**
+     * Set the sentence_location_serialized_name.
+     *
+     * @param sentenceLocation the sentenceLocation
+     * @return the NluEnrichmentEntities builder
+     */
+    public NluEnrichmentEntitiesBuilder sentenceLocation(Boolean sentenceLocation) {
+      this.sentence_location_serialized_name = sentenceLocation;
+      return this;
+    }
+
+    /**
+     * Set the model_serialized_name.
+     *
+     * @param model the model
+     * @return the NluEnrichmentEntities builder
+     */
+    public NluEnrichmentEntitiesBuilder model(String model) {
+      this.model_serialized_name = model;
+      return this;
+    }
+  }
+
+  /**
    * NluEnrichmentFeatures.
    */
   public class NluEnrichmentFeatures extends IBMWatsonGenericModel {
@@ -7552,6 +8153,13 @@ public class IBMDiscoveryV1Models {
     private NluEnrichmentCategories categories_serialized_name;
     private NluEnrichmentSemanticRoles semantic_roles_serialized_name;
     private NluEnrichmentRelations relations_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NluEnrichmentFeatures() { }
+
     /**
      * Gets the keywords_serialized_name.
      *
@@ -7629,68 +8237,23 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentRelations getRelations() {
       return relations_serialized_name;
     }
-
-    /**
-     * Sets the keywords_serialized_name.
-     *
-     * @param keywords the new keywords
-     */
-    public void setKeywords(final NluEnrichmentKeywords keywords) {
-      this.keywords_serialized_name = keywords;
+    private NluEnrichmentFeatures(NluEnrichmentFeaturesBuilder builder) {
+      keywords_serialized_name = builder.keywords_serialized_name;
+      entities_serialized_name = builder.entities_serialized_name;
+      sentiment_serialized_name = builder.sentiment_serialized_name;
+      emotion_serialized_name = builder.emotion_serialized_name;
+      categories_serialized_name = builder.categories_serialized_name;
+      semantic_roles_serialized_name = builder.semantic_roles_serialized_name;
+      relations_serialized_name = builder.relations_serialized_name;
     }
 
     /**
-     * Sets the entities_serialized_name.
+     * New builder.
      *
-     * @param entities the new entities
+     * @return a NluEnrichmentFeatures builder
      */
-    public void setEntities(final NluEnrichmentEntities entities) {
-      this.entities_serialized_name = entities;
-    }
-
-    /**
-     * Sets the sentiment_serialized_name.
-     *
-     * @param sentiment the new sentiment
-     */
-    public void setSentiment(final NluEnrichmentSentiment sentiment) {
-      this.sentiment_serialized_name = sentiment;
-    }
-
-    /**
-     * Sets the emotion_serialized_name.
-     *
-     * @param emotion the new emotion
-     */
-    public void setEmotion(final NluEnrichmentEmotion emotion) {
-      this.emotion_serialized_name = emotion;
-    }
-
-    /**
-     * Sets the categories_serialized_name.
-     *
-     * @param categories the new categories
-     */
-    public void setCategories(final NluEnrichmentCategories categories) {
-      this.categories_serialized_name = categories;
-    }
-
-    /**
-     * Sets the semantic_roles_serialized_name.
-     *
-     * @param semanticRoles the new semanticRoles
-     */
-    public void setSemanticRoles(final NluEnrichmentSemanticRoles semanticRoles) {
-      this.semantic_roles_serialized_name = semanticRoles;
-    }
-
-    /**
-     * Sets the relations_serialized_name.
-     *
-     * @param relations the new relations
-     */
-    public void setRelations(final NluEnrichmentRelations relations) {
-      this.relations_serialized_name = relations;
+    public NluEnrichmentFeaturesBuilder newBuilder() {
+      return new NluEnrichmentFeaturesBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7699,36 +8262,152 @@ public class IBMDiscoveryV1Models {
       }
 
       NluEnrichmentFeatures ret = (NluEnrichmentFeatures) super.deserialize(jsonString, jsonMap, classType);
+      NluEnrichmentFeaturesBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for keywords_serialized_name
       NluEnrichmentKeywords newKeywords = (NluEnrichmentKeywords) new NluEnrichmentKeywords().deserialize(JSON.serialize(ret.getKeywords()), (Map<String, Object>) jsonMap.get('keywords_serialized_name'), NluEnrichmentKeywords.class);
-      ret.setKeywords(newKeywords);
+      retBuilder.keywords(newKeywords);
 
       // calling custom deserializer for entities_serialized_name
       NluEnrichmentEntities newEntities = (NluEnrichmentEntities) new NluEnrichmentEntities().deserialize(JSON.serialize(ret.getEntities()), (Map<String, Object>) jsonMap.get('entities_serialized_name'), NluEnrichmentEntities.class);
-      ret.setEntities(newEntities);
+      retBuilder.entities(newEntities);
 
       // calling custom deserializer for sentiment_serialized_name
       NluEnrichmentSentiment newSentiment = (NluEnrichmentSentiment) new NluEnrichmentSentiment().deserialize(JSON.serialize(ret.getSentiment()), (Map<String, Object>) jsonMap.get('sentiment_serialized_name'), NluEnrichmentSentiment.class);
-      ret.setSentiment(newSentiment);
+      retBuilder.sentiment(newSentiment);
 
       // calling custom deserializer for emotion_serialized_name
       NluEnrichmentEmotion newEmotion = (NluEnrichmentEmotion) new NluEnrichmentEmotion().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion_serialized_name'), NluEnrichmentEmotion.class);
-      ret.setEmotion(newEmotion);
+      retBuilder.emotion(newEmotion);
 
       // calling custom deserializer for categories_serialized_name
       NluEnrichmentCategories newCategories = (NluEnrichmentCategories) new NluEnrichmentCategories().deserialize(JSON.serialize(ret.getCategories()), (Map<String, Object>) jsonMap.get('categories_serialized_name'), NluEnrichmentCategories.class);
-      ret.setCategories(newCategories);
+      retBuilder.categories(newCategories);
 
       // calling custom deserializer for semantic_roles_serialized_name
       NluEnrichmentSemanticRoles newSemanticRoles = (NluEnrichmentSemanticRoles) new NluEnrichmentSemanticRoles().deserialize(JSON.serialize(ret.getSemanticRoles()), (Map<String, Object>) jsonMap.get('semantic_roles_serialized_name'), NluEnrichmentSemanticRoles.class);
-      ret.setSemanticRoles(newSemanticRoles);
+      retBuilder.semanticRoles(newSemanticRoles);
 
       // calling custom deserializer for relations_serialized_name
       NluEnrichmentRelations newRelations = (NluEnrichmentRelations) new NluEnrichmentRelations().deserialize(JSON.serialize(ret.getRelations()), (Map<String, Object>) jsonMap.get('relations_serialized_name'), NluEnrichmentRelations.class);
-      ret.setRelations(newRelations);
+      retBuilder.relations(newRelations);
 
-      return ret;
+      return retBuilder.build();
+    }
+  }
+
+    /**
+   * NluEnrichmentFeatures Builder.
+   */
+  public class NluEnrichmentFeaturesBuilder {
+    private NluEnrichmentKeywords keywords_serialized_name;
+    private NluEnrichmentEntities entities_serialized_name;
+    private NluEnrichmentSentiment sentiment_serialized_name;
+    private NluEnrichmentEmotion emotion_serialized_name;
+    private NluEnrichmentCategories categories_serialized_name;
+    private NluEnrichmentSemanticRoles semantic_roles_serialized_name;
+    private NluEnrichmentRelations relations_serialized_name;
+
+    private NluEnrichmentFeaturesBuilder(NluEnrichmentFeatures nluEnrichmentFeatures) {
+      keywords_serialized_name = nluEnrichmentFeatures.keywords_serialized_name;
+      entities_serialized_name = nluEnrichmentFeatures.entities_serialized_name;
+      sentiment_serialized_name = nluEnrichmentFeatures.sentiment_serialized_name;
+      emotion_serialized_name = nluEnrichmentFeatures.emotion_serialized_name;
+      categories_serialized_name = nluEnrichmentFeatures.categories_serialized_name;
+      semantic_roles_serialized_name = nluEnrichmentFeatures.semantic_roles_serialized_name;
+      relations_serialized_name = nluEnrichmentFeatures.relations_serialized_name;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public NluEnrichmentFeaturesBuilder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentFeatures.
+     *
+     * @return the nluEnrichmentFeatures
+     */
+    public NluEnrichmentFeatures build() {
+      return new NluEnrichmentFeatures(this);
+    }
+
+    /**
+     * Set the keywords_serialized_name.
+     *
+     * @param keywords the keywords
+     * @return the NluEnrichmentFeatures builder
+     */
+    public NluEnrichmentFeaturesBuilder keywords(NluEnrichmentKeywords keywords) {
+      this.keywords_serialized_name = keywords;
+      return this;
+    }
+
+    /**
+     * Set the entities_serialized_name.
+     *
+     * @param entities the entities
+     * @return the NluEnrichmentFeatures builder
+     */
+    public NluEnrichmentFeaturesBuilder entities(NluEnrichmentEntities entities) {
+      this.entities_serialized_name = entities;
+      return this;
+    }
+
+    /**
+     * Set the sentiment_serialized_name.
+     *
+     * @param sentiment the sentiment
+     * @return the NluEnrichmentFeatures builder
+     */
+    public NluEnrichmentFeaturesBuilder sentiment(NluEnrichmentSentiment sentiment) {
+      this.sentiment_serialized_name = sentiment;
+      return this;
+    }
+
+    /**
+     * Set the emotion_serialized_name.
+     *
+     * @param emotion the emotion
+     * @return the NluEnrichmentFeatures builder
+     */
+    public NluEnrichmentFeaturesBuilder emotion(NluEnrichmentEmotion emotion) {
+      this.emotion_serialized_name = emotion;
+      return this;
+    }
+
+    /**
+     * Set the categories_serialized_name.
+     *
+     * @param categories the categories
+     * @return the NluEnrichmentFeatures builder
+     */
+    public NluEnrichmentFeaturesBuilder categories(NluEnrichmentCategories categories) {
+      this.categories_serialized_name = categories;
+      return this;
+    }
+
+    /**
+     * Set the semantic_roles_serialized_name.
+     *
+     * @param semanticRoles the semanticRoles
+     * @return the NluEnrichmentFeatures builder
+     */
+    public NluEnrichmentFeaturesBuilder semanticRoles(NluEnrichmentSemanticRoles semanticRoles) {
+      this.semantic_roles_serialized_name = semanticRoles;
+      return this;
+    }
+
+    /**
+     * Set the relations_serialized_name.
+     *
+     * @param relations the relations
+     * @return the NluEnrichmentFeatures builder
+     */
+    public NluEnrichmentFeaturesBuilder relations(NluEnrichmentRelations relations) {
+      this.relations_serialized_name = relations;
+      return this;
     }
   }
 
@@ -7739,6 +8418,13 @@ public class IBMDiscoveryV1Models {
     private Boolean sentiment_serialized_name;
     private Boolean emotion_serialized_name;
     private Long limit_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NluEnrichmentKeywords() { }
+
     /**
      * Gets the sentiment_serialized_name.
      *
@@ -7772,32 +8458,19 @@ public class IBMDiscoveryV1Models {
     public Long getLimit() {
       return limit_serialized_name;
     }
-
-    /**
-     * Sets the sentiment_serialized_name.
-     *
-     * @param sentiment the new sentiment
-     */
-    public void setSentiment(final Boolean sentiment) {
-      this.sentiment_serialized_name = sentiment;
+    private NluEnrichmentKeywords(NluEnrichmentKeywordsBuilder builder) {
+      sentiment_serialized_name = builder.sentiment_serialized_name;
+      emotion_serialized_name = builder.emotion_serialized_name;
+      limit_serialized_name = builder.limit_serialized_name;
     }
 
     /**
-     * Sets the emotion_serialized_name.
+     * New builder.
      *
-     * @param emotion the new emotion
+     * @return a NluEnrichmentKeywords builder
      */
-    public void setEmotion(final Boolean emotion) {
-      this.emotion_serialized_name = emotion;
-    }
-
-    /**
-     * Sets the limit_serialized_name.
-     *
-     * @param limitVar the new limitVar
-     */
-    public void setLimit(final long limitVar) {
-      this.limit_serialized_name = limitVar;
+    public NluEnrichmentKeywordsBuilder newBuilder() {
+      return new NluEnrichmentKeywordsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7808,6 +8481,69 @@ public class IBMDiscoveryV1Models {
       NluEnrichmentKeywords ret = (NluEnrichmentKeywords) super.deserialize(jsonString, jsonMap, classType);
 
       return ret;
+    }
+  }
+
+    /**
+   * NluEnrichmentKeywords Builder.
+   */
+  public class NluEnrichmentKeywordsBuilder {
+    private Boolean sentiment_serialized_name;
+    private Boolean emotion_serialized_name;
+    private Long limit_serialized_name;
+
+    private NluEnrichmentKeywordsBuilder(NluEnrichmentKeywords nluEnrichmentKeywords) {
+      sentiment_serialized_name = nluEnrichmentKeywords.sentiment_serialized_name;
+      emotion_serialized_name = nluEnrichmentKeywords.emotion_serialized_name;
+      limit_serialized_name = nluEnrichmentKeywords.limit_serialized_name;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public NluEnrichmentKeywordsBuilder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentKeywords.
+     *
+     * @return the nluEnrichmentKeywords
+     */
+    public NluEnrichmentKeywords build() {
+      return new NluEnrichmentKeywords(this);
+    }
+
+    /**
+     * Set the sentiment_serialized_name.
+     *
+     * @param sentiment the sentiment
+     * @return the NluEnrichmentKeywords builder
+     */
+    public NluEnrichmentKeywordsBuilder sentiment(Boolean sentiment) {
+      this.sentiment_serialized_name = sentiment;
+      return this;
+    }
+
+    /**
+     * Set the emotion_serialized_name.
+     *
+     * @param emotion the emotion
+     * @return the NluEnrichmentKeywords builder
+     */
+    public NluEnrichmentKeywordsBuilder emotion(Boolean emotion) {
+      this.emotion_serialized_name = emotion;
+      return this;
+      }
+
+    /**
+     * Set the limit_serialized_name.
+     *
+     * @param limitVar the limitVar
+     * @return the NluEnrichmentKeywords builder
+     */
+    public NluEnrichmentKeywordsBuilder limitField(Long limitVar) {
+      this.limit_serialized_name = limitVar;
+      return this;
     }
   }
 
@@ -7855,6 +8591,13 @@ public class IBMDiscoveryV1Models {
     private Boolean entities_serialized_name;
     private Boolean keywords_serialized_name;
     private Long limit_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NluEnrichmentSemanticRoles() { }
+
     /**
      * Gets the entities_serialized_name.
      *
@@ -7888,32 +8631,19 @@ public class IBMDiscoveryV1Models {
     public Long getLimit() {
       return limit_serialized_name;
     }
-
-    /**
-     * Sets the entities_serialized_name.
-     *
-     * @param entities the new entities
-     */
-    public void setEntities(final Boolean entities) {
-      this.entities_serialized_name = entities;
+    private NluEnrichmentSemanticRoles(NluEnrichmentSemanticRolesBuilder builder) {
+      entities_serialized_name = builder.entities_serialized_name;
+      keywords_serialized_name = builder.keywords_serialized_name;
+      limit_serialized_name = builder.limit_serialized_name;
     }
 
     /**
-     * Sets the keywords_serialized_name.
+     * New builder.
      *
-     * @param keywords the new keywords
+     * @return a NluEnrichmentSemanticRoles builder
      */
-    public void setKeywords(final Boolean keywords) {
-      this.keywords_serialized_name = keywords;
-    }
-
-    /**
-     * Sets the limit_serialized_name.
-     *
-     * @param limitVar the new limitVar
-     */
-    public void setLimit(final long limitVar) {
-      this.limit_serialized_name = limitVar;
+    public NluEnrichmentSemanticRolesBuilder newBuilder() {
+      return new NluEnrichmentSemanticRolesBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7928,11 +8658,81 @@ public class IBMDiscoveryV1Models {
   }
 
   /**
+   * NluEnrichmentSemanticRoles Builder.
+   */
+  public class NluEnrichmentSemanticRolesBuilder {
+    private Boolean entities_serialized_name;
+    private Boolean keywords_serialized_name;
+    private Long limit_serialized_name;
+
+    private NluEnrichmentSemanticRolesBuilder(NluEnrichmentSemanticRoles nluEnrichmentSemanticRoles) {
+      entities_serialized_name = nluEnrichmentSemanticRoles.entities_serialized_name;
+      keywords_serialized_name = nluEnrichmentSemanticRoles.keywords_serialized_name;
+      limit_serialized_name = nluEnrichmentSemanticRoles.limit_serialized_name;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public NluEnrichmentSemanticRolesBuilder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentSemanticRoles.
+     *
+     * @return the nluEnrichmentSemanticRoles
+     */
+    public NluEnrichmentSemanticRoles build() {
+      return new NluEnrichmentSemanticRoles(this);
+    }
+
+    /**
+     * Set the entities_serialized_name.
+     *
+     * @param entities the entities
+     * @return the NluEnrichmentSemanticRoles builder
+     */
+    public NluEnrichmentSemanticRolesBuilder entities(Boolean entities) {
+      this.entities_serialized_name = entities;
+      return this;
+    }
+
+    /**
+     * Set the keywords_serialized_name.
+     *
+     * @param keywords the keywords
+     * @return the NluEnrichmentSemanticRoles builder
+     */
+    public NluEnrichmentSemanticRolesBuilder keywords(Boolean keywords) {
+      this.keywords_serialized_name = keywords;
+      return this;
+      }
+
+    /**
+     * Set the limit_serialized_name.
+     *
+     * @param limitVar the limitVar
+     * @return the NluEnrichmentSemanticRoles builder
+     */
+    public NluEnrichmentSemanticRolesBuilder limitField(Long limitVar) {
+      this.limit_serialized_name = limitVar;
+      return this;
+    }
+  }
+
+  /**
    * An object specifying the sentiment extraction enrichment and related parameters.
    */
   public class NluEnrichmentSentiment extends IBMWatsonGenericModel {
     private Boolean document_serialized_name;
     private List<String> targets_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NluEnrichmentSentiment() { }
+
     /**
      * Gets the document_serialized_name.
      *
@@ -7955,23 +8755,18 @@ public class IBMDiscoveryV1Models {
     public List<String> getTargets() {
       return targets_serialized_name;
     }
-
-    /**
-     * Sets the document_serialized_name.
-     *
-     * @param document the new document
-     */
-    public void setDocument(final Boolean document) {
-      this.document_serialized_name = document;
+    private NluEnrichmentSentiment(NluEnrichmentSentimentBuilder builder) {
+      document_serialized_name = builder.document_serialized_name;
+      targets_serialized_name = builder.targets_serialized_name;
     }
 
     /**
-     * Sets the targets_serialized_name.
+     * New builder.
      *
-     * @param targets the new targets
+     * @return a NluEnrichmentSentiment builder
      */
-    public void setTargets(final List<String> targets) {
-      this.targets_serialized_name = targets;
+    public NluEnrichmentSentimentBuilder newBuilder() {
+      return new NluEnrichmentSentimentBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7982,6 +8777,72 @@ public class IBMDiscoveryV1Models {
       NluEnrichmentSentiment ret = (NluEnrichmentSentiment) super.deserialize(jsonString, jsonMap, classType);
 
       return ret;
+    }
+  }
+
+  /**
+   * NluEnrichmentSentiment Builder.
+   */
+  public class NluEnrichmentSentimentBuilder {
+    private Boolean document_serialized_name;
+    private List<String> targets_serialized_name;
+
+    private NluEnrichmentSentimentBuilder(NluEnrichmentSentiment nluEnrichmentSentiment) {
+      document_serialized_name = nluEnrichmentSentiment.document_serialized_name;
+      targets_serialized_name = nluEnrichmentSentiment.targets_serialized_name;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public NluEnrichmentSentimentBuilder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentSentiment.
+     *
+     * @return the nluEnrichmentSentiment
+     */
+    public NluEnrichmentSentiment build() {
+      return new NluEnrichmentSentiment(this);
+    }
+
+    /**
+     * Adds an targets to targets_serialized_name.
+     *
+     * @param targets the new targets
+     * @return the NluEnrichmentSentiment builder
+     */
+    public NluEnrichmentSentimentBuilder addTargets(String targets) {
+      IBMWatsonValidator.notNull(targets, 'targets cannot be null');
+      if (this.targets_serialized_name == null) {
+        this.targets_serialized_name = new List<String>();
+      }
+      this.targets_serialized_name.add(targets);
+      return this;
+    }
+
+    /**
+     * Set the document_serialized_name.
+     *
+     * @param document the document
+     * @return the NluEnrichmentSentiment builder
+     */
+    public NluEnrichmentSentimentBuilder document(Boolean document) {
+      this.document_serialized_name = document;
+      return this;
+    }
+
+    /**
+     * Set the targets_serialized_name.
+     * Existing targets_serialized_name will be replaced.
+     *
+     * @param targets the targets
+     * @return the NluEnrichmentSentiment builder
+     */
+    public NluEnrichmentSentimentBuilder targets(List<String> targets) {
+      this.targets_serialized_name = targets;
+      return this;
     }
   }
 
@@ -8567,7 +9428,7 @@ public class IBMDiscoveryV1Models {
   /**
    * Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`.
    */
-  public class QueryEntitiesContext extends IBMWatsonGenericModel {
+  public class QueryEntitiesContext {
     private String text_serialized_name;
     /**
      * Gets the text_serialized_name.
@@ -8576,7 +9437,6 @@ public class IBMDiscoveryV1Models {
      *
      * @return the text_serialized_name
      */
-    @AuraEnabled
     public String getText() {
       return text_serialized_name;
     }
@@ -8590,15 +9450,6 @@ public class IBMDiscoveryV1Models {
       this.text_serialized_name = text;
     }
 
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      QueryEntitiesContext ret = (QueryEntitiesContext) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
   }
 
   /**
@@ -8662,7 +9513,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The queryEntities options.
    */
-  public class QueryEntitiesOptions {
+  public class QueryEntitiesOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String feature_serialized_name;
@@ -8750,6 +9601,7 @@ public class IBMDiscoveryV1Models {
       context_serialized_name = builder.context_serialized_name;
       count_serialized_name = builder.count_serialized_name;
       evidence_count_serialized_name = builder.evidence_count_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -8766,7 +9618,7 @@ public class IBMDiscoveryV1Models {
   /**
    * QueryEntitiesOptions Builder.
    */
-  public class QueryEntitiesOptionsBuilder {
+  public class QueryEntitiesOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String feature_serialized_name;
@@ -8887,12 +9739,24 @@ public class IBMDiscoveryV1Models {
       this.evidence_count_serialized_name = evidenceCount;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the QueryEntitiesOptions builder
+     */
+    public QueryEntitiesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * An array of entities resulting from the query.
    */
-  public class QueryEntitiesResponse extends IBMWatsonGenericModel {
+  public class QueryEntitiesResponse extends IBMWatsonResponseModel {
     private List<QueryEntitiesResponseItem> entities_serialized_name;
     /**
      * Gets the entities_serialized_name.
@@ -9266,7 +10130,7 @@ public class IBMDiscoveryV1Models {
   /**
    * QueryFilterType.
    */
-  public class QueryFilterType extends IBMWatsonGenericModel {
+  public class QueryFilterType {
     private List<String> exclude_serialized_name;
     private List<String> include_serialized_name;
     /**
@@ -9276,7 +10140,6 @@ public class IBMDiscoveryV1Models {
      *
      * @return the exclude_serialized_name
      */
-    @AuraEnabled
     public List<String> getExclude() {
       return exclude_serialized_name;
     }
@@ -9287,7 +10150,6 @@ public class IBMDiscoveryV1Models {
      *
      * @return the include_serialized_name
      */
-    @AuraEnabled
     public List<String> getInclude() {
       return include_serialized_name;
     }
@@ -9310,21 +10172,12 @@ public class IBMDiscoveryV1Models {
       this.include_serialized_name = include;
     }
 
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      QueryFilterType ret = (QueryFilterType) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
   }
 
   /**
    * The queryNotices options.
    */
-  public class QueryNoticesOptions {
+  public class QueryNoticesOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String filter_serialized_name;
@@ -9556,6 +10409,7 @@ public class IBMDiscoveryV1Models {
       similar_serialized_name = builder.similar_serialized_name;
       similar_document_ids_serialized_name = builder.similar_document_ids_serialized_name;
       similar_fields_serialized_name = builder.similar_fields_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -9572,7 +10426,7 @@ public class IBMDiscoveryV1Models {
   /**
    * QueryNoticesOptions Builder.
    */
-  public class QueryNoticesOptionsBuilder {
+  public class QueryNoticesOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String filter_serialized_name;
@@ -9929,12 +10783,24 @@ public class IBMDiscoveryV1Models {
       this.similar_fields_serialized_name = similarFields;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the QueryNoticesOptions builder
+     */
+    public QueryNoticesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
    * QueryNoticesResponse.
    */
-  public class QueryNoticesResponse extends IBMWatsonGenericModel {
+  public class QueryNoticesResponse extends IBMWatsonResponseModel {
     private Long matching_results_serialized_name;
     private List<QueryNoticesResult> results_serialized_name;
     private List<QueryAggregation> aggregations_serialized_name;
@@ -10340,7 +11206,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The query options.
    */
-  public class QueryOptions {
+  public class QueryOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String filter_serialized_name;
@@ -10584,6 +11450,7 @@ public class IBMDiscoveryV1Models {
       similar_serialized_name = builder.similar_serialized_name;
       similar_document_ids_serialized_name = builder.similar_document_ids_serialized_name;
       similar_fields_serialized_name = builder.similar_fields_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -10600,7 +11467,7 @@ public class IBMDiscoveryV1Models {
   /**
    * QueryOptions Builder.
    */
-  public class QueryOptionsBuilder {
+  public class QueryOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String filter_serialized_name;
@@ -10970,6 +11837,18 @@ public class IBMDiscoveryV1Models {
       this.similar_fields_serialized_name = similarFields;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the QueryOptions builder
+     */
+    public QueryOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
@@ -11165,7 +12044,7 @@ public class IBMDiscoveryV1Models {
   /**
    * QueryRelationsEntity.
    */
-  public class QueryRelationsEntity extends IBMWatsonGenericModel {
+  public class QueryRelationsEntity {
     private String text_serialized_name;
     private String type_serialized_name;
     private Boolean exact_serialized_name;
@@ -11176,7 +12055,6 @@ public class IBMDiscoveryV1Models {
      *
      * @return the text_serialized_name
      */
-    @AuraEnabled
     public String getText() {
       return text_serialized_name;
     }
@@ -11187,7 +12065,6 @@ public class IBMDiscoveryV1Models {
      *
      * @return the type_serialized_name
      */
-    @AuraEnabled
     public String getType() {
       return type_serialized_name;
     }
@@ -11198,7 +12075,6 @@ public class IBMDiscoveryV1Models {
      *
      * @return the exact_serialized_name
      */
-    @AuraEnabled
     public Boolean getExact() {
       return exact_serialized_name;
     }
@@ -11230,21 +12106,12 @@ public class IBMDiscoveryV1Models {
       this.exact_serialized_name = exact;
     }
 
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      QueryRelationsEntity ret = (QueryRelationsEntity) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
   }
 
   /**
    * QueryRelationsFilter.
    */
-  public class QueryRelationsFilter extends IBMWatsonGenericModel {
+  public class QueryRelationsFilter {
     private QueryFilterType relation_types_serialized_name;
     private QueryFilterType entity_types_serialized_name;
     private List<String> document_ids_serialized_name;
@@ -11255,7 +12122,6 @@ public class IBMDiscoveryV1Models {
      *
      * @return the relation_types_serialized_name
      */
-    @AuraEnabled
     public QueryFilterType getRelationTypes() {
       return relation_types_serialized_name;
     }
@@ -11266,7 +12132,6 @@ public class IBMDiscoveryV1Models {
      *
      * @return the entity_types_serialized_name
      */
-    @AuraEnabled
     public QueryFilterType getEntityTypes() {
       return entity_types_serialized_name;
     }
@@ -11277,7 +12142,6 @@ public class IBMDiscoveryV1Models {
      *
      * @return the document_ids_serialized_name
      */
-    @AuraEnabled
     public List<String> getDocumentIds() {
       return document_ids_serialized_name;
     }
@@ -11309,29 +12173,12 @@ public class IBMDiscoveryV1Models {
       this.document_ids_serialized_name = documentIds;
     }
 
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      QueryRelationsFilter ret = (QueryRelationsFilter) super.deserialize(jsonString, jsonMap, classType);
-
-      // calling custom deserializer for relation_types_serialized_name
-      QueryFilterType newRelationTypes = (QueryFilterType) new QueryFilterType().deserialize(JSON.serialize(ret.getRelationTypes()), (Map<String, Object>) jsonMap.get('relation_types_serialized_name'), QueryFilterType.class);
-      ret.setRelationTypes(newRelationTypes);
-
-      // calling custom deserializer for entity_types_serialized_name
-      QueryFilterType newEntityTypes = (QueryFilterType) new QueryFilterType().deserialize(JSON.serialize(ret.getEntityTypes()), (Map<String, Object>) jsonMap.get('entity_types_serialized_name'), QueryFilterType.class);
-      ret.setEntityTypes(newEntityTypes);
-
-      return ret;
-    }
   }
 
   /**
    * The queryRelations options.
    */
-  public class QueryRelationsOptions {
+  public class QueryRelationsOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private List<QueryRelationsEntity> entities_serialized_name;
@@ -11431,6 +12278,7 @@ public class IBMDiscoveryV1Models {
       filter_serialized_name = builder.filter_serialized_name;
       count_serialized_name = builder.count_serialized_name;
       evidence_count_serialized_name = builder.evidence_count_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -11447,7 +12295,7 @@ public class IBMDiscoveryV1Models {
   /**
    * QueryRelationsOptions Builder.
    */
-  public class QueryRelationsOptionsBuilder {
+  public class QueryRelationsOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private List<QueryRelationsEntity> entities_serialized_name;
@@ -11597,6 +12445,18 @@ public class IBMDiscoveryV1Models {
       this.evidence_count_serialized_name = evidenceCount;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the QueryRelationsOptions builder
+     */
+    public QueryRelationsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+  }
   }
 
   /**
@@ -11728,7 +12588,7 @@ public class IBMDiscoveryV1Models {
   /**
    * QueryRelationsResponse.
    */
-  public class QueryRelationsResponse extends IBMWatsonGenericModel {
+  public class QueryRelationsResponse extends IBMWatsonResponseModel {
     private List<QueryRelationsRelationship> relations_serialized_name;
     /**
      * Gets the relations_serialized_name.
@@ -11776,7 +12636,7 @@ public class IBMDiscoveryV1Models {
   /**
    * A response containing the documents and aggregations for the query.
    */
-  public class QueryResponse extends IBMWatsonGenericModel {
+  public class QueryResponse extends IBMWatsonResponseModel {
     private Long matching_results_serialized_name;
     private List<QueryResult> results_serialized_name;
     private List<QueryAggregation> aggregations_serialized_name;
@@ -12164,7 +13024,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The testConfigurationInEnvironment options.
    */
-  public class TestConfigurationInEnvironmentOptions {
+  public class TestConfigurationInEnvironmentOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String configuration_serialized_name;
     private String step_serialized_name;
@@ -12266,6 +13126,7 @@ public class IBMDiscoveryV1Models {
       filename_serialized_name = builder.filename_serialized_name;
       metadata_serialized_name = builder.metadata_serialized_name;
       file_content_type_serialized_name = builder.file_content_type_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -12282,7 +13143,7 @@ public class IBMDiscoveryV1Models {
   /**
    * TestConfigurationInEnvironmentOptions Builder.
    */
-  public class TestConfigurationInEnvironmentOptionsBuilder {
+  public class TestConfigurationInEnvironmentOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String configuration_serialized_name;
     private String step_serialized_name;
@@ -12414,12 +13275,24 @@ public class IBMDiscoveryV1Models {
       this.file_content_type_serialized_name = fileContentType;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the TestConfigurationInEnvironmentOptions builder
+     */
+    public TestConfigurationInEnvironmentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * TestDocument.
    */
-  public class TestDocument extends IBMWatsonGenericModel {
+  public class TestDocument extends IBMWatsonResponseModel {
     private String configuration_id_serialized_name;
     private String status_serialized_name;
     private Long enriched_field_units_serialized_name;
@@ -12622,7 +13495,7 @@ public class IBMDiscoveryV1Models {
   /**
    * TrainingDataSet.
    */
-  public class TrainingDataSet extends IBMWatsonGenericModel {
+  public class TrainingDataSet extends IBMWatsonResponseModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private List<TrainingQuery> queries_serialized_name;
@@ -12708,7 +13581,7 @@ public class IBMDiscoveryV1Models {
   /**
    * TrainingExample.
    */
-  public class TrainingExample extends IBMWatsonGenericModel {
+  public class TrainingExample extends IBMWatsonResponseModel {
     private String document_id_serialized_name;
     private String cross_reference_serialized_name;
     private Long relevance_serialized_name;
@@ -12781,7 +13654,7 @@ public class IBMDiscoveryV1Models {
   /**
    * TrainingExampleList.
    */
-  public class TrainingExampleList extends IBMWatsonGenericModel {
+  public class TrainingExampleList extends IBMWatsonResponseModel {
     private List<TrainingExample> examples_serialized_name;
     /**
      * Gets the examples_serialized_name.
@@ -12829,7 +13702,7 @@ public class IBMDiscoveryV1Models {
   /**
    * TrainingQuery.
    */
-  public class TrainingQuery extends IBMWatsonGenericModel {
+  public class TrainingQuery extends IBMWatsonResponseModel {
     private String query_id_serialized_name;
     private String natural_language_query_serialized_name;
     private String filter_serialized_name;
@@ -13130,7 +14003,7 @@ public class IBMDiscoveryV1Models {
   /**
    * The updateCollection options.
    */
-  public class UpdateCollectionOptions {
+  public class UpdateCollectionOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String name_serialized_name;
@@ -13194,6 +14067,7 @@ public class IBMDiscoveryV1Models {
       name_serialized_name = builder.name_serialized_name;
       description_serialized_name = builder.description_serialized_name;
       configuration_id_serialized_name = builder.configuration_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -13210,7 +14084,7 @@ public class IBMDiscoveryV1Models {
   /**
    * UpdateCollectionOptions Builder.
    */
-  public class UpdateCollectionOptionsBuilder {
+  public class UpdateCollectionOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String name_serialized_name;
@@ -13305,12 +14179,24 @@ public class IBMDiscoveryV1Models {
       this.configuration_id_serialized_name = configurationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateCollectionOptions builder
+     */
+    public UpdateCollectionOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateConfiguration options.
    */
-  public class UpdateConfigurationOptions {
+  public class UpdateConfigurationOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String configuration_id_serialized_name;
     private String name_serialized_name;
@@ -13398,6 +14284,7 @@ public class IBMDiscoveryV1Models {
       conversions_serialized_name = builder.conversions_serialized_name;
       enrichments_serialized_name = builder.enrichments_serialized_name;
       normalizations_serialized_name = builder.normalizations_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -13414,7 +14301,7 @@ public class IBMDiscoveryV1Models {
   /**
    * UpdateConfigurationOptions Builder.
    */
-  public class UpdateConfigurationOptionsBuilder {
+  public class UpdateConfigurationOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String configuration_id_serialized_name;
     private String name_serialized_name;
@@ -13582,12 +14469,24 @@ public class IBMDiscoveryV1Models {
       this.normalizations_serialized_name = configuration.getNormalizations();
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateConfigurationOptions builder
+     */
+    public UpdateConfigurationOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateDocument options.
    */
-  public class UpdateDocumentOptions {
+  public class UpdateDocumentOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String document_id_serialized_name;
@@ -13679,6 +14578,7 @@ public class IBMDiscoveryV1Models {
       filename_serialized_name = builder.filename_serialized_name;
       metadata_serialized_name = builder.metadata_serialized_name;
       file_content_type_serialized_name = builder.file_content_type_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -13695,7 +14595,7 @@ public class IBMDiscoveryV1Models {
   /**
    * UpdateDocumentOptions Builder.
    */
-  public class UpdateDocumentOptionsBuilder {
+  public class UpdateDocumentOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String document_id_serialized_name;
@@ -13818,12 +14718,24 @@ public class IBMDiscoveryV1Models {
       this.file_content_type_serialized_name = fileContentType;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateDocumentOptions builder
+     */
+    public UpdateDocumentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateEnvironment options.
    */
-  public class UpdateEnvironmentOptions {
+  public class UpdateEnvironmentOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -13862,6 +14774,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = builder.environment_id_serialized_name;
       name_serialized_name = builder.name_serialized_name;
       description_serialized_name = builder.description_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -13878,7 +14791,7 @@ public class IBMDiscoveryV1Models {
   /**
    * UpdateEnvironmentOptions Builder.
    */
-  public class UpdateEnvironmentOptionsBuilder {
+  public class UpdateEnvironmentOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -13945,12 +14858,24 @@ public class IBMDiscoveryV1Models {
       this.description_serialized_name = description;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateEnvironmentOptions builder
+     */
+    public UpdateEnvironmentOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateTrainingExample options.
    */
-  public class UpdateTrainingExampleOptions {
+  public class UpdateTrainingExampleOptions extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -14024,6 +14949,7 @@ public class IBMDiscoveryV1Models {
       example_id_serialized_name = builder.example_id_serialized_name;
       cross_reference_serialized_name = builder.cross_reference_serialized_name;
       relevance_serialized_name = builder.relevance_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -14040,7 +14966,7 @@ public class IBMDiscoveryV1Models {
   /**
    * UpdateTrainingExampleOptions Builder.
    */
-  public class UpdateTrainingExampleOptionsBuilder {
+  public class UpdateTrainingExampleOptionsBuilder extends IBMWatsonOptionsModel {
     private String environment_id_serialized_name;
     private String collection_id_serialized_name;
     private String query_id_serialized_name;
@@ -14150,6 +15076,18 @@ public class IBMDiscoveryV1Models {
      */
     public UpdateTrainingExampleOptionsBuilder relevance(Long relevance) {
       this.relevance_serialized_name = relevance;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateTrainingExampleOptions builder
+     */
+    public UpdateTrainingExampleOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }

--- a/force-app/main/default/classes/IBMDiscoveryV1Models.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Models.cls
@@ -113,6 +113,7 @@ public class IBMDiscoveryV1Models {
       filename_serialized_name = addDocumentOptions.filename_serialized_name;
       metadata_serialized_name = addDocumentOptions.metadata_serialized_name;
       file_content_type_serialized_name = addDocumentOptions.file_content_type_serialized_name;
+      this.requestHeaders.putAll(addDocumentOptions.requestHeaders());
     }
 
     /**
@@ -311,6 +312,7 @@ public class IBMDiscoveryV1Models {
       natural_language_query_serialized_name = addTrainingDataOptions.natural_language_query_serialized_name;
       filter_serialized_name = addTrainingDataOptions.filter_serialized_name;
       examples_serialized_name = addTrainingDataOptions.examples_serialized_name;
+      this.requestHeaders.putAll(addTrainingDataOptions.requestHeaders());
     }
 
     /**
@@ -1241,6 +1243,7 @@ public class IBMDiscoveryV1Models {
       description_serialized_name = createCollectionOptions.description_serialized_name;
       configuration_id_serialized_name = createCollectionOptions.configuration_id_serialized_name;
       language_serialized_name = createCollectionOptions.language_serialized_name;
+      this.requestHeaders.putAll(createCollectionOptions.requestHeaders());
     }
 
     /**
@@ -1447,6 +1450,7 @@ public class IBMDiscoveryV1Models {
       conversions_serialized_name = createConfigurationOptions.conversions_serialized_name;
       enrichments_serialized_name = createConfigurationOptions.enrichments_serialized_name;
       normalizations_serialized_name = createConfigurationOptions.normalizations_serialized_name;
+      this.requestHeaders.putAll(createConfigurationOptions.requestHeaders());
     }
 
     /**
@@ -1667,6 +1671,7 @@ public class IBMDiscoveryV1Models {
       name_serialized_name = createEnvironmentOptions.name_serialized_name;
       description_serialized_name = createEnvironmentOptions.description_serialized_name;
       size_serialized_name = createEnvironmentOptions.size_serialized_name;
+      this.requestHeaders.putAll(createEnvironmentOptions.requestHeaders());
     }
 
     /**
@@ -1808,6 +1813,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = createExpansionsOptions.environment_id_serialized_name;
       collection_id_serialized_name = createExpansionsOptions.collection_id_serialized_name;
       expansions_serialized_name = createExpansionsOptions.expansions_serialized_name;
+      this.requestHeaders.putAll(createExpansionsOptions.requestHeaders());
     }
 
     /**
@@ -2015,6 +2021,7 @@ public class IBMDiscoveryV1Models {
       document_id_serialized_name = createTrainingExampleOptions.document_id_serialized_name;
       cross_reference_serialized_name = createTrainingExampleOptions.cross_reference_serialized_name;
       relevance_serialized_name = createTrainingExampleOptions.relevance_serialized_name;
+      this.requestHeaders.putAll(createTrainingExampleOptions.requestHeaders());
     }
 
     /**
@@ -2192,6 +2199,7 @@ public class IBMDiscoveryV1Models {
     private DeleteAllTrainingDataOptionsBuilder(DeleteAllTrainingDataOptions deleteAllTrainingDataOptions) {
       environment_id_serialized_name = deleteAllTrainingDataOptions.environment_id_serialized_name;
       collection_id_serialized_name = deleteAllTrainingDataOptions.collection_id_serialized_name;
+      this.requestHeaders.putAll(deleteAllTrainingDataOptions.requestHeaders());
     }
 
     /**
@@ -2310,6 +2318,7 @@ public class IBMDiscoveryV1Models {
     private DeleteCollectionOptionsBuilder(DeleteCollectionOptions deleteCollectionOptions) {
       environment_id_serialized_name = deleteCollectionOptions.environment_id_serialized_name;
       collection_id_serialized_name = deleteCollectionOptions.collection_id_serialized_name;
+      this.requestHeaders.putAll(deleteCollectionOptions.requestHeaders());
     }
 
     /**
@@ -2428,6 +2437,7 @@ public class IBMDiscoveryV1Models {
     private DeleteConfigurationOptionsBuilder(DeleteConfigurationOptions deleteConfigurationOptions) {
       environment_id_serialized_name = deleteConfigurationOptions.environment_id_serialized_name;
       configuration_id_serialized_name = deleteConfigurationOptions.configuration_id_serialized_name;
+      this.requestHeaders.putAll(deleteConfigurationOptions.requestHeaders());
     }
 
     /**
@@ -2561,6 +2571,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = deleteDocumentOptions.environment_id_serialized_name;
       collection_id_serialized_name = deleteDocumentOptions.collection_id_serialized_name;
       document_id_serialized_name = deleteDocumentOptions.document_id_serialized_name;
+      this.requestHeaders.putAll(deleteDocumentOptions.requestHeaders());
     }
 
     /**
@@ -2677,6 +2688,7 @@ public class IBMDiscoveryV1Models {
 
     private DeleteEnvironmentOptionsBuilder(DeleteEnvironmentOptions deleteEnvironmentOptions) {
       environment_id_serialized_name = deleteEnvironmentOptions.environment_id_serialized_name;
+      this.requestHeaders.putAll(deleteEnvironmentOptions.requestHeaders());
     }
 
     /**
@@ -2782,6 +2794,7 @@ public class IBMDiscoveryV1Models {
     private DeleteExpansionsOptionsBuilder(DeleteExpansionsOptions deleteExpansionsOptions) {
       environment_id_serialized_name = deleteExpansionsOptions.environment_id_serialized_name;
       collection_id_serialized_name = deleteExpansionsOptions.collection_id_serialized_name;
+      this.requestHeaders.putAll(deleteExpansionsOptions.requestHeaders());
     }
 
     /**
@@ -2915,6 +2928,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = deleteTrainingDataOptions.environment_id_serialized_name;
       collection_id_serialized_name = deleteTrainingDataOptions.collection_id_serialized_name;
       query_id_serialized_name = deleteTrainingDataOptions.query_id_serialized_name;
+      this.requestHeaders.putAll(deleteTrainingDataOptions.requestHeaders());
     }
 
     /**
@@ -3076,6 +3090,7 @@ public class IBMDiscoveryV1Models {
       collection_id_serialized_name = deleteTrainingExampleOptions.collection_id_serialized_name;
       query_id_serialized_name = deleteTrainingExampleOptions.query_id_serialized_name;
       example_id_serialized_name = deleteTrainingExampleOptions.example_id_serialized_name;
+      this.requestHeaders.putAll(deleteTrainingExampleOptions.requestHeaders());
     }
 
     /**
@@ -4471,6 +4486,7 @@ public class IBMDiscoveryV1Models {
       similar_serialized_name = federatedQueryNoticesOptions.similar_serialized_name;
       similar_document_ids_serialized_name = federatedQueryNoticesOptions.similar_document_ids_serialized_name;
       similar_fields_serialized_name = federatedQueryNoticesOptions.similar_fields_serialized_name;
+      this.requestHeaders.putAll(federatedQueryNoticesOptions.requestHeaders());
     }
 
     /**
@@ -5008,6 +5024,7 @@ public class IBMDiscoveryV1Models {
       similar_serialized_name = federatedQueryOptions.similar_serialized_name;
       similar_document_ids_serialized_name = federatedQueryOptions.similar_document_ids_serialized_name;
       similar_fields_serialized_name = federatedQueryOptions.similar_fields_serialized_name;
+      this.requestHeaders.putAll(federatedQueryOptions.requestHeaders());
     }
 
     /**
@@ -5530,6 +5547,7 @@ public class IBMDiscoveryV1Models {
     private GetCollectionOptionsBuilder(GetCollectionOptions getCollectionOptions) {
       environment_id_serialized_name = getCollectionOptions.environment_id_serialized_name;
       collection_id_serialized_name = getCollectionOptions.collection_id_serialized_name;
+      this.requestHeaders.putAll(getCollectionOptions.requestHeaders());
     }
 
     /**
@@ -5648,6 +5666,7 @@ public class IBMDiscoveryV1Models {
     private GetConfigurationOptionsBuilder(GetConfigurationOptions getConfigurationOptions) {
       environment_id_serialized_name = getConfigurationOptions.environment_id_serialized_name;
       configuration_id_serialized_name = getConfigurationOptions.configuration_id_serialized_name;
+      this.requestHeaders.putAll(getConfigurationOptions.requestHeaders());
     }
 
     /**
@@ -5781,6 +5800,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = getDocumentStatusOptions.environment_id_serialized_name;
       collection_id_serialized_name = getDocumentStatusOptions.collection_id_serialized_name;
       document_id_serialized_name = getDocumentStatusOptions.document_id_serialized_name;
+      this.requestHeaders.putAll(getDocumentStatusOptions.requestHeaders());
     }
 
     /**
@@ -5897,6 +5917,7 @@ public class IBMDiscoveryV1Models {
 
     private GetEnvironmentOptionsBuilder(GetEnvironmentOptions getEnvironmentOptions) {
       environment_id_serialized_name = getEnvironmentOptions.environment_id_serialized_name;
+      this.requestHeaders.putAll(getEnvironmentOptions.requestHeaders());
     }
 
     /**
@@ -6017,6 +6038,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = getTrainingDataOptions.environment_id_serialized_name;
       collection_id_serialized_name = getTrainingDataOptions.collection_id_serialized_name;
       query_id_serialized_name = getTrainingDataOptions.query_id_serialized_name;
+      this.requestHeaders.putAll(getTrainingDataOptions.requestHeaders());
     }
 
     /**
@@ -6178,6 +6200,7 @@ public class IBMDiscoveryV1Models {
       collection_id_serialized_name = getTrainingExampleOptions.collection_id_serialized_name;
       query_id_serialized_name = getTrainingExampleOptions.query_id_serialized_name;
       example_id_serialized_name = getTrainingExampleOptions.example_id_serialized_name;
+      this.requestHeaders.putAll(getTrainingExampleOptions.requestHeaders());
     }
 
     /**
@@ -6576,6 +6599,7 @@ public class IBMDiscoveryV1Models {
     private ListCollectionFieldsOptionsBuilder(ListCollectionFieldsOptions listCollectionFieldsOptions) {
       environment_id_serialized_name = listCollectionFieldsOptions.environment_id_serialized_name;
       collection_id_serialized_name = listCollectionFieldsOptions.collection_id_serialized_name;
+      this.requestHeaders.putAll(listCollectionFieldsOptions.requestHeaders());
     }
 
     /**
@@ -6743,6 +6767,7 @@ public class IBMDiscoveryV1Models {
     private ListCollectionsOptionsBuilder(ListCollectionsOptions listCollectionsOptions) {
       environment_id_serialized_name = listCollectionsOptions.environment_id_serialized_name;
       name_serialized_name = listCollectionsOptions.name_serialized_name;
+      this.requestHeaders.putAll(listCollectionsOptions.requestHeaders());
     }
 
     /**
@@ -6908,6 +6933,7 @@ public class IBMDiscoveryV1Models {
     private ListConfigurationsOptionsBuilder(ListConfigurationsOptions listConfigurationsOptions) {
       environment_id_serialized_name = listConfigurationsOptions.environment_id_serialized_name;
       name_serialized_name = listConfigurationsOptions.name_serialized_name;
+      this.requestHeaders.putAll(listConfigurationsOptions.requestHeaders());
     }
 
     /**
@@ -7058,6 +7084,7 @@ public class IBMDiscoveryV1Models {
 
     private ListEnvironmentsOptionsBuilder(ListEnvironmentsOptions listEnvironmentsOptions) {
       name_serialized_name = listEnvironmentsOptions.name_serialized_name;
+      this.requestHeaders.putAll(listEnvironmentsOptions.requestHeaders());
     }
 
     /**
@@ -7204,6 +7231,7 @@ public class IBMDiscoveryV1Models {
     private ListExpansionsOptionsBuilder(ListExpansionsOptions listExpansionsOptions) {
       environment_id_serialized_name = listExpansionsOptions.environment_id_serialized_name;
       collection_id_serialized_name = listExpansionsOptions.collection_id_serialized_name;
+      this.requestHeaders.putAll(listExpansionsOptions.requestHeaders());
     }
 
     /**
@@ -7322,6 +7350,7 @@ public class IBMDiscoveryV1Models {
     private ListFieldsOptionsBuilder(ListFieldsOptions listFieldsOptions) {
       environment_id_serialized_name = listFieldsOptions.environment_id_serialized_name;
       collection_ids_serialized_name = listFieldsOptions.collection_ids_serialized_name;
+      this.requestHeaders.putAll(listFieldsOptions.requestHeaders());
     }
 
     /**
@@ -7456,6 +7485,7 @@ public class IBMDiscoveryV1Models {
     private ListTrainingDataOptionsBuilder(ListTrainingDataOptions listTrainingDataOptions) {
       environment_id_serialized_name = listTrainingDataOptions.environment_id_serialized_name;
       collection_id_serialized_name = listTrainingDataOptions.collection_id_serialized_name;
+      this.requestHeaders.putAll(listTrainingDataOptions.requestHeaders());
     }
 
     /**
@@ -7589,6 +7619,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = listTrainingExamplesOptions.environment_id_serialized_name;
       collection_id_serialized_name = listTrainingExamplesOptions.collection_id_serialized_name;
       query_id_serialized_name = listTrainingExamplesOptions.query_id_serialized_name;
+      this.requestHeaders.putAll(listTrainingExamplesOptions.requestHeaders());
     }
 
     /**
@@ -9640,6 +9671,7 @@ public class IBMDiscoveryV1Models {
       context_serialized_name = queryEntitiesOptions.context_serialized_name;
       count_serialized_name = queryEntitiesOptions.count_serialized_name;
       evidence_count_serialized_name = queryEntitiesOptions.evidence_count_serialized_name;
+      this.requestHeaders.putAll(queryEntitiesOptions.requestHeaders());
     }
 
     /**
@@ -10472,6 +10504,7 @@ public class IBMDiscoveryV1Models {
       similar_serialized_name = queryNoticesOptions.similar_serialized_name;
       similar_document_ids_serialized_name = queryNoticesOptions.similar_document_ids_serialized_name;
       similar_fields_serialized_name = queryNoticesOptions.similar_fields_serialized_name;
+      this.requestHeaders.putAll(queryNoticesOptions.requestHeaders());
     }
 
     /**
@@ -11515,6 +11548,7 @@ public class IBMDiscoveryV1Models {
       similar_serialized_name = queryOptions.similar_serialized_name;
       similar_document_ids_serialized_name = queryOptions.similar_document_ids_serialized_name;
       similar_fields_serialized_name = queryOptions.similar_fields_serialized_name;
+      this.requestHeaders.putAll(queryOptions.requestHeaders());
     }
 
     /**
@@ -12319,6 +12353,7 @@ public class IBMDiscoveryV1Models {
       filter_serialized_name = queryRelationsOptions.filter_serialized_name;
       count_serialized_name = queryRelationsOptions.count_serialized_name;
       evidence_count_serialized_name = queryRelationsOptions.evidence_count_serialized_name;
+      this.requestHeaders.putAll(queryRelationsOptions.requestHeaders());
     }
 
     /**
@@ -13167,6 +13202,7 @@ public class IBMDiscoveryV1Models {
       filename_serialized_name = testConfigurationInEnvironmentOptions.filename_serialized_name;
       metadata_serialized_name = testConfigurationInEnvironmentOptions.metadata_serialized_name;
       file_content_type_serialized_name = testConfigurationInEnvironmentOptions.file_content_type_serialized_name;
+      this.requestHeaders.putAll(testConfigurationInEnvironmentOptions.requestHeaders());
     }
 
     /**
@@ -14102,6 +14138,7 @@ public class IBMDiscoveryV1Models {
       name_serialized_name = updateCollectionOptions.name_serialized_name;
       description_serialized_name = updateCollectionOptions.description_serialized_name;
       configuration_id_serialized_name = updateCollectionOptions.configuration_id_serialized_name;
+      this.requestHeaders.putAll(updateCollectionOptions.requestHeaders());
     }
 
     /**
@@ -14323,6 +14360,7 @@ public class IBMDiscoveryV1Models {
       conversions_serialized_name = updateConfigurationOptions.conversions_serialized_name;
       enrichments_serialized_name = updateConfigurationOptions.enrichments_serialized_name;
       normalizations_serialized_name = updateConfigurationOptions.normalizations_serialized_name;
+      this.requestHeaders.putAll(updateConfigurationOptions.requestHeaders());
     }
 
     /**
@@ -14617,6 +14655,7 @@ public class IBMDiscoveryV1Models {
       filename_serialized_name = updateDocumentOptions.filename_serialized_name;
       metadata_serialized_name = updateDocumentOptions.metadata_serialized_name;
       file_content_type_serialized_name = updateDocumentOptions.file_content_type_serialized_name;
+      this.requestHeaders.putAll(updateDocumentOptions.requestHeaders());
     }
 
     /**
@@ -14805,6 +14844,7 @@ public class IBMDiscoveryV1Models {
       environment_id_serialized_name = updateEnvironmentOptions.environment_id_serialized_name;
       name_serialized_name = updateEnvironmentOptions.name_serialized_name;
       description_serialized_name = updateEnvironmentOptions.description_serialized_name;
+      this.requestHeaders.putAll(updateEnvironmentOptions.requestHeaders());
     }
 
     /**
@@ -14986,6 +15026,7 @@ public class IBMDiscoveryV1Models {
       example_id_serialized_name = updateTrainingExampleOptions.example_id_serialized_name;
       cross_reference_serialized_name = updateTrainingExampleOptions.cross_reference_serialized_name;
       relevance_serialized_name = updateTrainingExampleOptions.relevance_serialized_name;
+      this.requestHeaders.putAll(updateTrainingExampleOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMDiscoveryV1Models.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Models.cls
@@ -217,7 +217,7 @@ public class IBMDiscoveryV1Models {
     public AddDocumentOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -420,7 +420,7 @@ public class IBMDiscoveryV1Models {
     public AddTrainingDataOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -1334,7 +1334,7 @@ public class IBMDiscoveryV1Models {
     public CreateCollectionOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -1596,7 +1596,7 @@ public class IBMDiscoveryV1Models {
     public CreateConfigurationOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -1736,7 +1736,7 @@ public class IBMDiscoveryV1Models {
     public CreateEnvironmentOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -1906,7 +1906,7 @@ public class IBMDiscoveryV1Models {
     public CreateExpansionsOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -2134,7 +2134,7 @@ public class IBMDiscoveryV1Models {
     public CreateTrainingExampleOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -2252,7 +2252,7 @@ public class IBMDiscoveryV1Models {
     public DeleteAllTrainingDataOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -2370,7 +2370,7 @@ public class IBMDiscoveryV1Models {
     public DeleteCollectionOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -2488,7 +2488,7 @@ public class IBMDiscoveryV1Models {
     public DeleteConfigurationOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -2634,7 +2634,7 @@ public class IBMDiscoveryV1Models {
     public DeleteDocumentOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -2724,7 +2724,7 @@ public class IBMDiscoveryV1Models {
     public DeleteEnvironmentOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -2842,7 +2842,7 @@ public class IBMDiscoveryV1Models {
     public DeleteExpansionsOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -2988,7 +2988,7 @@ public class IBMDiscoveryV1Models {
     public DeleteTrainingDataOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -3162,7 +3162,7 @@ public class IBMDiscoveryV1Models {
     public DeleteTrainingExampleOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -4754,7 +4754,7 @@ public class IBMDiscoveryV1Models {
     public FederatedQueryNoticesOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -5302,7 +5302,7 @@ public class IBMDiscoveryV1Models {
     public FederatedQueryOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -5590,7 +5590,7 @@ public class IBMDiscoveryV1Models {
     public GetCollectionOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -5708,7 +5708,7 @@ public class IBMDiscoveryV1Models {
     public GetConfigurationOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -5854,7 +5854,7 @@ public class IBMDiscoveryV1Models {
     public GetDocumentStatusOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -5944,7 +5944,7 @@ public class IBMDiscoveryV1Models {
     public GetEnvironmentOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -6090,7 +6090,7 @@ public class IBMDiscoveryV1Models {
     public GetTrainingDataOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -6264,7 +6264,7 @@ public class IBMDiscoveryV1Models {
     public GetTrainingExampleOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -6636,7 +6636,7 @@ public class IBMDiscoveryV1Models {
     public ListCollectionFieldsOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -6801,7 +6801,7 @@ public class IBMDiscoveryV1Models {
     public ListCollectionsOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -6966,7 +6966,7 @@ public class IBMDiscoveryV1Models {
     public ListConfigurationsOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -7096,7 +7096,7 @@ public class IBMDiscoveryV1Models {
     public ListEnvironmentsOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -7264,7 +7264,7 @@ public class IBMDiscoveryV1Models {
     public ListExpansionsOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -7398,7 +7398,7 @@ public class IBMDiscoveryV1Models {
     public ListFieldsOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -7516,7 +7516,7 @@ public class IBMDiscoveryV1Models {
     public ListTrainingDataOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -7662,7 +7662,7 @@ public class IBMDiscoveryV1Models {
     public ListTrainingExamplesOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -7831,8 +7831,9 @@ public class IBMDiscoveryV1Models {
       }
 
       NluEnrichmentEmotion ret = (NluEnrichmentEmotion) super.deserialize(jsonString, jsonMap, classType);
+      NluEnrichmentEmotionBuilder retBuilder = ret.newBuilder();
 
-      return ret;
+      return retBuilder.build();
     }
   }
 
@@ -8022,8 +8023,9 @@ public class IBMDiscoveryV1Models {
       }
 
       NluEnrichmentEntities ret = (NluEnrichmentEntities) super.deserialize(jsonString, jsonMap, classType);
+      NluEnrichmentEntitiesBuilder retBuilder = ret.newBuilder();
 
-      return ret;
+      return retBuilder.build();
     }
   }
 
@@ -8479,8 +8481,9 @@ public class IBMDiscoveryV1Models {
       }
 
       NluEnrichmentKeywords ret = (NluEnrichmentKeywords) super.deserialize(jsonString, jsonMap, classType);
+      NluEnrichmentKeywordsBuilder retBuilder = ret.newBuilder();
 
-      return ret;
+      return retBuilder.build();
     }
   }
 
@@ -8652,8 +8655,9 @@ public class IBMDiscoveryV1Models {
       }
 
       NluEnrichmentSemanticRoles ret = (NluEnrichmentSemanticRoles) super.deserialize(jsonString, jsonMap, classType);
+      NluEnrichmentSemanticRolesBuilder retBuilder = ret.newBuilder();
 
-      return ret;
+      return retBuilder.build();
     }
   }
 
@@ -8775,8 +8779,9 @@ public class IBMDiscoveryV1Models {
       }
 
       NluEnrichmentSentiment ret = (NluEnrichmentSentiment) super.deserialize(jsonString, jsonMap, classType);
+      NluEnrichmentSentimentBuilder retBuilder = ret.newBuilder();
 
-      return ret;
+      return retBuilder.build();
     }
   }
 
@@ -9750,7 +9755,7 @@ public class IBMDiscoveryV1Models {
     public QueryEntitiesOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -10794,7 +10799,7 @@ public class IBMDiscoveryV1Models {
     public QueryNoticesOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -11848,7 +11853,7 @@ public class IBMDiscoveryV1Models {
     public QueryOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**
@@ -12456,7 +12461,7 @@ public class IBMDiscoveryV1Models {
     public QueryRelationsOptionsBuilder addHeader(String name, String value) {
       this.requestHeaders.put(name, value);
       return this;
-  }
+    }
   }
 
   /**

--- a/force-app/main/default/classes/IBMDiscoveryV1Test.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Test.cls
@@ -1357,40 +1357,47 @@ private class IBMDiscoveryV1Test {
     enrichment.setOverwrite(true);
     enrichment.setEnrichment('test Description');
     enrichment.setIgnoreDownstreamErrors(true);
-    IBMDiscoveryV1Models.EnrichmentOptions enrichmentOptions = new IBMDiscoveryV1Models.EnrichmentOptions();
-    IBMDiscoveryV1Models.NluEnrichmentFeatures enrichmentFeatures = new IBMDiscoveryV1Models.NluEnrichmentFeatures();
-    IBMDiscoveryV1Models.NluEnrichmentEmotion enrichmentEmotion = new IBMDiscoveryV1Models.NluEnrichmentEmotion();
-    enrichmentEmotion.setDocument(true);
-    enrichmentEmotion.setTargets(new List<String>{'Target1', 'Target2'});
-    enrichmentFeatures.setEmotion(enrichmentEmotion);
-    IBMDiscoveryV1Models.NluEnrichmentEntities enrichmentEntities = new IBMDiscoveryV1Models.NluEnrichmentEntities();
-    enrichmentEntities.setEmotion(true);
-    enrichmentEntities.setLimit(5);
-    enrichmentEntities.setMentions(true);
-    enrichmentEntities.setMentionTypes(true);
-    enrichmentEntities.setModel('test');
-    enrichmentEntities.setSentenceLocation(true);
-    enrichmentEntities.setSentiment(true);
-    enrichmentFeatures.setEntities(enrichmentEntities);
-    IBMDiscoveryV1Models.NluEnrichmentKeywords enrichmentKeywords = new IBMDiscoveryV1Models.NluEnrichmentKeywords();
-    enrichmentKeywords.setEmotion(true);
-    enrichmentKeywords.setLimit(5);
-    enrichmentKeywords.setSentiment(true);
-    enrichmentFeatures.setKeywords(enrichmentKeywords);
+    IBMDiscoveryV1Models.NluEnrichmentEmotion enrichmentEmotion = new IBMDiscoveryV1Models.NluEnrichmentEmotionBuilder()
+      .document(true)
+      .targets(new List<String>{'Target1', 'Target2'})
+      .build();
+    IBMDiscoveryV1Models.NluEnrichmentEntities enrichmentEntities = new IBMDiscoveryV1Models.NluEnrichmentEntitiesBuilder()
+      .emotion(true)
+      .limitField(5)
+      .mentions(true)
+      .mentionTypes(true)
+      .model('test')
+      .sentenceLocation(true)
+      .sentiment(true)
+      .build();
+    IBMDiscoveryV1Models.NluEnrichmentKeywords enrichmentKeywords = new IBMDiscoveryV1Models.NluEnrichmentKeywordsBuilder()
+      .emotion(true)
+      .limitField(5)
+      .sentiment(true)
+      .build();
     IBMDiscoveryV1Models.NluEnrichmentRelations enrichmentRelations = new IBMDiscoveryV1Models.NluEnrichmentRelations();
     enrichmentRelations.setModel('test');
-    enrichmentFeatures.setRelations(enrichmentRelations);
-    IBMDiscoveryV1Models.NluEnrichmentSemanticRoles enrichmentSemanticRoles = new IBMDiscoveryV1Models.NluEnrichmentSemanticRoles();
-    enrichmentSemanticRoles.setEntities(true);
-    enrichmentSemanticRoles.setKeywords(true);
-    enrichmentSemanticRoles.setLimit(5);
-    enrichmentFeatures.setSemanticRoles(enrichmentSemanticRoles);
-    IBMDiscoveryV1Models.NluEnrichmentSentiment enrichmentSentiment = new IBMDiscoveryV1Models.NluEnrichmentSentiment();
-    enrichmentSentiment.setDocument(true);
-    enrichmentSentiment.setTargets(new List<String>{'Target1', 'Target2'});
-    enrichmentFeatures.setSentiment(enrichmentSentiment);
-    enrichmentOptions.setFeatures(enrichmentFeatures);
-    enrichmentOptions.setModel('test');
+    IBMDiscoveryV1Models.NluEnrichmentSemanticRoles enrichmentSemanticRoles = new IBMDiscoveryV1Models.NluEnrichmentSemanticRolesBuilder()
+      .entities(true)
+      .keywords(true)
+      .limitField(5)
+      .build();
+    IBMDiscoveryV1Models.NluEnrichmentSentiment enrichmentSentiment = new IBMDiscoveryV1Models.NluEnrichmentSentimentBuilder()
+      .document(true)
+      .targets(new List<String>{'Target1', 'Target2'})
+      .build();
+    IBMDiscoveryV1Models.NluEnrichmentFeatures enrichmentFeatures = new IBMDiscoveryV1Models.NluEnrichmentFeaturesBuilder()
+      .emotion(enrichmentEmotion)
+      .entities(enrichmentEntities)
+      .keywords(enrichmentKeywords)
+      .relations(enrichmentRelations)
+      .semanticRoles(enrichmentSemanticRoles)
+      .sentiment(enrichmentSentiment)
+      .build();
+    IBMDiscoveryV1Models.EnrichmentOptions enrichmentOptions = new IBMDiscoveryV1Models.EnrichmentOptionsBuilder()
+      .features(enrichmentFeatures)
+      .model('test')
+      .build();
     enrichment.setOptions(enrichmentOptions);
     configuration.setEnrichments(new List<IBMDiscoveryV1Models.Enrichment>{enrichment});
     configuration.setNormalizations(new List<IBMDiscoveryV1Models.NormalizationOperation>{normalizationOperation});

--- a/force-app/main/default/classes/IBMDiscoveryV1Test.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Test.cls
@@ -19,6 +19,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.CreateEnvironmentOptions options = new IBMDiscoveryV1Models.CreateEnvironmentOptionsBuilder()
       .name(text)
       .description('test_environment description')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -74,6 +75,7 @@ private class IBMDiscoveryV1Test {
       IBMDiscoveryV1Models.CreateEnvironmentOptions options = new IBMDiscoveryV1Models.CreateEnvironmentOptionsBuilder()
         .name(text)
         .description('test_environment description')
+        .addHeader('Test-Header', 'test_value')
         .build();
       IBMDiscoveryV1Models.Environment resp =
         discovery.createEnvironment(options);
@@ -101,6 +103,7 @@ private class IBMDiscoveryV1Test {
     String text = 'test_environment';
     IBMDiscoveryV1Models.ListEnvironmentsOptions options = new IBMDiscoveryV1Models.ListEnvironmentsOptionsBuilder()
       .name(text)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -128,6 +131,7 @@ private class IBMDiscoveryV1Test {
     String text = '5ae96bb9-80e5-43ea-916e-1f3412fbc283';
     IBMDiscoveryV1Models.DeleteEnvironmentOptions options = new IBMDiscoveryV1Models.DeleteEnvironmentOptionsBuilder()
       .environmentId(text)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -150,6 +154,7 @@ private class IBMDiscoveryV1Test {
       String text = '';
       IBMDiscoveryV1Models.DeleteEnvironmentOptions options = new IBMDiscoveryV1Models.DeleteEnvironmentOptionsBuilder()
         .environmentId(text)
+        .addHeader('Test-Header', 'test_value')
         .build();
       discovery.deleteEnvironment(options);
     }
@@ -175,6 +180,7 @@ private class IBMDiscoveryV1Test {
     String text = '5ae96bb9-80e5-43ea-916e-1f3412fbc283';
     IBMDiscoveryV1Models.GetEnvironmentOptions options = new IBMDiscoveryV1Models.GetEnvironmentOptionsBuilder()
       .environmentId(text)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -201,6 +207,7 @@ private class IBMDiscoveryV1Test {
     try {
       IBMDiscoveryV1Models.GetEnvironmentOptions options = new IBMDiscoveryV1Models.GetEnvironmentOptionsBuilder()
         .environmentId(text)
+        .addHeader('Test-Header', 'test_value')
         .build();
       IBMDiscoveryV1Models.Environment resp =
         discovery.getEnvironment(options);
@@ -227,6 +234,7 @@ private class IBMDiscoveryV1Test {
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .name('test_environment')
       .description('test_environment description')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -252,6 +260,7 @@ private class IBMDiscoveryV1Test {
         .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
         .name('')
         .description('test_environment description')
+        .addHeader('Test-Header', 'test_value')
         .build();
       IBMDiscoveryV1Models.Environment resp =
         discovery.updateEnvironment(options);
@@ -278,6 +287,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.ListFieldsOptions options = new IBMDiscoveryV1Models.ListFieldsOptionsBuilder()
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionIds(collectionIds)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -351,6 +361,7 @@ private class IBMDiscoveryV1Test {
       .addNormalizations(normalizationOperation)
       .normalizations(new List<IBMDiscoveryV1Models.NormalizationOperation>{normalizationOperation})
       .conversions(conversions)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -379,6 +390,7 @@ private class IBMDiscoveryV1Test {
       IBMDiscoveryV1Models.CreateConfigurationOptions options = new IBMDiscoveryV1Models.CreateConfigurationOptionsBuilder()
         .name('test_environment')
         .description('test_environment description')
+        .addHeader('Test-Header', 'test_value')
         .build();
       IBMDiscoveryV1Models.Configuration resp =
         discovery.createConfiguration(options);
@@ -404,6 +416,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteConfigurationOptions options = new IBMDiscoveryV1Models.DeleteConfigurationOptionsBuilder('5ae96bb9-80e5-43ea-916e-1f3412fbc283', '5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .configurationId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -426,6 +439,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetConfigurationOptions options = new IBMDiscoveryV1Models.GetConfigurationOptionsBuilder()
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .configurationId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -449,6 +463,7 @@ private class IBMDiscoveryV1Test {
     discovery.setUsernameAndPassword('username', 'password');
     IBMDiscoveryV1Models.ListConfigurationsOptions options = new IBMDiscoveryV1Models.ListConfigurationsOptionsBuilder()
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -474,6 +489,7 @@ private class IBMDiscoveryV1Test {
       .name('test_environment')
       .description('test_environment description')
       .configurationId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -500,6 +516,7 @@ private class IBMDiscoveryV1Test {
         .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
         .name('test_environment')
         .description('test_environment description')
+        .addHeader('Test-Header', 'test_value')
         .build();
       IBMDiscoveryV1Models.Configuration resp =
         discovery.updateConfiguration(options);
@@ -527,6 +544,7 @@ private class IBMDiscoveryV1Test {
       .configurationId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .name('test_environment')
       .description('test_environment description')
+      .addHeader('Test-Header', 'test_value')
       .language('de')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
@@ -552,6 +570,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteCollectionOptions options = new IBMDiscoveryV1Models.DeleteCollectionOptionsBuilder('5ae96bb9-80e5-43ea-916e-1f3412fbc283', '5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -574,6 +593,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetCollectionOptions options = new IBMDiscoveryV1Models.GetCollectionOptionsBuilder()
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -618,6 +638,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetCollectionOptions options = new IBMDiscoveryV1Models.GetCollectionOptionsBuilder()
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -661,6 +682,7 @@ private class IBMDiscoveryV1Test {
     discovery.setUsernameAndPassword('username', 'password');
     IBMDiscoveryV1Models.ListCollectionsOptions options = new IBMDiscoveryV1Models.ListCollectionsOptionsBuilder()
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -686,6 +708,7 @@ private class IBMDiscoveryV1Test {
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .name('test_environment')
       .description('test_environment description')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -712,6 +735,7 @@ private class IBMDiscoveryV1Test {
         .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
         .name('test_environment')
         .description('test_environment description')
+        .addHeader('Test-Header', 'test_value')
         .build();
       IBMDiscoveryV1Models.Collection resp =
         discovery.updateCollection(options);
@@ -738,6 +762,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.ListCollectionFieldsOptions options = new IBMDiscoveryV1Models.ListCollectionFieldsOptionsBuilder()
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -763,6 +788,7 @@ private class IBMDiscoveryV1Test {
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .documentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -786,6 +812,7 @@ private class IBMDiscoveryV1Test {
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .documentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -836,6 +863,7 @@ private class IBMDiscoveryV1Test {
       .similar(true)
       .similarDocumentIds(new List<String> { 'doc1', 'doc2' })
       .similarFields(new List<String> { 'field1', 'field2' })
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -877,6 +905,7 @@ private class IBMDiscoveryV1Test {
       .similar(true)
       .similarDocumentIds(new List<String> { 'doc1', 'doc2' })
       .similarFields(new List<String> { 'field1', 'field2' })
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -975,6 +1004,7 @@ private class IBMDiscoveryV1Test {
       .similar(true)
       .similarDocumentIds(new List<String> { 'doc1', 'doc2' })
       .similarFields(new List<String> { 'field1', 'field2' })
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1006,6 +1036,7 @@ private class IBMDiscoveryV1Test {
       .similar(true)
       .similarDocumentIds(new List<String> { 'doc1', 'doc2' })
       .similarFields(new List<String> { 'field1', 'field2' })
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1052,6 +1083,7 @@ private class IBMDiscoveryV1Test {
       .filter('test')
       .addExamples(te)
       .examples(new List<IBMDiscoveryV1Models.TrainingExample>{te})
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1090,6 +1122,7 @@ private class IBMDiscoveryV1Test {
       .documentId('test')
       .relevance(2)
       .crossReference('test')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1114,6 +1147,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteAllTrainingDataOptions options = new IBMDiscoveryV1Models.DeleteAllTrainingDataOptionsBuilder('5ae96bb9-80e5-43ea-916e-1f3412fbc283', '5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1137,6 +1171,7 @@ private class IBMDiscoveryV1Test {
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .queryId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1160,6 +1195,7 @@ private class IBMDiscoveryV1Test {
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .queryId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1188,6 +1224,7 @@ private class IBMDiscoveryV1Test {
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .queryId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .exampleId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1213,6 +1250,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.ListTrainingDataOptions options = new IBMDiscoveryV1Models.ListTrainingDataOptionsBuilder()
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1244,6 +1282,7 @@ private class IBMDiscoveryV1Test {
       .exampleId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .relevance(2)
       .crossReference('test')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1407,6 +1446,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.CreateConfigurationOptions options = new IBMDiscoveryV1Models.CreateConfigurationOptionsBuilder()
       .environmentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .configuration(configuration)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1479,6 +1519,7 @@ private class IBMDiscoveryV1Test {
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .queryId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .exampleId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1513,6 +1554,7 @@ private class IBMDiscoveryV1Test {
       .file(testfile)
       .filename('test.txt')
       .fileContentType('text/plain')
+      .addHeader('Test-Header', 'test_value')
       .build();
      //you can add more attributes using following builder method. This step is not necessary
      options = options.newBuilder().build();
@@ -1546,6 +1588,7 @@ private class IBMDiscoveryV1Test {
       .file(testfile)
       .filename('test.txt')
       .fileContentType('text/plain')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1579,6 +1622,7 @@ private class IBMDiscoveryV1Test {
       .file(testfile)
       .filename('test.txt')
       .fileContentType('text/plain')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1615,6 +1659,7 @@ private class IBMDiscoveryV1Test {
         .environmentId('environment_id')
         .collectionId('collection_id')
         .expansions(expansions)
+        .addHeader('Test-Header', 'test_value')
         .build();
     IBMDiscoveryV1Models.Expansions createResults = discovery.createExpansions(createOptions);
 
@@ -1648,6 +1693,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.ListExpansionsOptions listOptions = new IBMDiscoveryV1Models.ListExpansionsOptionsBuilder()
         .environmentId('environment_id')
         .collectionId('collection_id')
+        .addHeader('Test-Header', 'test_value')
         .build();
     IBMDiscoveryV1Models.Expansions listResults = discovery.listExpansions(listOptions);
 
@@ -1668,6 +1714,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteExpansionsOptions deleteOptions = new IBMDiscoveryV1Models.DeleteExpansionsOptionsBuilder()
         .environmentId('environment_id')
         .collectionId('collection_id')
+        .addHeader('Test-Header', 'test_value')
         .build();
     discovery.deleteExpansions(deleteOptions);
 
@@ -1696,6 +1743,7 @@ private class IBMDiscoveryV1Test {
       .entity(entity)
       .evidenceCount(10)
       .feature('feature')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMDiscoveryV1Models.QueryEntitiesResponse resp = discovery.queryEntities(options);
 
@@ -1745,6 +1793,7 @@ private class IBMDiscoveryV1Test {
       .evidenceCount(10)
       .filter(filter)
       .sortField('text')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMDiscoveryV1Models.QueryRelationsResponse resp = discovery.queryRelations(options);
 

--- a/force-app/main/default/classes/IBMLanguageTranslatorV2.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV2.cls
@@ -54,6 +54,12 @@ public class IBMLanguageTranslatorV2 extends IBMWatsonService {
   public IBMLanguageTranslatorV2Models.TranslationResult translate(IBMLanguageTranslatorV2Models.TranslateOptions translateOptions) {
     IBMWatsonValidator.notNull(translateOptions, 'translateOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v2/translate');
+    Map<String, String> requestHeaders = (translateOptions != null) ? translateOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('text', translateOptions.text());
     if (translateOptions.modelId() != null) {
@@ -81,6 +87,12 @@ public class IBMLanguageTranslatorV2 extends IBMWatsonService {
   public IBMLanguageTranslatorV2Models.IdentifiedLanguages identify(IBMLanguageTranslatorV2Models.IdentifyOptions identifyOptions) {
     IBMWatsonValidator.notNull(identifyOptions, 'identifyOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v2/identify');
+    Map<String, String> requestHeaders = (identifyOptions != null) ? identifyOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.bodyContent(identifyOptions.text(), 'text/plain');
 
     return (IBMLanguageTranslatorV2Models.IdentifiedLanguages) createServiceCall(builder.build(), IBMLanguageTranslatorV2Models.IdentifiedLanguages.class);
@@ -96,6 +108,12 @@ public class IBMLanguageTranslatorV2 extends IBMWatsonService {
    */
   public IBMLanguageTranslatorV2Models.IdentifiableLanguages listIdentifiableLanguages(IBMLanguageTranslatorV2Models.ListIdentifiableLanguagesOptions listIdentifiableLanguagesOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v2/identifiable_languages');
+    Map<String, String> requestHeaders = (listIdentifiableLanguagesOptions != null) ? listIdentifiableLanguagesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMLanguageTranslatorV2Models.IdentifiableLanguages) createServiceCall(builder.build(), IBMLanguageTranslatorV2Models.IdentifiableLanguages.class);
   }
@@ -112,6 +130,12 @@ public class IBMLanguageTranslatorV2 extends IBMWatsonService {
     IBMWatsonValidator.notNull(createModelOptions, 'createModelOptions cannot be null');
     IBMWatsonValidator.isTrue((createModelOptions.forcedGlossary() != null) || (createModelOptions.parallelCorpus() != null) || (createModelOptions.monolingualCorpus() != null), 'At least one of forced_glossary, parallel_corpus, or monolingual_corpus must be supplied.');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v2/models');
+    Map<String, String> requestHeaders = (createModelOptions != null) ? createModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (createModelOptions.baseModelId() != null) {
       builder.query('base_model_id', createModelOptions.baseModelId());
     }
@@ -149,6 +173,12 @@ public class IBMLanguageTranslatorV2 extends IBMWatsonService {
   public void deleteModel(IBMLanguageTranslatorV2Models.DeleteModelOptions deleteModelOptions) {
     IBMWatsonValidator.notNull(deleteModelOptions, 'deleteModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v2/models/{0}', new String[]{ deleteModelOptions.modelId() }));
+    Map<String, String> requestHeaders = (deleteModelOptions != null) ? deleteModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
@@ -164,6 +194,12 @@ public class IBMLanguageTranslatorV2 extends IBMWatsonService {
   public IBMLanguageTranslatorV2Models.TranslationModel getModel(IBMLanguageTranslatorV2Models.GetModelOptions getModelOptions) {
     IBMWatsonValidator.notNull(getModelOptions, 'getModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v2/models/{0}', new String[]{ getModelOptions.modelId() }));
+    Map<String, String> requestHeaders = (getModelOptions != null) ? getModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMLanguageTranslatorV2Models.TranslationModel) createServiceCall(builder.build(), IBMLanguageTranslatorV2Models.TranslationModel.class);
   }
@@ -178,6 +214,12 @@ public class IBMLanguageTranslatorV2 extends IBMWatsonService {
    */
   public IBMLanguageTranslatorV2Models.TranslationModels listModels(IBMLanguageTranslatorV2Models.ListModelsOptions listModelsOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v2/models');
+    Map<String, String> requestHeaders = (listModelsOptions != null) ? listModelsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (listModelsOptions != null && listModelsOptions.source() != null) {
       builder.query('source', listModelsOptions.source());
     }

--- a/force-app/main/default/classes/IBMLanguageTranslatorV2Models.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV2Models.cls
@@ -2,7 +2,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * The createModel options.
    */
-  public class CreateModelOptions {
+  public class CreateModelOptions extends IBMWatsonOptionsModel {
     private String base_model_id_serialized_name;
     private String name_serialized_name;
     private IBMWatsonFile forced_glossary_serialized_name;
@@ -101,6 +101,7 @@ public class IBMLanguageTranslatorV2Models {
       parallel_corpus_filename_serialized_name = builder.parallel_corpus_filename_serialized_name;
       monolingual_corpus_serialized_name = builder.monolingual_corpus_serialized_name;
       monolingual_corpus_filename_serialized_name = builder.monolingual_corpus_filename_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -117,7 +118,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * CreateModelOptions Builder.
    */
-  public class CreateModelOptionsBuilder {
+  public class CreateModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String base_model_id_serialized_name;
     private String name_serialized_name;
     private IBMWatsonFile forced_glossary_serialized_name;
@@ -249,12 +250,24 @@ public class IBMLanguageTranslatorV2Models {
       this.monolingual_corpus_filename_serialized_name = monolingualCorpusFilename;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateModelOptions builder
+     */
+    public CreateModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteModel options.
    */
-  public class DeleteModelOptions {
+  public class DeleteModelOptions extends IBMWatsonOptionsModel {
     private String model_id_serialized_name;
     /**
      * Gets the model_id_serialized_name.
@@ -269,6 +282,7 @@ public class IBMLanguageTranslatorV2Models {
     private DeleteModelOptions(DeleteModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.model_id_serialized_name, 'model_id_serialized_name cannot be empty');
       model_id_serialized_name = builder.model_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -285,7 +299,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * DeleteModelOptions Builder.
    */
-  public class DeleteModelOptionsBuilder {
+  public class DeleteModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String model_id_serialized_name;
 
     private DeleteModelOptionsBuilder(DeleteModelOptions deleteModelOptions) {
@@ -326,12 +340,24 @@ public class IBMLanguageTranslatorV2Models {
       this.model_id_serialized_name = modelId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteModelOptions builder
+     */
+    public DeleteModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getModel options.
    */
-  public class GetModelOptions {
+  public class GetModelOptions extends IBMWatsonOptionsModel {
     private String model_id_serialized_name;
     /**
      * Gets the model_id_serialized_name.
@@ -346,6 +372,7 @@ public class IBMLanguageTranslatorV2Models {
     private GetModelOptions(GetModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.model_id_serialized_name, 'model_id_serialized_name cannot be empty');
       model_id_serialized_name = builder.model_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -362,7 +389,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * GetModelOptions Builder.
    */
-  public class GetModelOptionsBuilder {
+  public class GetModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String model_id_serialized_name;
 
     private GetModelOptionsBuilder(GetModelOptions getModelOptions) {
@@ -401,6 +428,18 @@ public class IBMLanguageTranslatorV2Models {
      */
     public GetModelOptionsBuilder modelId(String modelId) {
       this.model_id_serialized_name = modelId;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetModelOptions builder
+     */
+    public GetModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -466,7 +505,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * IdentifiableLanguages.
    */
-  public class IdentifiableLanguages extends IBMWatsonGenericModel {
+  public class IdentifiableLanguages extends IBMWatsonResponseModel {
     private List<IdentifiableLanguage> languages_serialized_name;
     /**
      * Gets the languages_serialized_name.
@@ -574,7 +613,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * IdentifiedLanguages.
    */
-  public class IdentifiedLanguages extends IBMWatsonGenericModel {
+  public class IdentifiedLanguages extends IBMWatsonResponseModel {
     private List<IdentifiedLanguage> languages_serialized_name;
     /**
      * Gets the languages_serialized_name.
@@ -624,7 +663,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * The identify options.
    */
-  public class IdentifyOptions {
+  public class IdentifyOptions extends IBMWatsonOptionsModel {
     private String text_serialized_name;
     /**
      * Gets the text_serialized_name.
@@ -639,6 +678,7 @@ public class IBMLanguageTranslatorV2Models {
     private IdentifyOptions(IdentifyOptionsBuilder builder) {
       IBMWatsonValidator.notNull(builder.text_serialized_name, 'text_serialized_name cannot be null');
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -655,7 +695,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * IdentifyOptions Builder.
    */
-  public class IdentifyOptionsBuilder {
+  public class IdentifyOptionsBuilder extends IBMWatsonOptionsModel {
     private String text_serialized_name;
 
     private IdentifyOptionsBuilder(IdentifyOptions identifyOptions) {
@@ -696,13 +736,26 @@ public class IBMLanguageTranslatorV2Models {
       this.text_serialized_name = text;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the IdentifyOptions builder
+     */
+    public IdentifyOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listIdentifiableLanguages options.
    */
-  public class ListIdentifiableLanguagesOptions {
+  public class ListIdentifiableLanguagesOptions extends IBMWatsonOptionsModel {
     private ListIdentifiableLanguagesOptions(ListIdentifiableLanguagesOptionsBuilder builder) {
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -719,7 +772,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * ListIdentifiableLanguagesOptions Builder.
    */
-  public class ListIdentifiableLanguagesOptionsBuilder {
+  public class ListIdentifiableLanguagesOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListIdentifiableLanguagesOptionsBuilder(ListIdentifiableLanguagesOptions listIdentifiableLanguagesOptions) {
     }
@@ -738,12 +791,24 @@ public class IBMLanguageTranslatorV2Models {
     public ListIdentifiableLanguagesOptions build() {
       return new ListIdentifiableLanguagesOptions(this);
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListIdentifiableLanguagesOptions builder
+     */
+    public ListIdentifiableLanguagesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listModels options.
    */
-  public class ListModelsOptions {
+  public class ListModelsOptions extends IBMWatsonOptionsModel {
     private String source_serialized_name;
     private String target_serialized_name;
     private Boolean default_serialized_name;
@@ -781,6 +846,7 @@ public class IBMLanguageTranslatorV2Models {
       source_serialized_name = builder.source_serialized_name;
       target_serialized_name = builder.target_serialized_name;
       default_serialized_name = builder.default_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -797,7 +863,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * ListModelsOptions Builder.
    */
-  public class ListModelsOptionsBuilder {
+  public class ListModelsOptionsBuilder extends IBMWatsonOptionsModel {
     private String source_serialized_name;
     private String target_serialized_name;
     private Boolean default_serialized_name;
@@ -855,12 +921,24 @@ public class IBMLanguageTranslatorV2Models {
       this.default_serialized_name = defaultVar;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListModelsOptions builder
+     */
+    public ListModelsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The translate options.
    */
-  public class TranslateOptions {
+  public class TranslateOptions extends IBMWatsonOptionsModel {
     private List<String> text_serialized_name;
     private String model_id_serialized_name;
     private String source_serialized_name;
@@ -911,6 +989,7 @@ public class IBMLanguageTranslatorV2Models {
       model_id_serialized_name = builder.model_id_serialized_name;
       source_serialized_name = builder.source_serialized_name;
       target_serialized_name = builder.target_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -927,7 +1006,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * TranslateOptions Builder.
    */
-  public class TranslateOptionsBuilder {
+  public class TranslateOptionsBuilder extends IBMWatsonOptionsModel {
     private List<String> text_serialized_name;
     private String model_id_serialized_name;
     private String source_serialized_name;
@@ -1023,6 +1102,18 @@ public class IBMLanguageTranslatorV2Models {
       this.target_serialized_name = target;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the TranslateOptions builder
+     */
+    public TranslateOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
@@ -1065,7 +1156,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * Response payload for models.
    */
-  public class TranslationModel extends IBMWatsonGenericModel {
+  public class TranslationModel extends IBMWatsonResponseModel {
     private String model_id_serialized_name;
     private String name_serialized_name;
     private String source_serialized_name;
@@ -1291,7 +1382,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * The response type for listing existing translation models.
    */
-  public class TranslationModels extends IBMWatsonGenericModel {
+  public class TranslationModels extends IBMWatsonResponseModel {
     private List<TranslationModel> models_serialized_name;
     /**
      * Gets the models_serialized_name.
@@ -1341,7 +1432,7 @@ public class IBMLanguageTranslatorV2Models {
   /**
    * TranslationResult.
    */
-  public class TranslationResult extends IBMWatsonGenericModel {
+  public class TranslationResult extends IBMWatsonResponseModel {
     private Long word_count_serialized_name;
     private Long character_count_serialized_name;
     private List<Translation> translations_serialized_name;

--- a/force-app/main/default/classes/IBMLanguageTranslatorV2Models.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV2Models.cls
@@ -137,6 +137,7 @@ public class IBMLanguageTranslatorV2Models {
       parallel_corpus_filename_serialized_name = createModelOptions.parallel_corpus_filename_serialized_name;
       monolingual_corpus_serialized_name = createModelOptions.monolingual_corpus_serialized_name;
       monolingual_corpus_filename_serialized_name = createModelOptions.monolingual_corpus_filename_serialized_name;
+      this.requestHeaders.putAll(createModelOptions.requestHeaders());
     }
 
     /**
@@ -304,6 +305,7 @@ public class IBMLanguageTranslatorV2Models {
 
     private DeleteModelOptionsBuilder(DeleteModelOptions deleteModelOptions) {
       model_id_serialized_name = deleteModelOptions.model_id_serialized_name;
+      this.requestHeaders.putAll(deleteModelOptions.requestHeaders());
     }
 
     /**
@@ -394,6 +396,7 @@ public class IBMLanguageTranslatorV2Models {
 
     private GetModelOptionsBuilder(GetModelOptions getModelOptions) {
       model_id_serialized_name = getModelOptions.model_id_serialized_name;
+      this.requestHeaders.putAll(getModelOptions.requestHeaders());
     }
 
     /**
@@ -700,6 +703,7 @@ public class IBMLanguageTranslatorV2Models {
 
     private IdentifyOptionsBuilder(IdentifyOptions identifyOptions) {
       text_serialized_name = identifyOptions.text_serialized_name;
+      this.requestHeaders.putAll(identifyOptions.requestHeaders());
     }
 
     /**
@@ -775,6 +779,7 @@ public class IBMLanguageTranslatorV2Models {
   public class ListIdentifiableLanguagesOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListIdentifiableLanguagesOptionsBuilder(ListIdentifiableLanguagesOptions listIdentifiableLanguagesOptions) {
+      this.requestHeaders.putAll(listIdentifiableLanguagesOptions.requestHeaders());
     }
 
     /**
@@ -872,6 +877,7 @@ public class IBMLanguageTranslatorV2Models {
       source_serialized_name = listModelsOptions.source_serialized_name;
       target_serialized_name = listModelsOptions.target_serialized_name;
       default_serialized_name = listModelsOptions.default_serialized_name;
+      this.requestHeaders.putAll(listModelsOptions.requestHeaders());
     }
 
     /**
@@ -1017,6 +1023,7 @@ public class IBMLanguageTranslatorV2Models {
       model_id_serialized_name = translateOptions.model_id_serialized_name;
       source_serialized_name = translateOptions.source_serialized_name;
       target_serialized_name = translateOptions.target_serialized_name;
+      this.requestHeaders.putAll(translateOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMLanguageTranslatorV2Test.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV2Test.cls
@@ -23,6 +23,7 @@ private class IBMLanguageTranslatorV2Test {
       .modelId(modelId)
       .text(new List<String>{'Hello'})
       .addText('World')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMLanguageTranslatorV2Models.TranslationResult translate =
       service.translate(translateOptions);
@@ -48,6 +49,7 @@ private class IBMLanguageTranslatorV2Test {
     IBMLanguageTranslatorV2Models.IdentifyOptions identifyOptions =
       new IBMLanguageTranslatorV2Models.IdentifyOptionsBuilder()
       .text('sample')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMLanguageTranslatorV2Models.IdentifiedLanguages identify =
       service.identify(identifyOptions);
@@ -65,6 +67,7 @@ private class IBMLanguageTranslatorV2Test {
     IBMLanguageTranslatorV2 service = new IBMLanguageTranslatorV2();
     IBMLanguageTranslatorV2Models.ListIdentifiableLanguagesOptions listIdentifiableLanguagesOptions =
       new IBMLanguageTranslatorV2Models.ListIdentifiableLanguagesOptionsBuilder()
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMLanguageTranslatorV2Models.IdentifiableLanguages listIdentifiableLanguages =
       service.listIdentifiableLanguages(listIdentifiableLanguagesOptions);
@@ -127,6 +130,7 @@ private class IBMLanguageTranslatorV2Test {
       .parallelCorpusFilename('parallelCorpus.txt')
       .monolingualCorpus(monolingualCorpus)
       .monolingualCorpusFilename('monolingualCorpus.txt')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMLanguageTranslatorV2Models.TranslationModel TranslationModel =
       service.createModel(createModelOptions);
@@ -169,6 +173,7 @@ private class IBMLanguageTranslatorV2Test {
     IBMLanguageTranslatorV2Models.DeleteModelOptions deleteModelOptions =
       new IBMLanguageTranslatorV2Models.DeleteModelOptionsBuilder()
       .modelId('3e7dfdbe-f757-4150-afee-458e71eb93fb')
+      .addHeader('Test-Header', 'test_value')
       .build();
     service.deleteModel(deleteModelOptions);
     IBMLanguageTranslatorV2Models.DeleteModelOptionsBuilder newDeleteModelOptionsBuilder1 =
@@ -190,6 +195,7 @@ private class IBMLanguageTranslatorV2Test {
     IBMLanguageTranslatorV2Models.GetModelOptions getModelOptions =
       new IBMLanguageTranslatorV2Models.GetModelOptionsBuilder()
       .modelId('3e7dfdbe-f757-4150-afee-458e71eb93fb')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMLanguageTranslatorV2Models.TranslationModel getModel =
       service.getModel(getModelOptions);
@@ -214,6 +220,7 @@ private class IBMLanguageTranslatorV2Test {
       .source('en')
       .target('es')
       .defaultField(false)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMLanguageTranslatorV2Models.TranslationModels listModels =
       service.listModels(listModelsOptions);

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
@@ -53,6 +53,12 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
   public IBMNaturalLanguageClassifierV1Models.Classification classify(IBMNaturalLanguageClassifierV1Models.ClassifyOptions classifyOptions) {
     IBMWatsonValidator.notNull(classifyOptions, 'classifyOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/classifiers/{0}/classify', new String[]{ classifyOptions.classifierId() }));
+    Map<String, String> requestHeaders = (classifyOptions != null) ? classifyOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('text', classifyOptions.text());
     builder.bodyJson(JSON.serialize(contentJson, true));
@@ -71,6 +77,12 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
   public IBMNaturalLanguageClassifierV1Models.ClassificationCollection classifyCollection(IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptions classifyCollectionOptions) {
     IBMWatsonValidator.notNull(classifyCollectionOptions, 'classifyCollectionOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/classifiers/{0}/classify_collection', new String[]{ classifyCollectionOptions.classifierId() }));
+    Map<String, String> requestHeaders = (classifyCollectionOptions != null) ? classifyCollectionOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('collection', classifyCollectionOptions.collection());
     builder.bodyJson(JSON.serialize(contentJson, true));
@@ -89,6 +101,12 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
   public IBMNaturalLanguageClassifierV1Models.Classifier createClassifier(IBMNaturalLanguageClassifierV1Models.CreateClassifierOptions createClassifierOptions) {
     IBMWatsonValidator.notNull(createClassifierOptions, 'createClassifierOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/classifiers');
+    Map<String, String> requestHeaders = (createClassifierOptions != null) ? createClassifierOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
     IBMWatsonRequestBody metadataFileBody = IBMWatsonRequestBody.create(createClassifierOptions.trainingMetadata(), 'application/json');
@@ -110,6 +128,12 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
   public void deleteClassifier(IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptions deleteClassifierOptions) {
     IBMWatsonValidator.notNull(deleteClassifierOptions, 'deleteClassifierOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/classifiers/{0}', new String[]{ deleteClassifierOptions.classifierId() }));
+    Map<String, String> requestHeaders = (deleteClassifierOptions != null) ? deleteClassifierOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
@@ -125,6 +149,12 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
   public IBMNaturalLanguageClassifierV1Models.Classifier getClassifier(IBMNaturalLanguageClassifierV1Models.GetClassifierOptions getClassifierOptions) {
     IBMWatsonValidator.notNull(getClassifierOptions, 'getClassifierOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/classifiers/{0}', new String[]{ getClassifierOptions.classifierId() }));
+    Map<String, String> requestHeaders = (getClassifierOptions != null) ? getClassifierOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMNaturalLanguageClassifierV1Models.Classifier) createServiceCall(builder.build(), IBMNaturalLanguageClassifierV1Models.Classifier.class);
   }
@@ -139,6 +169,12 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
    */
   public IBMNaturalLanguageClassifierV1Models.ClassifierList listClassifiers(IBMNaturalLanguageClassifierV1Models.ListClassifiersOptions listClassifiersOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/classifiers');
+    Map<String, String> requestHeaders = (listClassifiersOptions != null) ? listClassifiersOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMNaturalLanguageClassifierV1Models.ClassifierList) createServiceCall(builder.build(), IBMNaturalLanguageClassifierV1Models.ClassifierList.class);
   }

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
@@ -524,6 +524,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     private ClassifyCollectionOptionsBuilder(ClassifyCollectionOptions classifyCollectionOptions) {
       classifier_id_serialized_name = classifyCollectionOptions.classifier_id_serialized_name;
       collection_serialized_name = classifyCollectionOptions.collection_serialized_name;
+      this.requestHeaders.putAll(classifyCollectionOptions.requestHeaders());
     }
 
     /**
@@ -685,6 +686,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     private ClassifyOptionsBuilder(ClassifyOptions classifyOptions) {
       classifier_id_serialized_name = classifyOptions.classifier_id_serialized_name;
       text_serialized_name = classifyOptions.text_serialized_name;
+      this.requestHeaders.putAll(classifyOptions.requestHeaders());
     }
 
     /**
@@ -923,6 +925,7 @@ public class IBMNaturalLanguageClassifierV1Models {
       training_metadata_filename_serialized_name = createClassifierOptions.training_metadata_filename_serialized_name;
       training_data_serialized_name = createClassifierOptions.training_data_serialized_name;
       training_data_filename_serialized_name = createClassifierOptions.training_data_filename_serialized_name;
+      this.requestHeaders.putAll(createClassifierOptions.requestHeaders());
     }
 
     /**
@@ -1048,6 +1051,7 @@ public class IBMNaturalLanguageClassifierV1Models {
 
     private DeleteClassifierOptionsBuilder(DeleteClassifierOptions deleteClassifierOptions) {
       classifier_id_serialized_name = deleteClassifierOptions.classifier_id_serialized_name;
+      this.requestHeaders.putAll(deleteClassifierOptions.requestHeaders());
     }
 
     /**
@@ -1138,6 +1142,7 @@ public class IBMNaturalLanguageClassifierV1Models {
 
     private GetClassifierOptionsBuilder(GetClassifierOptions getClassifierOptions) {
       classifier_id_serialized_name = getClassifierOptions.classifier_id_serialized_name;
+      this.requestHeaders.putAll(getClassifierOptions.requestHeaders());
     }
 
     /**
@@ -1213,6 +1218,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   public class ListClassifiersOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListClassifiersOptionsBuilder(ListClassifiersOptions listClassifiersOptions) {
+      this.requestHeaders.putAll(listClassifiersOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
@@ -2,7 +2,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * Response from the classifier for a phrase.
    */
-  public class Classification extends IBMWatsonGenericModel {
+  public class Classification extends IBMWatsonResponseModel {
     private String classifier_id_serialized_name;
     private String url_serialized_name;
     private String text_serialized_name;
@@ -136,7 +136,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * Response from the classifier for multiple phrases.
    */
-  public class ClassificationCollection extends IBMWatsonGenericModel {
+  public class ClassificationCollection extends IBMWatsonResponseModel {
     private String classifier_id_serialized_name;
     private String url_serialized_name;
     private List<CollectionItem> collection_serialized_name;
@@ -286,7 +286,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * A classifier for natural language phrases.
    */
-  public class Classifier extends IBMWatsonGenericModel {
+  public class Classifier extends IBMWatsonResponseModel {
     private String name_serialized_name;
     private String url_serialized_name;
     private String status_serialized_name;
@@ -422,7 +422,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * List of available classifiers.
    */
-  public class ClassifierList extends IBMWatsonGenericModel {
+  public class ClassifierList extends IBMWatsonResponseModel {
     private List<Classifier> classifiers_serialized_name;
     /**
      * Gets the classifiers_serialized_name.
@@ -472,7 +472,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * The classifyCollection options.
    */
-  public class ClassifyCollectionOptions {
+  public class ClassifyCollectionOptions extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     private List<ClassifyInput> collection_serialized_name;
     /**
@@ -500,6 +500,7 @@ public class IBMNaturalLanguageClassifierV1Models {
       IBMWatsonValidator.notNull(builder.collection_serialized_name, 'collection_serialized_name cannot be null');
       classifier_id_serialized_name = builder.classifier_id_serialized_name;
       collection_serialized_name = builder.collection_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -516,7 +517,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * ClassifyCollectionOptions Builder.
    */
-  public class ClassifyCollectionOptionsBuilder {
+  public class ClassifyCollectionOptionsBuilder extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     private List<ClassifyInput> collection_serialized_name;
 
@@ -588,12 +589,24 @@ public class IBMNaturalLanguageClassifierV1Models {
       this.collection_serialized_name = collection;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ClassifyCollectionOptions builder
+     */
+    public ClassifyCollectionOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * Request payload to classify.
    */
-  public class ClassifyInput extends IBMWatsonGenericModel {
+  public class ClassifyInput {
     private String text_serialized_name;
     /**
      * Gets the text_serialized_name.
@@ -602,7 +615,6 @@ public class IBMNaturalLanguageClassifierV1Models {
      *
      * @return the text_serialized_name
      */
-    @AuraEnabled
     public String getText() {
       return text_serialized_name;
     }
@@ -616,21 +628,12 @@ public class IBMNaturalLanguageClassifierV1Models {
       this.text_serialized_name = text;
     }
 
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      ClassifyInput ret = (ClassifyInput) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
   }
 
   /**
    * The classify options.
    */
-  public class ClassifyOptions {
+  public class ClassifyOptions extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     private String text_serialized_name;
     /**
@@ -658,6 +661,7 @@ public class IBMNaturalLanguageClassifierV1Models {
       IBMWatsonValidator.notNull(builder.text_serialized_name, 'text_serialized_name cannot be null');
       classifier_id_serialized_name = builder.classifier_id_serialized_name;
       text_serialized_name = builder.text_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -674,7 +678,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * ClassifyOptions Builder.
    */
-  public class ClassifyOptionsBuilder {
+  public class ClassifyOptionsBuilder extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     private String text_serialized_name;
 
@@ -728,6 +732,18 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     public ClassifyOptionsBuilder text(String text) {
       this.text_serialized_name = text;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ClassifyOptions builder
+     */
+    public ClassifyOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -827,7 +843,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * The createClassifier options.
    */
-  public class CreateClassifierOptions {
+  public class CreateClassifierOptions extends IBMWatsonOptionsModel {
     private IBMWatsonFile training_metadata_serialized_name;
     private String training_metadata_filename_serialized_name;
     private IBMWatsonFile training_data_serialized_name;
@@ -879,6 +895,7 @@ public class IBMNaturalLanguageClassifierV1Models {
       training_metadata_filename_serialized_name = builder.training_metadata_filename_serialized_name;
       training_data_serialized_name = builder.training_data_serialized_name;
       training_data_filename_serialized_name = builder.training_data_filename_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -895,7 +912,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * CreateClassifierOptions Builder.
    */
-  public class CreateClassifierOptionsBuilder {
+  public class CreateClassifierOptionsBuilder extends IBMWatsonOptionsModel {
     private IBMWatsonFile training_metadata_serialized_name;
     private String training_metadata_filename_serialized_name;
     private IBMWatsonFile training_data_serialized_name;
@@ -977,12 +994,24 @@ public class IBMNaturalLanguageClassifierV1Models {
       this.training_data_filename_serialized_name = trainingDataFilename;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateClassifierOptions builder
+     */
+    public CreateClassifierOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteClassifier options.
    */
-  public class DeleteClassifierOptions {
+  public class DeleteClassifierOptions extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     /**
      * Gets the classifier_id_serialized_name.
@@ -997,6 +1026,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     private DeleteClassifierOptions(DeleteClassifierOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.classifier_id_serialized_name, 'classifier_id_serialized_name cannot be empty');
       classifier_id_serialized_name = builder.classifier_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1013,7 +1043,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * DeleteClassifierOptions Builder.
    */
-  public class DeleteClassifierOptionsBuilder {
+  public class DeleteClassifierOptionsBuilder extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
 
     private DeleteClassifierOptionsBuilder(DeleteClassifierOptions deleteClassifierOptions) {
@@ -1054,12 +1084,24 @@ public class IBMNaturalLanguageClassifierV1Models {
       this.classifier_id_serialized_name = classifierId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteClassifierOptions builder
+     */
+    public DeleteClassifierOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getClassifier options.
    */
-  public class GetClassifierOptions {
+  public class GetClassifierOptions extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     /**
      * Gets the classifier_id_serialized_name.
@@ -1074,6 +1116,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     private GetClassifierOptions(GetClassifierOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.classifier_id_serialized_name, 'classifier_id_serialized_name cannot be empty');
       classifier_id_serialized_name = builder.classifier_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1090,7 +1133,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * GetClassifierOptions Builder.
    */
-  public class GetClassifierOptionsBuilder {
+  public class GetClassifierOptionsBuilder extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
 
     private GetClassifierOptionsBuilder(GetClassifierOptions getClassifierOptions) {
@@ -1131,13 +1174,26 @@ public class IBMNaturalLanguageClassifierV1Models {
       this.classifier_id_serialized_name = classifierId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetClassifierOptions builder
+     */
+    public GetClassifierOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listClassifiers options.
    */
-  public class ListClassifiersOptions {
+  public class ListClassifiersOptions extends IBMWatsonOptionsModel {
     private ListClassifiersOptions(ListClassifiersOptionsBuilder builder) {
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1154,7 +1210,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * ListClassifiersOptions Builder.
    */
-  public class ListClassifiersOptionsBuilder {
+  public class ListClassifiersOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListClassifiersOptionsBuilder(ListClassifiersOptions listClassifiersOptions) {
     }
@@ -1172,6 +1228,18 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     public ListClassifiersOptions build() {
       return new ListClassifiersOptions(this);
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListClassifiersOptions builder
+     */
+    public ListClassifiersOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
     }
   }
 

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
@@ -22,6 +22,7 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1Models.ClassifyOptions classifyOptions = new IBMNaturalLanguageClassifierV1Models.ClassifyOptionsBuilder()
       .classifierId(classifier_id_serialized_name)
       .text(text_serialized_name)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMNaturalLanguageClassifierV1Models.Classification classification = service.classify(classifyOptions);
     System.assertEquals(classification.getClassifierId(), classifier_id_serialized_name);
@@ -68,6 +69,7 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptions classifyOptions = new IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptionsBuilder()
       .classifierId(classifierId)
       .collection(inputCollection)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMNaturalLanguageClassifierV1Models.ClassificationCollection classification = service.classifyCollection(classifyOptions);
     System.assertEquals(classification.getClassifierId(), classifierId);
@@ -113,6 +115,7 @@ private class IBMNaturalLanguageClassifierV1Test {
       .trainingMetadataFilename(training_metadata_filename_serialized_name)
       .trainingData(training_data_serialized_name)
       .trainingDataFilename(training_data_filename_serialized_name)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMNaturalLanguageClassifierV1Models.Classifier Classifier = service.createClassifier(createClassifierOptions);
     System.assertEquals(Classifier.getName(), 'My Classifier');
@@ -145,6 +148,7 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptions deleteClassifierOptions =
       new IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptionsBuilder()
       .classifierId(classifier_id_serialized_name)
+      .addHeader('Test-Header', 'test_value')
       .build();
     service.deleteClassifier(deleteClassifierOptions);
     IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptionsBuilder DeleteClassifierOptionsBuilder =
@@ -165,6 +169,7 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1Models.GetClassifierOptions getClassifierOption =
       new IBMNaturalLanguageClassifierV1Models.GetClassifierOptionsBuilder()
       .classifierId(classifier_id_serialized_name)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMNaturalLanguageClassifierV1Models.Classifier Classifier = service.getClassifier(getClassifierOption);
     System.assertEquals(Classifier.getName(), 'My Classifier');
@@ -188,6 +193,7 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1();
     IBMNaturalLanguageClassifierV1Models.ListClassifiersOptions listClassifiersOptions =
       new IBMNaturalLanguageClassifierV1Models.ListClassifiersOptionsBuilder()
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMNaturalLanguageClassifierV1Models.ClassifierList ClassifierList = service.listClassifiers(listClassifiersOptions);
     List<IBMNaturalLanguageClassifierV1Models.Classifier> Classifiers = ClassifierList.getClassifiers();

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
@@ -3,43 +3,6 @@
  * Language Understanding will give you results for the features you request. The service cleans HTML content before
  * analysis by default, so the results can ignore most advertisements and other unwanted content.
  *
- * ### Concepts
- * Identify general concepts that are referenced or alluded to in your content. Concepts that are detected typically
- * have an associated link to a DBpedia resource.
- *
- * ### Entities
- * Detect important people, places, geopolitical entities and other types of entities in your content. Entity detection
- * recognizes consecutive coreferences of each entity. For example, analysis of the following text would count "Barack
- * Obama" and "He" as the same entity:
- *
- * "Barack Obama was the 44th President of the United States. He took office in January 2009."
- *
- * ### Keywords
- * Determine the most important keywords in your content. Keyword phrases are organized by relevance in the results.
- *
- * ### Categories
- * Categorize your content into a hierarchical 5-level taxonomy. For example, "Leonardo DiCaprio won an Oscar" returns
- * "/art and entertainment/movies and tv/movies" as the most confident classification.
- *
- * ### Sentiment
- * Determine whether your content conveys postive or negative sentiment. Sentiment information can be returned for
- * detected entities, keywords, or user-specified target phrases found in the text.
- *
- * ### Emotion
- * Detect anger, disgust, fear, joy, or sadness that is conveyed by your content. Emotion information can be returned
- * for detected entities, keywords, or user-specified target phrases found in the text.
- *
- * ### Relations
- * Recognize when two entities are related, and identify the type of relation.  For example, you can identify an
- * "awardedTo" relation between an award and its recipient.
- *
- * ### Semantic Roles
- * Parse sentences into subject-action-object form, and identify entities and keywords that are subjects or objects of
- * an action.
- *
- * ### Metadata
- * Get author information, publication date, and the title of your text/HTML content.
- *
  * @version V1
  * @see <a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">Natural Language Understanding</a>
  */
@@ -103,6 +66,12 @@ public class IBMNaturalLanguageUnderstandingV1 extends IBMWatsonService {
   public IBMNaturalLanguageUnderstandingV1Models.AnalysisResults analyze(IBMNaturalLanguageUnderstandingV1Models.AnalyzeOptions analyzeOptions) {
     IBMWatsonValidator.notNull(analyzeOptions, 'analyzeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/analyze');
+    Map<String, String> requestHeaders = (analyzeOptions != null) ? analyzeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (analyzeOptions.text() != null) {
@@ -149,6 +118,12 @@ public class IBMNaturalLanguageUnderstandingV1 extends IBMWatsonService {
   public void deleteModel(IBMNaturalLanguageUnderstandingV1Models.DeleteModelOptions deleteModelOptions) {
     IBMWatsonValidator.notNull(deleteModelOptions, 'deleteModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/models/{0}', new String[]{ deleteModelOptions.modelId() }));
+    Map<String, String> requestHeaders = (deleteModelOptions != null) ? deleteModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -164,6 +139,12 @@ public class IBMNaturalLanguageUnderstandingV1 extends IBMWatsonService {
    */
   public IBMNaturalLanguageUnderstandingV1Models.ListModelsResults listModels(IBMNaturalLanguageUnderstandingV1Models.ListModelsOptions listModelsOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/models');
+    Map<String, String> requestHeaders = (listModelsOptions != null) ? listModelsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMNaturalLanguageUnderstandingV1Models.ListModelsResults) createServiceCall(builder.build(), IBMNaturalLanguageUnderstandingV1Models.ListModelsResults.class);

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
@@ -548,6 +548,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return_analyzed_text_serialized_name = analyzeOptions.return_analyzed_text_serialized_name;
       language_serialized_name = analyzeOptions.language_serialized_name;
       limit_text_characters_serialized_name = analyzeOptions.limit_text_characters_serialized_name;
+      this.requestHeaders.putAll(analyzeOptions.requestHeaders());
     }
 
     /**
@@ -996,6 +997,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
 
     private DeleteModelOptionsBuilder(DeleteModelOptions deleteModelOptions) {
       model_id_serialized_name = deleteModelOptions.model_id_serialized_name;
+      this.requestHeaders.putAll(deleteModelOptions.requestHeaders());
     }
 
     /**
@@ -2553,6 +2555,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class ListModelsOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListModelsOptionsBuilder(ListModelsOptions listModelsOptions) {
+      this.requestHeaders.putAll(listModelsOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
@@ -2,7 +2,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   /**
    * Results of the analysis, organized by feature.
    */
-  public class AnalysisResults extends IBMWatsonGenericModel {
+  public class AnalysisResults extends IBMWatsonResponseModel {
     private String language_serialized_name;
     private String analyzed_text_serialized_name;
     private String retrieved_url_serialized_name;
@@ -385,7 +385,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   /**
    * The analyze options.
    */
-  public class AnalyzeOptions {
+  public class AnalyzeOptions extends IBMWatsonOptionsModel {
     private String text_serialized_name;
     private String html_serialized_name;
     private String url_serialized_name;
@@ -508,6 +508,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return_analyzed_text_serialized_name = builder.return_analyzed_text_serialized_name;
       language_serialized_name = builder.language_serialized_name;
       limit_text_characters_serialized_name = builder.limit_text_characters_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -524,7 +525,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   /**
    * AnalyzeOptions Builder.
    */
-  public class AnalyzeOptionsBuilder {
+  public class AnalyzeOptionsBuilder extends IBMWatsonOptionsModel {
     private String text_serialized_name;
     private String html_serialized_name;
     private String url_serialized_name;
@@ -682,6 +683,18 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       this.limit_text_characters_serialized_name = limitTextCharacters;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the AnalyzeOptions builder
+     */
+    public AnalyzeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
@@ -737,23 +750,6 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return this.getDynamicProperties();
     }
 
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      CategoriesOptions ret = (CategoriesOptions) super.deserialize(jsonString, jsonMap, classType);
-
-      Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
-
-      for (String key : jsonMap.keySet()) {
-        if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
-        }
-      }
-
-      return ret;
-    }
   }
 
   /**
@@ -963,7 +959,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   /**
    * The deleteModel options.
    */
-  public class DeleteModelOptions {
+  public class DeleteModelOptions extends IBMWatsonOptionsModel {
     private String model_id_serialized_name;
     /**
      * Gets the model_id_serialized_name.
@@ -978,6 +974,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private DeleteModelOptions(DeleteModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.model_id_serialized_name, 'model_id_serialized_name cannot be empty');
       model_id_serialized_name = builder.model_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -994,7 +991,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   /**
    * DeleteModelOptions Builder.
    */
-  public class DeleteModelOptionsBuilder {
+  public class DeleteModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String model_id_serialized_name;
 
     private DeleteModelOptionsBuilder(DeleteModelOptions deleteModelOptions) {
@@ -1033,6 +1030,18 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     public DeleteModelOptionsBuilder modelId(String modelId) {
       this.model_id_serialized_name = modelId;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteModelOptions builder
+     */
+    public DeleteModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -2522,8 +2531,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   /**
    * The listModels options.
    */
-  public class ListModelsOptions {
+  public class ListModelsOptions extends IBMWatsonOptionsModel {
     private ListModelsOptions(ListModelsOptionsBuilder builder) {
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2540,7 +2550,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   /**
    * ListModelsOptions Builder.
    */
-  public class ListModelsOptionsBuilder {
+  public class ListModelsOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListModelsOptionsBuilder(ListModelsOptions listModelsOptions) {
     }
@@ -2559,12 +2569,24 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public ListModelsOptions build() {
       return new ListModelsOptions(this);
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListModelsOptions builder
+     */
+    public ListModelsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * Models available for Relations and Entities features.
    */
-  public class ListModelsResults extends IBMWatsonGenericModel {
+  public class ListModelsResults extends IBMWatsonResponseModel {
     private List<Model> models_serialized_name;
     /**
      * Gets the models_serialized_name.
@@ -2625,23 +2647,6 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return this.getDynamicProperties();
     }
 
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      MetadataOptions ret = (MetadataOptions) super.deserialize(jsonString, jsonMap, classType);
-
-      Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
-
-      for (String key : jsonMap.keySet()) {
-        if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
-        }
-      }
-
-      return ret;
-    }
   }
 
   /**

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Test.cls
@@ -81,6 +81,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
       .returnAnalyzedText(true)
       .language('en')
       .limitTextCharacters(100)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -277,6 +278,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
     naturalLanguageUnderstanding.setEndPoint('https://gateway.watsonplatform.net/natural-language-understanding/api');
     naturalLanguageUnderstanding.setUsernameAndPassword('username', 'password');
     IBMNaturalLanguageUnderstandingV1Models.ListModelsOptions options = new IBMNaturalLanguageUnderstandingV1Models.ListModelsOptionsBuilder()
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -299,6 +301,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
     naturalLanguageUnderstanding.setEndPoint('https://gateway.watsonplatform.net/natural-language-understanding/api');
     IBMNaturalLanguageUnderstandingV1Models.DeleteModelOptions options = new IBMNaturalLanguageUnderstandingV1Models.DeleteModelOptionsBuilder()
       .modelId('test')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -316,6 +319,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
       naturalLanguageUnderstanding.setEndPoint('https://gateway.watsonplatform.net/natural-language-understanding/api');
       IBMNaturalLanguageUnderstandingV1Models.DeleteModelOptions options = new IBMNaturalLanguageUnderstandingV1Models.DeleteModelOptionsBuilder()
         .modelId('test')
+        .addHeader('Test-Header', 'test_value')
         .build();
       naturalLanguageUnderstanding.deleteModel(options);
     }

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3.cls
@@ -1,34 +1,19 @@
 /**
- * ### Service Overview
- * The IBM Watson Personality Insights service provides a Representational State Transfer (REST) Application Programming
- * Interface (API) that enables applications to derive insights from social media, enterprise data, or other digital
- * communications. The service uses linguistic analytics to infer individuals' intrinsic personality characteristics,
- * including Big Five, Needs, and Values, from digital communications such as email, text messages, tweets, and forum
- * posts. The service can automatically infer, from potentially noisy social media, portraits of individuals that
- * reflect their personality characteristics. The service can report consumption preferences based on the results of its
- * analysis, and for JSON content that is timestamped, it can report temporal behavior.
- * ### API Usage
- * The following information provides details about using the service to obtain a personality profile:
- * * **The profile method:** The service offers a single `/v3/profile` method that accepts up to 20 MB of input data and
- * produces results in JSON or CSV format. The service accepts input in Arabic, English, Japanese, Korean, or Spanish
- * and can produce output in a variety of languages.
- * * **Authentication:** You authenticate to the service by using your service credentials. You can use your credentials
- * to authenticate via a proxy server that resides in IBM Cloud, or you can use your credentials to obtain a token and
- * contact the service directly. See [Service credentials for Watson
- * services](https://console.bluemix.net/docs/services/watson/getting-started-credentials.html) and [Tokens for
- * authentication](https://console.bluemix.net/docs/services/watson/getting-started-tokens.html).
- * * **Request Logging:** By default, all Watson services log requests and their results. Data is collected only to
- * improve the Watson services. If you do not want to share your data, set the header parameter
- * `X-Watson-Learning-Opt-Out` to `true` for each request. Data is collected for any request that omits this header. See
- * [Controlling request logging for Watson
- * services](https://console.bluemix.net/docs/services/watson/getting-started-logging.html).
+ * The IBM Watson Personality Insights service enables applications to derive insights from social media, enterprise
+ * data, or other digital communications. The service uses linguistic analytics to infer individuals' intrinsic
+ * personality characteristics, including Big Five, Needs, and Values, from digital communications such as email, text
+ * messages, tweets, and forum posts.
  *
- * For more information about the service, see [About Personality
- * Insights](https://console.bluemix.net/docs/services/personality-insights/index.html). For information about calling
- * the service and the responses it can generate, see [Requesting a
- * profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON
- * profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV
- * profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
+ * The service can automatically infer, from potentially noisy social media, portraits of individuals that reflect their
+ * personality characteristics. The service can infer consumption preferences based on the results of its analysis and,
+ * for JSON content that is timestamped, can report temporal behavior.
+ * * For information about the meaning of the models that the service uses to describe personality characteristics, see
+ * [Personality models](https://console.bluemix.net/docs/services/personality-insights/models.html).
+ * * For information about the meaning of the consumption preferences, see [Consumption
+ * preferences](https://console.bluemix.net/docs/services/personality-insights/preferences.html).
+ *
+ * **Note:** Request logging is disabled for the Personality Insights service. The service neither logs nor retains data
+ * from requests and responses, regardless of whether the `X-Watson-Learning-Opt-Out` request header is set.
  *
  * @version V3
  * @see <a href="http://www.ibm.com/watson/developercloud/personality-insights.html">Personality Insights</a>
@@ -83,9 +68,9 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
   }
 
   /**
-   * Generates a personality profile based on input text.
+   * Get profile.
    *
-   * Derives personality insights for up to 20 MB of input content written by an author, though the service requires much less text to produce an accurate profile; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). Accepts input in Arabic, English, Japanese, Korean, or Spanish and produces output in one of eleven languages. Provide plain text, HTML, or JSON content, and receive results in JSON or CSV format.
+   * Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input content, but it requires much less text to produce an accurate profile; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept** parameter; CSV output includes a fixed number of columns and optional headers.   Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`.   For detailed information about calling the service and the responses it can generate, see [Requesting a profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
    *
    * @param profileOptions the {@link IBMPersonalityInsightsV3Models.ProfileOptions} containing the options for the call
    * @return the {@link IBMPersonalityInsightsV3Models.Profile} with the response
@@ -99,6 +84,12 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
     }
     if (profileOptions.acceptLanguage() != null) {
       builder.addHeader('Accept-Language', profileOptions.acceptLanguage());
+    }
+    Map<String, String> requestHeaders = (profileOptions != null) ? profileOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
     }
     builder.query('version', versionDate);
     if (profileOptions.rawScores() != null) {
@@ -117,6 +108,14 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
     return (IBMPersonalityInsightsV3Models.Profile) createServiceCall(builder.build(), IBMPersonalityInsightsV3Models.Profile.class);
   }
 
+  /**
+   * Get profile. as csv
+   *
+   * Generates a personality profile for the author of the input text. The service accepts a maximum of 20 MB of input content, but it requires much less text to produce an accurate profile; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). The service analyzes text in Arabic, English, Japanese, Korean, or Spanish and returns its results in a variety of languages. You can provide plain text, HTML, or JSON input by specifying the **Content-Type** parameter; the default is `text/plain`. Request a JSON or comma-separated values (CSV) response by specifying the **Accept** parameter; CSV output includes a fixed number of columns and optional headers.   Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`.   For detailed information about calling the service and the responses it can generate, see [Requesting a profile](https://console.bluemix.net/docs/services/personality-insights/input.html), [Understanding a JSON profile](https://console.bluemix.net/docs/services/personality-insights/output.html), and [Understanding a CSV profile](https://console.bluemix.net/docs/services/personality-insights/output-csv.html).
+   *
+   * @param profileOptions the {@link IBMPersonalityInsightsV3Models.ProfileOptions} containing the options for the call
+   * @return the {@link IBMPersonalityInsightsV3Models.Profile} with the response
+   */
   public String getProfileAsCSV(IBMPersonalityInsightsV3Models.ProfileOptions profileOptions, boolean includeHeaders) {
     IBMWatsonValidator.notNull(profileOptions, 'profileOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v3/profile');
@@ -127,6 +126,12 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
     }
     if (profileOptions.acceptLanguage() != null) {
       builder.addHeader('Accept-Language', profileOptions.acceptLanguage());
+    }
+    Map<String, String> requestHeaders = (profileOptions != null) ? profileOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
     }
     if (profileOptions.rawScores() != null) {
       builder.query('raw_scores', String.valueOf(profileOptions.rawScores()));

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3Models.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3Models.cls
@@ -10,7 +10,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the trait_id_serialized_name.
      *
-     * The unique identifier of the characteristic to which the results pertain. IDs have the form `behavior_{value}`.
+     * The unique, non-localized identifier of the characteristic to which the results pertain. IDs have the form `behavior_{value}`.
      *
      * @return the trait_id_serialized_name
      */
@@ -21,7 +21,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the name_serialized_name.
      *
-     * The user-visible name of the characteristic.
+     * The user-visible, localized name of the characteristic.
      *
      * @return the name_serialized_name
      */
@@ -109,7 +109,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the consumption_preference_id_serialized_name.
      *
-     * The unique identifier of the consumption preference to which the results pertain. IDs have the form `consumption_preferences_{preference}`.
+     * The unique, non-localized identifier of the consumption preference to which the results pertain. IDs have the form `consumption_preferences_{preference}`.
      *
      * @return the consumption_preference_id_serialized_name
      */
@@ -120,7 +120,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the name_serialized_name.
      *
-     * The user-visible name of the consumption preference.
+     * The user-visible, localized name of the consumption preference.
      *
      * @return the name_serialized_name
      */
@@ -188,7 +188,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the consumption_preference_category_id_serialized_name.
      *
-     * The unique identifier of the consumption preferences category to which the results pertain. IDs have the form `consumption_preferences_{category}`.
+     * The unique, non-localized identifier of the consumption preferences category to which the results pertain. IDs have the form `consumption_preferences_{category}`.
      *
      * @return the consumption_preference_category_id_serialized_name
      */
@@ -379,7 +379,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the content_serialized_name.
      *
-     * Content that is to be analyzed. The service supports up to 20 MB of content for all items combined.
+     * The content that is to be analyzed. The service supports up to 20 MB of content for all `ContentItem` objects combined.
      *
      * @return the content_serialized_name
      */
@@ -389,7 +389,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the id_serialized_name.
      *
-     * Unique identifier for this content item.
+     * A unique identifier for this content item.
      *
      * @return the id_serialized_name
      */
@@ -399,7 +399,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the created_serialized_name.
      *
-     * Timestamp that identifies when this content was created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
+     * A timestamp that identifies when this content was created. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
      *
      * @return the created_serialized_name
      */
@@ -409,7 +409,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the updated_serialized_name.
      *
-     * Timestamp that identifies when this content was last updated. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
+     * A timestamp that identifies when this content was last updated. Specify a value in milliseconds since the UNIX Epoch (January 1, 1970, at 0:00 UTC). Required only for results that include temporal behavior data.
      *
      * @return the updated_serialized_name
      */
@@ -419,7 +419,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the contenttype_serialized_name.
      *
-     * MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
+     * The MIME type of the content. The default is plain text. The tags are stripped from HTML content before it is analyzed; plain text is processed as submitted.
      *
      * @return the contenttype_serialized_name
      */
@@ -429,7 +429,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the language_serialized_name.
      *
-     * Language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the `Content-Type` header overrides the value of this parameter; any content items that specify a different language are ignored. Omit the `Content-Type` header to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
+     * The language identifier (two-letter ISO 639-1 identifier) for the language of the content item. The default is `en` (English). Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. A language specified with the **Content-Type** parameter overrides the value of this parameter; any content items that specify a different language are ignored. Omit the **Content-Type** parameter to base the language on the most prevalent specification among the content items; again, content items that specify a different language are ignored. You can specify any combination of languages for the input and response content.
      *
      * @return the language_serialized_name
      */
@@ -439,7 +439,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the parentid_serialized_name.
      *
-     * Unique ID of the parent content item for this item. Used to identify hierarchical relationships between posts/replies, messages/replies, and so on.
+     * The unique ID of the parent content item for this item. Used to identify hierarchical relationships between posts/replies, messages/replies, and so on.
      *
      * @return the parentid_serialized_name
      */
@@ -643,13 +643,13 @@ public class IBMPersonalityInsightsV3Models {
   /**
    * Profile.
    */
-  public class Profile extends IBMWatsonGenericModel {
+  public class Profile extends IBMWatsonResponseModel {
     private String processed_language_serialized_name;
     private Long word_count_serialized_name;
     private String word_count_message_serialized_name;
     private List<Trait> personality_serialized_name;
-    private List<Trait> values_serialized_name;
     private List<Trait> needs_serialized_name;
+    private List<Trait> values_serialized_name;
     private List<Behavior> behavior_serialized_name;
     private List<ConsumptionPreferencesCategory> consumption_preferences_serialized_name;
     private List<Warning> warnings_serialized_name;
@@ -667,7 +667,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the word_count_serialized_name.
      *
-     * The number of words that were found in the input.
+     * The number of words from the input that were used to produce the profile.
      *
      * @return the word_count_serialized_name
      */
@@ -689,7 +689,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the personality_serialized_name.
      *
-     * Detailed results for the Big Five personality characteristics (dimensions and facets) inferred from the input text.
+     * A recursive array of `Trait` objects that provides detailed results for the Big Five personality characteristics (dimensions and facets) inferred from the input text.
      *
      * @return the personality_serialized_name
      */
@@ -698,26 +698,26 @@ public class IBMPersonalityInsightsV3Models {
       return personality_serialized_name;
     }
     /**
-     * Gets the values_serialized_name.
-     *
-     * Detailed results for the Needs characteristics inferred from the input text.
-     *
-     * @return the values_serialized_name
-     */
-    @AuraEnabled
-    public List<Trait> getValues() {
-      return values_serialized_name;
-    }
-    /**
      * Gets the needs_serialized_name.
      *
-     * Detailed results for the Values characteristics inferred from the input text.
+     * Detailed results for the Needs characteristics inferred from the input text.
      *
      * @return the needs_serialized_name
      */
     @AuraEnabled
     public List<Trait> getNeeds() {
       return needs_serialized_name;
+    }
+    /**
+     * Gets the values_serialized_name.
+     *
+     * Detailed results for the Values characteristics inferred from the input text.
+     *
+     * @return the values_serialized_name
+     */
+    @AuraEnabled
+    public List<Trait> getValues() {
+      return values_serialized_name;
     }
     /**
      * Gets the behavior_serialized_name.
@@ -733,7 +733,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the consumption_preferences_serialized_name.
      *
-     * If the `consumption_preferences` query parameter is `true`, detailed results for each category of consumption preferences. Each element of the array provides information inferred from the input text for the individual preferences of that category.
+     * If the **consumption_preferences** parameter is `true`, detailed results for each category of consumption preferences. Each element of the array provides information inferred from the input text for the individual preferences of that category.
      *
      * @return the consumption_preferences_serialized_name
      */
@@ -790,21 +790,21 @@ public class IBMPersonalityInsightsV3Models {
     }
 
     /**
-     * Sets the values_serialized_name.
-     *
-     * @param values the new values
-     */
-    public void setValues(final List<Trait> values) {
-      this.values_serialized_name = values;
-    }
-
-    /**
      * Sets the needs_serialized_name.
      *
      * @param needs the new needs
      */
     public void setNeeds(final List<Trait> needs) {
       this.needs_serialized_name = needs;
+    }
+
+    /**
+     * Sets the values_serialized_name.
+     *
+     * @param values the new values
+     */
+    public void setValues(final List<Trait> values) {
+      this.values_serialized_name = values;
     }
 
     /**
@@ -854,19 +854,6 @@ public class IBMPersonalityInsightsV3Models {
         ret.setPersonality(newPersonality);
       }
 
-      // calling custom deserializer for values_serialized_name
-      List<Trait> newValues = new List<Trait>();
-      List<Trait> deserializedValues = ret.getValues();
-      if (deserializedValues != null) {
-        for (Integer i = 0; i < deserializedValues.size(); i++) {
-          Trait currentItem = ret.getValues().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('values_serialized_name');
-          Trait newItem = (Trait) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Trait.class);
-          newValues.add(newItem);
-        }
-        ret.setValues(newValues);
-      }
-
       // calling custom deserializer for needs_serialized_name
       List<Trait> newNeeds = new List<Trait>();
       List<Trait> deserializedNeeds = ret.getNeeds();
@@ -878,6 +865,19 @@ public class IBMPersonalityInsightsV3Models {
           newNeeds.add(newItem);
         }
         ret.setNeeds(newNeeds);
+      }
+
+      // calling custom deserializer for values_serialized_name
+      List<Trait> newValues = new List<Trait>();
+      List<Trait> deserializedValues = ret.getValues();
+      if (deserializedValues != null) {
+        for (Integer i = 0; i < deserializedValues.size(); i++) {
+          Trait currentItem = ret.getValues().get(i);
+          List<Object> itemInMap = (List<Object>) jsonMap.get('values_serialized_name');
+          Trait newItem = (Trait) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Trait.class);
+          newValues.add(newItem);
+        }
+        ret.setValues(newValues);
       }
 
       // calling custom deserializer for behavior_serialized_name
@@ -926,7 +926,7 @@ public class IBMPersonalityInsightsV3Models {
   /**
    * The profile options.
    */
-  public class ProfileOptions {
+  public class ProfileOptions extends IBMWatsonOptionsModel {
     private Content content_serialized_name;
     private String body_serialized_name;
     private String content_type_serialized_name;
@@ -937,7 +937,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the content_serialized_name.
      *
-     * A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). A JSON request must conform to the `Content` model.
+     * A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For JSON input, provide an object of type `Content`.
      *
      * @return the content_serialized_name
      */
@@ -947,7 +947,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the body_serialized_name.
      *
-     * A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). A JSON request must conform to the `Content` model.
+     * A maximum of 20 MB of content to analyze, though the service requires much less text; for more information, see [Providing sufficient input](https://console.bluemix.net/docs/services/personality-insights/input.html#sufficient). For JSON input, provide an object of type `Content`.
      *
      * @return the body_serialized_name
      */
@@ -967,7 +967,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the content_language_serialized_name.
      *
-     * The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The effect of the `Content-Language` header depends on the `Content-Type` header. When `Content-Type` is `text/plain` or `text/html`, `Content-Language` is the only way to specify the language. When `Content-Type` is `application/json`, `Content-Language` overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this header to base the language on the specification of the content items. You can specify any combination of languages for `Content-Language` and `Accept-Language`.
+     * The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`.   The effect of the **Content-Language** parameter depends on the **Content-Type** parameter. When **Content-Type** is `text/plain` or `text/html`, **Content-Language** is the only way to specify the language. When **Content-Type** is `application/json`, **Content-Language** overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this parameter to base the language on the specification of the content items. You can specify any combination of languages for **Content-Language** and **Accept-Language**.
      *
      * @return the content_language_serialized_name
      */
@@ -987,7 +987,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the raw_scores_serialized_name.
      *
-     * If `true`, a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. If `false` (the default), only normalized percentiles are returned.
+     * Indicates whether a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. By default, only normalized percentiles are returned.
      *
      * @return the raw_scores_serialized_name
      */
@@ -997,7 +997,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the consumption_preferences_serialized_name.
      *
-     * If `true`, information about consumption preferences is returned with the results; if `false` (the default), the response does not include the information.
+     * Indicates whether consumption preferences are returned with the results. By default, no consumption preferences are returned.
      *
      * @return the consumption_preferences_serialized_name
      */
@@ -1013,6 +1013,7 @@ public class IBMPersonalityInsightsV3Models {
       accept_language_serialized_name = builder.accept_language_serialized_name;
       raw_scores_serialized_name = builder.raw_scores_serialized_name;
       consumption_preferences_serialized_name = builder.consumption_preferences_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1029,7 +1030,7 @@ public class IBMPersonalityInsightsV3Models {
   /**
    * ProfileOptions Builder.
    */
-  public class ProfileOptionsBuilder {
+  public class ProfileOptionsBuilder extends IBMWatsonOptionsModel {
     private Content content_serialized_name;
     private String body_serialized_name;
     private String content_type_serialized_name;
@@ -1142,6 +1143,18 @@ public class IBMPersonalityInsightsV3Models {
       this.content_type_serialized_name = IBMWatsonHttpMediaType.TEXT_PLAIN;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ProfileOptions builder
+     */
+    public ProfileOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
@@ -1158,7 +1171,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the trait_id_serialized_name.
      *
-     * The unique identifier of the characteristic to which the results pertain. IDs have the form `big5_{characteristic}` for Big Five personality characteristics, `need_{characteristic}` for Needs, or `value_{characteristic}` for Values.
+     * The unique, non-localized identifier of the characteristic to which the results pertain. IDs have the form * `big5_{characteristic}` for Big Five personality dimensions * `facet_{characteristic}` for Big Five personality facets * `need_{characteristic}` for Needs  *`value_{characteristic}` for Values.
      *
      * @return the trait_id_serialized_name
      */
@@ -1169,7 +1182,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the name_serialized_name.
      *
-     * The user-visible name of the characteristic.
+     * The user-visible, localized name of the characteristic.
      *
      * @return the name_serialized_name
      */
@@ -1180,7 +1193,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the category_serialized_name.
      *
-     * The category of the characteristic: * `personality` for Big Five personality characteristics * `needs` for Needs * `values` for Values.
+     * The category of the characteristic: `personality` for Big Five personality characteristics, `needs` for Needs, and `values` for Values.
      *
      * @return the category_serialized_name
      */
@@ -1202,7 +1215,7 @@ public class IBMPersonalityInsightsV3Models {
     /**
      * Gets the raw_score_serialized_name.
      *
-     * The raw score for the characteristic. The range is 0 to 1. A higher score generally indicates a greater likelihood that the author has that characteristic, but raw scores must be considered in aggregate: The range of values in practice might be much smaller than 0 to 1, so an individual score must be considered in the context of the overall scores and their range. The raw score is computed based on the input and the service model; it is not normalized or compared with a sample population. The raw score enables comparison of the results against a different sampling population and with a custom normalization approach.
+     * The raw score for the characteristic. The range is 0 to 1. A higher score generally indicates a greater likelihood that the author has that characteristic, but raw scores must be considered in aggregate: The range of values in practice might be much smaller than 0 to 1, so an individual score must be considered in the context of the overall scores and their range.   The raw score is computed based on the input and the service model; it is not normalized or compared with a sample population. The raw score enables comparison of the results against a different sampling population and with a custom normalization approach.
      *
      * @return the raw_score_serialized_name
      */

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3Models.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3Models.cls
@@ -1047,6 +1047,7 @@ public class IBMPersonalityInsightsV3Models {
       accept_language_serialized_name = profileOptions.accept_language_serialized_name;
       raw_scores_serialized_name = profileOptions.raw_scores_serialized_name;
       consumption_preferences_serialized_name = profileOptions.consumption_preferences_serialized_name;
+      this.requestHeaders.putAll(profileOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3Test.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3Test.cls
@@ -46,6 +46,7 @@ private class IBMPersonalityInsightsV3Test {
       .content(content)
       .html('<html><body>test</body></html>')
       .text('test')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -127,6 +128,7 @@ private class IBMPersonalityInsightsV3Test {
       .content(content)
       .html('<html><body>test</body></html>')
       .text('test')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();

--- a/force-app/main/default/classes/IBMSpeechToTextV1.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1.cls
@@ -1,9 +1,57 @@
 /**
- * The Speech to Text service uses IBM's speech recognition capabilities to convert English speech into text. The
- * transcription of incoming audio is continuously sent back to the client with minimal delay, and it is corrected as
- * more speech is heard.
+ * The IBM&reg; Speech to Text service provides an API that enables you to add IBM's speech recognition capabilities to
+ * your applications. The service transcribes speech from various languages and audio formats to text with low latency.
+ * For most languages, the service supports two sampling rates, broadband and narrowband. The service returns all JSON
+ * response content in the UTF-8 character set. For more information about the service, see the [IBM&reg; Cloud
+ * documentation](https://console.bluemix.net/docs/services/speech-to-text/getting-started.html).
+ * ### API Overview
+ * The Speech to Text service provides the following endpoints:
+ * * **Models** includes methods that return information about the language models that are available for speech
+ * recognition.
+ * * **WebSockets** includes a single method that establishes a persistent connection with the service over the
+ * WebSocket protocol.
+ * * **Sessionless** includes a method that provides a simple means of transcribing audio without the overhead of
+ * establishing and maintaining a session.
+ * * **Sessions** provides methods that allow a client to maintain a long, multi-turn exchange, or session, with the
+ * service or to establish multiple parallel conversations with a particular instance of the service.
+ * * **Asynchronous** provides a non-blocking interface for transcribing audio. You can register a callback URL to be
+ * notified of job status and, optionally, results, or you can poll the service to learn job status and retrieve results
+ * manually.
+ * * **Custom language models** provides an interface for creating and managing custom language models. The interface
+ * lets you expand the vocabulary of a base model with domain-specific terminology.
+ * * **Custom corpora** provides an interface for managing the corpora associated with a custom language model. You add
+ * corpora to extract out-of-vocabulary (OOV) words from the corpora into the custom language model's vocabulary. You
+ * can add, list, and delete corpora from a custom language model.
+ * * **Custom words** provides an interface for managing individual words in a custom language model. You can add,
+ * modify, list, and delete words from a custom language model.
+ * * **Custom acoustic models** provides an interface for creating and managing custom acoustic models. The interface
+ * lets you adapt a base model for the audio characteristics of your environment and speakers.
+ * * **Custom audio resources** provides an interface for managing the audio resources associated with a custom acoustic
+ * model. You add audio resources that closely match the acoustic characteristics of the audio that you want to
+ * transcribe. You can add, list, and delete audio resources from a custom acoustic model.
+ * ### Usage guidelines for customization
+ * The following information pertains to methods of the customization interface:
+ * * Language model customization is not available for all languages; it is generally available for production use for
+ * all languages for which it is available. Acoustic model customization is beta functionality that is available for all
+ * languages supported by the service. For a complete list of supported languages and the status of their availability,
+ * see [Language support for
+ * customization](https://console.bluemix.net/docs/services/speech-to-text/custom.html#languageSupport).
+ * * In all cases, you must use service credentials created for the instance of the service that owns a custom model to
+ * use the methods described in this documentation with that model. For more information, see [Ownership of custom
+ * language models](https://console.bluemix.net/docs/services/speech-to-text/custom.html#customOwner).
+ * * How the service handles request logging for the customization interface depends on the request. The service does
+ * not log data that are used to build custom models. But it does log data when a custom model is used with a
+ * recognition request. For more information, see [Request logging and data
+ * privacy](https://console.bluemix.net/docs/services/speech-to-text/custom.html#customLogging).
+ * * Each custom model is identified by a customization ID, which is a Globally Unique Identifier (GUID). A GUID is a
+ * hexadecimal string that has the same format as Watson service credentials: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+ * You specify a custom model's GUID with the appropriate customization parameter of methods that support customization.
  *
- * @version v1
+ *
+ * For more information about using the service's customization interface, see [The customization
+ * interface](https://console.bluemix.net/docs/services/speech-to-text/custom.html).
+ *
+ * @version V1
  * @see <a href="http://www.ibm.com/watson/developercloud/speech-to-text.html">Speech to Text</a>
  */
 public class IBMSpeechToTextV1 extends IBMWatsonService {
@@ -43,9 +91,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Retrieves information about the model.
+   * Get a model.
    *
-   * Returns information about a single specified language model that is available for use with the service. The information includes the name of the model and its minimum sampling rate in Hertz, among other things.
+   * Retrieves information about a single specified language model that is available for use with the service. The information includes the name of the model and its minimum sampling rate in Hertz, among other things.
    *
    * @param getModelOptions the {@link IBMSpeechToTextV1Models.GetModelOptions} containing the options for the call
    * @return the {@link IBMSpeechToTextV1Models.SpeechModel} with the response
@@ -53,51 +101,55 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.SpeechModel getModel(IBMSpeechToTextV1Models.GetModelOptions getModelOptions) {
     IBMWatsonValidator.notNull(getModelOptions, 'getModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/models/{0}', new String[]{ getModelOptions.modelId() }));
+    Map<String, String> requestHeaders = (getModelOptions != null) ? getModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.SpeechModel) createServiceCall(builder.build(), IBMSpeechToTextV1Models.SpeechModel.class);
   }
 
   /**
-   * Retrieves the models available for the service.
+   * Get models.
    *
-   * Returns a list of all language models that are available for use with the service. The information includes the name of the model and its minimum sampling rate in Hertz, among other things.
+   * Retrieves a list of all language models that are available for use with the service. The information includes the name of the model and its minimum sampling rate in Hertz, among other things.
    *
    * @param listModelsOptions the {@link IBMSpeechToTextV1Models.ListModelsOptions} containing the options for the call
    * @return the {@link IBMSpeechToTextV1Models.SpeechModels} with the response
    */
   public IBMSpeechToTextV1Models.SpeechModels listModels(IBMSpeechToTextV1Models.ListModelsOptions listModelsOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/models');
+    Map<String, String> requestHeaders = (listModelsOptions != null) ? listModelsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.SpeechModels) createServiceCall(builder.build(), IBMSpeechToTextV1Models.SpeechModels.class);
   }
 
   /**
-   * Recognizes an audio file and returns {@link SpeechRecognitionResults}.<br>
-   * <br>
-   * Here is an example of how to recognize an audio file:
+   * Sends audio for speech recognition in sessionless mode.
    *
-   * <pre>
-   * SpeechToText service = new SpeechToText();
-   * service.setUsernameAndPassword(&quot;USERNAME&quot;, &quot;PASSWORD&quot;);
-   * service.setEndPoint(&quot;SERVICE_URL&quot;);
+   * Sends audio and returns transcription results for a sessionless recognition request. Returns only the final results; to enable interim results, use session-based requests or the WebSocket API. The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding. (For the `audio/l16` format, you can specify the endianness.)   ###Streaming mode   For requests to transcribe live audio as it becomes available, you must set the `Transfer-Encoding` header to `chunked` to use streaming mode. In streaming mode, the server closes the connection (status code 408) if the service receives no data chunk for 30 seconds and the service has no audio to transcribe for 30 seconds. The server also closes the connection (status code 400) if no speech is detected for `inactivity_timeout` seconds of audio (not processing time); use the `inactivity_timeout` parameter to change the default of 30 seconds.   ###Audio formats (content types)   Use the `Content-Type` header to specify the audio format (MIME type) of the audio. The service accepts the following formats: * `audio/basic` (Use only with narrowband models.) * `audio/flac` * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of channels (`channels`) and endianness (`endianness`) of the audio.) * `audio/mp3` * `audio/mpeg` * `audio/mulaw` (Specify the sampling rate (`rate`) of the audio.) * `audio/ogg` (The service automatically detects the codec of the input audio.) * `audio/ogg;codecs=opus` * `audio/ogg;codecs=vorbis` * `audio/wav` (Provide audio with a maximum of nine channels.) * `audio/webm` (The service automatically detects the codec of the input audio.) * `audio/webm;codecs=opus` * `audio/webm;codecs=vorbis`   For information about the supported audio formats, including specifying the sampling rate, channels, and endianness for the indicated formats, see [Audio formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).   ###Multipart speech recognition   The method also supports multipart recognition requests. With multipart requests, you pass all audio data as multipart form data. You specify some parameters as request headers and query parameters, but you pass JSON metadata as form data to control most aspects of the transcription.   The multipart approach is intended for use with browsers for which JavaScript is disabled or when the parameters used with the request are greater than the 8 KB limit imposed by most HTTP servers and proxies. You can encounter this limit, for example, if you want to spot a very large number of keywords.   For information about submitting a multipart request, see [Submitting multipart requests as form data](https://console.bluemix.net/docs/services/speech-to-text/http.html#HTTP-multi).
    *
-   * RecognizeOptions options = new RecognizeOptions().maxAlternatives(3).continuous(true);
-   *
-   * File audio = new File(&quot;sample1.wav&quot;);
-   *
-   * SpeechResults results = service.recognize(audio, options).execute();
-   * System.out.println(results);
-   * </pre>
-   *
-   * @param recognizeOptions the recognize options
-   * @return the {@link SpeechRecognitionResults}
+   * @param recognizeSessionlessOptions the {@link IBMSpeechToTextV1Models.RecognizeSessionlessOptions} containing the options for the call
+   * @return the {@link IBMSpeechToTextV1Models.SpeechRecognitionResults} with the response
    */
-  public IBMSpeechToTextV1Models.SpeechResults recognize(IBMSpeechToTextV1Models.RecognizeOptions recognizeOptions) {
+  public IBMSpeechToTextV1Models.SpeechRecognitionResults recognize(IBMSpeechToTextV1Models.RecognizeOptions recognizeOptions) {
     IBMWatsonValidator.notNull(recognizeOptions, 'recognizeOptions cannot be null');
-    IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint()
-      + '/v1/recognize');
+    IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/recognize');
 
     builder.addHeader('Content-Type', recognizeOptions.fileContentType());
+    Map<String, String> requestHeaders = (recognizeOptions != null) ? recognizeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
     if (recognizeOptions.audio() != null) {
@@ -152,13 +204,13 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     IBMWatsonMultipartBody multipartBody = multipartBuilder.build();
     builder.body(multipartBody);
 
-    return (IBMSpeechToTextV1Models.SpeechResults) createServiceCall(builder.build(), IBMSpeechToTextV1Models.SpeechResults.class);
+    return (IBMSpeechToTextV1Models.SpeechRecognitionResults) createServiceCall(builder.build(), IBMSpeechToTextV1Models.SpeechRecognitionResults.class);
   }
 
   /**
-   * Checks the status of the specified asynchronous job.
+   * Check a job.
    *
-   * Returns information about the specified job. The response always includes the status of the job and its creation and update times. If the status is `completed`, the response includes the results of the recognition request. You must submit the request with the service credentials of the user who created the job.   You can use the method to retrieve the results of any job, regardless of whether it was submitted with a callback URL and the `recognitions.completed_with_results` event, and you can retrieve the results multiple times for as long as they remain available.
+   * Returns information about the specified job. The response always includes the status of the job and its creation and update times. If the status is `completed`, the response includes the results of the recognition request. You must submit the request with the service credentials of the user who created the job.   You can use the method to retrieve the results of any job, regardless of whether it was submitted with a callback URL and the `recognitions.completed_with_results` event, and you can retrieve the results multiple times for as long as they remain available. Use the **Check jobs** method to request information about the most recent jobs associated with the calling user.
    *
    * @param checkJobOptions the {@link IBMSpeechToTextV1Models.CheckJobOptions} containing the options for the call
    * @return the {@link IBMSpeechToTextV1Models.RecognitionJob} with the response
@@ -166,28 +218,40 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.RecognitionJob checkJob(IBMSpeechToTextV1Models.CheckJobOptions checkJobOptions) {
     IBMWatsonValidator.notNull(checkJobOptions, 'checkJobOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/recognitions/{0}', new String[]{ checkJobOptions.id() }));
+    Map<String, String> requestHeaders = (checkJobOptions != null) ? checkJobOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.RecognitionJob) createServiceCall(builder.build(), IBMSpeechToTextV1Models.RecognitionJob.class);
   }
 
   /**
-   * Checks the status of all asynchronous jobs.
+   * Check jobs.
    *
-   * Returns the ID and status of the latest 100 outstanding jobs associated with the service credentials with which it is called. The method also returns the creation and update times of each job, and, if a job was created with a callback URL and a user token, the user token for the job. To obtain the results for a job whose status is `completed` or not one of the latest 100 outstanding jobs, use the `GET /v1/recognitions/{id}` method. A job and its results remain available until you delete them with the `DELETE /v1/recognitions/{id}` method or until the job's time to live expires, whichever comes first.
+   * Returns the ID and status of the latest 100 outstanding jobs associated with the service credentials with which it is called. The method also returns the creation and update times of each job, and, if a job was created with a callback URL and a user token, the user token for the job. To obtain the results for a job whose status is `completed` or not one of the latest 100 outstanding jobs, use the **Check a job** method. A job and its results remain available until you delete them with the **Delete a job** method or until the job's time to live expires, whichever comes first.
    *
    * @param checkJobsOptions the {@link IBMSpeechToTextV1Models.CheckJobsOptions} containing the options for the call
    * @return the {@link IBMSpeechToTextV1Models.RecognitionJobs} with the response
    */
   public IBMSpeechToTextV1Models.RecognitionJobs checkJobs(IBMSpeechToTextV1Models.CheckJobsOptions checkJobsOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/recognitions');
+    Map<String, String> requestHeaders = (checkJobsOptions != null) ? checkJobsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.RecognitionJobs) createServiceCall(builder.build(), IBMSpeechToTextV1Models.RecognitionJobs.class);
   }
 
   /**
-   * Creates a job for an asynchronous recognition request.
+   * Create a job.
    *
-   * Creates a job for a new asynchronous recognition request. The job is owned by the user whose service credentials are used to create it. How you learn the status and results of a job depends on the parameters you include with the job creation request: * By callback notification: Include the `callback_url` query parameter to specify a URL to which the service is to send callback notifications when the status of the job changes. Optionally, you can also include the `events` and `user_token` query parameters to subscribe to specific events and to specify a string that is to be included with each notification for the job. * By polling the service: Omit the `callback_url`, `events`, and `user_token` query parameters. You must then use the `GET /v1/recognitions` or `GET /v1/recognitions/{id}` methods to check the status of the job, using the latter to retrieve the results when the job is complete.  The two approaches are not mutually exclusive. You can poll the service for job status or obtain results from the service manually even if you include a callback URL. In both cases, you can include the `results_ttl` parameter to specify how long the results are to remain available after the job is complete. Note that using the HTTPS `GET /v1/recognitions/{id}` method to retrieve results is more secure than receiving them via callback notification over HTTP because it provides confidentiality in addition to authentication and data integrity.   The method supports the same basic parameters as other HTTP and WebSocket recognition requests. The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding. (For the `audio/l16` format, you can specify the endianness.).
+   * Creates a job for a new asynchronous recognition request. The job is owned by the user whose service credentials are used to create it. How you learn the status and results of a job depends on the parameters you include with the job creation request: * By callback notification: Include the `callback_url` parameter to specify a URL to which the service is to send callback notifications when the status of the job changes. Optionally, you can also include the `events` and `user_token` parameters to subscribe to specific events and to specify a string that is to be included with each notification for the job. * By polling the service: Omit the `callback_url`, `events`, and `user_token` parameters. You must then use the **Check jobs** or **Check a job** methods to check the status of the job, using the latter to retrieve the results when the job is complete.  The two approaches are not mutually exclusive. You can poll the service for job status or obtain results from the service manually even if you include a callback URL. In both cases, you can include the `results_ttl` parameter to specify how long the results are to remain available after the job is complete. For detailed usage information about the two approaches, including callback notifications, see [Creating a job](https://console.bluemix.net/docs/services/speech-to-text/async.html#create). Note that using the HTTPS **Check a job** method to retrieve results is more secure than receiving them via callback notification over HTTP because it provides confidentiality in addition to authentication and data integrity.   The method supports the same basic parameters as other HTTP and WebSocket recognition requests. The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding. (For the `audio/l16` format, you can specify the endianness.)   ###Audio formats (content types)   Use the `Content-Type` parameter to specify the audio format (MIME type) of the audio: * `audio/basic` (Use only with narrowband models.) * `audio/flac` * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of channels (`channels`) and endianness (`endianness`) of the audio.) * `audio/mp3` * `audio/mpeg` * `audio/mulaw` (Specify the sampling rate (`rate`) of the audio.) * `audio/ogg` (The service automatically detects the codec of the input audio.) * `audio/ogg;codecs=opus` * `audio/ogg;codecs=vorbis` * `audio/wav` (Provide audio with a maximum of nine channels.) * `audio/webm` (The service automatically detects the codec of the input audio.) * `audio/webm;codecs=opus` * `audio/webm;codecs=vorbis`   For information about the supported audio formats, including specifying the sampling rate, channels, and endianness for the indicated formats, see [Audio formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
    *
    * @param createJobOptions the {@link IBMSpeechToTextV1Models.CreateJobOptions} containing the options for the call
    * @return the {@link IBMSpeechToTextV1Models.RecognitionJob} with the response
@@ -196,6 +260,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     IBMWatsonValidator.notNull(createJobOptions, 'createJobOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/recognitions');
     builder.addHeader('Content-Type', createJobOptions.contentType());
+    Map<String, String> requestHeaders = (createJobOptions != null) ? createJobOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
     if (createJobOptions.audio() != null) {
@@ -225,11 +295,11 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     if (createJobOptions.acousticCustomizationId() != null) {
       builder.query('acoustic_customization_id', createJobOptions.acousticCustomizationId());
     }
+    if (createJobOptions.baseModelVersion() != null) {
+      builder.query('base_model_version', createJobOptions.baseModelVersion());
+    }
     if (createJobOptions.customizationWeight() != null) {
       builder.query('customization_weight', String.valueOf(createJobOptions.customizationWeight()));
-    }
-    if (createJobOptions.version() != null) {
-      builder.query('base_model_version', createJobOptions.version());
     }
     if (createJobOptions.inactivityTimeout() != null) {
       builder.query('inactivity_timeout', String.valueOf(createJobOptions.inactivityTimeout()));
@@ -268,7 +338,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Deletes the specified asynchronous job.
+   * Delete a job.
    *
    * Deletes the specified job. You cannot delete a job that the service is actively processing. Once you delete a job, its results are no longer available. The service automatically deletes a job and its results when the time to live for the results expires. You must submit the request with the service credentials of the user who created the job.
    *
@@ -278,14 +348,20 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void deleteJob(IBMSpeechToTextV1Models.DeleteJobOptions deleteJobOptions) {
     IBMWatsonValidator.notNull(deleteJobOptions, 'deleteJobOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/recognitions/{0}', new String[]{ deleteJobOptions.id() }));
+    Map<String, String> requestHeaders = (deleteJobOptions != null) ? deleteJobOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Registers a callback URL for use with the asynchronous interface.
+   * Register a callback.
    *
-   * Registers a callback URL with the service for use with subsequent asynchronous recognition requests. The service attempts to register, or white-list, the callback URL if it is not already registered by sending a `GET` request to the callback URL. The service passes a random alphanumeric challenge string via the `challenge_string` query parameter of the request. The request includes an `Accept` header that specifies `text/plain` as the required response type.   To be registered successfully, the callback URL must respond to the `GET` request from the service. The response must send status code 200 and must include the challenge string in its body. Set the `Content-Type` response header to `text/plain`. Upon receiving this response, the service responds to the original `POST` registration request with response code 201.   The service sends only a single `GET` request to the callback URL. If the service does not receive a reply with a response code of 200 and a body that echoes the challenge string sent by the service within five seconds, it does not white-list the URL; it instead sends status code 400 in response to the `POST` registration request. If the requested callback URL is already white-listed, the service responds to the initial registration request with response code 200.   If you specify a user secret with the request, the service uses it as a key to calculate an HMAC-SHA1 signature of the challenge string in its response to the `POST` request. It sends this signature in the `X-Callback-Signature` header of its `GET` request to the URL during registration. It also uses the secret to calculate a signature over the payload of every callback notification that uses the URL. The signature provides authentication and data integrity for HTTP communications.   Once you successfully register a callback URL, you can use it with an indefinite number of recognition requests. You can register a maximum of 20 callback URLS in a one-hour span of time. For more information, see [Registering a callback URL](https://console.bluemix.net/docs/services/speech-to-text/async.html#register).
+   * Registers a callback URL with the service for use with subsequent asynchronous recognition requests. The service attempts to register, or white-list, the callback URL if it is not already registered by sending a `GET` request to the callback URL. The service passes a random alphanumeric challenge string via the `challenge_string` parameter of the request. The request includes an `Accept` header that specifies `text/plain` as the required response type.   To be registered successfully, the callback URL must respond to the `GET` request from the service. The response must send status code 200 and must include the challenge string in its body. Set the `Content-Type` response header to `text/plain`. Upon receiving this response, the service responds to the original registration request with response code 201.   The service sends only a single `GET` request to the callback URL. If the service does not receive a reply with a response code of 200 and a body that echoes the challenge string sent by the service within five seconds, it does not white-list the URL; it instead sends status code 400 in response to the **Register a callback** request. If the requested callback URL is already white-listed, the service responds to the initial registration request with response code 200.   If you specify a user secret with the request, the service uses it as a key to calculate an HMAC-SHA1 signature of the challenge string in its response to the `POST` request. It sends this signature in the `X-Callback-Signature` header of its `GET` request to the URL during registration. It also uses the secret to calculate a signature over the payload of every callback notification that uses the URL. The signature provides authentication and data integrity for HTTP communications.   After you successfully register a callback URL, you can use it with an indefinite number of recognition requests. You can register a maximum of 20 callback URLS in a one-hour span of time. For more information, see [Registering a callback URL](https://console.bluemix.net/docs/services/speech-to-text/async.html#register).
    *
    * @param registerCallbackOptions the {@link IBMSpeechToTextV1Models.RegisterCallbackOptions} containing the options for the call
    * @return the {@link IBMSpeechToTextV1Models.RegisterStatus} with the response
@@ -293,6 +369,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.RegisterStatus registerCallback(IBMSpeechToTextV1Models.RegisterCallbackOptions registerCallbackOptions) {
     IBMWatsonValidator.notNull(registerCallbackOptions, 'registerCallbackOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/register_callback');
+    Map<String, String> requestHeaders = (registerCallbackOptions != null) ? registerCallbackOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (registerCallbackOptions.callbackUrl() != null) {
       builder.query('callback_url', registerCallbackOptions.callbackUrl());
     }
@@ -305,9 +387,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Removes the registration for an asynchronous callback URL.
+   * Unregister a callback.
    *
-   * Unregisters a callback URL that was previously white-listed with a `POST register_callback` request for use with the asynchronous interface. Once unregistered, the URL can no longer be used with asynchronous recognition requests.
+   * Unregisters a callback URL that was previously white-listed with a **Register a callback** request for use with the asynchronous interface. Once unregistered, the URL can no longer be used with asynchronous recognition requests.
    *
    * @param unregisterCallbackOptions the {@link IBMSpeechToTextV1Models.UnregisterCallbackOptions} containing the options for the call
    * @return the service call
@@ -315,6 +397,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void unregisterCallback(IBMSpeechToTextV1Models.UnregisterCallbackOptions unregisterCallbackOptions) {
     IBMWatsonValidator.notNull(unregisterCallbackOptions, 'unregisterCallbackOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/unregister_callback');
+    Map<String, String> requestHeaders = (unregisterCallbackOptions != null) ? unregisterCallbackOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (unregisterCallbackOptions.callbackUrl() != null) {
       builder.query('callback_url', unregisterCallbackOptions.callbackUrl());
     }
@@ -324,9 +412,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Creates a custom language model.
+   * Create a custom language model.
    *
-   * Creates a new custom language model for a specified base model. The custom language model can be used only with the base model for which it is created. The model is owned by the instance of the service whose credentials are used to create it.
+   * Creates a new custom language model for a specified base model. The custom language model can be used only with the base model for which it is created. The model is owned by the instance of the service whose credentials are used to create it. You must pass a value of `application/json` with the `Content-Type` header.
    *
    * @param createLanguageModelOptions the {@link IBMSpeechToTextV1Models.CreateLanguageModelOptions} containing the options for the call
    * @return the {@link IBMSpeechToTextV1Models.LanguageModel} with the response
@@ -334,6 +422,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.LanguageModel createLanguageModel(IBMSpeechToTextV1Models.CreateLanguageModelOptions createLanguageModelOptions) {
     IBMWatsonValidator.notNull(createLanguageModelOptions, 'createLanguageModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/customizations');
+    Map<String, String> requestHeaders = (createLanguageModelOptions != null) ? createLanguageModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('name', createLanguageModelOptions.name());
     contentJson.put('base_model_name', createLanguageModelOptions.baseModelName());
@@ -349,7 +443,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Deletes a custom language model.
+   * Delete a custom language model.
    *
    * Deletes an existing custom language model. The custom model cannot be deleted if another request, such as adding a corpus to the model, is currently being processed. You must use credentials for the instance of the service that owns a model to delete it.
    *
@@ -359,12 +453,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void deleteLanguageModel(IBMSpeechToTextV1Models.DeleteLanguageModelOptions deleteLanguageModelOptions) {
     IBMWatsonValidator.notNull(deleteLanguageModelOptions, 'deleteLanguageModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/customizations/{0}', new String[]{ deleteLanguageModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (deleteLanguageModelOptions != null) ? deleteLanguageModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Lists information about a custom language model.
+   * List a custom language model.
    *
    * Lists information about a specified custom language model. You must use credentials for the instance of the service that owns a model to list information about it.
    *
@@ -374,12 +474,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.LanguageModel getLanguageModel(IBMSpeechToTextV1Models.GetLanguageModelOptions getLanguageModelOptions) {
     IBMWatsonValidator.notNull(getLanguageModelOptions, 'getLanguageModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/customizations/{0}', new String[]{ getLanguageModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (getLanguageModelOptions != null) ? getLanguageModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.LanguageModel) createServiceCall(builder.build(), IBMSpeechToTextV1Models.LanguageModel.class);
   }
 
   /**
-   * Lists information about all custom language models.
+   * List custom language models.
    *
    * Lists information about all custom language models that are owned by an instance of the service. Use the `language` parameter to see all custom language models for the specified language; omit the parameter to see all custom language models for all languages. You must use credentials for the instance of the service that owns a model to list information about it.
    *
@@ -388,6 +494,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
    */
   public IBMSpeechToTextV1Models.LanguageModels listLanguageModels(IBMSpeechToTextV1Models.ListLanguageModelsOptions listLanguageModelsOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/customizations');
+    Map<String, String> requestHeaders = (listLanguageModelsOptions != null) ? listLanguageModelsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (listLanguageModelsOptions != null && listLanguageModelsOptions.language() != null) {
       builder.query('language', listLanguageModelsOptions.language());
     }
@@ -396,7 +508,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Resets a custom language model.
+   * Reset a custom language model.
    *
    * Resets a custom language model by removing all corpora and words from the model. Resetting a custom language model initializes the model to its state when it was first created. Metadata such as the name and language of the model are preserved, but the model's words resource is removed and must be re-created. You must use credentials for the instance of the service that owns a model to reset it.
    *
@@ -406,15 +518,21 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void resetLanguageModel(IBMSpeechToTextV1Models.ResetLanguageModelOptions resetLanguageModelOptions) {
     IBMWatsonValidator.notNull(resetLanguageModelOptions, 'resetLanguageModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/customizations/{0}/reset', new String[]{ resetLanguageModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (resetLanguageModelOptions != null) ? resetLanguageModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.bodyJson('{}');
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Trains a custom language model.
+   * Train a custom language model.
    *
-   * Initiates the training of a custom language model with new corpora, custom words, or both. After adding, modifying, or deleting corpora or words for a custom language model, use this method to begin the actual training of the model on the latest data. You can specify whether the custom language model is to be trained with all words from its words resource or only with words that were added or modified by the user. You must use credentials for the instance of the service that owns a model to train it.   The training method is asynchronous. It can take on the order of minutes to complete depending on the amount of data on which the service is being trained and the current load on the service. The method returns an HTTP 200 response code to indicate that the training process has begun.   You can monitor the status of the training by using the `GET /v1/customizations/{customization_id}` method to poll the model's status. Use a loop to check the status every 10 seconds. The method returns a `Customization` object that includes `status` and `progress` fields. A status of `available` means that the custom model is trained and ready to use. The service cannot accept subsequent training requests, or requests to add new corpora or words, until the existing request completes.   Training can fail to start for the following reasons: * The service is currently handling another request for the custom model, such as another training request or a request to add a corpus or words to the model. * No training data (corpora or words) have been added to the custom model. * One or more words that were added to the custom model have invalid sounds-like pronunciations that you must fix.
+   * Initiates the training of a custom language model with new corpora, custom words, or both. After adding, modifying, or deleting corpora or words for a custom language model, use this method to begin the actual training of the model on the latest data. You can specify whether the custom language model is to be trained with all words from its words resource or only with words that were added or modified by the user. You must use credentials for the instance of the service that owns a model to train it.   The training method is asynchronous. It can take on the order of minutes to complete depending on the amount of data on which the service is being trained and the current load on the service. The method returns an HTTP 200 response code to indicate that the training process has begun.   You can monitor the status of the training by using the **List a custom language model** method to poll the model's status. Use a loop to check the status every 10 seconds. The method returns a `Customization` object that includes `status` and `progress` fields. A status of `available` means that the custom model is trained and ready to use. The service cannot accept subsequent training requests, or requests to add new corpora or words, until the existing request completes.   Training can fail to start for the following reasons: * The service is currently handling another request for the custom model, such as another training request or a request to add a corpus or words to the model. * No training data (corpora or words) have been added to the custom model. * One or more words that were added to the custom model have invalid sounds-like pronunciations that you must fix.
    *
    * @param trainLanguageModelOptions the {@link IBMSpeechToTextV1Models.TrainLanguageModelOptions} containing the options for the call
    * @return the service call
@@ -422,6 +540,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void trainLanguageModel(IBMSpeechToTextV1Models.TrainLanguageModelOptions trainLanguageModelOptions) {
     IBMWatsonValidator.notNull(trainLanguageModelOptions, 'trainLanguageModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/customizations/{0}/train', new String[]{ trainLanguageModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (trainLanguageModelOptions != null) ? trainLanguageModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (trainLanguageModelOptions.wordTypeToAdd() != null) {
       builder.query('word_type_to_add', trainLanguageModelOptions.wordTypeToAdd());
     }
@@ -434,9 +558,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Upgrades a custom language model.
+   * Upgrade a custom language model.
    *
-   * Initiates the upgrade of a custom language model to the latest version of its base language model. The upgrade method is asynchronous. It can take on the order of minutes to complete depending on the amount of data in the custom model and the current load on the service. A custom model must be in the `ready` or `available` state to be upgraded. You must use credentials for the instance of the service that owns a model to upgrade it.   The method returns an HTTP 200 response code to indicate that the upgrade process has begun successfully. You can monitor the status of the upgrade by using the `GET /v1/customizations/{customization_id}` method to poll the model's status. Use a loop to check the status every 10 seconds. While it is being upgraded, the custom model has the status `upgrading`. When the upgrade is complete, the model resumes the status that it had prior to upgrade. The service cannot accept subsequent requests for the model until the upgrade completes.   For more information, see [Upgrading custom models](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html).
+   * Initiates the upgrade of a custom language model to the latest version of its base language model. The upgrade method is asynchronous. It can take on the order of minutes to complete depending on the amount of data in the custom model and the current load on the service. A custom model must be in the `ready` or `available` state to be upgraded. You must use credentials for the instance of the service that owns a model to upgrade it.   The method returns an HTTP 200 response code to indicate that the upgrade process has begun successfully. You can monitor the status of the upgrade by using the **List a custom language model** method to poll the model's status. Use a loop to check the status every 10 seconds. While it is being upgraded, the custom model has the status `upgrading`. When the upgrade is complete, the model resumes the status that it had prior to upgrade. The service cannot accept subsequent requests for the model until the upgrade completes.   For more information, see [Upgrading custom models](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html).
    *
    * @param upgradeLanguageModelOptions the {@link IBMSpeechToTextV1Models.UpgradeLanguageModelOptions} containing the options for the call
    * @return the service call
@@ -444,15 +568,21 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void upgradeLanguageModel(IBMSpeechToTextV1Models.UpgradeLanguageModelOptions upgradeLanguageModelOptions) {
     IBMWatsonValidator.notNull(upgradeLanguageModelOptions, 'upgradeLanguageModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/customizations/{0}/upgrade_model', new String[]{ upgradeLanguageModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (upgradeLanguageModelOptions != null) ? upgradeLanguageModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.bodyJson('{}');
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Adds a corpus text file to a custom language model.
+   * Add a corpus.
    *
-   * Adds a single corpus text file of new training data to a custom language model. Use multiple requests to submit multiple corpus text files. You must use credentials for the instance of the service that owns a model to add a corpus to it. Note that adding a corpus does not affect the custom language model until you train the model for the new data by using the `POST /v1/customizations/{customization_id}/train` method.   Submit a plain text file that contains sample sentences from the domain of interest to enable the service to extract words in context. The more sentences you add that represent the context in which speakers use words from the domain, the better the service's recognition accuracy. For guidelines about adding a corpus text file and for information about how the service parses a corpus file, see [Preparing a corpus text file](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#prepareCorpus).   The call returns an HTTP 201 response code if the corpus is valid. The service then asynchronously processes the contents of the corpus and automatically extracts new words that it finds. This can take on the order of a minute or two to complete depending on the total number of words and the number of new words in the corpus, as well as the current load on the service. You cannot submit requests to add additional corpora or words to the custom model, or to train the model, until the service's analysis of the corpus for the current request completes. Use the `GET /v1/customizations/{customization_id}/corpora/{corpus_name}` method to check the status of the analysis.   The service auto-populates the model's words resource with any word that is not found in its base vocabulary; these are referred to as out-of-vocabulary (OOV) words. You can use the `GET /v1/customizations/{customization_id}/words` method to examine the words resource, using other words method to eliminate typos and modify how words are pronounced as needed.   To add a corpus file that has the same name as an existing corpus, set the allow_overwrite query parameter to true; otherwise, the request fails. Overwriting an existing corpus causes the service to process the corpus text file and extract OOV words anew. Before doing so, it removes any OOV words associated with the existing corpus from the model's words resource unless they were also added by another corpus or they have been modified in some way with the `POST /v1/customizations/{customization_id}/words` or `PUT /v1/customizations/{customization_id}/words/{word_name}` method.   The service limits the overall amount of data that you can add to a custom model to a maximum of 10 million total words from all corpora combined. Also, you can add no more than 30 thousand new custom words to a model; this includes words that the service extracts from corpora and words that you add directly.
+   * Adds a single corpus text file of new training data to a custom language model. Use multiple requests to submit multiple corpus text files. You must use credentials for the instance of the service that owns a model to add a corpus to it. Note that adding a corpus does not affect the custom language model until you train the model for the new data by using the **Train a custom language model** method.   Submit a plain text file that contains sample sentences from the domain of interest to enable the service to extract words in context. The more sentences you add that represent the context in which speakers use words from the domain, the better the service's recognition accuracy. For guidelines about adding a corpus text file and for information about how the service parses a corpus file, see [Preparing a corpus text file](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#prepareCorpus).   The call returns an HTTP 201 response code if the corpus is valid. The service then asynchronously processes the contents of the corpus and automatically extracts new words that it finds. This can take on the order of a minute or two to complete depending on the total number of words and the number of new words in the corpus, as well as the current load on the service. You cannot submit requests to add additional corpora or words to the custom model, or to train the model, until the service's analysis of the corpus for the current request completes. Use the **List a corpus** method to check the status of the analysis.   The service auto-populates the model's words resource with any word that is not found in its base vocabulary; these are referred to as out-of-vocabulary (OOV) words. You can use the **List custom words** method to examine the words resource, using other words method to eliminate typos and modify how words are pronounced as needed.   To add a corpus file that has the same name as an existing corpus, set the `allow_overwrite` parameter to `true`; otherwise, the request fails. Overwriting an existing corpus causes the service to process the corpus text file and extract OOV words anew. Before doing so, it removes any OOV words associated with the existing corpus from the model's words resource unless they were also added by another corpus or they have been modified in some way with the **Add custom words** or **Add a custom word** method.   The service limits the overall amount of data that you can add to a custom model to a maximum of 10 million total words from all corpora combined. Also, you can add no more than 30 thousand custom (OOV) words to a model; this includes words that the service extracts from corpora and words that you add directly.
    *
    * @param addCorpusOptions the {@link IBMSpeechToTextV1Models.AddCorpusOptions} containing the options for the call
    * @return the service call
@@ -460,6 +590,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void addCorpus(IBMSpeechToTextV1Models.AddCorpusOptions addCorpusOptions) {
     IBMWatsonValidator.notNull(addCorpusOptions, 'addCorpusOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/customizations/{0}/corpora/{1}', new String[]{ addCorpusOptions.customizationId(), addCorpusOptions.corpusName() }));
+    Map<String, String> requestHeaders = (addCorpusOptions != null) ? addCorpusOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (addCorpusOptions.allowOverwrite() != null) {
       builder.query('allow_overwrite', String.valueOf(addCorpusOptions.allowOverwrite()));
     }
@@ -474,9 +610,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Deletes a corpus from a custom language model.
+   * Delete a corpus.
    *
-   * Deletes an existing corpus from a custom language model. The service removes any out-of-vocabulary (OOV) words associated with the corpus from the custom model's words resource unless they were also added by another corpus or they have been modified in some way with the `POST /v1/customizations/{customization_id}/words` or `PUT /v1/customizations/{customization_id}/words/{word_name}` method. Removing a corpus does not affect the custom model until you train the model with the `POST /v1/customizations/{customization_id}/train` method. You must use credentials for the instance of the service that owns a model to delete its corpora.
+   * Deletes an existing corpus from a custom language model. The service removes any out-of-vocabulary (OOV) words associated with the corpus from the custom model's words resource unless they were also added by another corpus or they have been modified in some way with the **Add custom words** or **Add a custom word** method. Removing a corpus does not affect the custom model until you train the model with the **Train a custom language model** method. You must use credentials for the instance of the service that owns a model to delete its corpora.
    *
    * @param deleteCorpusOptions the {@link IBMSpeechToTextV1Models.DeleteCorpusOptions} containing the options for the call
    * @return the service call
@@ -484,12 +620,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void deleteCorpus(IBMSpeechToTextV1Models.DeleteCorpusOptions deleteCorpusOptions) {
     IBMWatsonValidator.notNull(deleteCorpusOptions, 'deleteCorpusOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/customizations/{0}/corpora/{1}', new String[]{ deleteCorpusOptions.customizationId(), deleteCorpusOptions.corpusName() }));
+    Map<String, String> requestHeaders = (deleteCorpusOptions != null) ? deleteCorpusOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Lists information about a corpus for a custom language model.
+   * List a corpus.
    *
    * Lists information about a corpus from a custom language model. The information includes the total number of words and out-of-vocabulary (OOV) words, name, and status of the corpus. You must use credentials for the instance of the service that owns a model to list its corpora.
    *
@@ -499,12 +641,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.Corpus getCorpus(IBMSpeechToTextV1Models.GetCorpusOptions getCorpusOptions) {
     IBMWatsonValidator.notNull(getCorpusOptions, 'getCorpusOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/customizations/{0}/corpora/{1}', new String[]{ getCorpusOptions.customizationId(), getCorpusOptions.corpusName() }));
+    Map<String, String> requestHeaders = (getCorpusOptions != null) ? getCorpusOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.Corpus) createServiceCall(builder.build(), IBMSpeechToTextV1Models.Corpus.class);
   }
 
   /**
-   * Lists information about all corpora for a custom language model.
+   * List corpora.
    *
    * Lists information about all corpora from a custom language model. The information includes the total number of words and out-of-vocabulary (OOV) words, name, and status of each corpus. You must use credentials for the instance of the service that owns a model to list its corpora.
    *
@@ -514,14 +662,20 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.Corpora listCorpora(IBMSpeechToTextV1Models.ListCorporaOptions listCorporaOptions) {
     IBMWatsonValidator.notNull(listCorporaOptions, 'listCorporaOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/customizations/{0}/corpora', new String[]{ listCorporaOptions.customizationId() }));
+    Map<String, String> requestHeaders = (listCorporaOptions != null) ? listCorporaOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.Corpora) createServiceCall(builder.build(), IBMSpeechToTextV1Models.Corpora.class);
   }
 
   /**
-   * Adds a custom word to a custom language model.
+   * Add a custom word.
    *
-   * Adds a custom word to a custom language model. The service populates the words resource for a custom model with out-of-vocabulary (OOV) words found in each corpus added to the model. You can use this method to add additional words or to modify existing words in the words resource. You must use credentials for the instance of the service that owns a model to add or modify a custom word for the model. Adding or modifying a custom word does not affect the custom model until you train the model for the new data by using the `POST /v1/customizations/{customization_id}/train` method.   Use the `word_name` path parameter to specify the custom word that is to be added or modified. Use the `CustomWord` object to provide one or both of the optional `sounds_like` and `display_as` fields for the word. * The `sounds_like` field provides an array of one or more pronunciations for the word. Use the parameter to specify how the word can be pronounced by users. Use the parameter for words that are difficult to pronounce, foreign words, acronyms, and so on. For example, you might specify that the word `IEEE` can sound like `i triple e`. You can specify a maximum of five sounds-like pronunciations for a word. For information about pronunciation rules, see [Using the sounds_like field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#soundsLike). * The `display_as` field provides a different way of spelling the word in a transcript. Use the parameter when you want the word to appear different from its usual representation or from its spelling in corpora training data. For example, you might indicate that the word `IBM(trademark)` is to be displayed as `IBM`. For more information, see [Using the display_as field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#displayAs).    If you add a custom word that already exists in the words resource for the custom model, the new definition overwrites the existing data for the word. If the service encounters an error, it does not add the word to the words resource. Use the `GET /v1/customizations/{customization_id}/words/{word_name}` method to review the word that you add.
+   * Adds a custom word to a custom language model. The service populates the words resource for a custom model with out-of-vocabulary (OOV) words found in each corpus added to the model. You can use this method to add a word or to modify an existing word in the words resource. The words resource for a model can contain a maximum of 30 thousand custom (OOV) words, including words that the service extracts from corpora and words that you add directly.   You must use credentials for the instance of the service that owns a model to add or modify a custom word for the model. You must pass a value of `application/json` with the `Content-Type` header. Adding or modifying a custom word does not affect the custom model until you train the model for the new data by using the **Train a custom language model** method.   Use the `word_name` parameter to specify the custom word that is to be added or modified. Use the `CustomWord` object to provide one or both of the optional `sounds_like` and `display_as` fields for the word. * The `sounds_like` field provides an array of one or more pronunciations for the word. Use the parameter to specify how the word can be pronounced by users. Use the parameter for words that are difficult to pronounce, foreign words, acronyms, and so on. For example, you might specify that the word `IEEE` can sound like `i triple e`. You can specify a maximum of five sounds-like pronunciations for a word. For information about pronunciation rules, see [Using the sounds_like field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#soundsLike). * The `display_as` field provides a different way of spelling the word in a transcript. Use the parameter when you want the word to appear different from its usual representation or from its spelling in corpora training data. For example, you might indicate that the word `IBM(trademark)` is to be displayed as `IBM`. For more information, see [Using the display_as field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#displayAs).    If you add a custom word that already exists in the words resource for the custom model, the new definition overwrites the existing data for the word. If the service encounters an error, it does not add the word to the words resource. Use the **List a custom word** method to review the word that you add.
    *
    * @param addWordOptions the {@link IBMSpeechToTextV1Models.AddWordOptions} containing the options for the call
    * @return the service call
@@ -529,6 +683,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void addWord(IBMSpeechToTextV1Models.AddWordOptions addWordOptions) {
     IBMWatsonValidator.notNull(addWordOptions, 'addWordOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPut(getEndPoint() + String.format('/v1/customizations/{0}/words/{1}', new String[]{ addWordOptions.customizationId(), addWordOptions.wordName() }));
+    Map<String, String> requestHeaders = (addWordOptions != null) ? addWordOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (addWordOptions.word() != null) {
       contentJson.put('word', addWordOptions.word());
@@ -545,9 +705,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Adds one or more custom words to a custom language model.
+   * Add custom words.
    *
-   * Adds one or more custom words to a custom language model. The service populates the words resource for a custom model with out-of-vocabulary (OOV) words found in each corpus added to the model. You can use this method to add additional words or to modify existing words in the words resource. You must use credentials for the instance of the service that owns a model to add or modify custom words for the model. Adding or modifying custom words does not affect the custom model until you train the model for the new data by using the `POST /v1/customizations/{customization_id}/train` method.   You add custom words by providing a `Words` object, which is an array of `Word` objects, one per word. You must use the object's word parameter to identify the word that is to be added. You can also provide one or both of the optional `sounds_like` and `display_as` fields for each word. * The `sounds_like` field provides an array of one or more pronunciations for the word. Use the parameter to specify how the word can be pronounced by users. Use the parameter for words that are difficult to pronounce, foreign words, acronyms, and so on. For example, you might specify that the word `IEEE` can sound like `i triple e`. You can specify a maximum of five sounds-like pronunciations for a word. For information about pronunciation rules, see [Using the sounds_like field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#soundsLike). * The `display_as` field provides a different way of spelling the word in a transcript. Use the parameter when you want the word to appear different from its usual representation or from its spelling in corpora training data. For example, you might indicate that the word `IBM(trademark)` is to be displayed as `IBM`. For more information, see [Using the display_as field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#displayAs).    If you add a custom word that already exists in the words resource for the custom model, the new definition overwrites the existing data for the word. If the service encounters an error with the input data, it returns a failure code and does not add any of the words to the words resource.   The call returns an HTTP 201 response code if the input data is valid. It then asynchronously processes the words to add them to the model's words resource. The time that it takes for the analysis to complete depends on the number of new words that you add but is generally faster than adding a corpus or training a model.   You can monitor the status of the request by using the `GET /v1/customizations/{customization_id}` method to poll the model's status. Use a loop to check the status every 10 seconds. The method returns a `Customization` object that includes a `status` field. A status of `ready` means that the words have been added to the custom model. The service cannot accept requests to add new corpora or words or to train the model until the existing request completes.   You can use the `GET /v1/customizations/{customization_id}/words` or `GET /v1/customizations/{customization_id}/words/{word_name}` method to review the words that you add. Words with an invalid `sounds_like` field include an `error` field that describes the problem. You can use other words methods to correct errors, eliminate typos, and modify how words are pronounced as needed.
+   * Adds one or more custom words to a custom language model. The service populates the words resource for a custom model with out-of-vocabulary (OOV) words found in each corpus added to the model. You can use this method to add additional words or to modify existing words in the words resource. The words resource for a model can contain a maximum of 30 thousand custom (OOV) words, including words that the service extracts from corpora and words that you add directly.   You must use credentials for the instance of the service that owns a model to add or modify custom words for the model. You must pass a value of `application/json` with the `Content-Type` header. Adding or modifying custom words does not affect the custom model until you train the model for the new data by using the **Train a custom language model** method.   You add custom words by providing a `Words` object, which is an array of `Word` objects, one per word. You must use the object's word parameter to identify the word that is to be added. You can also provide one or both of the optional `sounds_like` and `display_as` fields for each word. * The `sounds_like` field provides an array of one or more pronunciations for the word. Use the parameter to specify how the word can be pronounced by users. Use the parameter for words that are difficult to pronounce, foreign words, acronyms, and so on. For example, you might specify that the word `IEEE` can sound like `i triple e`. You can specify a maximum of five sounds-like pronunciations for a word. For information about pronunciation rules, see [Using the sounds_like field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#soundsLike). * The `display_as` field provides a different way of spelling the word in a transcript. Use the parameter when you want the word to appear different from its usual representation or from its spelling in corpora training data. For example, you might indicate that the word `IBM(trademark)` is to be displayed as `IBM`. For more information, see [Using the display_as field](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#displayAs).    If you add a custom word that already exists in the words resource for the custom model, the new definition overwrites the existing data for the word. If the service encounters an error with the input data, it returns a failure code and does not add any of the words to the words resource.   The call returns an HTTP 201 response code if the input data is valid. It then asynchronously processes the words to add them to the model's words resource. The time that it takes for the analysis to complete depends on the number of new words that you add but is generally faster than adding a corpus or training a model.   You can monitor the status of the request by using the **List a custom language model** method to poll the model's status. Use a loop to check the status every 10 seconds. The method returns a `Customization` object that includes a `status` field. A status of `ready` means that the words have been added to the custom model. The service cannot accept requests to add new corpora or words or to train the model until the existing request completes.   You can use the **List custom words** or **List a custom word** method to review the words that you add. Words with an invalid `sounds_like` field include an `error` field that describes the problem. You can use other words-related methods to correct errors, eliminate typos, and modify how words are pronounced as needed.
    *
    * @param addWordsOptions the {@link IBMSpeechToTextV1Models.AddWordsOptions} containing the options for the call
    * @return the service call
@@ -555,6 +715,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void addWords(IBMSpeechToTextV1Models.AddWordsOptions addWordsOptions) {
     IBMWatsonValidator.notNull(addWordsOptions, 'addWordsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/customizations/{0}/words', new String[]{ addWordsOptions.customizationId() }));
+    Map<String, String> requestHeaders = (addWordsOptions != null) ? addWordsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('words', addWordsOptions.words());
     builder.bodyJson(JSON.serialize(contentJson, true));
@@ -563,9 +729,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Deletes a custom word from a custom language model.
+   * Delete a custom word.
    *
-   * Deletes a custom word from a custom language model. You can remove any word that you added to the custom model's words resource via any means. However, if the word also exists in the service's base vocabulary, the service removes only the custom pronunciation for the word; the word remains in the base vocabulary. Removing a custom word does not affect the custom model until you train the model with the `POST /v1/customizations/{customization_id}/train` method. You must use credentials for the instance of the service that owns a model to delete its words.
+   * Deletes a custom word from a custom language model. You can remove any word that you added to the custom model's words resource via any means. However, if the word also exists in the service's base vocabulary, the service removes only the custom pronunciation for the word; the word remains in the base vocabulary. Removing a custom word does not affect the custom model until you train the model with the **Train a custom language model** method. You must use credentials for the instance of the service that owns a model to delete its words.
    *
    * @param deleteWordOptions the {@link IBMSpeechToTextV1Models.DeleteWordOptions} containing the options for the call
    * @return the service call
@@ -573,12 +739,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void deleteWord(IBMSpeechToTextV1Models.DeleteWordOptions deleteWordOptions) {
     IBMWatsonValidator.notNull(deleteWordOptions, 'deleteWordOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/customizations/{0}/words/{1}', new String[]{ deleteWordOptions.customizationId(), deleteWordOptions.wordName() }));
+    Map<String, String> requestHeaders = (deleteWordOptions != null) ? deleteWordOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Lists a custom word from a custom language model.
+   * List a custom word.
    *
    * Lists information about a custom word from a custom language model. You must use credentials for the instance of the service that owns a model to query information about its words.
    *
@@ -588,12 +760,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.Word getWord(IBMSpeechToTextV1Models.GetWordOptions getWordOptions) {
     IBMWatsonValidator.notNull(getWordOptions, 'getWordOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/customizations/{0}/words/{1}', new String[]{ getWordOptions.customizationId(), getWordOptions.wordName() }));
+    Map<String, String> requestHeaders = (getWordOptions != null) ? getWordOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.Word) createServiceCall(builder.build(), IBMSpeechToTextV1Models.Word.class);
   }
 
   /**
-   * Lists all custom words from a custom language model.
+   * List custom words.
    *
    * Lists information about custom words from a custom language model. You can list all words from the custom model's words resource, only custom words that were added or modified by the user, or only out-of-vocabulary (OOV) words that were extracted from corpora. You can also indicate the order in which the service is to return words; by default, words are listed in ascending alphabetical order. You must use credentials for the instance of the service that owns a model to query information about its words.
    *
@@ -603,6 +781,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.Words listWords(IBMSpeechToTextV1Models.ListWordsOptions listWordsOptions) {
     IBMWatsonValidator.notNull(listWordsOptions, 'listWordsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/customizations/{0}/words', new String[]{ listWordsOptions.customizationId() }));
+    Map<String, String> requestHeaders = (listWordsOptions != null) ? listWordsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (listWordsOptions.wordType() != null) {
       builder.query('word_type', listWordsOptions.wordType());
     }
@@ -614,9 +798,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Creates a custom acoustic model.
+   * Create a custom acoustic model.
    *
-   * Creates a new custom acoustic model for a specified base model. The custom acoustic model can be used only with the base model for which it is created. The model is owned by the instance of the service whose credentials are used to create it.
+   * Creates a new custom acoustic model for a specified base model. The custom acoustic model can be used only with the base model for which it is created. The model is owned by the instance of the service whose credentials are used to create it. You must pass a value of `application/json` with the `Content-Type` header.
    *
    * @param createAcousticModelOptions the {@link IBMSpeechToTextV1Models.CreateAcousticModelOptions} containing the options for the call
    * @return the {@link IBMSpeechToTextV1Models.AcousticModel} with the response
@@ -624,6 +808,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.AcousticModel createAcousticModel(IBMSpeechToTextV1Models.CreateAcousticModelOptions createAcousticModelOptions) {
     IBMWatsonValidator.notNull(createAcousticModelOptions, 'createAcousticModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/acoustic_customizations');
+    Map<String, String> requestHeaders = (createAcousticModelOptions != null) ? createAcousticModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('name', createAcousticModelOptions.name());
     contentJson.put('base_model_name', createAcousticModelOptions.baseModelName());
@@ -636,7 +826,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Deletes a custom acoustic model.
+   * Delete a custom acoustic model.
    *
    * Deletes an existing custom acoustic model. The custom model cannot be deleted if another request, such as adding an audio resource to the model, is currently being processed. You must use credentials for the instance of the service that owns a model to delete it.
    *
@@ -646,12 +836,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void deleteAcousticModel(IBMSpeechToTextV1Models.DeleteAcousticModelOptions deleteAcousticModelOptions) {
     IBMWatsonValidator.notNull(deleteAcousticModelOptions, 'deleteAcousticModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/acoustic_customizations/{0}', new String[]{ deleteAcousticModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (deleteAcousticModelOptions != null) ? deleteAcousticModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Lists information about a custom acoustic model.
+   * List a custom acoustic model.
    *
    * Lists information about a specified custom acoustic model. You must use credentials for the instance of the service that owns a model to list information about it.
    *
@@ -661,12 +857,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.AcousticModel getAcousticModel(IBMSpeechToTextV1Models.GetAcousticModelOptions getAcousticModelOptions) {
     IBMWatsonValidator.notNull(getAcousticModelOptions, 'getAcousticModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/acoustic_customizations/{0}', new String[]{ getAcousticModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (getAcousticModelOptions != null) ? getAcousticModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.AcousticModel) createServiceCall(builder.build(), IBMSpeechToTextV1Models.AcousticModel.class);
   }
 
   /**
-   * Lists information about all custom acoustic models.
+   * List custom acoustic models.
    *
    * Lists information about all custom acoustic models that are owned by an instance of the service. Use the `language` parameter to see all custom acoustic models for the specified language; omit the parameter to see all custom acoustic models for all languages. You must use credentials for the instance of the service that owns a model to list information about it.
    *
@@ -675,6 +877,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
    */
   public IBMSpeechToTextV1Models.AcousticModels listAcousticModels(IBMSpeechToTextV1Models.ListAcousticModelsOptions listAcousticModelsOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/acoustic_customizations');
+    Map<String, String> requestHeaders = (listAcousticModelsOptions != null) ? listAcousticModelsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (listAcousticModelsOptions != null && listAcousticModelsOptions.language() != null) {
       builder.query('language', listAcousticModelsOptions.language());
     }
@@ -683,7 +891,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Resets a custom acoustic model.
+   * Reset a custom acoustic model.
    *
    * Resets a custom acoustic model by removing all audio resources from the model. Resetting a custom acoustic model initializes the model to its state when it was first created. Metadata such as the name and language of the model are preserved, but the model's audio resources are removed and must be re-created. You must use credentials for the instance of the service that owns a model to reset it.
    *
@@ -693,15 +901,21 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void resetAcousticModel(IBMSpeechToTextV1Models.ResetAcousticModelOptions resetAcousticModelOptions) {
     IBMWatsonValidator.notNull(resetAcousticModelOptions, 'resetAcousticModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/acoustic_customizations/{0}/reset', new String[]{ resetAcousticModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (resetAcousticModelOptions != null) ? resetAcousticModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.bodyJson('{}');
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Trains a custom acoustic model.
+   * Train a custom acoustic model.
    *
-   * Initiates the training of a custom acoustic model with new or changed audio resources. After adding or deleting audio resources for a custom acoustic model, use this method to begin the actual training of the model on the latest audio data. The custom acoustic model does not reflect its changed data until you train it. You must use credentials for the instance of the service that owns a model to train it.   The training method is asynchronous. It can take on the order of minutes or hours to complete depending on the total amount of audio data on which the model is being trained and the current load on the service. Typically, training takes approximately two to four times the length of its audio data. The range of time depends on the model being trained and the nature of the audio, such as whether the audio is clean or noisy. The method returns an HTTP 200 response code to indicate that the training process has begun.   You can monitor the status of the training by using the `GET /v1/acoustic_customizations/{customization_id}` method to poll the model's status. Use a loop to check the status once a minute. The method returns an `Customization` object that includes `status` and `progress` fields. A status of `available` indicates that the custom model is trained and ready to use. The service cannot accept subsequent training requests, or requests to add new audio resources, until the existing request completes.   You can use the optional `custom_language_model_id` query parameter to specify the GUID of a separately created custom language model that is to be used during training. Specify a custom language model if you have verbatim transcriptions of the audio files that you have added to the custom model or you have either corpora (text files) or a list of words that are relevant to the contents of the audio files. For information about creating a separate custom language model, see [Creating a custom language model](https://console.bluemix.net/docs/services/speech-to-text/language-create.html).   Training can fail to start for the following reasons: * The service is currently handling another request for the custom model, such as another training request or a request to add audio resources to the model. * The custom model contains less than 10 minutes or more than 50 hours of audio data. * One or more of the custom model's audio resources is invalid.
+   * Initiates the training of a custom acoustic model with new or changed audio resources. After adding or deleting audio resources for a custom acoustic model, use this method to begin the actual training of the model on the latest audio data. The custom acoustic model does not reflect its changed data until you train it. You must use credentials for the instance of the service that owns a model to train it.   The training method is asynchronous. It can take on the order of minutes or hours to complete depending on the total amount of audio data on which the custom acoustic model is being trained and the current load on the service. Typically, training a custom acoustic model takes approximately two to four times the length of its audio data. The range of time depends on the model being trained and the nature of the audio, such as whether the audio is clean or noisy. The method returns an HTTP 200 response code to indicate that the training process has begun.   You can monitor the status of the training by using the **List a custom acoustic model** method to poll the model's status. Use a loop to check the status once a minute. The method returns an `Customization` object that includes `status` and `progress` fields. A status of `available` indicates that the custom model is trained and ready to use. The service cannot accept subsequent training requests, or requests to add new audio resources, until the existing request completes.   You can use the optional `custom_language_model_id` parameter to specify the GUID of a separately created custom language model that is to be used during training. Specify a custom language model if you have verbatim transcriptions of the audio files that you have added to the custom model or you have either corpora (text files) or a list of words that are relevant to the contents of the audio files. For information about creating a separate custom language model, see [Creating a custom language model](https://console.bluemix.net/docs/services/speech-to-text/language-create.html).   Training can fail to start for the following reasons: * The service is currently handling another request for the custom model, such as another training request or a request to add audio resources to the model. * The custom model contains less than 10 minutes or more than 50 hours of audio data. * One or more of the custom model's audio resources is invalid.
    *
    * @param trainAcousticModelOptions the {@link IBMSpeechToTextV1Models.TrainAcousticModelOptions} containing the options for the call
    * @return the service call
@@ -709,6 +923,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void trainAcousticModel(IBMSpeechToTextV1Models.TrainAcousticModelOptions trainAcousticModelOptions) {
     IBMWatsonValidator.notNull(trainAcousticModelOptions, 'trainAcousticModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/acoustic_customizations/{0}/train', new String[]{ trainAcousticModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (trainAcousticModelOptions != null) ? trainAcousticModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (trainAcousticModelOptions.customLanguageModelId() != null) {
       builder.query('custom_language_model_id', trainAcousticModelOptions.customLanguageModelId());
     }
@@ -718,9 +938,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Upgrades a custom acoustic model.
+   * Upgrade a custom acoustic model.
    *
-   * Initiates the upgrade of a custom acoustic model to the latest version of its base language model. The upgrade method is asynchronous. It can take on the order of minutes or hours to complete depending on the amount of data in the custom model and the current load on the service; typically, upgrade takes approximately twice the length of the total audio contained in the custom model. A custom model must be in the `ready` or `available` state to be upgraded. You must use credentials for the instance of the service that owns a model to upgrade it.   The method returns an HTTP 200 response code to indicate that the upgrade process has begun successfully. You can monitor the status of the upgrade by using the `GET /v1/acoustic_customizations/{customization_id}` method to poll the model's status. Use a loop to check the status once a minute. While it is being upgraded, the custom model has the status `upgrading`. When the upgrade is complete, the model resumes the status that it had prior to upgrade. The service cannot accept subsequent requests for the model until the upgrade completes.   If the custom acoustic model was trained with a separately created custom language model, you must use the `custom_language_model_id` query parameter to specify the GUID of that custom language model. The custom language model must be upgraded before the custom acoustic model can be upgraded. Omit the parameter if the custom acoustic model was not trained with a custom language model.   For more information, see [Upgrading custom models](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html).
+   * Initiates the upgrade of a custom acoustic model to the latest version of its base language model. The upgrade method is asynchronous. It can take on the order of minutes or hours to complete depending on the amount of data in the custom model and the current load on the service; typically, upgrade takes approximately twice the length of the total audio contained in the custom model. A custom model must be in the `ready` or `available` state to be upgraded. You must use credentials for the instance of the service that owns a model to upgrade it.   The method returns an HTTP 200 response code to indicate that the upgrade process has begun successfully. You can monitor the status of the upgrade by using the **List a custom acoustic model** method to poll the model's status. Use a loop to check the status once a minute. While it is being upgraded, the custom model has the status `upgrading`. When the upgrade is complete, the model resumes the status that it had prior to upgrade. The service cannot accept subsequent requests for the model until the upgrade completes.   If the custom acoustic model was trained with a separately created custom language model, you must use the `custom_language_model_id` parameter to specify the GUID of that custom language model. The custom language model must be upgraded before the custom acoustic model can be upgraded. Omit the parameter if the custom acoustic model was not trained with a custom language model.   For more information, see [Upgrading custom models](https://console.bluemix.net/docs/services/speech-to-text/custom-upgrade.html).
    *
    * @param upgradeAcousticModelOptions the {@link IBMSpeechToTextV1Models.UpgradeAcousticModelOptions} containing the options for the call
    * @return the service call
@@ -728,6 +948,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void upgradeAcousticModel(IBMSpeechToTextV1Models.UpgradeAcousticModelOptions upgradeAcousticModelOptions) {
     IBMWatsonValidator.notNull(upgradeAcousticModelOptions, 'upgradeAcousticModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/acoustic_customizations/{0}/upgrade_model', new String[]{ upgradeAcousticModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (upgradeAcousticModelOptions != null) ? upgradeAcousticModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (upgradeAcousticModelOptions.customLanguageModelId() != null) {
       builder.query('custom_language_model_id', upgradeAcousticModelOptions.customLanguageModelId());
     }
@@ -737,9 +963,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Adds an audio resource to a custom acoustic model.
+   * Add an audio resource.
    *
-   * Adds an audio resource to a custom acoustic model. Add audio content that reflects the acoustic characteristics of the audio that you plan to transcribe. You must use credentials for the instance of the service that owns a model to add an audio resource to it. Adding audio data does not affect the custom acoustic model until you train the model for the new data by using the `POST /v1/acoustic_customizations/{customization_id}/train` method.   You can add individual audio files or an archive file that contains multiple audio files. Adding multiple audio files via a single archive file is significantly more efficient than adding each file individually. * You can add an individual audio file in any format that the service supports for speech recognition. Use the `Content-Type` header to specify the format of the audio file. * You can add an archive file (**.zip** or **.tar.gz** file) that contains audio files in any format that the service supports for speech recognition. All audio files added with the same archive file must have the same audio format. Use the `Content-Type` header to specify the archive type, `application/zip` or `application/gzip`. Use the `Contained-Content-Type` header to specify the format of the contained audio files; the default format is `audio/wav`.   You can use this method to add any number of audio resources to a custom model by calling the method once for each audio or archive file. But the addition of one audio resource must be fully complete before you can add another. You must add a minimum of 10 minutes and a maximum of 50 hours of audio that includes speech, not just silence, to a custom acoustic model before you can train it. No audio resource, audio- or archive-type, can be larger than 100 MB.   The method is asynchronous. It can take several seconds to complete depending on the duration of the audio and, in the case of an archive file, the total number of audio files being processed. The service returns a 201 response code if the audio is valid. It then asynchronously analyzes the contents of the audio file or files and automatically extracts information about the audio such as its length, sampling rate, and encoding. You cannot submit requests to add additional audio resources to a custom acoustic model, or to train the model, until the service's analysis of all audio files for the current request completes.   To determine the status of the service's analysis of the audio, use the `GET /v1/acoustic_customizations/{customization_id}/audio/{audio_name}` method to poll the status of the audio. The method accepts the GUID of the custom model and the name of the audio resource, and it returns the status of the resource. Use a loop to check the status of the audio every few seconds until it becomes `ok`.   **Note:** The sampling rate of an audio file must match the sampling rate of the base model for the custom model: for broadband models, at least 16 kHz; for narrowband models, at least 8 kHz. If the sampling rate of the audio is higher than the minimum required rate, the service down-samples the audio to the appropriate rate. If the sampling rate of the audio is lower than the minimum required rate, the service labels the audio file as `invalid`.
+   * Adds an audio resource to a custom acoustic model. Add audio content that reflects the acoustic characteristics of the audio that you plan to transcribe. You must use credentials for the instance of the service that owns a model to add an audio resource to it. Adding audio data does not affect the custom acoustic model until you train the model for the new data by using the **Train a custom acoustic model** method.   You can add individual audio files or an archive file that contains multiple audio files. Adding multiple audio files via a single archive file is significantly more efficient than adding each file individually. You can add audio resources in any format that the service supports for speech recognition.   You can use this method to add any number of audio resources to a custom model by calling the method once for each audio or archive file. But the addition of one audio resource must be fully complete before you can add another. You must add a minimum of 10 minutes and a maximum of 50 hours of audio that includes speech, not just silence, to a custom acoustic model before you can train it. No audio resource, audio- or archive-type, can be larger than 100 MB. To add an audio resource that has the same name as an existing audio resource, set the `allow_overwrite` parameter to `true`; otherwise, the request fails.   The method is asynchronous. It can take several seconds to complete depending on the duration of the audio and, in the case of an archive file, the total number of audio files being processed. The service returns a 201 response code if the audio is valid. It then asynchronously analyzes the contents of the audio file or files and automatically extracts information about the audio such as its length, sampling rate, and encoding. You cannot submit requests to add additional audio resources to a custom acoustic model, or to train the model, until the service's analysis of all audio files for the current request completes.   To determine the status of the service's analysis of the audio, use the **List an audio resource** method to poll the status of the audio. The method accepts the GUID of the custom model and the name of the audio resource, and it returns the status of the resource. Use a loop to check the status of the audio every few seconds until it becomes `ok`.   ###Content types for audio-type resources   You can add an individual audio file in any format that the service supports for speech recognition. For an audio-type resource, use the `Content-Type` parameter to specify the audio format (MIME type) of the audio file: * `audio/basic` (Use only with narrowband models.) * `audio/flac` * `audio/l16` (Specify the sampling rate (`rate`) and optionally the number of channels (`channels`) and endianness (`endianness`) of the audio.) * `audio/mp3` * `audio/mpeg` * `audio/mulaw` (Specify the sampling rate (`rate`) of the audio.) * `audio/ogg` (The service automatically detects the codec of the input audio.) * `audio/ogg;codecs=opus` * `audio/ogg;codecs=vorbis` * `audio/wav` (Provide audio with a maximum of nine channels.) * `audio/webm` (The service automatically detects the codec of the input audio.) * `audio/webm;codecs=opus` * `audio/webm;codecs=vorbis`   For information about the supported audio formats, including specifying the sampling rate, channels, and endianness for the indicated formats, see [Audio formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).   **Note:** The sampling rate of an audio file must match the sampling rate of the base model for the custom model: for broadband models, at least 16 kHz; for narrowband models, at least 8 kHz. If the sampling rate of the audio is higher than the minimum required rate, the service down-samples the audio to the appropriate rate. If the sampling rate of the audio is lower than the minimum required rate, the service labels the audio file as `invalid`.   ###Content types for archive-type resources   You can add an archive file (**.zip** or **.tar.gz** file) that contains audio files in any format that the service supports for speech recognition. For an archive-type resource, use the `Content-Type` parameter to specify the media type of the archive file: * `application/zip` for a **.zip** file * `application/gzip` for a **.tar.gz** file.   All audio files contained in the archive must have the same audio format. Use the `Contained-Content-Type` parameter to specify the format of the contained audio files. The parameter accepts all of the audio formats supported for use with speech recognition and with the `Content-Type` header, including the `rate`, `channels`, and `endianness` parameters that are used with some formats. The default contained audio format is `audio/wav`.
    *
    * @param addAudioOptions the {@link IBMSpeechToTextV1Models.AddAudioOptions} containing the options for the call
    * @return the service call
@@ -748,6 +974,15 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     IBMWatsonValidator.notNull(addAudioOptions, 'addAudioOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/acoustic_customizations/{0}/audio/{1}', new String[]{ addAudioOptions.customizationId(), addAudioOptions.audioName() }));
     builder.addHeader('Content-Type', addAudioOptions.contentType());
+    if (addAudioOptions.containedContentType() != null) {
+      builder.addHeader('Contained-Content-Type', addAudioOptions.containedContentType());
+    }
+    Map<String, String> requestHeaders = (addAudioOptions != null) ? addAudioOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
     if (addAudioOptions.audio() != null) {
@@ -755,9 +990,6 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
         addAudioOptions.audio(), addAudioOptions.contentType()
       );
       multipartBuilder.addFormDataPart('audio', addAudioOptions.audioFilename(), fileBody);
-    }
-    if (addAudioOptions.containedContentType() != null) {
-      builder.addHeader('Contained-Content-Type', addAudioOptions.containedContentType());
     }
     if (addAudioOptions.allowOverwrite() != null) {
       builder.query('allow_overwrite', String.valueOf(addAudioOptions.allowOverwrite()));
@@ -769,9 +1001,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Deletes an audio resource from a custom acoustic model.
+   * Delete an audio resource.
    *
-   * Deletes an existing audio resource from a custom acoustic model. Deleting an archive-type audio resource removes the entire archive of files; the current interface does not allow deletion of individual files from an archive resource. Removing an audio resource does not affect the custom model until you train the model on its updated data by using the `POST /v1/acoustic_customizations/{customization_id}/train` method. You must use credentials for the instance of the service that owns a model to delete its audio resources.
+   * Deletes an existing audio resource from a custom acoustic model. Deleting an archive-type audio resource removes the entire archive of files; the current interface does not allow deletion of individual files from an archive resource. Removing an audio resource does not affect the custom model until you train the model on its updated data by using the **Train a custom acoustic model** method. You must use credentials for the instance of the service that owns a model to delete its audio resources.
    *
    * @param deleteAudioOptions the {@link IBMSpeechToTextV1Models.DeleteAudioOptions} containing the options for the call
    * @return the service call
@@ -779,12 +1011,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public void deleteAudio(IBMSpeechToTextV1Models.DeleteAudioOptions deleteAudioOptions) {
     IBMWatsonValidator.notNull(deleteAudioOptions, 'deleteAudioOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/acoustic_customizations/{0}/audio/{1}', new String[]{ deleteAudioOptions.customizationId(), deleteAudioOptions.audioName() }));
+    Map<String, String> requestHeaders = (deleteAudioOptions != null) ? deleteAudioOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Lists information about an audio resource for a custom acoustic model.
+   * List an audio resource.
    *
    * Lists information about an audio resource from a custom acoustic model. The method returns an `AudioListing` object whose fields depend on the type of audio resource you specify with the method's `audio_name` parameter: * **For an audio-type resource,** the object's fields match those of an `AudioResource` object: `duration`, `name`, `details`, and `status`. * **For an archive-type resource,** the object includes a `container` field whose fields match those of an `AudioResource` object. It also includes an `audio` field, which contains an array of `AudioResource` objects that provides information about the audio files that are contained in the archive.   The information includes the status of the specified audio resource, which is important for checking the service's analysis of the resource in response to a request to add it to the custom model. You must use credentials for the instance of the service that owns a model to list its audio resources.
    *
@@ -794,12 +1032,18 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.AudioListing getAudio(IBMSpeechToTextV1Models.GetAudioOptions getAudioOptions) {
     IBMWatsonValidator.notNull(getAudioOptions, 'getAudioOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/acoustic_customizations/{0}/audio/{1}', new String[]{ getAudioOptions.customizationId(), getAudioOptions.audioName() }));
+    Map<String, String> requestHeaders = (getAudioOptions != null) ? getAudioOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.AudioListing) createServiceCall(builder.build(), IBMSpeechToTextV1Models.AudioListing.class);
   }
 
   /**
-   * Lists information about all audio resources for a custom acoustic model.
+   * List audio resources.
    *
    * Lists information about all audio resources from a custom acoustic model. The information includes the name of the resource and information about its audio data, such as its duration. It also includes the status of the audio resource, which is important for checking the service's analysis of the resource in response to a request to add it to the custom acoustic model. You must use credentials for the instance of the service that owns a model to list its audio resources.
    *
@@ -809,6 +1053,12 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   public IBMSpeechToTextV1Models.AudioResources listAudio(IBMSpeechToTextV1Models.ListAudioOptions listAudioOptions) {
     IBMWatsonValidator.notNull(listAudioOptions, 'listAudioOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/acoustic_customizations/{0}/audio', new String[]{ listAudioOptions.customizationId() }));
+    Map<String, String> requestHeaders = (listAudioOptions != null) ? listAudioOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMSpeechToTextV1Models.AudioResources) createServiceCall(builder.build(), IBMSpeechToTextV1Models.AudioResources.class);
   }

--- a/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
@@ -414,6 +414,7 @@ public class IBMSpeechToTextV1Models {
       allow_overwrite_serialized_name = addAudioOptions.allow_overwrite_serialized_name;
       audio_serialized_name = addAudioOptions.audio_serialized_name;
       audio_filename_serialized_name = addAudioOptions.audio_filename_serialized_name;
+      this.requestHeaders.putAll(addAudioOptions.requestHeaders());
     }
 
     /**
@@ -613,6 +614,7 @@ public class IBMSpeechToTextV1Models {
       corpus_filename_serialized_name = addCorpusOptions.corpus_filename_serialized_name;
       allow_overwrite_serialized_name = addCorpusOptions.allow_overwrite_serialized_name;
       corpus_file_content_type_serialized_name = addCorpusOptions.corpus_file_content_type_serialized_name;
+      this.requestHeaders.putAll(addCorpusOptions.requestHeaders());
     }
 
     /**
@@ -819,6 +821,7 @@ public class IBMSpeechToTextV1Models {
       word_serialized_name = addWordOptions.word_serialized_name;
       sounds_like_serialized_name = addWordOptions.sounds_like_serialized_name;
       display_as_serialized_name = addWordOptions.display_as_serialized_name;
+      this.requestHeaders.putAll(addWordOptions.requestHeaders());
     }
 
     /**
@@ -986,6 +989,7 @@ public class IBMSpeechToTextV1Models {
     private AddWordsOptionsBuilder(AddWordsOptions addWordsOptions) {
       customization_id_serialized_name = addWordsOptions.customization_id_serialized_name;
       words_serialized_name = addWordsOptions.words_serialized_name;
+      this.requestHeaders.putAll(addWordsOptions.requestHeaders());
     }
 
     /**
@@ -1543,6 +1547,7 @@ public class IBMSpeechToTextV1Models {
 
     private CheckJobOptionsBuilder(CheckJobOptions checkJobOptions) {
       id_serialized_name = checkJobOptions.id_serialized_name;
+      this.requestHeaders.putAll(checkJobOptions.requestHeaders());
     }
 
     /**
@@ -1618,6 +1623,7 @@ public class IBMSpeechToTextV1Models {
   public class CheckJobsOptionsBuilder extends IBMWatsonOptionsModel {
 
     private CheckJobsOptionsBuilder(CheckJobsOptions checkJobsOptions) {
+      this.requestHeaders.putAll(checkJobsOptions.requestHeaders());
     }
 
     /**
@@ -1888,6 +1894,7 @@ public class IBMSpeechToTextV1Models {
       name_serialized_name = createAcousticModelOptions.name_serialized_name;
       base_model_name_serialized_name = createAcousticModelOptions.base_model_name_serialized_name;
       description_serialized_name = createAcousticModelOptions.description_serialized_name;
+      this.requestHeaders.putAll(createAcousticModelOptions.requestHeaders());
     }
 
     /**
@@ -2287,6 +2294,7 @@ public class IBMSpeechToTextV1Models {
       speaker_labels_serialized_name = createJobOptions.speaker_labels_serialized_name;
       audio_serialized_name = createJobOptions.audio_serialized_name;
       audio_filename_serialized_name = createJobOptions.audio_filename_serialized_name;
+      this.requestHeaders.putAll(createJobOptions.requestHeaders());
     }
 
     /**
@@ -2636,6 +2644,7 @@ public class IBMSpeechToTextV1Models {
       base_model_name_serialized_name = createLanguageModelOptions.base_model_name_serialized_name;
       dialect_serialized_name = createLanguageModelOptions.dialect_serialized_name;
       description_serialized_name = createLanguageModelOptions.description_serialized_name;
+      this.requestHeaders.putAll(createLanguageModelOptions.requestHeaders());
     }
 
     /**
@@ -2828,6 +2837,7 @@ public class IBMSpeechToTextV1Models {
 
     private DeleteAcousticModelOptionsBuilder(DeleteAcousticModelOptions deleteAcousticModelOptions) {
       customization_id_serialized_name = deleteAcousticModelOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(deleteAcousticModelOptions.requestHeaders());
     }
 
     /**
@@ -2933,6 +2943,7 @@ public class IBMSpeechToTextV1Models {
     private DeleteAudioOptionsBuilder(DeleteAudioOptions deleteAudioOptions) {
       customization_id_serialized_name = deleteAudioOptions.customization_id_serialized_name;
       audio_name_serialized_name = deleteAudioOptions.audio_name_serialized_name;
+      this.requestHeaders.putAll(deleteAudioOptions.requestHeaders());
     }
 
     /**
@@ -3051,6 +3062,7 @@ public class IBMSpeechToTextV1Models {
     private DeleteCorpusOptionsBuilder(DeleteCorpusOptions deleteCorpusOptions) {
       customization_id_serialized_name = deleteCorpusOptions.customization_id_serialized_name;
       corpus_name_serialized_name = deleteCorpusOptions.corpus_name_serialized_name;
+      this.requestHeaders.putAll(deleteCorpusOptions.requestHeaders());
     }
 
     /**
@@ -3154,6 +3166,7 @@ public class IBMSpeechToTextV1Models {
 
     private DeleteJobOptionsBuilder(DeleteJobOptions deleteJobOptions) {
       id_serialized_name = deleteJobOptions.id_serialized_name;
+      this.requestHeaders.putAll(deleteJobOptions.requestHeaders());
     }
 
     /**
@@ -3244,6 +3257,7 @@ public class IBMSpeechToTextV1Models {
 
     private DeleteLanguageModelOptionsBuilder(DeleteLanguageModelOptions deleteLanguageModelOptions) {
       customization_id_serialized_name = deleteLanguageModelOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(deleteLanguageModelOptions.requestHeaders());
     }
 
     /**
@@ -3349,6 +3363,7 @@ public class IBMSpeechToTextV1Models {
     private DeleteWordOptionsBuilder(DeleteWordOptions deleteWordOptions) {
       customization_id_serialized_name = deleteWordOptions.customization_id_serialized_name;
       word_name_serialized_name = deleteWordOptions.word_name_serialized_name;
+      this.requestHeaders.putAll(deleteWordOptions.requestHeaders());
     }
 
     /**
@@ -3452,6 +3467,7 @@ public class IBMSpeechToTextV1Models {
 
     private GetAcousticModelOptionsBuilder(GetAcousticModelOptions getAcousticModelOptions) {
       customization_id_serialized_name = getAcousticModelOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(getAcousticModelOptions.requestHeaders());
     }
 
     /**
@@ -3557,6 +3573,7 @@ public class IBMSpeechToTextV1Models {
     private GetAudioOptionsBuilder(GetAudioOptions getAudioOptions) {
       customization_id_serialized_name = getAudioOptions.customization_id_serialized_name;
       audio_name_serialized_name = getAudioOptions.audio_name_serialized_name;
+      this.requestHeaders.putAll(getAudioOptions.requestHeaders());
     }
 
     /**
@@ -3675,6 +3692,7 @@ public class IBMSpeechToTextV1Models {
     private GetCorpusOptionsBuilder(GetCorpusOptions getCorpusOptions) {
       customization_id_serialized_name = getCorpusOptions.customization_id_serialized_name;
       corpus_name_serialized_name = getCorpusOptions.corpus_name_serialized_name;
+      this.requestHeaders.putAll(getCorpusOptions.requestHeaders());
     }
 
     /**
@@ -3778,6 +3796,7 @@ public class IBMSpeechToTextV1Models {
 
     private GetLanguageModelOptionsBuilder(GetLanguageModelOptions getLanguageModelOptions) {
       customization_id_serialized_name = getLanguageModelOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(getLanguageModelOptions.requestHeaders());
     }
 
     /**
@@ -3868,6 +3887,7 @@ public class IBMSpeechToTextV1Models {
 
     private GetModelOptionsBuilder(GetModelOptions getModelOptions) {
       model_id_serialized_name = getModelOptions.model_id_serialized_name;
+      this.requestHeaders.putAll(getModelOptions.requestHeaders());
     }
 
     /**
@@ -3973,6 +3993,7 @@ public class IBMSpeechToTextV1Models {
     private GetWordOptionsBuilder(GetWordOptions getWordOptions) {
       customization_id_serialized_name = getWordOptions.customization_id_serialized_name;
       word_name_serialized_name = getWordOptions.word_name_serialized_name;
+      this.requestHeaders.putAll(getWordOptions.requestHeaders());
     }
 
     /**
@@ -4490,6 +4511,7 @@ public class IBMSpeechToTextV1Models {
 
     private ListAcousticModelsOptionsBuilder(ListAcousticModelsOptions listAcousticModelsOptions) {
       language_serialized_name = listAcousticModelsOptions.language_serialized_name;
+      this.requestHeaders.putAll(listAcousticModelsOptions.requestHeaders());
     }
 
     /**
@@ -4571,6 +4593,7 @@ public class IBMSpeechToTextV1Models {
 
     private ListAudioOptionsBuilder(ListAudioOptions listAudioOptions) {
       customization_id_serialized_name = listAudioOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(listAudioOptions.requestHeaders());
     }
 
     /**
@@ -4661,6 +4684,7 @@ public class IBMSpeechToTextV1Models {
 
     private ListCorporaOptionsBuilder(ListCorporaOptions listCorporaOptions) {
       customization_id_serialized_name = listCorporaOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(listCorporaOptions.requestHeaders());
     }
 
     /**
@@ -4750,6 +4774,7 @@ public class IBMSpeechToTextV1Models {
 
     private ListLanguageModelsOptionsBuilder(ListLanguageModelsOptions listLanguageModelsOptions) {
       language_serialized_name = listLanguageModelsOptions.language_serialized_name;
+      this.requestHeaders.putAll(listLanguageModelsOptions.requestHeaders());
     }
 
     /**
@@ -4816,6 +4841,7 @@ public class IBMSpeechToTextV1Models {
   public class ListModelsOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListModelsOptionsBuilder(ListModelsOptions listModelsOptions) {
+      this.requestHeaders.putAll(listModelsOptions.requestHeaders());
     }
 
     /**
@@ -4914,6 +4940,7 @@ public class IBMSpeechToTextV1Models {
       customization_id_serialized_name = listWordsOptions.customization_id_serialized_name;
       word_type_serialized_name = listWordsOptions.word_type_serialized_name;
       sort_serialized_name = listWordsOptions.sort_serialized_name;
+      this.requestHeaders.putAll(listWordsOptions.requestHeaders());
     }
 
     /**
@@ -5287,6 +5314,7 @@ public class IBMSpeechToTextV1Models {
     private RegisterCallbackOptionsBuilder(RegisterCallbackOptions registerCallbackOptions) {
       callback_url_serialized_name = registerCallbackOptions.callback_url_serialized_name;
       user_secret_serialized_name = registerCallbackOptions.user_secret_serialized_name;
+      this.requestHeaders.putAll(registerCallbackOptions.requestHeaders());
     }
 
     /**
@@ -5446,6 +5474,7 @@ public class IBMSpeechToTextV1Models {
 
     private ResetAcousticModelOptionsBuilder(ResetAcousticModelOptions resetAcousticModelOptions) {
       customization_id_serialized_name = resetAcousticModelOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(resetAcousticModelOptions.requestHeaders());
     }
 
     /**
@@ -5536,6 +5565,7 @@ public class IBMSpeechToTextV1Models {
 
     private ResetLanguageModelOptionsBuilder(ResetLanguageModelOptions resetLanguageModelOptions) {
       customization_id_serialized_name = resetLanguageModelOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(resetLanguageModelOptions.requestHeaders());
     }
 
     /**
@@ -6550,6 +6580,7 @@ public class IBMSpeechToTextV1Models {
     private TrainAcousticModelOptionsBuilder(TrainAcousticModelOptions trainAcousticModelOptions) {
       customization_id_serialized_name = trainAcousticModelOptions.customization_id_serialized_name;
       custom_language_model_id_serialized_name = trainAcousticModelOptions.custom_language_model_id_serialized_name;
+      this.requestHeaders.putAll(trainAcousticModelOptions.requestHeaders());
     }
 
     /**
@@ -6679,6 +6710,7 @@ public class IBMSpeechToTextV1Models {
       customization_id_serialized_name = trainLanguageModelOptions.customization_id_serialized_name;
       word_type_to_add_serialized_name = trainLanguageModelOptions.word_type_to_add_serialized_name;
       customization_weight_serialized_name = trainLanguageModelOptions.customization_weight_serialized_name;
+      this.requestHeaders.putAll(trainLanguageModelOptions.requestHeaders());
     }
 
     /**
@@ -6791,6 +6823,7 @@ public class IBMSpeechToTextV1Models {
 
     private UnregisterCallbackOptionsBuilder(UnregisterCallbackOptions unregisterCallbackOptions) {
       callback_url_serialized_name = unregisterCallbackOptions.callback_url_serialized_name;
+      this.requestHeaders.putAll(unregisterCallbackOptions.requestHeaders());
     }
 
     /**
@@ -6895,6 +6928,7 @@ public class IBMSpeechToTextV1Models {
     private UpgradeAcousticModelOptionsBuilder(UpgradeAcousticModelOptions upgradeAcousticModelOptions) {
       customization_id_serialized_name = upgradeAcousticModelOptions.customization_id_serialized_name;
       custom_language_model_id_serialized_name = upgradeAcousticModelOptions.custom_language_model_id_serialized_name;
+      this.requestHeaders.putAll(upgradeAcousticModelOptions.requestHeaders());
     }
 
     /**
@@ -6996,6 +7030,7 @@ public class IBMSpeechToTextV1Models {
 
     private UpgradeLanguageModelOptionsBuilder(UpgradeLanguageModelOptions upgradeLanguageModelOptions) {
       customization_id_serialized_name = upgradeLanguageModelOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(upgradeLanguageModelOptions.requestHeaders());
     }
 
     /**
@@ -7599,6 +7634,7 @@ public class IBMSpeechToTextV1Models {
       customization_id_serialized_name = recognizeOptions.customization_id_serialized_name;
       speaker_labels_serialized_name = recognizeOptions.speaker_labels_serialized_name;
       base_model_version_serialized_name = recognizeOptions.base_model_version_serialized_name;
+      this.requestHeaders.putAll(recognizeOptions.requestHeaders());
     }
 
     public RecognizeOptionsBuilder() {

--- a/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
@@ -500,6 +500,18 @@ public class IBMSpeechToTextV1Models {
       this.audio_filename_serialized_name = audioFilename;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the {{classname}} builder
+     */
+    public AddAudioOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**

--- a/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
@@ -2,7 +2,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * AcousticModel.
    */
-  public class AcousticModel extends IBMWatsonGenericModel {
+  public class AcousticModel extends IBMWatsonResponseModel {
     private String customization_id_serialized_name;
     private String created_serialized_name;
     private String language_serialized_name;
@@ -127,7 +127,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the warnings_serialized_name.
      *
-     * If the request included unknown query parameters, the following message: `Unexpected query parameter(s) ['parameters'] detected`, where `parameters` is a list that includes a quoted string for each unknown parameter.
+     * If the request included unknown parameters, the following message: `Unexpected query parameter(s) ['parameters'] detected`, where `parameters` is a list that includes a quoted string for each unknown parameter.
      *
      * @return the warnings_serialized_name
      */
@@ -249,7 +249,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * AcousticModels.
    */
-  public class AcousticModels extends IBMWatsonGenericModel {
+  public class AcousticModels extends IBMWatsonResponseModel {
     private List<AcousticModel> customizations_serialized_name;
     /**
      * Gets the customizations_serialized_name.
@@ -299,7 +299,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * The addAudio options.
    */
-  public class AddAudioOptions {
+  public class AddAudioOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String audio_name_serialized_name;
     private String content_type_serialized_name;
@@ -311,7 +311,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom acoustic model to which an audio resource is to be added. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -321,7 +321,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the audio_name_serialized_name.
      *
-     * The name of the audio resource that is to be added to the custom acoustic model. The name cannot contain spaces. Use a localized name that matches the language of the custom model.
+     * The name of the audio resource for the custom acoustic model. When adding an audio resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
      *
      * @return the audio_name_serialized_name
      */
@@ -341,7 +341,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the contained_content_type_serialized_name.
      *
-     * For an archive-type resource that contains audio files whose format is not `audio/wav`, specifies the format of the audio files. The header accepts all of the audio formats supported for use with speech recognition and with the `Content-Type` header, including the `rate`, `channels`, and `endianness` parameters that are used with some formats. For a complete list of supported audio formats, see [Audio formats](/docs/services/speech-to-text/input.html#formats).
+     * For an archive-type resource, specifies the format of the audio files contained in the archive file. The parameter accepts all of the audio formats supported for use with speech recognition, including the `rate`, `channels`, and `endianness` parameters that are used with some formats. For a complete list of supported audio formats, see [Audio formats](/docs/services/speech-to-text/input.html#formats).
      *
      * @return the contained_content_type_serialized_name
      */
@@ -351,7 +351,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the allow_overwrite_serialized_name.
      *
-     * Indicates whether the specified audio resource is to overwrite an existing resource with the same name. If a resource with the same name already exists, the request fails unless `allow_overwrite` is set to `true`; by default, the parameter is `false`. The parameter has no effect if a resource with the same name does not already exist.
+     * If `true`, the specified corpus or audio resource overwrites an existing corpus or audio resource with the same name. If `false` (the default), the request fails if a corpus or audio resource with the same name already exists. The parameter has no effect if a corpus or audio resource with the same name does not already exist.
      *
      * @return the allow_overwrite_serialized_name
      */
@@ -380,6 +380,7 @@ public class IBMSpeechToTextV1Models {
       allow_overwrite_serialized_name = builder.allow_overwrite_serialized_name;
       audio_serialized_name = builder.audio_serialized_name;
       audio_filename_serialized_name = builder.audio_filename_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -396,7 +397,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * AddAudioOptions Builder.
    */
-  public class AddAudioOptionsBuilder {
+  public class AddAudioOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String audio_name_serialized_name;
     private String content_type_serialized_name;
@@ -503,7 +504,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * The addCorpus options.
    */
-  public class AddCorpusOptions {
+  public class AddCorpusOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String corpus_name_serialized_name;
     private IBMWatsonFile corpus_file_serialized_name;
@@ -513,7 +514,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model to which a corpus is to be added. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -523,7 +524,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the corpus_name_serialized_name.
      *
-     * The name of the corpus that is to be added to the custom language model. The name cannot contain spaces and cannot be the string `user`, which is reserved by the service to denote custom words added or modified by the user. Use a localized name that matches the language of the custom model.
+     * The name of the corpus for the custom language model. When adding a corpus, do not include spaces in the name; use a localized name that matches the language of the custom model; and do not use the name `user`, which is reserved by the service to denote custom words added or modified by the user.
      *
      * @return the corpus_name_serialized_name
      */
@@ -553,7 +554,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the allow_overwrite_serialized_name.
      *
-     * Indicates whether the specified corpus is to overwrite an existing corpus with the same name. If a corpus with the same name already exists, the request fails unless `allow_overwrite` is set to `true`; by default, the parameter is `false`. The parameter has no effect if a corpus with the same name does not already exist.
+     * If `true`, the specified corpus or audio resource overwrites an existing corpus or audio resource with the same name. If `false` (the default), the request fails if a corpus or audio resource with the same name already exists. The parameter has no effect if a corpus or audio resource with the same name does not already exist.
      *
      * @return the allow_overwrite_serialized_name
      */
@@ -580,6 +581,7 @@ public class IBMSpeechToTextV1Models {
       corpus_filename_serialized_name = builder.corpus_filename_serialized_name;
       allow_overwrite_serialized_name = builder.allow_overwrite_serialized_name;
       corpus_file_content_type_serialized_name = builder.corpus_file_content_type_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -596,7 +598,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * AddCorpusOptions Builder.
    */
-  public class AddCorpusOptionsBuilder {
+  public class AddCorpusOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String corpus_name_serialized_name;
     private IBMWatsonFile corpus_file_serialized_name;
@@ -706,12 +708,24 @@ public class IBMSpeechToTextV1Models {
       this.corpus_file_content_type_serialized_name = corpusFileContentType;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the AddCorpusOptions builder
+     */
+    public AddCorpusOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The addWord options.
    */
-  public class AddWordOptions {
+  public class AddWordOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_name_serialized_name;
     private String word_serialized_name;
@@ -720,7 +734,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model to which a word is to be added. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -730,7 +744,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the word_name_serialized_name.
      *
-     * The custom word that is to be added to or updated in the custom model. Do not include spaces in the word. Use a - (dash) or _ (underscore) to connect the tokens of compound words.
+     * The custom word for the custom language model. When adding or updating a custom word, do not include spaces in the word; use a `-` (dash) or `_` (underscore) to connect the tokens of compound words.
      *
      * @return the word_name_serialized_name
      */
@@ -775,6 +789,7 @@ public class IBMSpeechToTextV1Models {
       word_serialized_name = builder.word_serialized_name;
       sounds_like_serialized_name = builder.sounds_like_serialized_name;
       display_as_serialized_name = builder.display_as_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -791,7 +806,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * AddWordOptions Builder.
    */
-  public class AddWordOptionsBuilder {
+  public class AddWordOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_name_serialized_name;
     private String word_serialized_name;
@@ -902,18 +917,30 @@ public class IBMSpeechToTextV1Models {
       this.display_as_serialized_name = displayAs;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the AddWordOptions builder
+     */
+    public AddWordOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The addWords options.
    */
-  public class AddWordsOptions {
+  public class AddWordsOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private List<CustomWord> words_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model to which words are to be added. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -935,6 +962,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notNull(builder.words_serialized_name, 'words_serialized_name cannot be null');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       words_serialized_name = builder.words_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -951,7 +979,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * AddWordsOptions Builder.
    */
-  public class AddWordsOptionsBuilder {
+  public class AddWordsOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private List<CustomWord> words_serialized_name;
 
@@ -1021,6 +1049,18 @@ public class IBMSpeechToTextV1Models {
      */
     public AddWordsOptionsBuilder words(List<CustomWord> words) {
       this.words_serialized_name = words;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the AddWordsOptions builder
+     */
+    public AddWordsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -1128,7 +1168,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * AudioListing.
    */
-  public class AudioListing extends IBMWatsonGenericModel {
+  public class AudioListing extends IBMWatsonResponseModel {
     private Double duration_serialized_name;
     private String name_serialized_name;
     private AudioDetails details_serialized_name;
@@ -1395,7 +1435,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * AudioResources.
    */
-  public class AudioResources extends IBMWatsonGenericModel {
+  public class AudioResources extends IBMWatsonResponseModel {
     private Double total_minutes_of_audio_serialized_name;
     private List<AudioResource> audio_serialized_name;
     /**
@@ -1466,12 +1506,12 @@ public class IBMSpeechToTextV1Models {
   /**
    * The checkJob options.
    */
-  public class CheckJobOptions {
+  public class CheckJobOptions extends IBMWatsonOptionsModel {
     private String id_serialized_name;
     /**
      * Gets the id_serialized_name.
      *
-     * The ID of the job whose status is to be checked.
+     * The ID of the asynchronous job.
      *
      * @return the id_serialized_name
      */
@@ -1481,6 +1521,7 @@ public class IBMSpeechToTextV1Models {
     private CheckJobOptions(CheckJobOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.id_serialized_name, 'id_serialized_name cannot be empty');
       id_serialized_name = builder.id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1497,7 +1538,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * CheckJobOptions Builder.
    */
-  public class CheckJobOptionsBuilder {
+  public class CheckJobOptionsBuilder extends IBMWatsonOptionsModel {
     private String id_serialized_name;
 
     private CheckJobOptionsBuilder(CheckJobOptions checkJobOptions) {
@@ -1538,13 +1579,26 @@ public class IBMSpeechToTextV1Models {
       this.id_serialized_name = id;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CheckJobOptions builder
+     */
+    public CheckJobOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The checkJobs options.
    */
-  public class CheckJobsOptions {
+  public class CheckJobsOptions extends IBMWatsonOptionsModel {
     private CheckJobsOptions(CheckJobsOptionsBuilder builder) {
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1561,7 +1615,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * CheckJobsOptions Builder.
    */
-  public class CheckJobsOptionsBuilder {
+  public class CheckJobsOptionsBuilder extends IBMWatsonOptionsModel {
 
     private CheckJobsOptionsBuilder(CheckJobsOptions checkJobsOptions) {
     }
@@ -1580,12 +1634,24 @@ public class IBMSpeechToTextV1Models {
     public CheckJobsOptions build() {
       return new CheckJobsOptions(this);
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CheckJobsOptions builder
+     */
+    public CheckJobsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * Corpora.
    */
-  public class Corpora extends IBMWatsonGenericModel {
+  public class Corpora extends IBMWatsonResponseModel {
     private List<Corpus> corpora_serialized_name;
     /**
      * Gets the corpora_serialized_name.
@@ -1635,7 +1701,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * Corpus.
    */
-  public class Corpus extends IBMWatsonGenericModel {
+  public class Corpus extends IBMWatsonResponseModel {
     private String name_serialized_name;
     private Long total_words_serialized_name;
     private Long out_of_vocabulary_words_serialized_name;
@@ -1756,7 +1822,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * The createAcousticModel options.
    */
-  public class CreateAcousticModelOptions {
+  public class CreateAcousticModelOptions extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String base_model_name_serialized_name;
     private String description_serialized_name;
@@ -1796,6 +1862,7 @@ public class IBMSpeechToTextV1Models {
       name_serialized_name = builder.name_serialized_name;
       base_model_name_serialized_name = builder.base_model_name_serialized_name;
       description_serialized_name = builder.description_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1812,7 +1879,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * CreateAcousticModelOptions Builder.
    */
-  public class CreateAcousticModelOptionsBuilder {
+  public class CreateAcousticModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String base_model_name_serialized_name;
     private String description_serialized_name;
@@ -1881,12 +1948,24 @@ public class IBMSpeechToTextV1Models {
       this.description_serialized_name = description;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateAcousticModelOptions builder
+     */
+    public CreateAcousticModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The createJob options.
    */
-  public class CreateJobOptions {
+  public class CreateJobOptions extends IBMWatsonOptionsModel {
     private String content_type_serialized_name;
     private String model_serialized_name;
     private String callback_url_serialized_name;
@@ -1895,8 +1974,8 @@ public class IBMSpeechToTextV1Models {
     private Long results_ttl_serialized_name;
     private String customization_id_serialized_name;
     private String acoustic_customization_id_serialized_name;
+    private String base_model_version_serialized_name;
     private Double customization_weight_serialized_name;
-    private String version_serialized_name;
     private Long inactivity_timeout_serialized_name;
     private List<String> keywords_serialized_name;
     private Double keywords_threshold_serialized_name;
@@ -1923,7 +2002,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the model_serialized_name.
      *
-     * The identifier of the model to be used for the recognition request. (Use `GET /v1/models` for a list of available models.).
+     * The identifier of the model that is to be used for the recognition request or, for the **Create a session** method, with the new session.
      *
      * @return the model_serialized_name
      */
@@ -1933,7 +2012,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the callback_url_serialized_name.
      *
-     * A URL to which callback notifications are to be sent. The URL must already be successfully white-listed by using the `POST /v1/register_callback` method. Omit the parameter to poll the service for job completion and results. You can include the same callback URL with any number of job creation requests. Use the `user_token` query parameter to specify a unique user-specified string with each job to differentiate the callback notifications for the jobs.
+     * A URL to which callback notifications are to be sent. The URL must already be successfully white-listed by using the **Register a callback** method. Omit the parameter to poll the service for job completion and results. You can include the same callback URL with any number of job creation requests. Use the `user_token` parameter to specify a unique user-specified string with each job to differentiate the callback notifications for the jobs.
      *
      * @return the callback_url_serialized_name
      */
@@ -1943,7 +2022,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the events_serialized_name.
      *
-     * If the job includes a callback URL, a comma-separated list of notification events to which to subscribe. Valid events are: `recognitions.started` generates a callback notification when the service begins to process the job. `recognitions.completed` generates a callback notification when the job is complete; you must use the `GET /v1/recognitions/{id}` method to retrieve the results before they time out or are deleted. `recognitions.completed_with_results` generates a callback notification when the job is complete; the notification includes the results of the request. `recognitions.failed` generates a callback notification if the service experiences an error while processing the job. Omit the parameter to subscribe to the default events: `recognitions.started`, `recognitions.completed`, and `recognitions.failed`. The `recognitions.completed` and `recognitions.completed_with_results` events are incompatible; you can specify only of the two events. If the job does not include a callback URL, omit the parameter.
+     * If the job includes a callback URL, a comma-separated list of notification events to which to subscribe. Valid events are: `recognitions.started` generates a callback notification when the service begins to process the job. `recognitions.completed` generates a callback notification when the job is complete; you must use the **Check a job** method to retrieve the results before they time out or are deleted. `recognitions.completed_with_results` generates a callback notification when the job is complete; the notification includes the results of the request. `recognitions.failed` generates a callback notification if the service experiences an error while processing the job. Omit the parameter to subscribe to the default events: `recognitions.started`, `recognitions.completed`, and `recognitions.failed`. The `recognitions.completed` and `recognitions.completed_with_results` events are incompatible; you can specify only of the two events. If the job does not include a callback URL, omit the parameter.
      *
      * @return the events_serialized_name
      */
@@ -1973,7 +2052,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of a custom language model that is to be used with the request. The base model of the specified custom language model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom language model is used.
+     * The customization ID (GUID) of a custom language model that is to be used with the recognition request or, for the **Create a session** method, with the new session. The base model of the specified custom language model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom language model is used.
      *
      * @return the customization_id_serialized_name
      */
@@ -1983,7 +2062,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the acoustic_customization_id_serialized_name.
      *
-     * The GUID of a custom acoustic model that is to be used with the request. The base model of the specified custom acoustic model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom acoustic model is used.
+     * The customization ID (GUID) of a custom acoustic model that is to be used with the recognition request or, for the **Create a session** method, with the new session. The base model of the specified custom acoustic model must match the model specified with the `model` parameter. You must make the request with service credentials created for the instance of the service that owns the custom model. By default, no custom acoustic model is used.
      *
      * @return the acoustic_customization_id_serialized_name
      */
@@ -1991,24 +2070,24 @@ public class IBMSpeechToTextV1Models {
       return acoustic_customization_id_serialized_name;
     }
     /**
+     * Gets the base_model_version_serialized_name.
+     *
+     * The version of the specified base model that is to be used with recognition request or, for the **Create a session** method, with the new session. Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model. The default value depends on whether the parameter is used with or without a custom model. For more information, see [Base model version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
+     *
+     * @return the base_model_version_serialized_name
+     */
+    public String baseModelVersion() {
+      return base_model_version_serialized_name;
+    }
+    /**
      * Gets the customization_weight_serialized_name.
      *
-     * If you specify a `customization_id` with the request, you can use the `customization_weight` parameter to tell the service how much weight to give to words from the custom language model compared to those from the base model for speech recognition.   Specify a value between 0.0 and 1.0. Unless a different customization weight was specified for the custom model when it was trained, the default value is 0.3. A customization weight that you specify overrides a weight that was specified when the custom model was trained.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect  performance on non-domain phrases.
+     * If you specify the customization ID (GUID) of a custom language model with the recognition request or, for sessions, with the **Create a session** method, the customization weight tells the service how much weight to give to words from the custom language model compared to those from the base model for the current request.   Specify a value between 0.0 and 1.0. Unless a different customization weight was specified for the custom model when it was trained, the default value is 0.3. A customization weight that you specify overrides a weight that was specified when the custom model was trained.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.
      *
      * @return the customization_weight_serialized_name
      */
     public Double customizationWeight() {
       return customization_weight_serialized_name;
-    }
-    /**
-     * Gets the version_serialized_name.
-     *
-     * The version of the specified base `model` that is to be used with the request. Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model. The default value depends on whether the parameter is used with or without a custom model. For more information, see [Base model version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
-     *
-     * @return the version_serialized_name
-     */
-    public String version() {
-      return version_serialized_name;
     }
     /**
      * Gets the inactivity_timeout_serialized_name.
@@ -2023,7 +2102,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the keywords_serialized_name.
      *
-     * Array of keyword strings to spot in the audio. Each keyword string can include one or more tokens. Keywords are spotted only in the final hypothesis, not in interim results. If you specify any keywords, you must also specify a keywords threshold. Omit the parameter or specify an empty array if you do not need to spot keywords.
+     * An array of keyword strings to spot in the audio. Each keyword string can include one or more tokens. Keywords are spotted only in the final hypothesis, not in interim results. If you specify any keywords, you must also specify a keywords threshold. You can spot a maximum of 1000 keywords. Omit the parameter or specify an empty array if you do not need to spot keywords.
      *
      * @return the keywords_serialized_name
      */
@@ -2033,7 +2112,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the keywords_threshold_serialized_name.
      *
-     * Confidence value that is the lower bound for spotting a keyword. A word is considered to match a keyword if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No keyword spotting is performed if you omit the parameter. If you specify a threshold, you must also specify one or more keywords.
+     * A confidence value that is the lower bound for spotting a keyword. A word is considered to match a keyword if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No keyword spotting is performed if you omit the parameter. If you specify a threshold, you must also specify one or more keywords.
      *
      * @return the keywords_threshold_serialized_name
      */
@@ -2043,7 +2122,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the max_alternatives_serialized_name.
      *
-     * Maximum number of alternative transcripts to be returned. By default, a single transcription is returned.
+     * The maximum number of alternative transcripts to be returned. By default, a single transcription is returned.
      *
      * @return the max_alternatives_serialized_name
      */
@@ -2053,7 +2132,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the word_alternatives_threshold_serialized_name.
      *
-     * Confidence value that is the lower bound for identifying a hypothesis as a possible word alternative (also known as "Confusion Networks"). An alternative word is considered if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No alternative words are computed if you omit the parameter.
+     * A confidence value that is the lower bound for identifying a hypothesis as a possible word alternative (also known as "Confusion Networks"). An alternative word is considered if its confidence is greater than or equal to the threshold. Specify a probability between 0 and 1 inclusive. No alternative words are computed if you omit the parameter.
      *
      * @return the word_alternatives_threshold_serialized_name
      */
@@ -2063,7 +2142,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the word_confidence_serialized_name.
      *
-     * If `true`, confidence measure per word is returned.
+     * If `true`, a confidence measure in the range of 0 to 1 is returned for each word. By default, no word confidence measures are returned.
      *
      * @return the word_confidence_serialized_name
      */
@@ -2073,7 +2152,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the timestamps_serialized_name.
      *
-     * If `true`, time alignment for each word is returned.
+     * If `true`, time alignment is returned for each word. By default, no timestamps are returned.
      *
      * @return the timestamps_serialized_name
      */
@@ -2093,7 +2172,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the smart_formatting_serialized_name.
      *
-     * If `true`, converts dates, times, series of digits and numbers, phone numbers, currency values, and Internet addresses into more readable, conventional representations in the final transcript of a recognition request. If `false` (the default), no formatting is performed. Applies to US English transcription only.
+     * If `true`, converts dates, times, series of digits and numbers, phone numbers, currency values, and Internet addresses into more readable, conventional representations in the final transcript of a recognition request. By default, no smart formatting is performed. Applies to US English transcription only.
      *
      * @return the smart_formatting_serialized_name
      */
@@ -2103,7 +2182,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the speaker_labels_serialized_name.
      *
-     * Indicates whether labels that identify which words were spoken by which participants in a multi-person exchange are to be included in the response. The default is `false`; no speaker labels are returned. Setting `speaker_labels` to `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.   To determine whether a language model supports speaker labels, use the `GET /v1/models` method and check that the attribute `speaker_labels` is set to `true`. You can also refer to [Speaker labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
+     * If `true`, the response includes labels that identify which words were spoken by which participants in a multi-person exchange. By default, no speaker labels are returned. Setting `speaker_labels` to `true` forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.   To determine whether a language model supports speaker labels, use the **Get models** method and check that the attribute `speaker_labels` is set to `true`. You can also refer to [Speaker labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
      *
      * @return the speaker_labels_serialized_name
      */
@@ -2122,8 +2201,6 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.isTrue(builder.content_type_serialized_name != null, 'content_type_serialized_name cannot be null');
       IBMWatsonValidator.notNull(builder.audio_serialized_name, 'audio cannot be null');
       IBMWatsonValidator.notEmpty(builder.audio_filename_serialized_name, 'audioFilename cannot be null');
-      audio_serialized_name = builder.audio_serialized_name;
-      audio_filename_serialized_name = builder.audio_filename_serialized_name;
       content_type_serialized_name = builder.content_type_serialized_name;
       model_serialized_name = builder.model_serialized_name;
       callback_url_serialized_name = builder.callback_url_serialized_name;
@@ -2132,8 +2209,8 @@ public class IBMSpeechToTextV1Models {
       results_ttl_serialized_name = builder.results_ttl_serialized_name;
       customization_id_serialized_name = builder.customization_id_serialized_name;
       acoustic_customization_id_serialized_name = builder.acoustic_customization_id_serialized_name;
+      base_model_version_serialized_name = builder.base_model_version_serialized_name;
       customization_weight_serialized_name = builder.customization_weight_serialized_name;
-      version_serialized_name = builder.version_serialized_name;
       inactivity_timeout_serialized_name = builder.inactivity_timeout_serialized_name;
       keywords_serialized_name = builder.keywords_serialized_name;
       keywords_threshold_serialized_name = builder.keywords_threshold_serialized_name;
@@ -2144,6 +2221,9 @@ public class IBMSpeechToTextV1Models {
       profanity_filter_serialized_name = builder.profanity_filter_serialized_name;
       smart_formatting_serialized_name = builder.smart_formatting_serialized_name;
       speaker_labels_serialized_name = builder.speaker_labels_serialized_name;
+      audio_serialized_name = builder.audio_serialized_name;
+      audio_filename_serialized_name = builder.audio_filename_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2160,7 +2240,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * CreateJobOptions Builder.
    */
-  public class CreateJobOptionsBuilder {
+  public class CreateJobOptionsBuilder extends IBMWatsonOptionsModel {
     private String content_type_serialized_name;
     private String model_serialized_name;
     private String callback_url_serialized_name;
@@ -2169,8 +2249,8 @@ public class IBMSpeechToTextV1Models {
     private Long results_ttl_serialized_name;
     private String customization_id_serialized_name;
     private String acoustic_customization_id_serialized_name;
+    private String base_model_version_serialized_name;
     private Double customization_weight_serialized_name;
-    private String version_serialized_name;
     private Long inactivity_timeout_serialized_name;
     private List<String> keywords_serialized_name;
     private Double keywords_threshold_serialized_name;
@@ -2193,8 +2273,8 @@ public class IBMSpeechToTextV1Models {
       results_ttl_serialized_name = createJobOptions.results_ttl_serialized_name;
       customization_id_serialized_name = createJobOptions.customization_id_serialized_name;
       acoustic_customization_id_serialized_name = createJobOptions.acoustic_customization_id_serialized_name;
+      base_model_version_serialized_name = createJobOptions.base_model_version_serialized_name;
       customization_weight_serialized_name = createJobOptions.customization_weight_serialized_name;
-      version_serialized_name = createJobOptions.version_serialized_name;
       inactivity_timeout_serialized_name = createJobOptions.inactivity_timeout_serialized_name;
       keywords_serialized_name = createJobOptions.keywords_serialized_name;
       keywords_threshold_serialized_name = createJobOptions.keywords_threshold_serialized_name;
@@ -2317,6 +2397,17 @@ public class IBMSpeechToTextV1Models {
     }
 
     /**
+     * Set the base_model_version_serialized_name.
+     *
+     * @param baseModelVersion the baseModelVersion
+     * @return the CreateJobOptions builder
+     */
+    public CreateJobOptionsBuilder baseModelVersion(String baseModelVersion) {
+      this.base_model_version_serialized_name = baseModelVersion;
+      return this;
+    }
+
+    /**
      * Set the customization_weight_serialized_name.
      *
      * @param customizationWeight the customizationWeight
@@ -2324,17 +2415,6 @@ public class IBMSpeechToTextV1Models {
      */
     public CreateJobOptionsBuilder customizationWeight(Double customizationWeight) {
       this.customization_weight_serialized_name = customizationWeight;
-      return this;
-    }
-
-    /**
-     * Set the version_serialized_name.
-     *
-     * @param version the version
-     * @return the CreateJobOptions builder
-     */
-    public CreateJobOptionsBuilder version(String version) {
-      this.version_serialized_name = version;
       return this;
     }
 
@@ -2459,12 +2539,24 @@ public class IBMSpeechToTextV1Models {
       this.audio_filename_serialized_name = audioFilename;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateJobOptions builder
+     */
+    public CreateJobOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The createLanguageModel options.
    */
-  public class CreateLanguageModelOptions {
+  public class CreateLanguageModelOptions extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String base_model_name_serialized_name;
     private String dialect_serialized_name;
@@ -2516,6 +2608,7 @@ public class IBMSpeechToTextV1Models {
       base_model_name_serialized_name = builder.base_model_name_serialized_name;
       dialect_serialized_name = builder.dialect_serialized_name;
       description_serialized_name = builder.description_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2532,7 +2625,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * CreateLanguageModelOptions Builder.
    */
-  public class CreateLanguageModelOptionsBuilder {
+  public class CreateLanguageModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String base_model_name_serialized_name;
     private String dialect_serialized_name;
@@ -2614,12 +2707,24 @@ public class IBMSpeechToTextV1Models {
       this.description_serialized_name = description;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateLanguageModelOptions builder
+     */
+    public CreateLanguageModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * CustomWord.
    */
-  public class CustomWord extends IBMWatsonGenericModel {
+  public class CustomWord {
     private String word_serialized_name;
     private List<String> sounds_like_serialized_name;
     private String display_as_serialized_name;
@@ -2630,7 +2735,6 @@ public class IBMSpeechToTextV1Models {
      *
      * @return the word_serialized_name
      */
-    @AuraEnabled
     public String getWord() {
       return word_serialized_name;
     }
@@ -2641,7 +2745,6 @@ public class IBMSpeechToTextV1Models {
      *
      * @return the sounds_like_serialized_name
      */
-    @AuraEnabled
     public List<String> getSoundsLike() {
       return sounds_like_serialized_name;
     }
@@ -2652,7 +2755,6 @@ public class IBMSpeechToTextV1Models {
      *
      * @return the display_as_serialized_name
      */
-    @AuraEnabled
     public String getDisplayAs() {
       return display_as_serialized_name;
     }
@@ -2684,26 +2786,17 @@ public class IBMSpeechToTextV1Models {
       this.display_as_serialized_name = displayAs;
     }
 
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      CustomWord ret = (CustomWord) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
   }
 
   /**
    * The deleteAcousticModel options.
    */
-  public class DeleteAcousticModelOptions {
+  public class DeleteAcousticModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom acoustic model that is to be deleted. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -2713,6 +2806,7 @@ public class IBMSpeechToTextV1Models {
     private DeleteAcousticModelOptions(DeleteAcousticModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2729,7 +2823,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * DeleteAcousticModelOptions Builder.
    */
-  public class DeleteAcousticModelOptionsBuilder {
+  public class DeleteAcousticModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private DeleteAcousticModelOptionsBuilder(DeleteAcousticModelOptions deleteAcousticModelOptions) {
@@ -2770,18 +2864,30 @@ public class IBMSpeechToTextV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteAcousticModelOptions builder
+     */
+    public DeleteAcousticModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteAudio options.
    */
-  public class DeleteAudioOptions {
+  public class DeleteAudioOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String audio_name_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom acoustic model from which an audio resource is to be deleted. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -2791,7 +2897,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the audio_name_serialized_name.
      *
-     * The name of the audio resource that is to be deleted from the custom acoustic model.
+     * The name of the audio resource for the custom acoustic model. When adding an audio resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
      *
      * @return the audio_name_serialized_name
      */
@@ -2803,6 +2909,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notEmpty(builder.audio_name_serialized_name, 'audio_name_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       audio_name_serialized_name = builder.audio_name_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2819,7 +2926,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * DeleteAudioOptions Builder.
    */
-  public class DeleteAudioOptionsBuilder {
+  public class DeleteAudioOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String audio_name_serialized_name;
 
@@ -2875,18 +2982,30 @@ public class IBMSpeechToTextV1Models {
       this.audio_name_serialized_name = audioName;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteAudioOptions builder
+     */
+    public DeleteAudioOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteCorpus options.
    */
-  public class DeleteCorpusOptions {
+  public class DeleteCorpusOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String corpus_name_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model from which a corpus is to be deleted. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -2896,7 +3015,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the corpus_name_serialized_name.
      *
-     * The name of the corpus that is to be deleted from the custom language model.
+     * The name of the corpus for the custom language model. When adding a corpus, do not include spaces in the name; use a localized name that matches the language of the custom model; and do not use the name `user`, which is reserved by the service to denote custom words added or modified by the user.
      *
      * @return the corpus_name_serialized_name
      */
@@ -2908,6 +3027,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notEmpty(builder.corpus_name_serialized_name, 'corpus_name_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       corpus_name_serialized_name = builder.corpus_name_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2924,7 +3044,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * DeleteCorpusOptions Builder.
    */
-  public class DeleteCorpusOptionsBuilder {
+  public class DeleteCorpusOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String corpus_name_serialized_name;
 
@@ -2980,17 +3100,29 @@ public class IBMSpeechToTextV1Models {
       this.corpus_name_serialized_name = corpusName;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteCorpusOptions builder
+     */
+    public DeleteCorpusOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteJob options.
    */
-  public class DeleteJobOptions {
+  public class DeleteJobOptions extends IBMWatsonOptionsModel {
     private String id_serialized_name;
     /**
      * Gets the id_serialized_name.
      *
-     * The ID of the job that is to be deleted.
+     * The ID of the asynchronous job.
      *
      * @return the id_serialized_name
      */
@@ -3000,6 +3132,7 @@ public class IBMSpeechToTextV1Models {
     private DeleteJobOptions(DeleteJobOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.id_serialized_name, 'id_serialized_name cannot be empty');
       id_serialized_name = builder.id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3016,7 +3149,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * DeleteJobOptions Builder.
    */
-  public class DeleteJobOptionsBuilder {
+  public class DeleteJobOptionsBuilder extends IBMWatsonOptionsModel {
     private String id_serialized_name;
 
     private DeleteJobOptionsBuilder(DeleteJobOptions deleteJobOptions) {
@@ -3057,17 +3190,29 @@ public class IBMSpeechToTextV1Models {
       this.id_serialized_name = id;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteJobOptions builder
+     */
+    public DeleteJobOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteLanguageModel options.
    */
-  public class DeleteLanguageModelOptions {
+  public class DeleteLanguageModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model that is to be deleted. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -3077,6 +3222,7 @@ public class IBMSpeechToTextV1Models {
     private DeleteLanguageModelOptions(DeleteLanguageModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3093,7 +3239,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * DeleteLanguageModelOptions Builder.
    */
-  public class DeleteLanguageModelOptionsBuilder {
+  public class DeleteLanguageModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private DeleteLanguageModelOptionsBuilder(DeleteLanguageModelOptions deleteLanguageModelOptions) {
@@ -3134,18 +3280,30 @@ public class IBMSpeechToTextV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteLanguageModelOptions builder
+     */
+    public DeleteLanguageModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteWord options.
    */
-  public class DeleteWordOptions {
+  public class DeleteWordOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_name_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model from which a word is to be deleted. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -3155,7 +3313,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the word_name_serialized_name.
      *
-     * The custom word that is to be deleted from the custom language model.
+     * The custom word for the custom language model. When adding or updating a custom word, do not include spaces in the word; use a `-` (dash) or `_` (underscore) to connect the tokens of compound words.
      *
      * @return the word_name_serialized_name
      */
@@ -3167,6 +3325,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notEmpty(builder.word_name_serialized_name, 'word_name_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       word_name_serialized_name = builder.word_name_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3183,7 +3342,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * DeleteWordOptions Builder.
    */
-  public class DeleteWordOptionsBuilder {
+  public class DeleteWordOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_name_serialized_name;
 
@@ -3239,17 +3398,29 @@ public class IBMSpeechToTextV1Models {
       this.word_name_serialized_name = wordName;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteWordOptions builder
+     */
+    public DeleteWordOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getAcousticModel options.
    */
-  public class GetAcousticModelOptions {
+  public class GetAcousticModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom acoustic model for which information is to be returned. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -3259,6 +3430,7 @@ public class IBMSpeechToTextV1Models {
     private GetAcousticModelOptions(GetAcousticModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3275,7 +3447,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * GetAcousticModelOptions Builder.
    */
-  public class GetAcousticModelOptionsBuilder {
+  public class GetAcousticModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private GetAcousticModelOptionsBuilder(GetAcousticModelOptions getAcousticModelOptions) {
@@ -3316,18 +3488,30 @@ public class IBMSpeechToTextV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetAcousticModelOptions builder
+     */
+    public GetAcousticModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getAudio options.
    */
-  public class GetAudioOptions {
+  public class GetAudioOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String audio_name_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom acoustic model for which an audio resource is to be listed. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -3337,7 +3521,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the audio_name_serialized_name.
      *
-     * The name of the audio resource about which information is to be listed.
+     * The name of the audio resource for the custom acoustic model. When adding an audio resource, do not include spaces in the name; use a localized name that matches the language of the custom model.
      *
      * @return the audio_name_serialized_name
      */
@@ -3349,6 +3533,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notEmpty(builder.audio_name_serialized_name, 'audio_name_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       audio_name_serialized_name = builder.audio_name_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3365,7 +3550,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * GetAudioOptions Builder.
    */
-  public class GetAudioOptionsBuilder {
+  public class GetAudioOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String audio_name_serialized_name;
 
@@ -3421,18 +3606,30 @@ public class IBMSpeechToTextV1Models {
       this.audio_name_serialized_name = audioName;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetAudioOptions builder
+     */
+    public GetAudioOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getCorpus options.
    */
-  public class GetCorpusOptions {
+  public class GetCorpusOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String corpus_name_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model for which a corpus is to be listed. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -3442,7 +3639,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the corpus_name_serialized_name.
      *
-     * The name of the corpus about which information is to be listed.
+     * The name of the corpus for the custom language model. When adding a corpus, do not include spaces in the name; use a localized name that matches the language of the custom model; and do not use the name `user`, which is reserved by the service to denote custom words added or modified by the user.
      *
      * @return the corpus_name_serialized_name
      */
@@ -3454,6 +3651,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notEmpty(builder.corpus_name_serialized_name, 'corpus_name_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       corpus_name_serialized_name = builder.corpus_name_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3470,7 +3668,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * GetCorpusOptions Builder.
    */
-  public class GetCorpusOptionsBuilder {
+  public class GetCorpusOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String corpus_name_serialized_name;
 
@@ -3526,17 +3724,29 @@ public class IBMSpeechToTextV1Models {
       this.corpus_name_serialized_name = corpusName;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetCorpusOptions builder
+     */
+    public GetCorpusOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getLanguageModel options.
    */
-  public class GetLanguageModelOptions {
+  public class GetLanguageModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model for which information is to be returned. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -3546,6 +3756,7 @@ public class IBMSpeechToTextV1Models {
     private GetLanguageModelOptions(GetLanguageModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3562,7 +3773,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * GetLanguageModelOptions Builder.
    */
-  public class GetLanguageModelOptionsBuilder {
+  public class GetLanguageModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private GetLanguageModelOptionsBuilder(GetLanguageModelOptions getLanguageModelOptions) {
@@ -3603,17 +3814,29 @@ public class IBMSpeechToTextV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetLanguageModelOptions builder
+     */
+    public GetLanguageModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getModel options.
    */
-  public class GetModelOptions {
+  public class GetModelOptions extends IBMWatsonOptionsModel {
     private String model_id_serialized_name;
     /**
      * Gets the model_id_serialized_name.
      *
-     * The identifier of the desired model in the form of its `name` from the output of `GET /v1/models`.
+     * The identifier of the model in the form of its name from the output of the **Get models** method.
      *
      * @return the model_id_serialized_name
      */
@@ -3623,6 +3846,7 @@ public class IBMSpeechToTextV1Models {
     private GetModelOptions(GetModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.model_id_serialized_name, 'model_id_serialized_name cannot be empty');
       model_id_serialized_name = builder.model_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3639,7 +3863,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * GetModelOptions Builder.
    */
-  public class GetModelOptionsBuilder {
+  public class GetModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String model_id_serialized_name;
 
     private GetModelOptionsBuilder(GetModelOptions getModelOptions) {
@@ -3680,18 +3904,30 @@ public class IBMSpeechToTextV1Models {
       this.model_id_serialized_name = modelId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetModelOptions builder
+     */
+    public GetModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getWord options.
    */
-  public class GetWordOptions {
+  public class GetWordOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_name_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model from which a word is to be queried. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -3701,7 +3937,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the word_name_serialized_name.
      *
-     * The custom word that is to be queried from the custom language model.
+     * The custom word for the custom language model. When adding or updating a custom word, do not include spaces in the word; use a `-` (dash) or `_` (underscore) to connect the tokens of compound words.
      *
      * @return the word_name_serialized_name
      */
@@ -3713,6 +3949,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notEmpty(builder.word_name_serialized_name, 'word_name_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       word_name_serialized_name = builder.word_name_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -3729,7 +3966,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * GetWordOptions Builder.
    */
-  public class GetWordOptionsBuilder {
+  public class GetWordOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_name_serialized_name;
 
@@ -3785,6 +4022,18 @@ public class IBMSpeechToTextV1Models {
       this.word_name_serialized_name = wordName;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetWordOptions builder
+     */
+    public GetWordOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
@@ -3802,7 +4051,6 @@ public class IBMSpeechToTextV1Models {
      *
      * @return the normalized_text_serialized_name
      */
-    @AuraEnabled
     public String getNormalizedText() {
       return normalized_text_serialized_name;
     }
@@ -3813,7 +4061,6 @@ public class IBMSpeechToTextV1Models {
      *
      * @return the start_time_serialized_name
      */
-    @AuraEnabled
     public Double getStartTime() {
       return start_time_serialized_name;
     }
@@ -3824,7 +4071,6 @@ public class IBMSpeechToTextV1Models {
      *
      * @return the end_time_serialized_name
      */
-    @AuraEnabled
     public Double getEndTime() {
       return end_time_serialized_name;
     }
@@ -3835,7 +4081,6 @@ public class IBMSpeechToTextV1Models {
      *
      * @return the confidence_serialized_name
      */
-    @AuraEnabled
     public Double getConfidence() {
       return confidence_serialized_name;
     }
@@ -3885,12 +4130,13 @@ public class IBMSpeechToTextV1Models {
 
       return ret;
     }
+
   }
 
   /**
    * LanguageModel.
    */
-  public class LanguageModel extends IBMWatsonGenericModel {
+  public class LanguageModel extends IBMWatsonResponseModel {
     private String customization_id_serialized_name;
     private String created_serialized_name;
     private String language_serialized_name;
@@ -4027,7 +4273,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the warnings_serialized_name.
      *
-     * If the request included unknown query parameters, the following message: `Unexpected query parameter(s) ['parameters'] detected`, where `parameters` is a list that includes a quoted string for each unknown parameter.
+     * If the request included unknown parameters, the following message: `Unexpected query parameter(s) ['parameters'] detected`, where `parameters` is a list that includes a quoted string for each unknown parameter.
      *
      * @return the warnings_serialized_name
      */
@@ -4158,7 +4404,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * LanguageModels.
    */
-  public class LanguageModels extends IBMWatsonGenericModel {
+  public class LanguageModels extends IBMWatsonResponseModel {
     private List<LanguageModel> customizations_serialized_name;
     /**
      * Gets the customizations_serialized_name.
@@ -4208,12 +4454,12 @@ public class IBMSpeechToTextV1Models {
   /**
    * The listAcousticModels options.
    */
-  public class ListAcousticModelsOptions {
+  public class ListAcousticModelsOptions extends IBMWatsonOptionsModel {
     private String language_serialized_name;
     /**
      * Gets the language_serialized_name.
      *
-     * The identifier of the language for which custom acoustic models are to be returned (for example, `en-US`). Omit the parameter to see all custom acoustic models owned by the requesting service credentials.
+     * The identifier of the language for which custom language or custom acoustic models are to be returned (for example, `en-US`). Omit the parameter to see all custom language or custom acoustic models owned by the requesting service credentials.
      *
      * @return the language_serialized_name
      */
@@ -4222,6 +4468,7 @@ public class IBMSpeechToTextV1Models {
     }
     private ListAcousticModelsOptions(ListAcousticModelsOptionsBuilder builder) {
       language_serialized_name = builder.language_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4238,7 +4485,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * ListAcousticModelsOptions Builder.
    */
-  public class ListAcousticModelsOptionsBuilder {
+  public class ListAcousticModelsOptionsBuilder extends IBMWatsonOptionsModel {
     private String language_serialized_name;
 
     private ListAcousticModelsOptionsBuilder(ListAcousticModelsOptions listAcousticModelsOptions) {
@@ -4270,17 +4517,29 @@ public class IBMSpeechToTextV1Models {
       this.language_serialized_name = language;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListAcousticModelsOptions builder
+     */
+    public ListAcousticModelsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listAudio options.
    */
-  public class ListAudioOptions {
+  public class ListAudioOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom acoustic model for which audio resources are to be listed. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -4290,6 +4549,7 @@ public class IBMSpeechToTextV1Models {
     private ListAudioOptions(ListAudioOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4306,7 +4566,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * ListAudioOptions Builder.
    */
-  public class ListAudioOptionsBuilder {
+  public class ListAudioOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private ListAudioOptionsBuilder(ListAudioOptions listAudioOptions) {
@@ -4347,17 +4607,29 @@ public class IBMSpeechToTextV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListAudioOptions builder
+     */
+    public ListAudioOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listCorpora options.
    */
-  public class ListCorporaOptions {
+  public class ListCorporaOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model for which corpora are to be listed. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -4367,6 +4639,7 @@ public class IBMSpeechToTextV1Models {
     private ListCorporaOptions(ListCorporaOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4383,7 +4656,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * ListCorporaOptions Builder.
    */
-  public class ListCorporaOptionsBuilder {
+  public class ListCorporaOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private ListCorporaOptionsBuilder(ListCorporaOptions listCorporaOptions) {
@@ -4424,17 +4697,29 @@ public class IBMSpeechToTextV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListCorporaOptions builder
+     */
+    public ListCorporaOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listLanguageModels options.
    */
-  public class ListLanguageModelsOptions {
+  public class ListLanguageModelsOptions extends IBMWatsonOptionsModel {
     private String language_serialized_name;
     /**
      * Gets the language_serialized_name.
      *
-     * The identifier of the language for which custom language models are to be returned (for example, `en-US`). Omit the parameter to see all custom language models owned by the requesting service credentials.
+     * The identifier of the language for which custom language or custom acoustic models are to be returned (for example, `en-US`). Omit the parameter to see all custom language or custom acoustic models owned by the requesting service credentials.
      *
      * @return the language_serialized_name
      */
@@ -4443,6 +4728,7 @@ public class IBMSpeechToTextV1Models {
     }
     private ListLanguageModelsOptions(ListLanguageModelsOptionsBuilder builder) {
       language_serialized_name = builder.language_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4459,7 +4745,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * ListLanguageModelsOptions Builder.
    */
-  public class ListLanguageModelsOptionsBuilder {
+  public class ListLanguageModelsOptionsBuilder extends IBMWatsonOptionsModel {
     private String language_serialized_name;
 
     private ListLanguageModelsOptionsBuilder(ListLanguageModelsOptions listLanguageModelsOptions) {
@@ -4491,13 +4777,26 @@ public class IBMSpeechToTextV1Models {
       this.language_serialized_name = language;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListLanguageModelsOptions builder
+     */
+    public ListLanguageModelsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listModels options.
    */
-  public class ListModelsOptions {
+  public class ListModelsOptions extends IBMWatsonOptionsModel {
     private ListModelsOptions(ListModelsOptionsBuilder builder) {
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4514,7 +4813,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * ListModelsOptions Builder.
    */
-  public class ListModelsOptionsBuilder {
+  public class ListModelsOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListModelsOptionsBuilder(ListModelsOptions listModelsOptions) {
     }
@@ -4533,19 +4832,31 @@ public class IBMSpeechToTextV1Models {
     public ListModelsOptions build() {
       return new ListModelsOptions(this);
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListModelsOptions builder
+     */
+    public ListModelsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listWords options.
    */
-  public class ListWordsOptions {
+  public class ListWordsOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_type_serialized_name;
     private String sort_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model from which words are to be queried. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -4577,6 +4888,7 @@ public class IBMSpeechToTextV1Models {
       customization_id_serialized_name = builder.customization_id_serialized_name;
       word_type_serialized_name = builder.word_type_serialized_name;
       sort_serialized_name = builder.sort_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4593,7 +4905,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * ListWordsOptions Builder.
    */
-  public class ListWordsOptionsBuilder {
+  public class ListWordsOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_type_serialized_name;
     private String sort_serialized_name;
@@ -4660,12 +4972,24 @@ public class IBMSpeechToTextV1Models {
       this.sort_serialized_name = sortVar;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListWordsOptions builder
+     */
+    public ListWordsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * RecognitionJob.
    */
-  public class RecognitionJob extends IBMWatsonGenericModel {
+  public class RecognitionJob extends IBMWatsonResponseModel {
     private String id_serialized_name;
     private String status_serialized_name;
     private String created_serialized_name;
@@ -4677,7 +5001,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the id_serialized_name.
      *
-     * The ID of the job.
+     * The ID of the asynchronous job.
      *
      * @return the id_serialized_name
      */
@@ -4721,7 +5045,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the url_serialized_name.
      *
-     * The URL to use to request information about the job with the `GET /v1/recognitions/{id}` method. **Note:** This field is returned only when you create a new job.
+     * The URL to use to request information about the job with the **Check a job** method. **Note:** This field is returned only when you create a new job.
      *
      * @return the url_serialized_name
      */
@@ -4754,7 +5078,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the warnings_serialized_name.
      *
-     * An array of warning messages about invalid query parameters included with the request. Each warning includes a descriptive message and a list of invalid argument strings, for example, `"unexpected query parameter 'user_token', query parameter 'callback_url' was not specified"`. The request succeeds despite the warnings. **Note:** This field can be returned only when you create a new job.
+     * An array of warning messages about invalid parameters included with the request. Each warning includes a descriptive message and a list of invalid argument strings, for example, `"unexpected query parameter 'user_token', query parameter 'callback_url' was not specified"`. The request succeeds despite the warnings. **Note:** This field can be returned only when you create a new job.
      *
      * @return the warnings_serialized_name
      */
@@ -4862,7 +5186,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * RecognitionJobs.
    */
-  public class RecognitionJobs extends IBMWatsonGenericModel {
+  public class RecognitionJobs extends IBMWatsonResponseModel {
     private List<RecognitionJob> recognitions_serialized_name;
     /**
      * Gets the recognitions_serialized_name.
@@ -4912,7 +5236,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * The registerCallback options.
    */
-  public class RegisterCallbackOptions {
+  public class RegisterCallbackOptions extends IBMWatsonOptionsModel {
     private String callback_url_serialized_name;
     private String user_secret_serialized_name;
     /**
@@ -4939,6 +5263,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notNull(builder.callback_url_serialized_name, 'callback_url_serialized_name cannot be null');
       callback_url_serialized_name = builder.callback_url_serialized_name;
       user_secret_serialized_name = builder.user_secret_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -4955,7 +5280,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * RegisterCallbackOptions Builder.
    */
-  public class RegisterCallbackOptionsBuilder {
+  public class RegisterCallbackOptionsBuilder extends IBMWatsonOptionsModel {
     private String callback_url_serialized_name;
     private String user_secret_serialized_name;
 
@@ -5009,12 +5334,24 @@ public class IBMSpeechToTextV1Models {
       this.user_secret_serialized_name = userSecret;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the RegisterCallbackOptions builder
+     */
+    public RegisterCallbackOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * RegisterStatus.
    */
-  public class RegisterStatus extends IBMWatsonGenericModel {
+  public class RegisterStatus extends IBMWatsonResponseModel {
     private String status_serialized_name;
     private String url_serialized_name;
     /**
@@ -5072,12 +5409,12 @@ public class IBMSpeechToTextV1Models {
   /**
    * The resetAcousticModel options.
    */
-  public class ResetAcousticModelOptions {
+  public class ResetAcousticModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom acoustic model that is to be reset. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -5087,6 +5424,7 @@ public class IBMSpeechToTextV1Models {
     private ResetAcousticModelOptions(ResetAcousticModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5103,7 +5441,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * ResetAcousticModelOptions Builder.
    */
-  public class ResetAcousticModelOptionsBuilder {
+  public class ResetAcousticModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private ResetAcousticModelOptionsBuilder(ResetAcousticModelOptions resetAcousticModelOptions) {
@@ -5144,17 +5482,29 @@ public class IBMSpeechToTextV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ResetAcousticModelOptions builder
+     */
+    public ResetAcousticModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The resetLanguageModel options.
    */
-  public class ResetLanguageModelOptions {
+  public class ResetLanguageModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model that is to be reset. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -5164,6 +5514,7 @@ public class IBMSpeechToTextV1Models {
     private ResetLanguageModelOptions(ResetLanguageModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -5180,7 +5531,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * ResetLanguageModelOptions Builder.
    */
-  public class ResetLanguageModelOptionsBuilder {
+  public class ResetLanguageModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private ResetLanguageModelOptionsBuilder(ResetLanguageModelOptions resetLanguageModelOptions) {
@@ -5219,6 +5570,18 @@ public class IBMSpeechToTextV1Models {
      */
     public ResetLanguageModelOptionsBuilder customizationId(String customizationId) {
       this.customization_id_serialized_name = customizationId;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ResetLanguageModelOptions builder
+     */
+    public ResetLanguageModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -5347,7 +5710,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * SpeechModel.
    */
-  public class SpeechModel extends IBMWatsonGenericModel {
+  public class SpeechModel extends IBMWatsonResponseModel {
     private String name_serialized_name;
     private String language_serialized_name;
     private Long rate_serialized_name;
@@ -5369,7 +5732,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the language_serialized_name.
      *
-     * The language identifier for the model (for example, `en-US`).
+     * The language identifier of the model (for example, `en-US`).
      *
      * @return the language_serialized_name
      */
@@ -5494,7 +5857,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * SpeechModels.
    */
-  public class SpeechModels extends IBMWatsonGenericModel {
+  public class SpeechModels extends IBMWatsonResponseModel {
     private List<SpeechModel> models_serialized_name;
     /**
      * Gets the models_serialized_name.
@@ -5547,8 +5910,8 @@ public class IBMSpeechToTextV1Models {
   public class SpeechRecognitionAlternative extends IBMWatsonGenericModel {
     private String transcript_serialized_name;
     private Double confidence_serialized_name;
-    private List<String> timestamps_serialized_name;
-    private List<String> word_confidence_serialized_name;
+    private List<List<String>> timestamps_serialized_name;
+    private List<List<String>> word_confidence_serialized_name;
     /**
      * Gets the transcript_serialized_name.
      *
@@ -5563,7 +5926,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the confidence_serialized_name.
      *
-     * A score that indicates the service's confidence in the transcript in the range of 0 to 1. Available only for the best alternative and only in results marked as final.
+     * A score that indicates the service's confidence in the transcript in the range of 0 to 1. Returned only for the best alternative and only with results marked as final.
      *
      * @return the confidence_serialized_name
      */
@@ -5574,23 +5937,23 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the timestamps_serialized_name.
      *
-     * Time alignments for each word from the transcript as a list of lists. Each inner list consists of three elements: the word followed by its start and end time in seconds. Example: `[["hello",0.0,1.2],["world",1.2,2.5]]`. Available only for the best alternative.
+     * Time alignments for each word from the transcript as a list of lists. Each inner list consists of three elements: the word followed by its start and end time in seconds. Example: `[["hello",0.0,1.2],["world",1.2,2.5]]`. Returned only for the best alternative.
      *
      * @return the timestamps_serialized_name
      */
     @AuraEnabled
-    public List<String> getTimestamps() {
+    public List<List<String>> getTimestamps() {
       return timestamps_serialized_name;
     }
     /**
      * Gets the word_confidence_serialized_name.
      *
-     * A confidence score for each word of the transcript as a list of lists. Each inner list consists of two elements: the word and its confidence score in the range of 0 to 1. Example: `[["hello",0.95],["world",0.866]]`. Available only for the best alternative and only in results marked as final.
+     * A confidence score for each word of the transcript as a list of lists. Each inner list consists of two elements: the word and its confidence score in the range of 0 to 1. Example: `[["hello",0.95],["world",0.866]]`. Returned only for the best alternative and only with results marked as final.
      *
      * @return the word_confidence_serialized_name
      */
     @AuraEnabled
-    public List<String> getWordConfidence() {
+    public List<List<String>> getWordConfidence() {
       return word_confidence_serialized_name;
     }
 
@@ -5617,7 +5980,7 @@ public class IBMSpeechToTextV1Models {
      *
      * @param timestamps the new timestamps
      */
-    public void setTimestamps(final List<String> timestamps) {
+    public void setTimestamps(final List<List<String>> timestamps) {
       this.timestamps_serialized_name = timestamps;
     }
 
@@ -5626,7 +5989,7 @@ public class IBMSpeechToTextV1Models {
      *
      * @param wordConfidence the new wordConfidence
      */
-    public void setWordConfidence(final List<String> wordConfidence) {
+    public void setWordConfidence(final List<List<String>> wordConfidence) {
       this.word_confidence_serialized_name = wordConfidence;
     }
 
@@ -5674,7 +6037,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the keywords_result_serialized_name.
      *
-     * A dictionary (or associative array) whose keys are the strings specified for `keywords` if both that parameter and `keywords_threshold` are specified. A keyword for which no matches are found is omitted from the array. The array is omitted if no keywords are found.
+     * A dictionary (or associative array) whose keys are the strings specified for `keywords` if both that parameter and `keywords_threshold` are specified. A keyword for which no matches are found is omitted from the array. The array is omitted if no matches are found for any keywords.
      *
      * @return the keywords_result_serialized_name
      */
@@ -5760,8 +6123,8 @@ public class IBMSpeechToTextV1Models {
           for (Integer i = 0; i < keywordResultList.size(); i++) {
             KeywordResult currentItem = keywordResultList.get(i);
             Map<String, Object> itemInMap = (Map<String, Object>) jsonMap.get('keywords_result_serialized_name');
-            List<Object> currentList = (List<Object>) itemInMap.get(key);
-            KeywordResult newItem = (KeywordResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(currentList.get(i))), KeywordResult.class);
+            Object innerKeywordResult = ((List<Object>) itemInMap.get(key)).get(i);
+            KeywordResult newItem = (KeywordResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(innerKeywordResult)), KeywordResult.class);
             newKeywordResult.add(newItem);
           }
           newKeywordsResult.put(key, newKeywordResult);
@@ -5789,7 +6152,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * SpeechRecognitionResults.
    */
-  public class SpeechRecognitionResults extends IBMWatsonGenericModel {
+  public class SpeechRecognitionResults extends IBMWatsonResponseModel {
     private List<SpeechRecognitionResult> results_serialized_name;
     private Long result_index_serialized_name;
     private List<SpeakerLabelsResult> speaker_labels_serialized_name;
@@ -5830,7 +6193,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the warnings_serialized_name.
      *
-     * An array of warning messages associated with the request: * Warnings for invalid query parameters or JSON fields can include a descriptive message and a list of invalid argument strings, for example, `"Unknown arguments:"` or `"Unknown url query arguments:"` followed by a list of the form `"invalid_arg_1, invalid_arg_2."` * The following warning is returned if the request passes a custom model that is based on an older version of a base model for which an updated version is available: `"Using previous version of base model, because your custom model has been built with it. Please note that this version will be supported only for a limited time. Consider updating your custom model to the new base model. If you do not do that you will be automatically switched to base model when you used the non-updated custom model."`  In both cases, the request succeeds despite the warnings.
+     * An array of warning messages associated with the request: * Warnings for invalid parameters or fields can include a descriptive message and a list of invalid argument strings, for example, `"Unknown arguments:"` or `"Unknown url query arguments:"` followed by a list of the form `"invalid_arg_1, invalid_arg_2."` * The following warning is returned if the request passes a custom model that is based on an older version of a base model for which an updated version is available: `"Using previous version of base model, because your custom model has been built with it. Please note that this version will be supported only for a limited time. Consider updating your custom model to the new base model. If you do not do that you will be automatically switched to base model when you used the non-updated custom model."`  In both cases, the request succeeds despite the warnings.
      *
      * @return the warnings_serialized_name
      */
@@ -5913,6 +6276,169 @@ public class IBMSpeechToTextV1Models {
   }
 
   /**
+   * SpeechSession.
+   */
+  public class SpeechSession extends IBMWatsonResponseModel {
+    private String recognize_serialized_name;
+    private String recognizeWS_serialized_name;
+    private String observe_result_serialized_name;
+    private String session_id_serialized_name;
+    private String new_session_uri_serialized_name;
+    private String state_serialized_name;
+    private String model_serialized_name;
+    /**
+     * Gets the recognize_serialized_name.
+     *
+     * URI for HTTP REST recognition requests.
+     *
+     * @return the recognize_serialized_name
+     */
+    @AuraEnabled
+    public String getRecognize() {
+      return recognize_serialized_name;
+    }
+    /**
+     * Gets the recognizeWS_serialized_name.
+     *
+     * URI for WebSocket recognition requests. **Note:** This field is needed only for working with the WebSocket interface.
+     *
+     * @return the recognizeWS_serialized_name
+     */
+    @AuraEnabled
+    public String getRecognizeWS() {
+      return recognizeWS_serialized_name;
+    }
+    /**
+     * Gets the observe_result_serialized_name.
+     *
+     * URI for HTTP REST results observers.
+     *
+     * @return the observe_result_serialized_name
+     */
+    @AuraEnabled
+    public String getObserveResult() {
+      return observe_result_serialized_name;
+    }
+    /**
+     * Gets the session_id_serialized_name.
+     *
+     * Identifier for the new session. **Note:** This field is returned only when you create a new session.
+     *
+     * @return the session_id_serialized_name
+     */
+    @AuraEnabled
+    public String getSessionId() {
+      return session_id_serialized_name;
+    }
+    /**
+     * Gets the new_session_uri_serialized_name.
+     *
+     * URI for the new session. **Note:** This field is returned only when you create a new session.
+     *
+     * @return the new_session_uri_serialized_name
+     */
+    @AuraEnabled
+    public String getNewSessionUri() {
+      return new_session_uri_serialized_name;
+    }
+    /**
+     * Gets the state_serialized_name.
+     *
+     * State of the session. The state must be `initialized` for the session to accept another recognition request. Other internal states are possible, but they have no meaning for the user. **Note:** This field is returned only when you request the status of an existing session.
+     *
+     * @return the state_serialized_name
+     */
+    @AuraEnabled
+    public String getState() {
+      return state_serialized_name;
+    }
+    /**
+     * Gets the model_serialized_name.
+     *
+     * URI for information about the model that is used with the session. **Note:** This field is returned only when you request the status of an existing session.
+     *
+     * @return the model_serialized_name
+     */
+    @AuraEnabled
+    public String getModel() {
+      return model_serialized_name;
+    }
+
+    /**
+     * Sets the recognize_serialized_name.
+     *
+     * @param recognize the new recognize
+     */
+    public void setRecognize(final String recognize) {
+      this.recognize_serialized_name = recognize;
+    }
+
+    /**
+     * Sets the recognizeWS_serialized_name.
+     *
+     * @param recognizeWS the new recognizeWS
+     */
+    public void setRecognizeWS(final String recognizeWS) {
+      this.recognizeWS_serialized_name = recognizeWS;
+    }
+
+    /**
+     * Sets the observe_result_serialized_name.
+     *
+     * @param observeResult the new observeResult
+     */
+    public void setObserveResult(final String observeResult) {
+      this.observe_result_serialized_name = observeResult;
+    }
+
+    /**
+     * Sets the session_id_serialized_name.
+     *
+     * @param sessionId the new sessionId
+     */
+    public void setSessionId(final String sessionId) {
+      this.session_id_serialized_name = sessionId;
+    }
+
+    /**
+     * Sets the new_session_uri_serialized_name.
+     *
+     * @param newSessionUri the new newSessionUri
+     */
+    public void setNewSessionUri(final String newSessionUri) {
+      this.new_session_uri_serialized_name = newSessionUri;
+    }
+
+    /**
+     * Sets the state_serialized_name.
+     *
+     * @param state the new state
+     */
+    public void setState(final String state) {
+      this.state_serialized_name = state;
+    }
+
+    /**
+     * Sets the model_serialized_name.
+     *
+     * @param model the new model
+     */
+    public void setModel(final String model) {
+      this.model_serialized_name = model;
+    }
+
+    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
+      if (jsonMap == null) {
+        return null;
+      }
+
+      SpeechSession ret = (SpeechSession) super.deserialize(jsonString, jsonMap, classType);
+
+      return ret;
+    }
+  }
+
+  /**
    * SupportedFeatures.
    */
   public class SupportedFeatures extends IBMWatsonGenericModel {
@@ -5932,7 +6458,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the speaker_labels_serialized_name.
      *
-     * Indicates whether the `speaker_labels` parameter can be used with the language model.
+     * Indicates whether the **speaker_labels** parameter can be used with the language model.
      *
      * @return the speaker_labels_serialized_name
      */
@@ -5973,13 +6499,13 @@ public class IBMSpeechToTextV1Models {
   /**
    * The trainAcousticModel options.
    */
-  public class TrainAcousticModelOptions {
+  public class TrainAcousticModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String custom_language_model_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom acoustic model that is to be trained. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -5989,7 +6515,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the custom_language_model_id_serialized_name.
      *
-     * The GUID of a custom language model that is to be used during training of the custom acoustic model. Specify a custom language model that has been trained with verbatim transcriptions of the audio resources or that contains words that are relevant to the contents of the audio resources.
+     * The customization ID (GUID) of a custom language model that is to be used during training of the custom acoustic model. Specify a custom language model that has been trained with verbatim transcriptions of the audio resources or that contains words that are relevant to the contents of the audio resources.
      *
      * @return the custom_language_model_id_serialized_name
      */
@@ -6000,6 +6526,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       custom_language_model_id_serialized_name = builder.custom_language_model_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6016,7 +6543,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * TrainAcousticModelOptions Builder.
    */
-  public class TrainAcousticModelOptionsBuilder {
+  public class TrainAcousticModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String custom_language_model_id_serialized_name;
 
@@ -6070,19 +6597,31 @@ public class IBMSpeechToTextV1Models {
       this.custom_language_model_id_serialized_name = customLanguageModelId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the TrainAcousticModelOptions builder
+     */
+    public TrainAcousticModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The trainLanguageModel options.
    */
-  public class TrainLanguageModelOptions {
+  public class TrainLanguageModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_type_to_add_serialized_name;
     private Double customization_weight_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model that is to be trained. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -6102,7 +6641,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the customization_weight_serialized_name.
      *
-     * Specifies a customization weight for the custom language model. The customization weight tells the service how much weight to give to words from the custom language model compared to those from the base model for speech recognition. Specify a value between 0.0 and 1.0. The default value is 0.3.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.   The value that you assign is used for all recognition requests that use the model. You can override it for any recognition request by specifying a customization weight for that request.
+     * Specifies a customization weight for the custom language model. The customization weight tells the service how much weight to give to words from the custom language model compared to those from the base model for speech recognition. Specify a value between 0.0 and 1.0; the default is 0.3.   The default value yields the best performance in general. Assign a higher value if your audio makes frequent use of OOV words from the custom model. Use caution when setting the weight: a higher value can improve the accuracy of phrases from the custom model's domain, but it can negatively affect performance on non-domain phrases.   The value that you assign is used for all recognition requests that use the model. You can override it for any recognition request by specifying a customization weight for that request.
      *
      * @return the customization_weight_serialized_name
      */
@@ -6114,6 +6653,7 @@ public class IBMSpeechToTextV1Models {
       customization_id_serialized_name = builder.customization_id_serialized_name;
       word_type_to_add_serialized_name = builder.word_type_to_add_serialized_name;
       customization_weight_serialized_name = builder.customization_weight_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6130,7 +6670,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * TrainLanguageModelOptions Builder.
    */
-  public class TrainLanguageModelOptionsBuilder {
+  public class TrainLanguageModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_type_to_add_serialized_name;
     private Double customization_weight_serialized_name;
@@ -6197,12 +6737,24 @@ public class IBMSpeechToTextV1Models {
       this.customization_weight_serialized_name = customizationWeight;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the TrainLanguageModelOptions builder
+     */
+    public TrainLanguageModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The unregisterCallback options.
    */
-  public class UnregisterCallbackOptions {
+  public class UnregisterCallbackOptions extends IBMWatsonOptionsModel {
     private String callback_url_serialized_name;
     /**
      * Gets the callback_url_serialized_name.
@@ -6217,6 +6769,7 @@ public class IBMSpeechToTextV1Models {
     private UnregisterCallbackOptions(UnregisterCallbackOptionsBuilder builder) {
       IBMWatsonValidator.notNull(builder.callback_url_serialized_name, 'callback_url_serialized_name cannot be null');
       callback_url_serialized_name = builder.callback_url_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6233,7 +6786,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * UnregisterCallbackOptions Builder.
    */
-  public class UnregisterCallbackOptionsBuilder {
+  public class UnregisterCallbackOptionsBuilder extends IBMWatsonOptionsModel {
     private String callback_url_serialized_name;
 
     private UnregisterCallbackOptionsBuilder(UnregisterCallbackOptions unregisterCallbackOptions) {
@@ -6274,18 +6827,30 @@ public class IBMSpeechToTextV1Models {
       this.callback_url_serialized_name = callbackUrl;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UnregisterCallbackOptions builder
+     */
+    public UnregisterCallbackOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The upgradeAcousticModel options.
    */
-  public class UpgradeAcousticModelOptions {
+  public class UpgradeAcousticModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String custom_language_model_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom acoustic model that is to be upgraded. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom acoustic model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -6295,7 +6860,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the custom_language_model_id_serialized_name.
      *
-     * If the custom acoustic model was trained with a custom language model, the GUID of that custom language model. The custom language model must be upgraded before the custom acoustic model can be upgraded.
+     * If the custom acoustic model was trained with a custom language model, the customization ID (GUID) of that custom language model. The custom language model must be upgraded before the custom acoustic model can be upgraded.
      *
      * @return the custom_language_model_id_serialized_name
      */
@@ -6306,6 +6871,7 @@ public class IBMSpeechToTextV1Models {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       custom_language_model_id_serialized_name = builder.custom_language_model_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6322,7 +6888,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * UpgradeAcousticModelOptions Builder.
    */
-  public class UpgradeAcousticModelOptionsBuilder {
+  public class UpgradeAcousticModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String custom_language_model_id_serialized_name;
 
@@ -6376,17 +6942,29 @@ public class IBMSpeechToTextV1Models {
       this.custom_language_model_id_serialized_name = customLanguageModelId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpgradeAcousticModelOptions builder
+     */
+    public UpgradeAcousticModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The upgradeLanguageModel options.
    */
-  public class UpgradeLanguageModelOptions {
+  public class UpgradeLanguageModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom language model that is to be upgraded. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom language model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -6396,6 +6974,7 @@ public class IBMSpeechToTextV1Models {
     private UpgradeLanguageModelOptions(UpgradeLanguageModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -6412,7 +6991,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * UpgradeLanguageModelOptions Builder.
    */
-  public class UpgradeLanguageModelOptionsBuilder {
+  public class UpgradeLanguageModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private UpgradeLanguageModelOptionsBuilder(UpgradeLanguageModelOptions upgradeLanguageModelOptions) {
@@ -6453,12 +7032,24 @@ public class IBMSpeechToTextV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpgradeLanguageModelOptions builder
+     */
+    public UpgradeLanguageModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * Word.
    */
-  public class Word extends IBMWatsonGenericModel {
+  public class Word extends IBMWatsonResponseModel {
     private String word_serialized_name;
     private List<String> sounds_like_serialized_name;
     private String display_as_serialized_name;
@@ -6800,7 +7391,7 @@ public class IBMSpeechToTextV1Models {
   /**
    * Words.
    */
-  public class Words extends IBMWatsonGenericModel {
+  public class Words extends IBMWatsonResponseModel {
     private List<Word> words_serialized_name;
     /**
      * Gets the words_serialized_name.
@@ -6847,7 +7438,7 @@ public class IBMSpeechToTextV1Models {
     }
   }
 
-  public class RecognizeOptions {
+  public class RecognizeOptions extends IBMWatsonOptionsModel {
     private IBMWatsonFile audio_serialized_name;
     private String audio_filename_serialized_name;
     private String file_content_type_serialized_name;
@@ -6961,6 +7552,7 @@ public class IBMSpeechToTextV1Models {
       customization_id_serialized_name = builder.customization_id_serialized_name;
       speaker_labels_serialized_name = builder.speaker_labels_serialized_name;
       base_model_version_serialized_name = builder.base_model_version_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     public RecognizeOptionsBuilder newBuilder() {
@@ -6968,7 +7560,7 @@ public class IBMSpeechToTextV1Models {
     }
   }
 
-  public class RecognizeOptionsBuilder {
+  public class RecognizeOptionsBuilder extends IBMWatsonOptionsModel {
     private IBMWatsonFile audio_serialized_name;
     private String audio_filename_serialized_name;
     private String file_content_type_serialized_name;
@@ -7111,273 +7703,17 @@ public class IBMSpeechToTextV1Models {
       this.base_model_version_serialized_name = baseModelVersion;
       return this;
     }
-  }
 
-  public class SpeechAlternative extends IBMWatsonGenericModel {
-    private Double confidence_serialized_name;
-    private List<SpeechTimestamp> timestamps_serialized_name;
-    private String transcript_serialized_name;
-    private List<SpeechWordConfidence> word_confidences_serialized_name;
-
-    @AuraEnabled
-    public Double getConfidence() {
-      return confidence_serialized_name;
-    }
-
-    @AuraEnabled
-    public List<SpeechTimestamp> getTimestamps() {
-      return timestamps_serialized_name;
-    }
-
-    @AuraEnabled
-    public String getTranscript() {
-      return transcript_serialized_name;
-    }
-
-    @AuraEnabled
-    public List<SpeechWordConfidence> getWordConfidences() {
-      return word_confidences_serialized_name;
-    }
-
-    public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
-    }
-
-    public void setTimestamps(final List<SpeechTimestamp> timestamps) {
-      this.timestamps_serialized_name = timestamps;
-    }
-
-    public void setTranscript(final String transcript) {
-      this.transcript_serialized_name = transcript;
-    }
-
-    public void setWordConfidences(final List<SpeechWordConfidence> wordConfidences) {
-      this.word_confidences_serialized_name = wordConfidences;
-    }
-
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      SpeechAlternative ret = (SpeechAlternative) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
-  }
-
-  public class SpeechResults extends IBMWatsonGenericModel {
-    private Integer result_index_serialized_name;
-    private List<Transcript> results_serialized_name;
-    private List<SpeakerLabelsResult> speaker_labels_serialized_name;
-
-    @AuraEnabled
-    public Integer getResultIndex() {
-      return result_index_serialized_name;
-    }
-
-    @AuraEnabled
-    public List<Transcript> getResults() {
-      return results_serialized_name;
-    }
-
-    @AuraEnabled
-    public List<SpeakerLabelsResult> getSpeakerLabels() {
-      return speaker_labels_serialized_name;
-    }
-
-    public void setResultIndex(final Integer resultIndex) {
-      this.result_index_serialized_name = resultIndex;
-    }
-
-    public void setResults(final List<Transcript> results) {
-      this.results_serialized_name = results;
-    }
-
-    public void setSpeakerLabels(final List<SpeakerLabelsResult> speakerLabels) {
-      this.speaker_labels_serialized_name = speakerLabels;
-    }
-
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      SpeechResults ret = (SpeechResults) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
-  }
-
-  public class SpeechTimestamp extends IBMWatsonGenericModel {
-    private Double end_time_serialized_name;
-    private Double start_time_serialized_name;
-    private String word_serialized_name;
-
-    @AuraEnabled
-    public Double getEndTime() {
-      return end_time_serialized_name;
-    }
-
-    @AuraEnabled
-    public Double getStartTime() {
-      return start_time_serialized_name;
-    }
-
-    @AuraEnabled
-    public String getWord() {
-      return word_serialized_name;
-    }
-
-    public void setEndTime(final Double endTime) {
-      this.end_time_serialized_name = endTime;
-    }
-
-    public void setStartTime(final Double startTime) {
-      this.start_time_serialized_name = startTime;
-    }
-
-    public void setWord(final String word) {
-      this.word_serialized_name = word;
-    }
-
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      SpeechTimestamp ret = (SpeechTimestamp) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
-  }
-
-  public class SpeechWordAlternatives extends IBMWatsonGenericModel {
-    private Double start_time_serialized_name;
-    private Double end_time_serialized_name;
-    private List<WordAlternativeResult> alternatives_serialized_name;
-
-    @AuraEnabled
-    public Double getStartTime() {
-      return start_time_serialized_name;
-    }
-
-    @AuraEnabled
-    public Double getEndTime() {
-      return end_time_serialized_name;
-    }
-
-    @AuraEnabled
-    public List<WordAlternativeResult> getAlternatives() {
-      return alternatives_serialized_name;
-    }
-
-    public void setStartTime(final Double startTime) {
-      this.start_time_serialized_name = startTime;
-    }
-
-    public void setEndTime(final Double endTime) {
-      this.end_time_serialized_name = endTime;
-    }
-
-    public void setAlternatives(final List<WordAlternativeResult> alternatives) {
-      this.alternatives_serialized_name = alternatives;
-    }
-
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      SpeechWordAlternatives ret = (SpeechWordAlternatives) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
-  }
-
-  public class SpeechWordConfidence extends IBMWatsonGenericModel {
-    private Double confidence_serialized_name;
-    private String word_serialized_name;
-
-    @AuraEnabled
-    public Double getConfidence() {
-      return confidence_serialized_name;
-    }
-
-    @AuraEnabled
-    public String getWord() {
-      return word_serialized_name;
-    }
-
-    public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
-    }
-
-    public void setWord(final String word) {
-      this.word_serialized_name = word;
-    }
-
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      SpeechWordConfidence ret = (SpeechWordConfidence) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
-    }
-  }
-
-  public class Transcript extends IBMWatsonGenericModel {
-    private Boolean ffinal_serialize_name;
-    private List<SpeechAlternative> alternatives_serialized_name;
-    private Map<String, List<KeywordResult>> keyword_results_serialized_name;
-    private List<SpeechWordAlternatives> word_alternatives_serialized_name;
-
-    @AuraEnabled
-    public Boolean getFinal() {
-      return ffinal_serialize_name;
-    }
-
-    @AuraEnabled
-    public List<SpeechAlternative> getAlternatives() {
-      return alternatives_serialized_name;
-    }
-
-    @AuraEnabled
-    public Map<String, List<KeywordResult>> getKeywordResults() {
-      return keyword_results_serialized_name;
-    }
-
-    @AuraEnabled
-    public List<SpeechWordAlternatives> getWordAlternatives() {
-      return word_alternatives_serialized_name;
-    }
-
-    public void setFinal(final Boolean isFinal) {
-      this.ffinal_serialize_name = isFinal;
-    }
-    
-    public void setAlternatives(final List<SpeechAlternative> alternatives) {
-      this.alternatives_serialized_name = alternatives;
-    }
-
-    public void setKeywordResults(final Map<String, List<KeywordResult>> keywordResults) {
-      this.keyword_results_serialized_name = keywordResults;
-    }
-
-    public void setWordAlternatives(final List<SpeechWordAlternatives> wordAlternatives) {
-      this.word_alternatives_serialized_name = wordAlternatives;
-    }
-
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      Transcript ret = (Transcript) super.deserialize(jsonString, jsonMap, classType);
-
-      return ret;
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpgradeLanguageModelOptions builder
+     */
+    public RecognizeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
     }
   }
 }

--- a/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
@@ -52,6 +52,7 @@ private class IBMSpeechToTextV1Test {
     speechToText.setEndPoint(URL);
     IBMSpeechToTextV1Models.GetModelOptions getModelOptions = new IBMSpeechToTextV1Models.GetModelOptionsBuilder('en-US_NarrowbandModel')
       .modelId('en-US_NarrowbandModel')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.SpeechModel speechModel = speechToText.getModel(getModelOptions);
     System.assertEquals(speechModel.getName(), 'en-US_NarrowbandModel');
@@ -77,6 +78,7 @@ private class IBMSpeechToTextV1Test {
       speechToText.setUsernameAndPassword(username, password);
     }
     IBMSpeechToTextV1Models.ListModelsOptions listModelsOptions = new IBMSpeechToTextV1Models.ListModelsOptionsBuilder()
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.SpeechModels speechModels = speechToText.listModels(listModelsOptions);
     System.assertEquals(speechModels.getModels()[0].getName(), 'en-US_NarrowbandModel');
@@ -124,6 +126,7 @@ private class IBMSpeechToTextV1Test {
       .smartFormatting(true)
       .speakerLabels(true)
       .baseModelVersion('version')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.RecognitionJob createJob = speechToText.createJob(createJobOptions);
     System.assertEquals(createJob.getUrl(), 'string');
@@ -168,6 +171,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.CheckJobOptionsBuilder CheckJobOptionsBuilder = new IBMSpeechToTextV1Models.CheckJobOptionsBuilder();
     IBMSpeechToTextV1Models.CheckJobOptions checkJobOptions = new IBMSpeechToTextV1Models.CheckJobOptionsBuilder('56d09f2c-e020-11e7-9ee3-33bf91161141')
       .id('56d09f2c-e020-11e7-9ee3-33bf91161141')
+      .addHeader('Test-Header', 'test_value')
       .build();
     checkJobOptions = checkJobOptions.newBuilder().build();
     IBMSpeechToTextV1Models.RecognitionJob checkJob = speechToText.checkJob(checkJobOptions);
@@ -186,6 +190,7 @@ private class IBMSpeechToTextV1Test {
       speechToText.setUsernameAndPassword(username, password);
     }
     IBMSpeechToTextV1Models.CheckJobsOptions checkJobsOptions = new IBMSpeechToTextV1Models.CheckJobsOptionsBuilder()
+      .addHeader('Test-Header', 'test_value')
       .build();
     checkJobsOptions = checkJobsOptions.newBuilder().build();
     IBMSpeechToTextV1Models.RecognitionJobs checkJobs = speechToText.checkJobs(checkJobsOptions);
@@ -205,6 +210,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.DeleteJobOptions deleteJobOptions = new IBMSpeechToTextV1Models.DeleteJobOptionsBuilder('56d09f2c-e020-11e7-9ee3-33bf91161141')
       .id('56d09f2c-e020-11e7-9ee3-33bf91161141')
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.deleteJob(deleteJobOptions);
     deleteJobOptions = deleteJobOptions.newBuilder().build();
@@ -224,6 +230,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.RegisterCallbackOptions registerCallbackOptions = new IBMSpeechToTextV1Models.RegisterCallbackOptionsBuilder(callbackBaseURL)
       .callbackUrl(callbackBaseURL)
       .userSecret('UserSecretTest')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.RegisterStatus registerCallback = speechToText.registerCallback(registerCallbackOptions);
     System.assertEquals(registerCallback.getStatus(), 'created');
@@ -243,6 +250,7 @@ private class IBMSpeechToTextV1Test {
       speechToText.setUsernameAndPassword(username, password);
     }
     IBMSpeechToTextV1Models.UnregisterCallbackOptions unregisterCallbackOptions = new IBMSpeechToTextV1Models.UnregisterCallbackOptionsBuilder(callbackBaseURL)
+      .addHeader('Test-Header', 'test_value')
       .build();
     unregisterCallbackOptions = unregisterCallbackOptions.newBuilder().build();
     speechToText.unregisterCallback(unregisterCallbackOptions);
@@ -266,6 +274,7 @@ private class IBMSpeechToTextV1Test {
       .baseModelName(baseModelName)
       .dialect('en-US')
       .description('model description')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.LanguageModel languageModel = speechToText.createLanguageModel(createLanguageModelOptions);
     System.assertEquals(languageModel.getCustomizationId(), '74f4807e-b5ff-4866-824e-6bba1a84fe96');
@@ -301,6 +310,7 @@ private class IBMSpeechToTextV1Test {
       .word('tornado')
       .soundsLike(new List<String>{'tornado', 'hurricane'})
       .displayAs('tornado')
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.addWord(addWordOptions);
     addWordOptions = addWordOptions.newBuilder().build();
@@ -325,6 +335,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.AddWordsOptions addWordsOptions = new IBMSpeechToTextV1Models.AddWordsOptionsBuilder()
       .customizationId(customizationId)
       .words(new List<IBMSpeechToTextV1Models.CustomWord>{ customWord })
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.addWords(addWordsOptions);
     addWordsOptions = addWordsOptions.newBuilder().build();
@@ -350,6 +361,7 @@ private class IBMSpeechToTextV1Test {
       .name(name)
       .baseModelName(baseModelName)
       .description('test')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.AcousticModel AcousticModel = speechToText.createAcousticModel(createAcousticModelOptions);
     createAcousticModelOptions = createAcousticModelOptions.newBuilder().build();
@@ -368,6 +380,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.DeleteLanguageModelOptions deleteLanguageModelOptions = new IBMSpeechToTextV1Models.DeleteLanguageModelOptionsBuilder('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
       .customizationId('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.deleteLanguageModel(deleteLanguageModelOptions);
     deleteLanguageModelOptions = deleteLanguageModelOptions.newBuilder().build();
@@ -400,6 +413,7 @@ private class IBMSpeechToTextV1Test {
       .audioName(audioName)
       .containedContentType('audio/mp3')
       .allowOverwrite(false)
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.addAudio(addAudioOptions);
     addAudioOptions = addAudioOptions.newBuilder().build();
@@ -418,6 +432,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.GetLanguageModelOptions getLanguageModelOptions = new IBMSpeechToTextV1Models.GetLanguageModelOptionsBuilder('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
       .customizationId('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.LanguageModel languageModel = speechToText.getLanguageModel(getLanguageModelOptions);
     System.assertEquals(languageModel.getCustomizationId(), 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5');
@@ -447,6 +462,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.ListLanguageModelsOptions listLanguageModelsOptions = new IBMSpeechToTextV1Models.ListLanguageModelsOptionsBuilder()
       .language('en-US')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.LanguageModels languageModels = speechToText.listLanguageModels(listLanguageModelsOptions);
     System.assertEquals(languageModels.getCustomizations()[0].getCustomizationId(), 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5');
@@ -466,6 +482,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.ResetLanguageModelOptions resetLanguageModelOptions = new IBMSpeechToTextV1Models.ResetLanguageModelOptionsBuilder('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
       .customizationId('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.resetLanguageModel(resetLanguageModelOptions);
     resetLanguageModelOptions = resetLanguageModelOptions.newBuilder().build();
@@ -485,6 +502,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.TrainLanguageModelOptions trainLanguageModelOptions = new IBMSpeechToTextV1Models.TrainLanguageModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.trainLanguageModel(trainLanguageModelOptions);
     Test.stopTest();
@@ -503,6 +521,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.UpgradeLanguageModelOptions upgradeLanguageModelOptions = new IBMSpeechToTextV1Models.UpgradeLanguageModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.upgradeLanguageModel(upgradeLanguageModelOptions);
     Test.stopTest();
@@ -533,6 +552,7 @@ private class IBMSpeechToTextV1Test {
       .corpusFile(corpusFile)
       .corpusFilename('corpora.txt')
       .corpusFileContentType('text/plain')
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.addCorpus(addCorpusOptions);
     addCorpusOptions = addCorpusOptions.newBuilder().build();
@@ -554,6 +574,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.DeleteCorpusOptions deleteCorpusOptions = new IBMSpeechToTextV1Models.DeleteCorpusOptionsBuilder(customizationId, corpusName)
       .customizationId(customizationId)
       .corpusName(corpusName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.deleteCorpus(deleteCorpusOptions);
     deleteCorpusOptions = deleteCorpusOptions.newBuilder().build();
@@ -575,6 +596,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.GetCorpusOptions getCorpusOptions = new IBMSpeechToTextV1Models.GetCorpusOptionsBuilder(customizationId, corpusName)
       .customizationId(customizationId)
       .corpusName(corpusName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.Corpus corpus = speechToText.getCorpus(getCorpusOptions);
     System.assertEquals(corpus.getError(), 'none');
@@ -598,6 +620,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.ListCorporaOptions listCorporaOptions = new IBMSpeechToTextV1Models.ListCorporaOptionsBuilder('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
       .customizationId('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.Corpora corpora = speechToText.listCorpora(listCorporaOptions);
     System.assertEquals(corpora.getCorpora()[0].getName(), 'custom_corpus');
@@ -620,6 +643,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.DeleteWordOptions deleteWordOptions = new IBMSpeechToTextV1Models.DeleteWordOptionsBuilder(customizationId, wordName)
       .customizationId(customizationId)
       .wordName(wordName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.deleteWord(deleteWordOptions);
     deleteWordOptions = deleteWordOptions.newBuilder().build();
@@ -641,6 +665,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.GetWordOptions getWordOptions = new IBMSpeechToTextV1Models.GetWordOptionsBuilder(customizationId, wordName)
       .customizationId(customizationId)
       .wordName(wordName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.Word wordResult =  speechToText.getWord(getWordOptions);
     System.assertEquals(wordResult.getDisplayAs(), 'words matter');
@@ -670,6 +695,7 @@ private class IBMSpeechToTextV1Test {
       .customizationId(customizationId)
       .wordType(wordType)
       .sortField(sortField)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.Words wordList = speechToText.listWords(listWordsOptions);
     System.assertEquals(wordList.getWords()[0].getDisplayAs(), 'words matter');
@@ -690,6 +716,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.DeleteAcousticModelOptions deleteAcousticModelOptions = new IBMSpeechToTextV1Models.DeleteAcousticModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.deleteAcousticModel(deleteAcousticModelOptions);
     deleteAcousticModelOptions = deleteAcousticModelOptions.newBuilder().build();
@@ -709,6 +736,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.GetAcousticModelOptions getAcousticModelOptions = new IBMSpeechToTextV1Models.GetAcousticModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.AcousticModel acousticModel = speechToText.getAcousticModel(getAcousticModelOptions);
     System.assertEquals(acousticModel.getCustomizationId(), '825485d7-af3f-44e7-b1ea-76130dec8a61');
@@ -737,6 +765,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.ListAcousticModelsOptions listAcousticModelsOptions = new IBMSpeechToTextV1Models.ListAcousticModelsOptionsBuilder()
       .language('en-US')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.AcousticModels acousticModels = speechToText.listAcousticModels(listAcousticModelsOptions);
     System.assertEquals(acousticModels.getCustomizations()[0].getCustomizationId(), '825485d7-af3f-44e7-b1ea-76130dec8a61');
@@ -757,6 +786,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.ResetAcousticModelOptions resetAcousticModelOptions = new IBMSpeechToTextV1Models.ResetAcousticModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.resetAcousticModel(resetAcousticModelOptions);
     resetAcousticModelOptions = resetAcousticModelOptions.newBuilder().build();
@@ -777,6 +807,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.TrainAcousticModelOptions trainAcousticModelOptions = new IBMSpeechToTextV1Models.TrainAcousticModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
       .customLanguageModelId('custom_language')
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.trainAcousticModel(trainAcousticModelOptions);
     Test.stopTest();
@@ -797,6 +828,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.DeleteAudioOptions deleteAudioOptions = new IBMSpeechToTextV1Models.DeleteAudioOptionsBuilder(customizationId, audioName)
       .customizationId(customizationId)
       .audioName(audioName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.deleteAudio(deleteAudioOptions);
     deleteAudioOptions = deleteAudioOptions.newBuilder().build();
@@ -818,6 +850,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.GetAudioOptions getAudioOptions = new IBMSpeechToTextV1Models.GetAudioOptionsBuilder(customizationId, audioName)
       .customizationId(customizationId)
       .audioName(audioName)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.AudioListing audioListing = speechToText.getAudio(getAudioOptions);
 //    System.assertEquals(audioListing.getTotalMinutesOfAudio(),0);
@@ -850,6 +883,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.ListAudioOptions listAudioOptions = new IBMSpeechToTextV1Models.ListAudioOptionsBuilder(customizationId)
       .customizationId(customizationId)
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.AudioResources AudioResources = speechToText.listAudio(listAudioOptions);
     listAudioOptions = listAudioOptions.newBuilder().build();
@@ -894,6 +928,7 @@ private class IBMSpeechToTextV1Test {
       .customizationId(customizationId)
       .speakerLabels(true)
       .baseModelVersion('version')
+      .addHeader('Test-Header', 'test_value')
       .build();
     IBMSpeechToTextV1Models.SpeechRecognitionResults speechResults = speechToText.recognize(recognizeOptions);
     System.assertEquals(speechResults.getResults()[0].getWordAlternatives()[0].getStartTime(),0.14);

--- a/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
@@ -123,7 +123,7 @@ private class IBMSpeechToTextV1Test {
       .profanityFilter(true)
       .smartFormatting(true)
       .speakerLabels(true)
-      .version('version')
+      .baseModelVersion('version')
       .build();
     IBMSpeechToTextV1Models.RecognitionJob createJob = speechToText.createJob(createJobOptions);
     System.assertEquals(createJob.getUrl(), 'string');
@@ -135,8 +135,6 @@ private class IBMSpeechToTextV1Test {
     System.assertEquals(createJob.getresults()[0].getresults()[0].getFinal(),true);
     System.assertEquals(createJob.getresults()[0].getresults()[0].getAlternatives()[0].getTranscript(), 'string');
     System.assertEquals(createJob.getresults()[0].getresults()[0].getAlternatives()[0].getConfidence(),0);
-    System.assertEquals(createJob.getresults()[0].getresults()[0].getAlternatives()[0].getTimestamps()[0], 'string');
-    System.assertEquals(createJob.getresults()[0].getresults()[0].getAlternatives()[0].getWordConfidence()[0], 'string');
     System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword_serialized_name')[0].getNormalizedText(), 'string');
     System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword_serialized_name')[0].getStartTime(),0);
     System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword_serialized_name')[0].getEndTime(),0);
@@ -897,11 +895,11 @@ private class IBMSpeechToTextV1Test {
       .speakerLabels(true)
       .baseModelVersion('version')
       .build();
-    IBMSpeechToTextV1Models.SpeechResults speechResults = speechToText.recognize(recognizeOptions);
-    System.assertEquals(speechResults.getResults()[0].getWordAlternatives()[0].getStartTime(),0.09);
-    System.assertEquals(speechResults.getResults()[0].getWordAlternatives()[0].getEndTime(),0.6);
+    IBMSpeechToTextV1Models.SpeechRecognitionResults speechResults = speechToText.recognize(recognizeOptions);
+    System.assertEquals(speechResults.getResults()[0].getWordAlternatives()[0].getStartTime(),0.14);
+    System.assertEquals(speechResults.getResults()[0].getWordAlternatives()[0].getEndTime(),0.28);
     System.assertEquals(speechResults.getResults()[0].getWordAlternatives()[0].getAlternatives()[0].getConfidence(),1);
-    System.assertEquals(speechResults.getResults()[0].getWordAlternatives()[0].getAlternatives()[0].getWord(), 'latest');
+    System.assertEquals(speechResults.getResults()[0].getWordAlternatives()[0].getAlternatives()[0].getWord(), 'a');
     recognizeOptions = recognizeOptions.newBuilder().build();
     Test.stopTest();
   }

--- a/force-app/main/default/classes/IBMTextToSpeechV1.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1.cls
@@ -1,21 +1,19 @@
 /**
  * ### Service Overview
- * The IBM Text to Speech service provides a Representational State Transfer (REST) Application Programming Interface
- * (API) that uses IBM's speech-synthesis capabilities to synthesize text into natural-sounding speech in a variety of
- * languages, dialects, and voices. The service currently synthesizes text from US English, UK English, French, German,
- * Italian, Japanese, Spanish, or Brazilian Portuguese into audio spoken in a male or female voice (the service supports
- * only a single gender for some languages). The audio is streamed back to the client with minimal delay.
+ * The IBM&reg; Text to Speech service provides an API that uses IBM's speech-synthesis capabilities to synthesize text
+ * into natural-sounding speech in a variety of languages, dialects, and voices. The service supports at least one male
+ * or female voice, sometimes both, for each language. The audio is streamed back to the client with minimal delay. For
+ * more information about the service, see the [IBM&reg; Cloud
+ * documentation](https://console.bluemix.net/docs/services/text-to-speech/getting-started.html).
  * ### API Overview
- * The Text to Speech service consists of the following related endpoints:
- * * `/v1/voices` provides information about the voices available for synthesized speech.
- * * `/v1/synthesize` synthesizes written text to audio speech.
- * * `/v1/pronunciation` returns the pronunciation for a specified word. The `/v1/pronunciation` method is currently
- * beta functionality.
- * * `/v1/customizations` and `/v1/customizations/{customization_id}` lets users create custom voice models, which are
- * dictionaries of words and their translations for use in speech synthesis. All `/v1/customizations` methods are
- * currently beta functionality.
- * * `/v1/customizations/{customization_id}/words` and `/v1/customizations/{customization_id}/words/{word}` lets users
- * manage the words in a custom voice model.
+ * The Text to Speech service provides the following endpoints:
+ * * **Voices** provides information about the voices available for synthesized speech.
+ * * **Synthesis** synthesizes written text to audio speech.
+ * * **Pronunciation** returns the pronunciation for a specified word. Currently a beta feature.
+ * * **Custom models** and let users create custom voice models, which are dictionaries of words and their translations
+ * for use in speech synthesis. All custom model methods are currently beta features.
+ * * **Custom words** let users manage the words in a custom voice model. All custom word methods are currently beta
+ * features.
  *
  *
  * **Note about the Try It Out feature:** The `Try it out!` button lets you experiment with the methods of the API by
@@ -45,36 +43,17 @@
  *
  *  For more information about customization and about sounds-like and phonetic translations, see [Understanding
  * customization](https://console.bluemix.net/docs/services/text-to-speech/custom-intro.html).
- * * **GUIDs:** The pronunciation and customization methods accept or return a Globally Unique Identifier (GUID). For
- * example, customization IDs (specified with the `customization_id` parameter) and service credentials are GUIDs. GUIDs
- * are hexadecimal strings that have the format `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
  * * **WebSocket interface:** The service also offers a WebSocket interface as an alternative to its HTTP REST interface
  * for speech synthesis. The WebSocket interface supports both plain text and SSML input, including the SSML
  * &lt;mark&gt; element and word timings. See [The WebSocket
  * interface](https://console.bluemix.net/docs/services/text-to-speech/websockets.html).
- * * **Authentication:** You authenticate to the service by using your service credentials. You can use your credentials
- * to authenticate via a proxy server that resides in IBM Cloud, or you can use your credentials to obtain a token and
- * contact the service directly. See [Service credentials for Watson
- * services](https://console.bluemix.net/docs/services/watson/getting-started-credentials.html) and [Tokens for
- * authentication](https://console.bluemix.net/docs/services/watson/getting-started-tokens.html).
+ * * **GUIDs:** The pronunciation and customization methods accept or return a Globally Unique Identifier (GUID). For
+ * example, customization IDs (specified with the `customization_id` parameter) and service credentials are GUIDs. GUIDs
+ * are hexadecimal strings that have the format `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
  * * **Custom voice model ownership:** In all cases, you must use service credentials created for the instance of the
  * service that owns a custom voice model to use the methods described in this documentation with that model. For more
  * information, see [Ownership of custom voice
  * models](https://console.bluemix.net/docs/services/text-to-speech/custom-models.html#customOwner).
- * * **Request Logging:** By default, all Watson services log requests and their results. Data is collected only to
- * improve the Watson services. If you do not want to share your data, set the header parameter
- * `X-Watson-Learning-Opt-Out` to `true` for each request. Data is collected for any request that omits this header. See
- * [Controlling request logging for Watson
- * services](https://console.bluemix.net/docs/services/watson/getting-started-logging.html).
- *
- *  The service does not log data (words and translations) that are used to build custom language models; your training
- * data is never used to improve the service's base models. The service does log data when a custom model is used with a
- * synthesize request; you must set the `X-Watson-Learning-Opt-Out` request header to prevent logging for recognition
- * requests. For more information, see [Request logging and data
- * privacy](https://console.bluemix.net/docs/services/text-to-speech/custom-models.html#customLogging).
- *
- * For more information about the service and its various interfaces, see [About Text to
- * Speech](https://console.bluemix.net/docs/services/text-to-speech/index.html).
  *
  * @version V1
  * @see <a href="http://www.ibm.com/watson/developercloud/text-to-speech.html">Text to Speech</a>
@@ -116,9 +95,9 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Retrieves a specific voice available for speech synthesis.
+   * Get a voice.
    *
-   * Lists information about the voice specified with the `voice` path parameter. Specify the `customization_id` query parameter to obtain information for that custom voice model of the specified voice. Use the `GET /v1/voices` method to see a list of all available voices.
+   * Lists information about the specified voice. The information includes the name, language, gender, and other details about the voice. Specify a customization ID to obtain information for that custom voice model of the specified voice.
    *
    * @param getVoiceOptions the {@link IBMTextToSpeechV1Models.GetVoiceOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.Voice} with the response
@@ -126,6 +105,12 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public IBMTextToSpeechV1Models.Voice getVoice(IBMTextToSpeechV1Models.GetVoiceOptions getVoiceOptions) {
     IBMWatsonValidator.notNull(getVoiceOptions, 'getVoiceOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/voices/{0}', new String[]{ getVoiceOptions.voice() }));
+    Map<String, String> requestHeaders = (getVoiceOptions != null) ? getVoiceOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (getVoiceOptions.customizationId() != null) {
       builder.query('customization_id', getVoiceOptions.customizationId());
     }
@@ -134,23 +119,29 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Retrieves all voices available for speech synthesis.
+   * Get voices.
    *
-   * Lists information about all available voices. To see information about a specific voice, use the `GET /v1/voices/{voice}` method.
+   * Retrieves a list of all voices available for use with the service. The information includes the name, language, gender, and other details about the voice.
    *
    * @param listVoicesOptions the {@link IBMTextToSpeechV1Models.ListVoicesOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.Voices} with the response
    */
   public IBMTextToSpeechV1Models.Voices listVoices(IBMTextToSpeechV1Models.ListVoicesOptions listVoicesOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/voices');
+    Map<String, String> requestHeaders = (listVoicesOptions != null) ? listVoicesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMTextToSpeechV1Models.Voices) createServiceCall(builder.build(), IBMTextToSpeechV1Models.Voices.class);
   }
 
   /**
-   * Streaming speech synthesis of the text in the body parameter.
+   * Synthesize audio.
    *
-   * Synthesizes text to spoken audio, returning the synthesized audio stream as an array of bytes. Identical to the `GET` method but passes longer text in the body of the request, not with the URL. Text size is limited to 5 KB. (For the `audio/l16` format, you can optionally specify `endianness=big-endian` or `endianness=little-endian`; the default is little endian.)   If a request includes invalid query parameters, the service returns a `Warnings` response header that provides messages about the invalid parameters. The warning includes a descriptive message and a list of invalid argument strings. For example, a message such as `\"Unknown arguments:\"` or `\"Unknown url query arguments:\"` followed by a list of the form `\"invalid_arg_1, invalid_arg_2.\"` The request succeeds despite the warnings.   **Note about the Try It Out feature:** The `Try it out!` button is **not** supported for use with the the `POST /v1/synthesize` method. For examples of calls to the method, see the [Text to Speech API reference](http://www.ibm.com/watson/developercloud/text-to-speech/api/v1/).
+   * Synthesizes text to spoken audio, returning the synthesized audio stream as an array of bytes. You can pass a maximum of 5 KB of text.  Use the `Accept` header or the `accept` query parameter to specify the requested format (MIME type) of the response audio. By default, the service uses `audio/ogg;codecs=opus`. For detailed information about the supported audio formats and sampling rates, see [Specifying an audio format](https://console.bluemix.net/docs/services/text-to-speech/http.html#format).   If a request includes invalid query parameters, the service returns a `Warnings` response header that provides messages about the invalid parameters. The warning includes a descriptive message and a list of invalid argument strings. For example, a message such as `\"Unknown arguments:\"` or `\"Unknown url query arguments:\"` followed by a list of the form `\"invalid_arg_1, invalid_arg_2.\"` The request succeeds despite the warnings.  **Note about the Try It Out feature:** The `Try it out!` button is **not** supported for use with the the `POST /v1/synthesize` method. For examples of calls to the method, see the [Text to Speech API reference](http://www.ibm.com/watson/developercloud/text-to-speech/api/v1/).
    *
    * @param synthesizeOptions the {@link IBMTextToSpeechV1Models.SynthesizeOptions} containing the options for the call
    * @return the {@link IBMWatsonFile} with the response
@@ -160,6 +151,12 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/synthesize');
     if (synthesizeOptions.accept() != null) {
       builder.addHeader('Accept', synthesizeOptions.accept());
+    }
+    Map<String, String> requestHeaders = (synthesizeOptions != null) ? synthesizeOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
     }
     if (synthesizeOptions.voice() != null) {
       builder.query('voice', synthesizeOptions.voice());
@@ -175,9 +172,9 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Gets the pronunciation for a word.
+   * Get pronunciation.
    *
-   * Returns the phonetic pronunciation for the word specified by the `text` parameter. You can request the pronunciation for a specific format. You can also request the pronunciation for a specific voice to see the default translation for the language of that voice or for a specific custom voice model to see the translation for that voice model.   **Note:** This method is currently a beta release.
+   * Returns the phonetic pronunciation for the specified word. You can request the pronunciation for a specific format. You can also request the pronunciation for a specific voice to see the default translation for the language of that voice or for a specific custom voice model to see the translation for that voice model.  **Note:** This method is currently a beta release.
    *
    * @param getPronunciationOptions the {@link IBMTextToSpeechV1Models.GetPronunciationOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.Pronunciation} with the response
@@ -185,6 +182,12 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public IBMTextToSpeechV1Models.Pronunciation getPronunciation(IBMTextToSpeechV1Models.GetPronunciationOptions getPronunciationOptions) {
     IBMWatsonValidator.notNull(getPronunciationOptions, 'getPronunciationOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/pronunciation');
+    Map<String, String> requestHeaders = (getPronunciationOptions != null) ? getPronunciationOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (getPronunciationOptions.text() != null) {
       builder.query('text', getPronunciationOptions.text());
     }
@@ -202,9 +205,9 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Creates a new custom voice model.
+   * Create a custom model.
    *
-   * Creates a new empty custom voice model. The model is owned by the instance of the service whose credentials are used to create it.   **Note:** This method is currently a beta release.
+   * Creates a new empty custom voice model. You must specify a name for the new custom model; you can optionally specify the language and a description of the new model. The model is owned by the instance of the service whose credentials are used to create it.  **Note:** This method is currently a beta release.
    *
    * @param createVoiceModelOptions the {@link IBMTextToSpeechV1Models.CreateVoiceModelOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.VoiceModel} with the response
@@ -212,6 +215,12 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public IBMTextToSpeechV1Models.VoiceModel createVoiceModel(IBMTextToSpeechV1Models.CreateVoiceModelOptions createVoiceModelOptions) {
     IBMWatsonValidator.notNull(createVoiceModelOptions, 'createVoiceModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/customizations');
+    Map<String, String> requestHeaders = (createVoiceModelOptions != null) ? createVoiceModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('name', createVoiceModelOptions.name());
     if (createVoiceModelOptions.language() != null) {
@@ -226,9 +235,9 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Deletes a custom voice model.
+   * Delete a custom model.
    *
-   * Deletes the custom voice model with the specified `customization_id`. You must use credentials for the instance of the service that owns a model to delete it.   **Note:** This method is currently a beta release.
+   * Deletes the specified custom voice model. You must use credentials for the instance of the service that owns a model to delete it.  **Note:** This method is currently a beta release.
    *
    * @param deleteVoiceModelOptions the {@link IBMTextToSpeechV1Models.DeleteVoiceModelOptions} containing the options for the call
    * @return the service call
@@ -236,14 +245,20 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public void deleteVoiceModel(IBMTextToSpeechV1Models.DeleteVoiceModelOptions deleteVoiceModelOptions) {
     IBMWatsonValidator.notNull(deleteVoiceModelOptions, 'deleteVoiceModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/customizations/{0}', new String[]{ deleteVoiceModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (deleteVoiceModelOptions != null) ? deleteVoiceModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Queries the contents of a custom voice model.
+   * List a custom model.
    *
-   * Lists all information about the custom voice model with the specified `customization_id`. In addition to metadata such as the name and description of the voice model, the output includes the words in the model and their translations as defined in the model. To see just the metadata for a voice model, use the `GET /v1/customizations` method. You must use credentials for the instance of the service that owns a model to list information about it.   **Note:** This method is currently a beta release.
+   * Lists all information about a specified custom voice model. In addition to metadata such as the name and description of the voice model, the output includes the words and their translations as defined in the model. To see just the metadata for a voice model, use the **List custom models** method.   **Note:** This method is currently a beta release.
    *
    * @param getVoiceModelOptions the {@link IBMTextToSpeechV1Models.GetVoiceModelOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.VoiceModel} with the response
@@ -251,20 +266,32 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public IBMTextToSpeechV1Models.VoiceModel getVoiceModel(IBMTextToSpeechV1Models.GetVoiceModelOptions getVoiceModelOptions) {
     IBMWatsonValidator.notNull(getVoiceModelOptions, 'getVoiceModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/customizations/{0}', new String[]{ getVoiceModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (getVoiceModelOptions != null) ? getVoiceModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMTextToSpeechV1Models.VoiceModel) createServiceCall(builder.build(), IBMTextToSpeechV1Models.VoiceModel.class);
   }
 
   /**
-   * Lists all available custom voice models for a language or for all languages.
+   * List custom models.
    *
-   * Lists metadata such as the name and description for the custom voice models that you own. Use the `language` query parameter to list the voice models that you own for the specified language only. Omit the parameter to see all voice models that you own for all languages. To see the words in addition to the metadata for a specific voice model, use the `GET /v1/customizations/{customization_id}` method. You must use credentials for the instance of the service that owns a model to list information about it.   **Note:** This method is currently a beta release.
+   * Lists metadata such as the name and description for all custom voice models that are owned by an instance of the service. Specify a language to list the voice models for that language only. To see the words in addition to the metadata for a specific voice model, use the **List a custom model** method. You must use credentials for the instance of the service that owns a model to list information about it.  **Note:** This method is currently a beta release.
    *
    * @param listVoiceModelsOptions the {@link IBMTextToSpeechV1Models.ListVoiceModelsOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.VoiceModels} with the response
    */
   public IBMTextToSpeechV1Models.VoiceModels listVoiceModels(IBMTextToSpeechV1Models.ListVoiceModelsOptions listVoiceModelsOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v1/customizations');
+    Map<String, String> requestHeaders = (listVoiceModelsOptions != null) ? listVoiceModelsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     if (listVoiceModelsOptions != null && listVoiceModelsOptions.language() != null) {
       builder.query('language', listVoiceModelsOptions.language());
     }
@@ -273,9 +300,9 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Updates information and words for a custom voice model.
+   * Update a custom model.
    *
-   * Updates information for the custom voice model with the specified `customization_id`. You can update the metadata such as the name and description of the voice model. You can also update the words in the model and their translations. Adding a new translation for a word that already exists in a custom model overwrites the word's existing translation. A custom model can contain no more than 20,000 entries. You must use credentials for the instance of the service that owns a model to update it.   **Note:** This method is currently a beta release.
+   * Updates information for the specified custom voice model. You can update metadata such as the name and description of the voice model. You can also update the words in the model and their translations. Adding a new translation for a word that already exists in a custom model overwrites the word's existing translation. A custom model can contain no more than 20,000 entries. You must use credentials for the instance of the service that owns a model to update it.  **Note:** This method is currently a beta release.
    *
    * @param updateVoiceModelOptions the {@link IBMTextToSpeechV1Models.UpdateVoiceModelOptions} containing the options for the call
    * @return the service call
@@ -283,6 +310,12 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public void updateVoiceModel(IBMTextToSpeechV1Models.UpdateVoiceModelOptions updateVoiceModelOptions) {
     IBMWatsonValidator.notNull(updateVoiceModelOptions, 'updateVoiceModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/customizations/{0}', new String[]{ updateVoiceModelOptions.customizationId() }));
+    Map<String, String> requestHeaders = (updateVoiceModelOptions != null) ? updateVoiceModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (updateVoiceModelOptions.name() != null) {
       contentJson.put('name', updateVoiceModelOptions.name());
@@ -299,9 +332,9 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Adds a word to a custom voice model.
+   * Add a custom word.
    *
-   * Adds a single word and its translation to the custom voice model with the specified `customization_id`. Adding a new translation for a word that already exists in a custom model overwrites the word's existing translation. A custom model can contain no more than 20,000 entries. You must use credentials for the instance of the service that owns a model to add a word to it.   **Note:** This method is currently a beta release.
+   * Adds a single word and its translation to the specified custom voice model. Adding a new translation for a word that already exists in a custom model overwrites the word's existing translation. A custom model can contain no more than 20,000 entries.  **Note:** This method is currently a beta release.
    *
    * @param addWordOptions the {@link IBMTextToSpeechV1Models.AddWordOptions} containing the options for the call
    * @return the service call
@@ -309,6 +342,12 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public void addWord(IBMTextToSpeechV1Models.AddWordOptions addWordOptions) {
     IBMWatsonValidator.notNull(addWordOptions, 'addWordOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPut(getEndPoint() + String.format('/v1/customizations/{0}/words/{1}', new String[]{ addWordOptions.customizationId(), addWordOptions.word() }));
+    Map<String, String> requestHeaders = (addWordOptions != null) ? addWordOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (addWordOptions.translation() != null) {
       contentJson.put('translation', addWordOptions.translation());
@@ -322,9 +361,9 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Adds one or more words to a custom voice model.
+   * Add custom words.
    *
-   * Adds one or more words and their translations to the custom voice model with the specified `customization_id`. Adding a new translation for a word that already exists in a custom model overwrites the word's existing translation. A custom model can contain no more than 20,000 entries. You must use credentials for the instance of the service that owns a model to add words to it.   **Note:** This method is currently a beta release.
+   * Adds one or more words and their translations to the specified custom voice model. Adding a new translation for a word that already exists in a custom model overwrites the word's existing translation. A custom model can contain no more than 20,000 entries.  **Note:** This method is currently a beta release.
    *
    * @param addWordsOptions the {@link IBMTextToSpeechV1Models.AddWordsOptions} containing the options for the call
    * @return the service call
@@ -332,6 +371,12 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public void addWords(IBMTextToSpeechV1Models.AddWordsOptions addWordsOptions) {
     IBMWatsonValidator.notNull(addWordsOptions, 'addWordsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v1/customizations/{0}/words', new String[]{ addWordsOptions.customizationId() }));
+    Map<String, String> requestHeaders = (addWordsOptions != null) ? addWordsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     final Map<String, Object> contentJson = new Map<String, Object>();
     if (addWordsOptions.words() != null) {
       contentJson.put('words', addWordsOptions.words());
@@ -342,9 +387,9 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Deletes a word from a custom voice model.
+   * Delete a custom word.
    *
-   * Deletes a single word from the custom voice model with the specified `customization_id`. You must use credentials for the instance of the service that owns a model to delete it.   **Note:** This method is currently a beta release.
+   * Deletes a single word from the specified custom voice model.  **Note:** This method is currently a beta release.
    *
    * @param deleteWordOptions the {@link IBMTextToSpeechV1Models.DeleteWordOptions} containing the options for the call
    * @return the service call
@@ -352,14 +397,20 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public void deleteWord(IBMTextToSpeechV1Models.DeleteWordOptions deleteWordOptions) {
     IBMWatsonValidator.notNull(deleteWordOptions, 'deleteWordOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v1/customizations/{0}/words/{1}', new String[]{ deleteWordOptions.customizationId(), deleteWordOptions.word() }));
+    Map<String, String> requestHeaders = (deleteWordOptions != null) ? deleteWordOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     createServiceCall(builder.build(), null);
   }
 
   /**
-   * Queries details about a word in a custom voice model.
+   * List a custom word.
    *
-   * Returns the translation for a single word from the custom model with the specified `customization_id`. The output shows the translation as it is defined in the model. You must use credentials for the instance of the service that owns a model to query information about its words.   **Note:** This method is currently a beta release.
+   * Returns the translation for a single word from the specified custom model. The output shows the translation as it is defined in the model.  **Note:** This method is currently a beta release.
    *
    * @param getWordOptions the {@link IBMTextToSpeechV1Models.GetWordOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.Translation} with the response
@@ -367,14 +418,20 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public IBMTextToSpeechV1Models.Translation getWord(IBMTextToSpeechV1Models.GetWordOptions getWordOptions) {
     IBMWatsonValidator.notNull(getWordOptions, 'getWordOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/customizations/{0}/words/{1}', new String[]{ getWordOptions.customizationId(), getWordOptions.word() }));
+    Map<String, String> requestHeaders = (getWordOptions != null) ? getWordOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMTextToSpeechV1Models.Translation) createServiceCall(builder.build(), IBMTextToSpeechV1Models.Translation.class);
   }
 
   /**
-   * Queries details about the words in a custom voice model.
+   * List custom words.
    *
-   * Lists all of the words and their translations for the custom voice model with the specified `customization_id`. The output shows the translations as they are defined in the model. You must use credentials for the instance of the service that owns a model to query information about its words.   **Note:** This method is currently a beta release.
+   * Lists all of the words and their translations for the specified custom voice model. The output shows the translations as they are defined in the model.  **Note:** This method is currently a beta release.
    *
    * @param listWordsOptions the {@link IBMTextToSpeechV1Models.ListWordsOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.Words} with the response
@@ -382,6 +439,12 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   public IBMTextToSpeechV1Models.Words listWords(IBMTextToSpeechV1Models.ListWordsOptions listWordsOptions) {
     IBMWatsonValidator.notNull(listWordsOptions, 'listWordsOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v1/customizations/{0}/words', new String[]{ listWordsOptions.customizationId() }));
+    Map<String, String> requestHeaders = (listWordsOptions != null) ? listWordsOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
 
     return (IBMTextToSpeechV1Models.Words) createServiceCall(builder.build(), IBMTextToSpeechV1Models.Words.class);
   }

--- a/force-app/main/default/classes/IBMTextToSpeechV1Models.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1Models.cls
@@ -82,6 +82,7 @@ public class IBMTextToSpeechV1Models {
       word_serialized_name = addWordOptions.word_serialized_name;
       translation_serialized_name = addWordOptions.translation_serialized_name;
       part_of_speech_serialized_name = addWordOptions.part_of_speech_serialized_name;
+      this.requestHeaders.putAll(addWordOptions.requestHeaders());
     }
 
     /**
@@ -233,6 +234,7 @@ public class IBMTextToSpeechV1Models {
     private AddWordsOptionsBuilder(AddWordsOptions addWordsOptions) {
       customization_id_serialized_name = addWordsOptions.customization_id_serialized_name;
       words_serialized_name = addWordsOptions.words_serialized_name;
+      this.requestHeaders.putAll(addWordsOptions.requestHeaders());
     }
 
     /**
@@ -389,6 +391,7 @@ public class IBMTextToSpeechV1Models {
       name_serialized_name = createVoiceModelOptions.name_serialized_name;
       language_serialized_name = createVoiceModelOptions.language_serialized_name;
       description_serialized_name = createVoiceModelOptions.description_serialized_name;
+      this.requestHeaders.putAll(createVoiceModelOptions.requestHeaders());
     }
 
     /**
@@ -501,6 +504,7 @@ public class IBMTextToSpeechV1Models {
 
     private DeleteVoiceModelOptionsBuilder(DeleteVoiceModelOptions deleteVoiceModelOptions) {
       customization_id_serialized_name = deleteVoiceModelOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(deleteVoiceModelOptions.requestHeaders());
     }
 
     /**
@@ -606,6 +610,7 @@ public class IBMTextToSpeechV1Models {
     private DeleteWordOptionsBuilder(DeleteWordOptions deleteWordOptions) {
       customization_id_serialized_name = deleteWordOptions.customization_id_serialized_name;
       word_serialized_name = deleteWordOptions.word_serialized_name;
+      this.requestHeaders.putAll(deleteWordOptions.requestHeaders());
     }
 
     /**
@@ -751,6 +756,7 @@ public class IBMTextToSpeechV1Models {
       voice_serialized_name = getPronunciationOptions.voice_serialized_name;
       format_serialized_name = getPronunciationOptions.format_serialized_name;
       customization_id_serialized_name = getPronunciationOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(getPronunciationOptions.requestHeaders());
     }
 
     /**
@@ -874,6 +880,7 @@ public class IBMTextToSpeechV1Models {
 
     private GetVoiceModelOptionsBuilder(GetVoiceModelOptions getVoiceModelOptions) {
       customization_id_serialized_name = getVoiceModelOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(getVoiceModelOptions.requestHeaders());
     }
 
     /**
@@ -978,6 +985,7 @@ public class IBMTextToSpeechV1Models {
     private GetVoiceOptionsBuilder(GetVoiceOptions getVoiceOptions) {
       voice_serialized_name = getVoiceOptions.voice_serialized_name;
       customization_id_serialized_name = getVoiceOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(getVoiceOptions.requestHeaders());
     }
 
     /**
@@ -1094,6 +1102,7 @@ public class IBMTextToSpeechV1Models {
     private GetWordOptionsBuilder(GetWordOptions getWordOptions) {
       customization_id_serialized_name = getWordOptions.customization_id_serialized_name;
       word_serialized_name = getWordOptions.word_serialized_name;
+      this.requestHeaders.putAll(getWordOptions.requestHeaders());
     }
 
     /**
@@ -1196,6 +1205,7 @@ public class IBMTextToSpeechV1Models {
 
     private ListVoiceModelsOptionsBuilder(ListVoiceModelsOptions listVoiceModelsOptions) {
       language_serialized_name = listVoiceModelsOptions.language_serialized_name;
+      this.requestHeaders.putAll(listVoiceModelsOptions.requestHeaders());
     }
 
     /**
@@ -1262,6 +1272,7 @@ public class IBMTextToSpeechV1Models {
   public class ListVoicesOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListVoicesOptionsBuilder(ListVoicesOptions listVoicesOptions) {
+      this.requestHeaders.putAll(listVoicesOptions.requestHeaders());
     }
 
     /**
@@ -1332,6 +1343,7 @@ public class IBMTextToSpeechV1Models {
 
     private ListWordsOptionsBuilder(ListWordsOptions listWordsOptions) {
       customization_id_serialized_name = listWordsOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(listWordsOptions.requestHeaders());
     }
 
     /**
@@ -1559,6 +1571,7 @@ public class IBMTextToSpeechV1Models {
       accept_serialized_name = synthesizeOptions.accept_serialized_name;
       voice_serialized_name = synthesizeOptions.voice_serialized_name;
       customization_id_serialized_name = synthesizeOptions.customization_id_serialized_name;
+      this.requestHeaders.putAll(synthesizeOptions.requestHeaders());
     }
 
     /**
@@ -1782,6 +1795,7 @@ public class IBMTextToSpeechV1Models {
       name_serialized_name = updateVoiceModelOptions.name_serialized_name;
       description_serialized_name = updateVoiceModelOptions.description_serialized_name;
       words_serialized_name = updateVoiceModelOptions.words_serialized_name;
+      this.requestHeaders.putAll(updateVoiceModelOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMTextToSpeechV1Models.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1Models.cls
@@ -2,7 +2,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * The addWord options.
    */
-  public class AddWordOptions {
+  public class AddWordOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_serialized_name;
     private String translation_serialized_name;
@@ -10,7 +10,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom voice model that is to be updated. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -54,6 +54,7 @@ public class IBMTextToSpeechV1Models {
       word_serialized_name = builder.word_serialized_name;
       translation_serialized_name = builder.translation_serialized_name;
       part_of_speech_serialized_name = builder.part_of_speech_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -70,7 +71,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * AddWordOptions Builder.
    */
-  public class AddWordOptionsBuilder {
+  public class AddWordOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_serialized_name;
     private String translation_serialized_name;
@@ -164,18 +165,30 @@ public class IBMTextToSpeechV1Models {
       this.part_of_speech_serialized_name = translation.getPartOfSpeech();
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the AddWordOptions builder
+     */
+    public AddWordOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The addWords options.
    */
-  public class AddWordsOptions {
+  public class AddWordsOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private List<Word> words_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom voice model that is to be updated. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -185,7 +198,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the words_serialized_name.
      *
-     * An array of words and their translations from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words.
+     * **When adding words to a custom voice model,** an array of `Word` objects that provides one or more words that are to be added or updated for the custom voice model and the translation for each specified word. **When listing words from a custom voice model,** an array of `Word` objects that lists the words and their translations from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words.
      *
      * @return the words_serialized_name
      */
@@ -196,6 +209,7 @@ public class IBMTextToSpeechV1Models {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       words_serialized_name = builder.words_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -212,7 +226,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * AddWordsOptions Builder.
    */
-  public class AddWordsOptionsBuilder {
+  public class AddWordsOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private List<Word> words_serialized_name;
 
@@ -293,12 +307,24 @@ public class IBMTextToSpeechV1Models {
       this.words_serialized_name = words.getWords();
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the AddWordsOptions builder
+     */
+    public AddWordsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The createVoiceModel options.
    */
-  public class CreateVoiceModelOptions {
+  public class CreateVoiceModelOptions extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String language_serialized_name;
     private String description_serialized_name;
@@ -337,6 +363,7 @@ public class IBMTextToSpeechV1Models {
       name_serialized_name = builder.name_serialized_name;
       language_serialized_name = builder.language_serialized_name;
       description_serialized_name = builder.description_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -353,7 +380,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * CreateVoiceModelOptions Builder.
    */
-  public class CreateVoiceModelOptionsBuilder {
+  public class CreateVoiceModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private String language_serialized_name;
     private String description_serialized_name;
@@ -420,17 +447,29 @@ public class IBMTextToSpeechV1Models {
       this.description_serialized_name = description;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateVoiceModelOptions builder
+     */
+    public CreateVoiceModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteVoiceModel options.
    */
-  public class DeleteVoiceModelOptions {
+  public class DeleteVoiceModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom voice model that is to be deleted. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -440,6 +479,7 @@ public class IBMTextToSpeechV1Models {
     private DeleteVoiceModelOptions(DeleteVoiceModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -456,7 +496,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * DeleteVoiceModelOptions Builder.
    */
-  public class DeleteVoiceModelOptionsBuilder {
+  public class DeleteVoiceModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private DeleteVoiceModelOptionsBuilder(DeleteVoiceModelOptions deleteVoiceModelOptions) {
@@ -497,18 +537,30 @@ public class IBMTextToSpeechV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteVoiceModelOptions builder
+     */
+    public DeleteVoiceModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteWord options.
    */
-  public class DeleteWordOptions {
+  public class DeleteWordOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom voice model from which to delete a word. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -530,6 +582,7 @@ public class IBMTextToSpeechV1Models {
       IBMWatsonValidator.notEmpty(builder.word_serialized_name, 'word_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       word_serialized_name = builder.word_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -546,7 +599,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * DeleteWordOptions Builder.
    */
-  public class DeleteWordOptionsBuilder {
+  public class DeleteWordOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_serialized_name;
 
@@ -602,12 +655,24 @@ public class IBMTextToSpeechV1Models {
       this.word_serialized_name = word;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteWordOptions builder
+     */
+    public DeleteWordOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getPronunciation options.
    */
-  public class GetPronunciationOptions {
+  public class GetPronunciationOptions extends IBMWatsonOptionsModel {
     private String text_serialized_name;
     private String voice_serialized_name;
     private String format_serialized_name;
@@ -625,7 +690,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the voice_serialized_name.
      *
-     * A voice that specifies the language in which the pronunciation is to be returned. All voices for the same language (for example, `en-US`) return the same translation. Retrieve available voices with the `GET /v1/voices` method.
+     * A voice that specifies the language in which the pronunciation is to be returned. All voices for the same language (for example, `en-US`) return the same translation.
      *
      * @return the voice_serialized_name
      */
@@ -645,7 +710,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of a custom voice model for which the pronunciation is to be returned. The language of a specified custom model must match the language of the specified voice. If the word is not defined in the specified custom model, the service returns the default translation for the custom model's language. You must make the request with service credentials created for the instance of the service that owns the custom model. Omit the parameter to see the translation for the specified voice with no customization.
+     * The customization ID (GUID) of a custom voice model for which the pronunciation is to be returned. The language of a specified custom model must match the language of the specified voice. If the word is not defined in the specified custom model, the service returns the default translation for the custom model's language. You must make the request with service credentials created for the instance of the service that owns the custom model. Omit the parameter to see the translation for the specified voice with no customization.
      *
      * @return the customization_id_serialized_name
      */
@@ -658,6 +723,7 @@ public class IBMTextToSpeechV1Models {
       voice_serialized_name = builder.voice_serialized_name;
       format_serialized_name = builder.format_serialized_name;
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -674,7 +740,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * GetPronunciationOptions Builder.
    */
-  public class GetPronunciationOptionsBuilder {
+  public class GetPronunciationOptionsBuilder extends IBMWatsonOptionsModel {
     private String text_serialized_name;
     private String voice_serialized_name;
     private String format_serialized_name;
@@ -754,17 +820,29 @@ public class IBMTextToSpeechV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetPronunciationOptions builder
+     */
+    public GetPronunciationOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getVoiceModel options.
    */
-  public class GetVoiceModelOptions {
+  public class GetVoiceModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom voice model that is to be queried. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -774,6 +852,7 @@ public class IBMTextToSpeechV1Models {
     private GetVoiceModelOptions(GetVoiceModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -790,7 +869,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * GetVoiceModelOptions Builder.
    */
-  public class GetVoiceModelOptionsBuilder {
+  public class GetVoiceModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private GetVoiceModelOptionsBuilder(GetVoiceModelOptions getVoiceModelOptions) {
@@ -831,18 +910,30 @@ public class IBMTextToSpeechV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetVoiceModelOptions builder
+     */
+    public GetVoiceModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getVoice options.
    */
-  public class GetVoiceOptions {
+  public class GetVoiceOptions extends IBMWatsonOptionsModel {
     private String voice_serialized_name;
     private String customization_id_serialized_name;
     /**
      * Gets the voice_serialized_name.
      *
-     * The voice for which information is to be returned. Retrieve available voices with the `GET /v1/voices` method.
+     * The voice for which information is to be returned.
      *
      * @return the voice_serialized_name
      */
@@ -852,7 +943,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of a custom voice model for which information is to be returned. You must make the request with service credentials created for the instance of the service that owns the custom model. Omit the parameter to see information about the specified voice with no customization.
+     * The customization ID (GUID) of a custom voice model for which information is to be returned. You must make the request with service credentials created for the instance of the service that owns the custom model. Omit the parameter to see information about the specified voice with no customization.
      *
      * @return the customization_id_serialized_name
      */
@@ -863,6 +954,7 @@ public class IBMTextToSpeechV1Models {
       IBMWatsonValidator.notEmpty(builder.voice_serialized_name, 'voice_serialized_name cannot be empty');
       voice_serialized_name = builder.voice_serialized_name;
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -879,7 +971,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * GetVoiceOptions Builder.
    */
-  public class GetVoiceOptionsBuilder {
+  public class GetVoiceOptionsBuilder extends IBMWatsonOptionsModel {
     private String voice_serialized_name;
     private String customization_id_serialized_name;
 
@@ -933,18 +1025,30 @@ public class IBMTextToSpeechV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetVoiceOptions builder
+     */
+    public GetVoiceOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getWord options.
    */
-  public class GetWordOptions {
+  public class GetWordOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom voice model from which to query a word. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -966,6 +1070,7 @@ public class IBMTextToSpeechV1Models {
       IBMWatsonValidator.notEmpty(builder.word_serialized_name, 'word_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
       word_serialized_name = builder.word_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -982,7 +1087,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * GetWordOptions Builder.
    */
-  public class GetWordOptionsBuilder {
+  public class GetWordOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String word_serialized_name;
 
@@ -1038,12 +1143,24 @@ public class IBMTextToSpeechV1Models {
       this.word_serialized_name = word;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetWordOptions builder
+     */
+    public GetWordOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listVoiceModels options.
    */
-  public class ListVoiceModelsOptions {
+  public class ListVoiceModelsOptions extends IBMWatsonOptionsModel {
     private String language_serialized_name;
     /**
      * Gets the language_serialized_name.
@@ -1057,6 +1174,7 @@ public class IBMTextToSpeechV1Models {
     }
     private ListVoiceModelsOptions(ListVoiceModelsOptionsBuilder builder) {
       language_serialized_name = builder.language_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1073,7 +1191,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * ListVoiceModelsOptions Builder.
    */
-  public class ListVoiceModelsOptionsBuilder {
+  public class ListVoiceModelsOptionsBuilder extends IBMWatsonOptionsModel {
     private String language_serialized_name;
 
     private ListVoiceModelsOptionsBuilder(ListVoiceModelsOptions listVoiceModelsOptions) {
@@ -1105,13 +1223,26 @@ public class IBMTextToSpeechV1Models {
       this.language_serialized_name = language;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListVoiceModelsOptions builder
+     */
+    public ListVoiceModelsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listVoices options.
    */
-  public class ListVoicesOptions {
+  public class ListVoicesOptions extends IBMWatsonOptionsModel {
     private ListVoicesOptions(ListVoicesOptionsBuilder builder) {
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1128,7 +1259,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * ListVoicesOptions Builder.
    */
-  public class ListVoicesOptionsBuilder {
+  public class ListVoicesOptionsBuilder extends IBMWatsonOptionsModel {
 
     private ListVoicesOptionsBuilder(ListVoicesOptions listVoicesOptions) {
     }
@@ -1147,17 +1278,29 @@ public class IBMTextToSpeechV1Models {
     public ListVoicesOptions build() {
       return new ListVoicesOptions(this);
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListVoicesOptions builder
+     */
+    public ListVoicesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The listWords options.
    */
-  public class ListWordsOptions {
+  public class ListWordsOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom voice model that is to be queried. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -1167,6 +1310,7 @@ public class IBMTextToSpeechV1Models {
     private ListWordsOptions(ListWordsOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.customization_id_serialized_name, 'customization_id_serialized_name cannot be empty');
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1183,7 +1327,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * ListWordsOptions Builder.
    */
-  public class ListWordsOptionsBuilder {
+  public class ListWordsOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
 
     private ListWordsOptionsBuilder(ListWordsOptions listWordsOptions) {
@@ -1224,12 +1368,24 @@ public class IBMTextToSpeechV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListWordsOptions builder
+     */
+    public ListWordsOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * Pronunciation.
    */
-  public class Pronunciation extends IBMWatsonGenericModel {
+  public class Pronunciation extends IBMWatsonResponseModel {
     private String pronunciation_serialized_name;
     /**
      * Gets the pronunciation_serialized_name.
@@ -1324,7 +1480,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * The synthesize options.
    */
-  public class SynthesizeOptions {
+  public class SynthesizeOptions extends IBMWatsonOptionsModel {
     private String text_serialized_name;
     private String accept_serialized_name;
     private String voice_serialized_name;
@@ -1352,7 +1508,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the voice_serialized_name.
      *
-     * The voice to use for synthesis. Retrieve available voices with the `GET /v1/voices` method.
+     * The voice to use for synthesis.
      *
      * @return the voice_serialized_name
      */
@@ -1362,7 +1518,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of a custom voice model to use for the synthesis. If a custom voice model is specified, it is guaranteed to work only if it matches the language of the indicated voice. You must make the request with service credentials created for the instance of the service that owns the custom model. Omit the parameter to use the specified voice with no customization.
+     * The customization ID (GUID) of a custom voice model to use for the synthesis. If a custom voice model is specified, it is guaranteed to work only if it matches the language of the indicated voice. You must make the request with service credentials created for the instance of the service that owns the custom model. Omit the parameter to use the specified voice with no customization.
      *
      * @return the customization_id_serialized_name
      */
@@ -1375,6 +1531,7 @@ public class IBMTextToSpeechV1Models {
       accept_serialized_name = builder.accept_serialized_name;
       voice_serialized_name = builder.voice_serialized_name;
       customization_id_serialized_name = builder.customization_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1391,7 +1548,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * SynthesizeOptions Builder.
    */
-  public class SynthesizeOptionsBuilder {
+  public class SynthesizeOptionsBuilder extends IBMWatsonOptionsModel {
     private String text_serialized_name;
     private String accept_serialized_name;
     private String voice_serialized_name;
@@ -1471,12 +1628,24 @@ public class IBMTextToSpeechV1Models {
       this.customization_id_serialized_name = customizationId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the SynthesizeOptions builder
+     */
+    public SynthesizeOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * Translation.
    */
-  public class Translation extends IBMWatsonGenericModel {
+  public class Translation extends IBMWatsonResponseModel {
     private String translation_serialized_name;
     private String part_of_speech_serialized_name;
     /**
@@ -1534,7 +1703,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * The updateVoiceModel options.
    */
-  public class UpdateVoiceModelOptions {
+  public class UpdateVoiceModelOptions extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -1542,7 +1711,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the customization_id_serialized_name.
      *
-     * The GUID of the custom voice model that is to be updated. You must make the request with service credentials created for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created for the instance of the service that owns the custom model.
      *
      * @return the customization_id_serialized_name
      */
@@ -1572,7 +1741,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the words_serialized_name.
      *
-     * An array of words and their translations that are to be added or updated for the custom voice model. Pass an empty array to make no additions or updates.
+     * An array of `Word` objects that provides the words and their translations that are to be added or updated for the custom voice model. Pass an empty array to make no additions or updates.
      *
      * @return the words_serialized_name
      */
@@ -1585,6 +1754,7 @@ public class IBMTextToSpeechV1Models {
       name_serialized_name = builder.name_serialized_name;
       description_serialized_name = builder.description_serialized_name;
       words_serialized_name = builder.words_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1601,7 +1771,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * UpdateVoiceModelOptions Builder.
    */
-  public class UpdateVoiceModelOptionsBuilder {
+  public class UpdateVoiceModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String customization_id_serialized_name;
     private String name_serialized_name;
     private String description_serialized_name;
@@ -1697,12 +1867,24 @@ public class IBMTextToSpeechV1Models {
       this.words_serialized_name = words;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateVoiceModelOptions builder
+     */
+    public UpdateVoiceModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * Voice.
    */
-  public class Voice extends IBMWatsonGenericModel {
+  public class Voice extends IBMWatsonResponseModel {
     private String url_serialized_name;
     private String gender_serialized_name;
     private String name_serialized_name;
@@ -1894,7 +2076,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * VoiceModel.
    */
-  public class VoiceModel extends IBMWatsonGenericModel {
+  public class VoiceModel extends IBMWatsonResponseModel {
     private String customization_id_serialized_name;
     private String name_serialized_name;
     private String language_serialized_name;
@@ -1983,7 +2165,7 @@ public class IBMTextToSpeechV1Models {
     /**
      * Gets the words_serialized_name.
      *
-     * An array of words and their translations from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words. **Note:** This field is returned only when you list information about a specific custom voice model.
+     * An array of `Word` objects that lists the words and their translations from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words. **Note:** This field is returned only when you list information about a specific custom voice model.
      *
      * @return the words_serialized_name
      */
@@ -2091,7 +2273,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * VoiceModels.
    */
-  public class VoiceModels extends IBMWatsonGenericModel {
+  public class VoiceModels extends IBMWatsonResponseModel {
     private List<VoiceModel> customizations_serialized_name;
     /**
      * Gets the customizations_serialized_name.
@@ -2141,7 +2323,7 @@ public class IBMTextToSpeechV1Models {
   /**
    * Voices.
    */
-  public class Voices extends IBMWatsonGenericModel {
+  public class Voices extends IBMWatsonResponseModel {
     private List<Voice> voices_serialized_name;
     /**
      * Gets the voices_serialized_name.
@@ -2270,12 +2452,12 @@ public class IBMTextToSpeechV1Models {
   /**
    * Words.
    */
-  public class Words extends IBMWatsonGenericModel {
+  public class Words extends IBMWatsonResponseModel {
     private List<Word> words_serialized_name;
     /**
      * Gets the words_serialized_name.
      *
-     * An array of words and their translations from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words.
+     * **When adding words to a custom voice model,** an array of `Word` objects that provides one or more words that are to be added or updated for the custom voice model and the translation for each specified word. **When listing words from a custom voice model,** an array of `Word` objects that lists the words and their translations from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words.
      *
      * @return the words_serialized_name
      */

--- a/force-app/main/default/classes/IBMTextToSpeechV1Test.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1Test.cls
@@ -21,6 +21,7 @@ private class IBMTextToSpeechV1Test {
       .name('I love Apples not oranges')
       .language('de-DE')
       .description('Salesforce is making it easier for developers to use IBM Watson\'s artificial intelligence engine within the firm\'s customer relationship management software, which could lead to some exciting new technology for advisers.')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -56,6 +57,7 @@ private class IBMTextToSpeechV1Test {
     IBMTextToSpeechV1Models.GetVoiceOptions options = new IBMTextToSpeechV1Models.GetVoiceOptionsBuilder()
       .customizationId('customizationId')
       .voice('en-US_AllisonVoice')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -88,6 +90,7 @@ private class IBMTextToSpeechV1Test {
       textToSpeech.setUsernameAndPassword(username, password);
     }
     IBMTextToSpeechV1Models.ListVoicesOptions options = new IBMTextToSpeechV1Models.ListVoicesOptionsBuilder()
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -113,6 +116,7 @@ private class IBMTextToSpeechV1Test {
     }
     IBMTextToSpeechV1Models.DeleteVoiceModelOptions options = new IBMTextToSpeechV1Models.DeleteVoiceModelOptionsBuilder()
       .customizationId('customizationId')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -136,6 +140,7 @@ private class IBMTextToSpeechV1Test {
     }
     IBMTextToSpeechV1Models.GetVoiceModelOptions options = new IBMTextToSpeechV1Models.GetVoiceModelOptionsBuilder()
       .customizationId('customizationId')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -160,6 +165,7 @@ private class IBMTextToSpeechV1Test {
       textToSpeech.setUsernameAndPassword(username, password);
     }
     IBMTextToSpeechV1Models.ListVoiceModelsOptions options = new IBMTextToSpeechV1Models.ListVoiceModelsOptionsBuilder()
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -189,6 +195,7 @@ private class IBMTextToSpeechV1Test {
     IBMTextToSpeechV1Models.UpdateVoiceModelOptions options = new IBMTextToSpeechV1Models.UpdateVoiceModelOptionsBuilder()
       .customizationId('customizationId')
       .addWords(word)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -219,6 +226,7 @@ private class IBMTextToSpeechV1Test {
       .translation('de-DE')
       .partOfSpeech('Josi')
       .translation(translation)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -248,6 +256,7 @@ private class IBMTextToSpeechV1Test {
       .customizationId('customizationId')
       .addWords(word)
       .words(new List<IBMTextToSpeechV1Models.Word>{word})
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -272,6 +281,7 @@ private class IBMTextToSpeechV1Test {
     IBMTextToSpeechV1Models.DeleteWordOptions options = new IBMTextToSpeechV1Models.DeleteWordOptionsBuilder()
       .customizationId('customizationId')
       .word('World')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -296,6 +306,7 @@ private class IBMTextToSpeechV1Test {
     IBMTextToSpeechV1Models.GetWordOptions options = new IBMTextToSpeechV1Models.GetWordOptionsBuilder()
       .customizationId('customizationId')
       .word('World')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -322,6 +333,7 @@ private class IBMTextToSpeechV1Test {
     }
     IBMTextToSpeechV1Models.ListWordsOptions options = new IBMTextToSpeechV1Models.ListWordsOptionsBuilder()
       .customizationId('customizationId')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -350,6 +362,7 @@ private class IBMTextToSpeechV1Test {
       .voice('de-DE_DieterVoice')
       .format('ipa')
       .customizationId('customizationId')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();

--- a/force-app/main/default/classes/IBMToneAnalyzerV3.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3.cls
@@ -5,6 +5,9 @@
  * service to learn the tone of their customers' communications and to respond to each customer appropriately, or to
  * understand and improve their customer conversations.
  *
+ * **Note:** Request logging is disabled for the Tone Analyzer service. The service neither logs nor retains data from
+ * requests and responses, regardless of whether the `X-Watson-Learning-Opt-Out` request header is set.
+ *
  * @version V3
  * @see <a href="http://www.ibm.com/watson/developercloud/tone-analyzer.html">Tone Analyzer</a>
  */
@@ -75,6 +78,12 @@ public class IBMToneAnalyzerV3 extends IBMWatsonService {
     if (toneOptions.acceptLanguage() != null) {
       builder.addHeader('Accept-Language', toneOptions.acceptLanguage());
     }
+    Map<String, String> requestHeaders = (toneOptions != null) ? toneOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (toneOptions.sentences() != null) {
       builder.query('sentences', String.valueOf(toneOptions.sentences()));
@@ -108,6 +117,12 @@ public class IBMToneAnalyzerV3 extends IBMWatsonService {
     }
     if (toneChatOptions.acceptLanguage() != null) {
       builder.addHeader('Accept-Language', toneChatOptions.acceptLanguage());
+    }
+    Map<String, String> requestHeaders = (toneChatOptions != null) ? toneChatOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
     }
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();

--- a/force-app/main/default/classes/IBMToneAnalyzerV3Models.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3Models.cls
@@ -275,7 +275,7 @@ public class IBMToneAnalyzerV3Models {
   /**
    * ToneAnalysis.
    */
-  public class ToneAnalysis extends IBMWatsonGenericModel {
+  public class ToneAnalysis extends IBMWatsonResponseModel {
     private DocumentAnalysis document_tone_serialized_name;
     private List<SentenceAnalysis> sentences_tone_serialized_name;
     /**
@@ -442,7 +442,7 @@ public class IBMToneAnalyzerV3Models {
   /**
    * The toneChat options.
    */
-  public class ToneChatOptions {
+  public class ToneChatOptions extends IBMWatsonOptionsModel {
     private List<Utterance> utterances_serialized_name;
     private String content_language_serialized_name;
     private String accept_language_serialized_name;
@@ -459,7 +459,7 @@ public class IBMToneAnalyzerV3Models {
     /**
      * Gets the content_language_serialized_name.
      *
-     * The language of the input text for the request: English or French. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not submit content that contains both languages. You can specify any combination of languages for `Content-Language` and `Accept-Language`. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
+     * The language of the input text for the request: English or French. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not submit content that contains both languages. You can use different languages for **Content-Language** and **Accept-Language**. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
      *
      * @return the content_language_serialized_name
      */
@@ -469,7 +469,7 @@ public class IBMToneAnalyzerV3Models {
     /**
      * Gets the accept_language_serialized_name.
      *
-     * The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`.
+     * The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language** and **Accept-Language**.
      *
      * @return the accept_language_serialized_name
      */
@@ -481,6 +481,7 @@ public class IBMToneAnalyzerV3Models {
       utterances_serialized_name = builder.utterances_serialized_name;
       content_language_serialized_name = builder.content_language_serialized_name;
       accept_language_serialized_name = builder.accept_language_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -497,7 +498,7 @@ public class IBMToneAnalyzerV3Models {
   /**
    * ToneChatOptions Builder.
    */
-  public class ToneChatOptionsBuilder {
+  public class ToneChatOptionsBuilder extends IBMWatsonOptionsModel {
     private List<Utterance> utterances_serialized_name;
     private String content_language_serialized_name;
     private String accept_language_serialized_name;
@@ -578,6 +579,18 @@ public class IBMToneAnalyzerV3Models {
      */
     public ToneChatOptionsBuilder acceptLanguage(String acceptLanguage) {
       this.accept_language_serialized_name = acceptLanguage;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ToneChatOptions builder
+     */
+    public ToneChatOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -741,7 +754,7 @@ public class IBMToneAnalyzerV3Models {
   /**
    * The tone options.
    */
-  public class ToneOptions {
+  public class ToneOptions extends IBMWatsonOptionsModel {
     private ToneInput tone_input_serialized_name;
     private String body_serialized_name;
     private String content_type_serialized_name;
@@ -802,7 +815,7 @@ public class IBMToneAnalyzerV3Models {
     /**
      * Gets the content_language_serialized_name.
      *
-     * The language of the input text for the request: English or French. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not submit content that contains both languages. You can specify any combination of languages for `Content-Language` and `Accept-Language`. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
+     * The language of the input text for the request: English or French. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The input content must match the specified language. Do not submit content that contains both languages. You can use different languages for **Content-Language** and **Accept-Language**. * **`2017-09-21`:** Accepts `en` or `fr`. * **`2016-05-19`:** Accepts only `en`.
      *
      * @return the content_language_serialized_name
      */
@@ -812,7 +825,7 @@ public class IBMToneAnalyzerV3Models {
     /**
      * Gets the accept_language_serialized_name.
      *
-     * The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for `Content-Language` and `Accept-Language`.
+     * The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can use different languages for **Content-Language** and **Accept-Language**.
      *
      * @return the accept_language_serialized_name
      */
@@ -828,6 +841,7 @@ public class IBMToneAnalyzerV3Models {
       tones_serialized_name = builder.tones_serialized_name;
       content_language_serialized_name = builder.content_language_serialized_name;
       accept_language_serialized_name = builder.accept_language_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -844,7 +858,7 @@ public class IBMToneAnalyzerV3Models {
   /**
    * ToneOptions Builder.
    */
-  public class ToneOptionsBuilder {
+  public class ToneOptionsBuilder extends IBMWatsonOptionsModel {
     private ToneInput tone_input_serialized_name;
     private String body_serialized_name;
     private String content_type_serialized_name;
@@ -971,6 +985,18 @@ public class IBMToneAnalyzerV3Models {
     public ToneOptionsBuilder html(String html) {
       this.body_serialized_name = html;
       this.content_type_serialized_name = IBMWatsonHttpMediaType.TEXT_HTML;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ToneOptions builder
+     */
+    public ToneOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }
@@ -1159,7 +1185,7 @@ public class IBMToneAnalyzerV3Models {
   /**
    * UtteranceAnalyses.
    */
-  public class UtteranceAnalyses extends IBMWatsonGenericModel {
+  public class UtteranceAnalyses extends IBMWatsonResponseModel {
     private List<UtteranceAnalysis> utterances_tone_serialized_name;
     private String warning_serialized_name;
     /**

--- a/force-app/main/default/classes/IBMToneAnalyzerV3Models.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3Models.cls
@@ -507,6 +507,7 @@ public class IBMToneAnalyzerV3Models {
       utterances_serialized_name = toneChatOptions.utterances_serialized_name;
       content_language_serialized_name = toneChatOptions.content_language_serialized_name;
       accept_language_serialized_name = toneChatOptions.accept_language_serialized_name;
+      this.requestHeaders.putAll(toneChatOptions.requestHeaders());
     }
 
     /**
@@ -875,6 +876,7 @@ public class IBMToneAnalyzerV3Models {
       tones_serialized_name = toneOptions.tones_serialized_name;
       content_language_serialized_name = toneOptions.content_language_serialized_name;
       accept_language_serialized_name = toneOptions.accept_language_serialized_name;
+      this.requestHeaders.putAll(toneOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMToneAnalyzerV3Test.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3Test.cls
@@ -28,6 +28,7 @@ private class IBMToneAnalyzerV3Test {
     .contentLanguage('en')
     .acceptLanguage('en')
     .toneInput(toneInput)
+    .addHeader('Test-Header', 'test_value')
     .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -66,6 +67,7 @@ private class IBMToneAnalyzerV3Test {
       .addUtterances(utterance)
       .acceptLanguage('en')
       .contentLanguage('en')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();

--- a/force-app/main/default/classes/IBMVisualRecognitionV3.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3.cls
@@ -107,6 +107,12 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
     if (classifyOptions.acceptLanguage() != null) {
       builder.addHeader('Accept-Language', classifyOptions.acceptLanguage());
     }
+    Map<String, String> requestHeaders = (classifyOptions != null) ? classifyOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
@@ -138,7 +144,7 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   /**
    * Detect faces in images.
    *
-   * **Important:** On April 2, 2018, the identity information in the response to calls to the Face model will be removed. The identity information refers to the `name` of the person, `score`, and `type_hierarchy` knowledge graph. For details about the enhanced Face model, see the [Release notes](https://console.bluemix.net/docs/services/visual-recognition/release-notes.html#23february2018).  Analyze and get data about faces in images. Responses can include estimated age and gender, and the service can identify celebrities. This feature uses a built-in classifier, so you do not train it on custom classifiers. The Detect faces method does not support general biometric facial recognition.
+   * **Important:** On April 2, 2018, the identity information in the response to calls to the Face model was removed. The identity information refers to the `name` of the person, `score`, and `type_hierarchy` knowledge graph. For details about the enhanced Face model, see the [Release notes](https://console.bluemix.net/docs/services/visual-recognition/release-notes.html#2april2018).  Analyze and get data about faces in images. Responses can include estimated age and gender. This feature uses a built-in model, so no training is necessary. The Detect faces method does not support general biometric facial recognition.  Supported image formats include .gif, .jpg, .png, and .tif. The maximum image size is 10 MB. The minimum recommended pixel density is 32X32 pixels per inch.
    *
    * @param detectFacesOptions the {@link IBMVisualRecognitionV3Models.DetectFacesOptions} containing the options for the call
    * @return the {@link IBMVisualRecognitionV3Models.DetectedFaces} with the response
@@ -147,6 +153,12 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
     IBMWatsonValidator.notNull(detectFacesOptions, 'detectFacesOptions cannot be null');
     IBMWatsonValidator.isTrue((detectFacesOptions.imagesFile() != null) || (detectFacesOptions.url() != null), 'At least one of images_file or url must be supplied.');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v3/detect_faces');
+    Map<String, String> requestHeaders = (detectFacesOptions != null) ? detectFacesOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
@@ -177,6 +189,12 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   public IBMVisualRecognitionV3Models.Classifier createClassifier(IBMVisualRecognitionV3Models.CreateClassifierOptions createClassifierOptions) {
     IBMWatsonValidator.notNull(createClassifierOptions, 'createClassifierOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v3/classifiers');
+    Map<String, String> requestHeaders = (createClassifierOptions != null) ? createClassifierOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
@@ -210,6 +228,12 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   public void deleteClassifier(IBMVisualRecognitionV3Models.DeleteClassifierOptions deleteClassifierOptions) {
     IBMWatsonValidator.notNull(deleteClassifierOptions, 'deleteClassifierOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpDelete(getEndPoint() + String.format('/v3/classifiers/{0}', new String[]{ deleteClassifierOptions.classifierId() }));
+    Map<String, String> requestHeaders = (deleteClassifierOptions != null) ? deleteClassifierOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     createServiceCall(builder.build(), null);
@@ -226,6 +250,12 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   public IBMVisualRecognitionV3Models.Classifier getClassifier(IBMVisualRecognitionV3Models.GetClassifierOptions getClassifierOptions) {
     IBMWatsonValidator.notNull(getClassifierOptions, 'getClassifierOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v3/classifiers/{0}', new String[]{ getClassifierOptions.classifierId() }));
+    Map<String, String> requestHeaders = (getClassifierOptions != null) ? getClassifierOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMVisualRecognitionV3Models.Classifier) createServiceCall(builder.build(), IBMVisualRecognitionV3Models.Classifier.class);
@@ -239,6 +269,12 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
    */
   public IBMVisualRecognitionV3Models.Classifiers listClassifiers(IBMVisualRecognitionV3Models.ListClassifiersOptions listClassifiersOptions) {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + '/v3/classifiers');
+    Map<String, String> requestHeaders = (listClassifiersOptions != null) ? listClassifiersOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     if (listClassifiersOptions != null && listClassifiersOptions.verbose() != null) {
       builder.query('verbose', String.valueOf(listClassifiersOptions.verbose()));
@@ -250,7 +286,7 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   /**
    * Update a classifier.
    *
-   * Update a custom classifier by adding new positive or negative classes (examples) or by adding new images to existing classes. You must supply at least one set of positive or negative examples. For details, see [Updating custom classifiers](https://console.bluemix.net/docs/services/visual-recognition/customizing.html#updating-custom-classifiers).  Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image file names, and classifier and class names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.  **Important:** You can't update a custom classifier with an API key for a Lite plan. To update a custom classifier on a Lite plan, create another service instance on a Standard plan and re-create your custom classifier.  **Tip:** Don't make retraining calls on a classifier until the status is ready. When you submit retraining requests in parallel, the last request overwrites the previous requests. The retrained property shows the last time the classifier retraining finished.
+   * Update a custom classifier by adding new positive or negative classes (examples) or by adding new images to existing classes. You must supply at least one set of positive or negative examples. For details, see [Updating custom classifiers](https://console.bluemix.net/docs/services/visual-recognition/customizing.html#updating-custom-classifiers).  Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image file names, and classifier and class names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.  **Tip:** Don't make retraining calls on a classifier until the status is ready. When you submit retraining requests in parallel, the last request overwrites the previous requests. The retrained property shows the last time the classifier retraining finished.
    *
    * @param updateClassifierOptions the {@link IBMVisualRecognitionV3Models.UpdateClassifierOptions} containing the options for the call
    * @return the {@link IBMVisualRecognitionV3Models.Classifier} with the response
@@ -258,6 +294,12 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   public IBMVisualRecognitionV3Models.Classifier updateClassifier(IBMVisualRecognitionV3Models.UpdateClassifierOptions updateClassifierOptions) {
     IBMWatsonValidator.notNull(updateClassifierOptions, 'updateClassifierOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + String.format('/v3/classifiers/{0}', new String[]{ updateClassifierOptions.classifierId() }));
+    Map<String, String> requestHeaders = (updateClassifierOptions != null) ? updateClassifierOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
     IBMWatsonMultipartBody.Builder multipartBuilder = new IBMWatsonMultipartBody.Builder();
     multipartBuilder.setType(IBMWatsonMultipartBody.FORM);
@@ -289,6 +331,12 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   public IBMWatsonFile getCoreMlModel(IBMVisualRecognitionV3Models.GetCoreMlModelOptions getCoreMlModelOptions) {
     IBMWatsonValidator.notNull(getCoreMlModelOptions, 'getCoreMlModelOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(getEndPoint() + String.format('/v3/classifiers/{0}/core_ml_model', new String[]{ getCoreMlModelOptions.classifierId() }));
+    Map<String, String> requestHeaders = (getCoreMlModelOptions != null) ? getCoreMlModelOptions.requestHeaders() : null;
+    if (requestHeaders != null && requestHeaders.size() > 0) {
+      for (String name : requestHeaders.keySet()) {
+        builder.addHeader(name, requestHeaders.get(name));
+      }
+    }
     builder.query('version', versionDate);
 
     return (IBMWatsonFile) createServiceCall(builder.build(), IBMWatsonFile.class);

--- a/force-app/main/default/classes/IBMVisualRecognitionV3Models.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3Models.cls
@@ -909,6 +909,7 @@ public class IBMVisualRecognitionV3Models {
       classifier_ids_serialized_name = classifyOptions.classifier_ids_serialized_name;
       images_file_content_type_serialized_name = classifyOptions.images_file_content_type_serialized_name;
       parameters_serialized_name = classifyOptions.parameters_serialized_name;
+      this.requestHeaders.putAll(classifyOptions.requestHeaders());
     }
 
     /**
@@ -1173,6 +1174,7 @@ public class IBMVisualRecognitionV3Models {
       classname_positive_examples_serialized_name.putAll(createClassifierOptions.classname_positive_examples_serialized_name);
       negative_examples_serialized_name = createClassifierOptions.negative_examples_serialized_name;
       negative_examples_filename_serialized_name = createClassifierOptions.negative_examples_filename_serialized_name;
+      this.requestHeaders.putAll(createClassifierOptions.requestHeaders());
     }
 
     /**
@@ -1304,6 +1306,7 @@ public class IBMVisualRecognitionV3Models {
 
     private DeleteClassifierOptionsBuilder(DeleteClassifierOptions deleteClassifierOptions) {
       classifier_id_serialized_name = deleteClassifierOptions.classifier_id_serialized_name;
+      this.requestHeaders.putAll(deleteClassifierOptions.requestHeaders());
     }
 
     /**
@@ -1449,6 +1452,7 @@ public class IBMVisualRecognitionV3Models {
       url_serialized_name = detectFacesOptions.url_serialized_name;
       images_file_content_type_serialized_name = detectFacesOptions.images_file_content_type_serialized_name;
       parameters_serialized_name = detectFacesOptions.parameters_serialized_name;
+      this.requestHeaders.putAll(detectFacesOptions.requestHeaders());
     }
 
     /**
@@ -2080,6 +2084,7 @@ public class IBMVisualRecognitionV3Models {
 
     private GetClassifierOptionsBuilder(GetClassifierOptions getClassifierOptions) {
       classifier_id_serialized_name = getClassifierOptions.classifier_id_serialized_name;
+      this.requestHeaders.putAll(getClassifierOptions.requestHeaders());
     }
 
     /**
@@ -2170,6 +2175,7 @@ public class IBMVisualRecognitionV3Models {
 
     private GetCoreMlModelOptionsBuilder(GetCoreMlModelOptions getCoreMlModelOptions) {
       classifier_id_serialized_name = getCoreMlModelOptions.classifier_id_serialized_name;
+      this.requestHeaders.putAll(getCoreMlModelOptions.requestHeaders());
     }
 
     /**
@@ -2395,6 +2401,7 @@ public class IBMVisualRecognitionV3Models {
 
     private ListClassifiersOptionsBuilder(ListClassifiersOptions listClassifiersOptions) {
       verbose_serialized_name = listClassifiersOptions.verbose_serialized_name;
+      this.requestHeaders.putAll(listClassifiersOptions.requestHeaders());
     }
 
     /**
@@ -2538,6 +2545,7 @@ public class IBMVisualRecognitionV3Models {
       classname_positive_examples_serialized_name.putAll(updateClassifierOptions.classname_positive_examples_serialized_name);
       negative_examples_serialized_name = updateClassifierOptions.negative_examples_serialized_name;
       negative_examples_filename_serialized_name = updateClassifierOptions.negative_examples_filename_serialized_name;
+      this.requestHeaders.putAll(updateClassifierOptions.requestHeaders());
     }
 
     /**

--- a/force-app/main/default/classes/IBMVisualRecognitionV3Models.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3Models.cls
@@ -46,7 +46,7 @@ public class IBMVisualRecognitionV3Models {
     /**
      * Gets the class_serialized_name.
      *
-     * The name of the class.
+     * Name of the class.
      *
      * @return the class_serialized_name
      */
@@ -116,7 +116,7 @@ public class IBMVisualRecognitionV3Models {
   }
 
   /**
-   * Classifier results for one image.
+   * Results for one image.
    */
   public class ClassifiedImage extends IBMWatsonGenericModel {
     private String source_url_serialized_name;
@@ -168,6 +168,8 @@ public class IBMVisualRecognitionV3Models {
     }
     /**
      * Gets the classifiers_serialized_name.
+     *
+     * The classifiers.
      *
      * @return the classifiers_serialized_name
      */
@@ -250,9 +252,9 @@ public class IBMVisualRecognitionV3Models {
   }
 
   /**
-   * Classify results for multiple images.
+   * Results for all images.
    */
-  public class ClassifiedImages extends IBMWatsonGenericModel {
+  public class ClassifiedImages extends IBMWatsonResponseModel {
     private Long custom_classes_serialized_name;
     private Long images_processed_serialized_name;
     private List<ClassifiedImage> images_serialized_name;
@@ -260,7 +262,7 @@ public class IBMVisualRecognitionV3Models {
     /**
      * Gets the custom_classes_serialized_name.
      *
-     * The number of custom classes identified in the images.
+     * Number of custom classes identified in the images.
      *
      * @return the custom_classes_serialized_name
      */
@@ -282,7 +284,7 @@ public class IBMVisualRecognitionV3Models {
     /**
      * Gets the images_serialized_name.
      *
-     * The array of classified images.
+     * Classified images.
      *
      * @return the images_serialized_name
      */
@@ -378,7 +380,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * Information about a classifier.
    */
-  public class Classifier extends IBMWatsonGenericModel {
+  public class Classifier extends IBMWatsonResponseModel {
     private String classifier_id_serialized_name;
     private String name_serialized_name;
     private String owner_serialized_name;
@@ -425,7 +427,7 @@ public class IBMVisualRecognitionV3Models {
     /**
      * Gets the status_serialized_name.
      *
-     * The training status of classifier.
+     * Training status of classifier.
      *
      * @return the status_serialized_name
      */
@@ -469,7 +471,7 @@ public class IBMVisualRecognitionV3Models {
     /**
      * Gets the classes_serialized_name.
      *
-     * Array of classes that define a classifier.
+     * Classes that define a classifier.
      *
      * @return the classes_serialized_name
      */
@@ -635,7 +637,7 @@ public class IBMVisualRecognitionV3Models {
     /**
      * Gets the classifier_id_serialized_name.
      *
-     * The ID of a classifier identified in the image.
+     * ID of a classifier identified in the image.
      *
      * @return the classifier_id_serialized_name
      */
@@ -646,7 +648,7 @@ public class IBMVisualRecognitionV3Models {
     /**
      * Gets the classes_serialized_name.
      *
-     * An array of classes within the classifier.
+     * Classes within the classifier.
      *
      * @return the classes_serialized_name
      */
@@ -707,12 +709,14 @@ public class IBMVisualRecognitionV3Models {
   }
 
   /**
-   * List of classifiers.
+   * A container for the list of classifiers.
    */
-  public class Classifiers extends IBMWatsonGenericModel {
+  public class Classifiers extends IBMWatsonResponseModel {
     private List<Classifier> classifiers_serialized_name;
     /**
      * Gets the classifiers_serialized_name.
+     *
+     * List of classifiers.
      *
      * @return the classifiers_serialized_name
      */
@@ -757,7 +761,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * The classify options.
    */
-  public class ClassifyOptions {
+  public class ClassifyOptions extends IBMWatsonOptionsModel {
     private IBMWatsonFile images_file_serialized_name;
     private String images_filename_serialized_name;
     private String accept_language_serialized_name;
@@ -867,6 +871,7 @@ public class IBMVisualRecognitionV3Models {
       classifier_ids_serialized_name = builder.classifier_ids_serialized_name;
       images_file_content_type_serialized_name = builder.images_file_content_type_serialized_name;
       parameters_serialized_name = builder.parameters_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -883,7 +888,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * ClassifyOptions Builder.
    */
-  public class ClassifyOptionsBuilder {
+  public class ClassifyOptionsBuilder extends IBMWatsonOptionsModel {
     private IBMWatsonFile images_file_serialized_name;
     private String images_filename_serialized_name;
     private String accept_language_serialized_name;
@@ -1051,12 +1056,24 @@ public class IBMVisualRecognitionV3Models {
       this.parameters_serialized_name = parameters;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ClassifyOptions builder
+     */
+    public ClassifyOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The createClassifier options.
    */
-  public class CreateClassifierOptions {
+  public class CreateClassifierOptions extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private Map<String, IBMWatsonFile> classname_positive_examples_serialized_name;
     private IBMWatsonFile negative_examples_serialized_name;
@@ -1127,6 +1144,7 @@ public class IBMVisualRecognitionV3Models {
       classname_positive_examples_serialized_name = builder.classname_positive_examples_serialized_name;
       negative_examples_serialized_name = builder.negative_examples_serialized_name;
       negative_examples_filename_serialized_name = builder.negative_examples_filename_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1143,7 +1161,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * CreateClassifierOptions Builder.
    */
-  public class CreateClassifierOptionsBuilder {
+  public class CreateClassifierOptionsBuilder extends IBMWatsonOptionsModel {
     private String name_serialized_name;
     private Map<String, IBMWatsonFile> classname_positive_examples_serialized_name;
     private IBMWatsonFile negative_examples_serialized_name;
@@ -1232,12 +1250,24 @@ public class IBMVisualRecognitionV3Models {
       this.negative_examples_filename_serialized_name = negativeExamplesFilename;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the CreateClassifierOptions builder
+     */
+    public CreateClassifierOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The deleteClassifier options.
    */
-  public class DeleteClassifierOptions {
+  public class DeleteClassifierOptions extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     /**
      * Gets the classifier_id_serialized_name.
@@ -1252,6 +1282,7 @@ public class IBMVisualRecognitionV3Models {
     private DeleteClassifierOptions(DeleteClassifierOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.classifier_id_serialized_name, 'classifier_id_serialized_name cannot be empty');
       classifier_id_serialized_name = builder.classifier_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1268,7 +1299,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * DeleteClassifierOptions Builder.
    */
-  public class DeleteClassifierOptionsBuilder {
+  public class DeleteClassifierOptionsBuilder extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
 
     private DeleteClassifierOptionsBuilder(DeleteClassifierOptions deleteClassifierOptions) {
@@ -1309,12 +1340,24 @@ public class IBMVisualRecognitionV3Models {
       this.classifier_id_serialized_name = classifierId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DeleteClassifierOptions builder
+     */
+    public DeleteClassifierOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The detectFaces options.
    */
-  public class DetectFacesOptions {
+  public class DetectFacesOptions extends IBMWatsonOptionsModel {
     private IBMWatsonFile images_file_serialized_name;
     private String images_filename_serialized_name;
     private String url_serialized_name;
@@ -1376,6 +1419,7 @@ public class IBMVisualRecognitionV3Models {
       url_serialized_name = builder.url_serialized_name;
       images_file_content_type_serialized_name = builder.images_file_content_type_serialized_name;
       parameters_serialized_name = builder.parameters_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -1392,7 +1436,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * DetectFacesOptions Builder.
    */
-  public class DetectFacesOptionsBuilder {
+  public class DetectFacesOptionsBuilder extends IBMWatsonOptionsModel {
     private IBMWatsonFile images_file_serialized_name;
     private String images_filename_serialized_name;
     private String url_serialized_name;
@@ -1476,12 +1520,24 @@ public class IBMVisualRecognitionV3Models {
       this.parameters_serialized_name = parameters;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the DetectFacesOptions builder
+     */
+    public DetectFacesOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
-   * DetectedFaces.
+   * Results for all faces.
    */
-  public class DetectedFaces extends IBMWatsonGenericModel {
+  public class DetectedFaces extends IBMWatsonResponseModel {
     private Long images_processed_serialized_name;
     private List<ImageWithFaces> images_serialized_name;
     private List<WarningInfo> warnings_serialized_name;
@@ -1499,7 +1555,7 @@ public class IBMVisualRecognitionV3Models {
     /**
      * Gets the images_serialized_name.
      *
-     * The array of images.
+     * The images.
      *
      * @return the images_serialized_name
      */
@@ -1586,7 +1642,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * Information about what might have caused a failure, such as an image that is too large. Not returned when there is no error.
    */
-  public class ErrorInfo extends IBMWatsonGenericModel {
+  public class ErrorInfo extends IBMWatsonResponseModel {
     private Long code_serialized_name;
     private String description_serialized_name;
     private String error_id_serialized_name;
@@ -1663,7 +1719,7 @@ public class IBMVisualRecognitionV3Models {
   }
 
   /**
-   * Provides information about the face.
+   * Information about the face.
    */
   public class Face extends IBMWatsonGenericModel {
     private FaceAge age_serialized_name;
@@ -1748,7 +1804,7 @@ public class IBMVisualRecognitionV3Models {
   }
 
   /**
-   * Provides age information about a face.
+   * Age information about a face.
    */
   public class FaceAge extends IBMWatsonGenericModel {
     private Long min_serialized_name;
@@ -1827,7 +1883,7 @@ public class IBMVisualRecognitionV3Models {
   }
 
   /**
-   * Provides information about the gender of the face.
+   * Information about the gender of the face.
    */
   public class FaceGender extends IBMWatsonGenericModel {
     private String gender_serialized_name;
@@ -1885,7 +1941,7 @@ public class IBMVisualRecognitionV3Models {
   }
 
   /**
-   * Defines the location of the bounding box around the face.
+   * The location of the bounding box around the face.
    */
   public class FaceLocation extends IBMWatsonGenericModel {
     private Double width_serialized_name;
@@ -1987,7 +2043,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * The getClassifier options.
    */
-  public class GetClassifierOptions {
+  public class GetClassifierOptions extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     /**
      * Gets the classifier_id_serialized_name.
@@ -2002,6 +2058,7 @@ public class IBMVisualRecognitionV3Models {
     private GetClassifierOptions(GetClassifierOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.classifier_id_serialized_name, 'classifier_id_serialized_name cannot be empty');
       classifier_id_serialized_name = builder.classifier_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2018,7 +2075,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * GetClassifierOptions Builder.
    */
-  public class GetClassifierOptionsBuilder {
+  public class GetClassifierOptionsBuilder extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
 
     private GetClassifierOptionsBuilder(GetClassifierOptions getClassifierOptions) {
@@ -2059,12 +2116,24 @@ public class IBMVisualRecognitionV3Models {
       this.classifier_id_serialized_name = classifierId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetClassifierOptions builder
+     */
+    public GetClassifierOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The getCoreMlModel options.
    */
-  public class GetCoreMlModelOptions {
+  public class GetCoreMlModelOptions extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     /**
      * Gets the classifier_id_serialized_name.
@@ -2079,6 +2148,7 @@ public class IBMVisualRecognitionV3Models {
     private GetCoreMlModelOptions(GetCoreMlModelOptionsBuilder builder) {
       IBMWatsonValidator.notEmpty(builder.classifier_id_serialized_name, 'classifier_id_serialized_name cannot be empty');
       classifier_id_serialized_name = builder.classifier_id_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2095,7 +2165,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * GetCoreMlModelOptions Builder.
    */
-  public class GetCoreMlModelOptionsBuilder {
+  public class GetCoreMlModelOptionsBuilder extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
 
     private GetCoreMlModelOptionsBuilder(GetCoreMlModelOptions getCoreMlModelOptions) {
@@ -2136,10 +2206,22 @@ public class IBMVisualRecognitionV3Models {
       this.classifier_id_serialized_name = classifierId;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the GetCoreMlModelOptions builder
+     */
+    public GetCoreMlModelOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
-   * ImageWithFaces.
+   * Information about faces in the image.
    */
   public class ImageWithFaces extends IBMWatsonGenericModel {
     private List<Face> faces_serialized_name;
@@ -2150,7 +2232,7 @@ public class IBMVisualRecognitionV3Models {
     /**
      * Gets the faces_serialized_name.
      *
-     * An array of the faces detected in the images.
+     * Faces detected in the images.
      *
      * @return the faces_serialized_name
      */
@@ -2277,7 +2359,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * The listClassifiers options.
    */
-  public class ListClassifiersOptions {
+  public class ListClassifiersOptions extends IBMWatsonOptionsModel {
     private Boolean verbose_serialized_name;
     /**
      * Gets the verbose_serialized_name.
@@ -2291,6 +2373,7 @@ public class IBMVisualRecognitionV3Models {
     }
     private ListClassifiersOptions(ListClassifiersOptionsBuilder builder) {
       verbose_serialized_name = builder.verbose_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2307,7 +2390,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * ListClassifiersOptions Builder.
    */
-  public class ListClassifiersOptionsBuilder {
+  public class ListClassifiersOptionsBuilder extends IBMWatsonOptionsModel {
     private Boolean verbose_serialized_name;
 
     private ListClassifiersOptionsBuilder(ListClassifiersOptions listClassifiersOptions) {
@@ -2339,12 +2422,24 @@ public class IBMVisualRecognitionV3Models {
       this.verbose_serialized_name = verbose;
       return this;
     }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the ListClassifiersOptions builder
+     */
+    public ListClassifiersOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
+      return this;
+    }
   }
 
   /**
    * The updateClassifier options.
    */
-  public class UpdateClassifierOptions {
+  public class UpdateClassifierOptions extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     private Map<String, IBMWatsonFile> classname_positive_examples_serialized_name;
     private IBMWatsonFile negative_examples_serialized_name;
@@ -2414,6 +2509,7 @@ public class IBMVisualRecognitionV3Models {
       classname_positive_examples_serialized_name = builder.classname_positive_examples_serialized_name;
       negative_examples_serialized_name = builder.negative_examples_serialized_name;
       negative_examples_filename_serialized_name = builder.negative_examples_filename_serialized_name;
+      this.requestHeaders = builder.requestHeaders;
     }
 
     /**
@@ -2430,7 +2526,7 @@ public class IBMVisualRecognitionV3Models {
   /**
    * UpdateClassifierOptions Builder.
    */
-  public class UpdateClassifierOptionsBuilder {
+  public class UpdateClassifierOptionsBuilder extends IBMWatsonOptionsModel {
     private String classifier_id_serialized_name;
     private Map<String, IBMWatsonFile> classname_positive_examples_serialized_name;
     private IBMWatsonFile negative_examples_serialized_name;
@@ -2489,8 +2585,7 @@ public class IBMVisualRecognitionV3Models {
      * @param positiveExamples the positive examples
      * @return the builder
      */
-    public UpdateClassifierOptionsBuilder addClass(String className,
-      IBMWatsonFile positiveExamples) {
+    public UpdateClassifierOptionsBuilder addClass(String className, IBMWatsonFile positiveExamples) {
       IBMWatsonValidator.notNull(className, 'className cannot be null');
       IBMWatsonValidator.notNull(positiveExamples, 'positiveExamples cannot be null');
       classname_positive_examples_serialized_name.put(className, positiveExamples);
@@ -2516,6 +2611,18 @@ public class IBMVisualRecognitionV3Models {
      */
     public UpdateClassifierOptionsBuilder negativeExamplesFilename(String negativeExamplesFilename) {
       this.negative_examples_filename_serialized_name = negativeExamplesFilename;
+      return this;
+    }
+
+    /**
+     * Add a request header.
+     *
+     * @param name the header name
+     * @param value the header value
+     * @return the UpdateClassifierOptions builder
+     */
+    public UpdateClassifierOptionsBuilder addHeader(String name, String value) {
+      this.requestHeaders.put(name, value);
       return this;
     }
   }

--- a/force-app/main/default/classes/IBMVisualRecognitionV3Test.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3Test.cls
@@ -15,6 +15,7 @@ private class IBMVisualRecognitionV3Test {
     visualRecognition.setEndPoint('https://gateway-a.watsonplatform.net/visual-recognition/api');
     IBMVisualRecognitionV3Models.ClassifyOptions options = new IBMVisualRecognitionV3Models.ClassifyOptionsBuilder()
       .url('http://www.indya101.com/gallery/Actors_TV/Sumeet_Sachdev/2011/12/27/Sumeet_Sachdevjpg_3_arnem.jpg')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -58,6 +59,7 @@ private class IBMVisualRecognitionV3Test {
       .imagesFile(testfile)
       .imagesFilename(att.Name)
       .imagesFileContentType(att.ContentType)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -94,6 +96,7 @@ private class IBMVisualRecognitionV3Test {
       .imagesFile(testfile)
       .imagesFilename(att.Name)
       .imagesFileContentType(att.ContentType)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -142,6 +145,7 @@ private class IBMVisualRecognitionV3Test {
       .addClass('test', testfile)
       .negativeExamples(testfile)
       .negativeExamplesFilename('test')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -179,6 +183,7 @@ private class IBMVisualRecognitionV3Test {
       .build();
     IBMVisualRecognitionV3Models.GetClassifierOptions options = new IBMVisualRecognitionV3Models.GetClassifierOptionsBuilder('classifierId')
       .classifierId('classifierId')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -214,6 +219,7 @@ private class IBMVisualRecognitionV3Test {
       .addClass('test', testfile)
       .negativeExamples(testfile)
       .negativeExamplesFilename('test')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -246,6 +252,7 @@ private class IBMVisualRecognitionV3Test {
       .build();
     IBMVisualRecognitionV3Models.DeleteClassifierOptions options = new IBMVisualRecognitionV3Models.DeleteClassifierOptionsBuilder('classifierId')
       .classifierId('classifierId')
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -265,6 +272,7 @@ private class IBMVisualRecognitionV3Test {
     visualRecognition.setEndPoint(NAMED_CREDENTIALS);
     IBMVisualRecognitionV3Models.ListClassifiersOptions options = new IBMVisualRecognitionV3Models.ListClassifiersOptionsBuilder()
       .verbose(true)
+      .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();

--- a/force-app/main/default/classes/IBMWatsonDynamicResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonDynamicResponseModel.cls
@@ -1,0 +1,23 @@
+public virtual class IBMWatsonDynamicResponseModel extends IBMWatsonResponseModel {
+  private Map<String, Object> additional_properties;
+
+  public Object get(String key) {
+    if (additional_properties == null) {
+      additional_properties = new Map<String, Object>();
+    }
+    return additional_properties.get(key);
+  }
+
+  public void put(String key, Object val) {
+    if (additional_properties == null) {
+      additional_properties = new Map<String, Object>();
+    }
+
+    String valJson = JSON.serialize(val).remove('_serialized_name');
+    additional_properties.put(key.removeEnd('_serialized_name'), JSON.deserializeUntyped(valJson));
+  }
+
+  public Map<String, Object> getDynamicProperties() {
+    return this.additional_properties;
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonDynamicResponseModel.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonDynamicResponseModel.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonMockResponses.cls
+++ b/force-app/main/default/classes/IBMWatsonMockResponses.cls
@@ -1935,10 +1935,17 @@ public class IBMWatsonMockResponses {
            '              "transcript": "string", ' +
            '              "confidence": 0, ' +
            '              "timestamps": [' +
-           '                "string"' +
+           '                [' +
+           '                  "thunderstorms", ' +
+           '                  1.49, ' +
+           '                  2.32 ' +
+           '                ]' +
            '              ], ' +
-           '              "word_confidence": [' +
-           '                "string"' +
+           '              "word_confidence": [ ' +
+           '                [' +
+           '                  "thunderstorms", ' +
+           '                  1' +
+           '                ]' +
            '              ]' +
            '            }' +
            '          ], ' +
@@ -2269,56 +2276,7 @@ public class IBMWatsonMockResponses {
   }
 
   public static String speechToTextRecognize() {
-    return '{' +
-     ' "results": [' +
-     '   {' +
-     '     "word_alternatives": [' +
-     '       {' +
-     '         "start_time": 0.09, ' +
-     '         "alternatives": [' +
-     '           {' +
-     '             "confidence": 1, ' +
-     '             "word": "latest"' +
-     '           }' +
-     '         ], ' +
-     '         "end_time": 0.6' +
-     '       }, ' +
-     '       {' +
-     '         "start_time": 0.85, ' +
-     '         "alternatives": [' +
-     '           {' +
-     '             "confidence": 0.9979, ' +
-     '             "word": "report"' +
-     '            }' +
-     '         ], ' +
-     '         "end_time": 1.52' +
-     '       }' +
-     '     ], ' +
-     '     "keywords_result": {}, ' +
-     '     "alternatives": [' +
-     '       {' +
-     '         "timestamps": [' +
-     '           {' +
-     '             "word": "the", ' +
-     '             "start_time": 0.03, ' +
-     '             "end_time": 0.09' +
-     '           }, ' +
-     '           {' +
-     '             "word": "report", ' +
-     '             "start_time": 0.85, ' +
-     '             "end_time": 1.52' +
-     '           }' +
-     '         ], ' +
-     '         "confidence": 0.983, ' +
-     '         "transcript": "the latest weather report "' +
-     '       }' +
-     '     ], ' +
-     '     "final": true' +
-     '   }' +
-     ' ], ' +
-     ' "result_index": 0' +
-     ' }' +
-     ' {' +
+    return ' {' +
      ' "results": [' +
      '   {' +
      '     "word_alternatives": [' +

--- a/force-app/main/default/classes/IBMWatsonOptionsModel.cls
+++ b/force-app/main/default/classes/IBMWatsonOptionsModel.cls
@@ -1,0 +1,7 @@
+public virtual class IBMWatsonOptionsModel {
+  public Map<String, String> requestHeaders = new Map<String, String>();
+  
+  public Map<String, String> requestHeaders() {
+    return this.requestHeaders;
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonOptionsModel.cls
+++ b/force-app/main/default/classes/IBMWatsonOptionsModel.cls
@@ -1,6 +1,9 @@
 public virtual class IBMWatsonOptionsModel {
   public Map<String, String> requestHeaders = new Map<String, String>();
   
+  /**
+   * Gets the internal request headers.
+   */
   public Map<String, String> requestHeaders() {
     return this.requestHeaders;
   }

--- a/force-app/main/default/classes/IBMWatsonOptionsModel.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonOptionsModel.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonResponseModel.cls
@@ -30,7 +30,7 @@ public virtual class IBMWatsonResponseModel {
       return false;
     }
 
-    IBMWatsonGenericModel other = (IBMWatsonGenericModel) obj;
+    IBMWatsonResponseModel other = (IBMWatsonResponseModel) obj;
 
     return this.toString().equals(other.toString());
   }

--- a/force-app/main/default/classes/IBMWatsonResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonResponseModel.cls
@@ -52,10 +52,18 @@ public virtual class IBMWatsonResponseModel {
     return ret;
   }
 
+  /**
+   * Gets the response headers attached to this response model.
+   */
   public Map<String, String> getHeaders() {
     return this.headers;
   }
 
+  /**
+   * Adds a header to this response model.
+   *
+   * Meant to only be used internally to populate response headers from the IBMWatsonService class.
+   */
   public void addHeader(String name, String value) {
     if (this.headers == null) {
       this.headers = new Map<String, String>();

--- a/force-app/main/default/classes/IBMWatsonResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonResponseModel.cls
@@ -1,0 +1,57 @@
+public virtual class IBMWatsonResponseModel {
+  private Map<String, String> headers = new Map<String, String>();
+
+  /**
+   * Allows user to see the JSON string by default for easier debugging.
+   *
+   * @return serialized String form of this
+   */
+  public override String toString() {
+    // get JSON string representation
+    String jsonString = JSON.serialize(this, true);
+
+    // call custom serializer to raise additional properties
+    jsonString = IBMWatsonJSONUtil.serialize(jsonString);
+
+    // pretty print formatting
+    jsonString = JSON.serializePretty(JSON.deserializeUntyped(jsonString));
+    return jsonString;
+  }
+
+  /**
+   * Allows comparison of custom models based on their serialized String form.
+   *
+   * @param obj the object this is being compared to
+   *
+   * @return Boolean indicating whether or not the two objects are equal
+   */
+  public Boolean equals(Object obj) {
+    if ((obj == null)) {
+      return false;
+    }
+
+    IBMWatsonGenericModel other = (IBMWatsonGenericModel) obj;
+
+    return this.toString().equals(other.toString());
+  }
+
+  public virtual Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
+    Object ret;
+    if (jsonString.equals('null')) {
+      ret = classType.newInstance();
+    }
+    else {
+      ret = JSON.deserialize(jsonString, classType);
+    }
+
+    return ret;
+  }
+
+  public Map<String, String> getHeaders() {
+    return this.headers;
+  }
+
+  public void addHeader(String name, String value) {
+    this.headers.put(name, value);
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonResponseModel.cls
@@ -10,12 +10,17 @@ public virtual class IBMWatsonResponseModel {
     // get JSON string representation
     String jsonString = JSON.serialize(this, true);
 
+    // remove response headers from string representation
+    Map<String, Object> fullJsonMap = (Map<String, Object>) JSON.deserializeUntyped(jsonString);
+    fullJsonMap.remove('headers');
+    String jsonStringWithoutHeaders = JSON.serialize(fullJsonMap);
+
     // call custom serializer to raise additional properties
-    jsonString = IBMWatsonJSONUtil.serialize(jsonString);
+    jsonStringWithoutHeaders = IBMWatsonJSONUtil.serialize(jsonStringWithoutHeaders);
 
     // pretty print formatting
-    jsonString = JSON.serializePretty(JSON.deserializeUntyped(jsonString));
-    return jsonString;
+    jsonStringWithoutHeaders = JSON.serializePretty(JSON.deserializeUntyped(jsonStringWithoutHeaders));
+    return jsonStringWithoutHeaders;
   }
 
   /**

--- a/force-app/main/default/classes/IBMWatsonResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonResponseModel.cls
@@ -52,6 +52,9 @@ public virtual class IBMWatsonResponseModel {
   }
 
   public void addHeader(String name, String value) {
+    if (this.headers == null) {
+      this.headers = new Map<String, String>();
+    }
     this.headers.put(name, value);
   }
 }

--- a/force-app/main/default/classes/IBMWatsonResponseModel.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonResponseModel.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -67,16 +67,28 @@ public abstract class IBMWatsonService {
           Map<String, Object> safeJsonMap = IBMWatsonJSONUtil.prepareResponse(jsonMap);
           Object targetObject = targetType.newInstance();
           String jsonString = JSON.serialize(safeJsonMap);
-          if (targetObject instanceof IBMWatsonDynamicModel) {
-            return ((IBMWatsonDynamicModel) targetObject).deserialize(jsonString, safeJsonMap, targetType);
+          if (targetObject instanceof IBMWatsonDynamicResponseModel) {
+            return (IBMWatsonDynamicResponseModel) addResponseHeaders(response, ((IBMWatsonResponseModel) targetObject).deserialize(jsonString, safeJsonMap, targetType));
           } else {
-            return ((IBMWatsonGenericModel) targetObject).deserialize(jsonString, safeJsonMap, targetType);
+            return (IBMWatsonResponseModel) addResponseHeaders(response, ((IBMWatsonResponseModel) targetObject).deserialize(jsonString, safeJsonMap, targetType));
           }
         }
       }
     }
 
     return null;
+  }
+
+  /**
+   * Adds headers onto the model returned from the service.
+   */
+  private Object addResponseHeaders(IBMWatsonResponse response, Object responseObject) {
+  	IBMWatsonResponseModel testModel = (IBMWatsonResponseModel) responseObject;
+    String[] headerKeys = response.getHeaderKeys();
+    for (String key : headerKeys) {
+      testModel.addHeader(key, response.getHeader(key));
+    }
+    return testModel;
   }
 
   /**

--- a/force-app/main/default/classes/IBMWatsonServiceTest.cls
+++ b/force-app/main/default/classes/IBMWatsonServiceTest.cls
@@ -1,5 +1,36 @@
 @isTest
 private class IBMWatsonServiceTest {
+
+  /**
+   * Simple service to use for testing purposes.
+   */
+  class TestService extends IBMWatsonService {
+    public TestService() {
+      super('test_service_v1');
+    }
+
+    public TestClass testingMethod() {
+      IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet('https://www.test.com');
+      builder.query('test_query', 'test_val');
+      return (TestClass) createServiceCall(builder.build(), TestClass.class);
+    }
+  }
+
+  /**
+   * Simple response model to use for testing purposes.
+   */
+  class TestClass extends IBMWatsonResponseModel {
+    public String test_key_serialized_name;
+
+    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
+      if (jsonMap == null) {
+        return null;
+      }
+      TestClass ret = (TestClass) super.deserialize(jsonString, jsonMap, classType);
+      return ret;
+    }
+  }
+
   /**
     *  Test available Request methods that are not used in example but available for developers.
     *
@@ -385,6 +416,25 @@ private class IBMWatsonServiceTest {
     System.assertEquals(multipartBody.parts().size(), 2);
     System.assert(multipartBody.getAllHeaders().get('Content-Type').contains('multipart/form-data; boundary'));
     System.assert(multipartBody.form64().contains(multipartBody.writeBoundary()));
+    Test.stopTest();
+  }
+
+  /**
+   * Test getting response headers from response model.
+   */
+  static testMethod void testResponseHeaders() {
+    Test.startTest();
+    String body = '{"test_key":"test_value"}';
+    Map<String, String> responseHeaders = new Map<String, String> { 'Test-Name' => 'test_val' };
+    IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, responseHeaders);
+    Test.setMock(HttpCalloutMock.class, mockResponse);
+
+    TestService testService = new TestService();
+    TestClass testClass = testService.testingMethod();
+
+    System.assert(testClass.getHeaders() != null);
+    System.assert(testClass.getHeaders().size() == 1);
+    System.assert(testClass.getHeaders().get('Test-Name').equals('test_val'));
     Test.stopTest();
   }
 }

--- a/force-app/main/default/classes/IBMWatsonStaticResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonStaticResponseModel.cls
@@ -1,0 +1,3 @@
+public virtual class IBMWatsonStaticResponseModel extends IBMWatsonResponseModel {
+
+}

--- a/force-app/main/default/classes/IBMWatsonStaticResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonStaticResponseModel.cls
@@ -1,3 +1,0 @@
-public virtual class IBMWatsonStaticResponseModel extends IBMWatsonResponseModel {
-
-}

--- a/force-app/main/default/classes/IBMWatsonStaticResponseModel.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonStaticResponseModel.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonStaticResponseModel.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonStaticResponseModel.cls-meta.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>41.0</apiVersion>
-    <status>Active</status>
-</ApexClass>


### PR DESCRIPTION
This PR is HUGE, so sorry in advance for any reviewers. Below are the highlights though, which should help you to navigate it.

The main change in this PR is adding support for sending custom headers with requests and parsing the headers returned by the service in the response model. The `IBMWatsonDynamicResponseModel`, `IBMWatsonOptionsModel`, and `IBMWatsonResponse` classes are new superclasses extended by the various service models to add this functionality. These also contribute to a lot of changes in the `Models` files.

Also related to the headers support is new methods and statements in models extending `IBMWatsonOptionsModel`. These are repeated across those models, so if one looks good, they should all be the same.

Testing file changes should also be repetitive for the most part. For test coverage purposes, an `addHeader()` call was added to every test method call. The biggest testing change is in `IBMWatsonServiceTest` to test the response headers.

One last big change was added in this PR as a result of doing some generator tweaking alongside these changes. The Discovery service is now using the builder pattern for its Enrichment models, which is consistent with what we do in Java and in the rest of this SDK. The only reason we weren't doing this before is the Apex generator wasn't handling certain models with builders in the past. This change will be the bulk of changes in the `IBMDiscoveryV1Models` and `IBMDiscoveryV1Test` files. Unfortunately, this will be a breaking change 😞 

