### PR TITLE
File upload fix

### DIFF
--- a/force-app/main/default/classes/IBMWatsonMultipartBody.cls
+++ b/force-app/main/default/classes/IBMWatsonMultipartBody.cls
@@ -129,9 +129,7 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
     String header = boundaryCrlf + contentDispositionCrlf + contentTypeCrlf;
 
     String HeaderCRLF = CRLF;
-    if ( !String.isBlank(mimeType) &&
-        (mimeType.equalsIgnoreCase('application/json') ||
-        mimeType.startsWith('text/')) ) {
+    if (!String.isBlank(mimeType)) {
        HeaderCRLF += CRLF;
     }
     String headerEncoded = EncodingUtil.base64Encode(Blob.valueOf(header + HeaderCRLF));

--- a/force-app/main/default/classes/IBMWatsonMultipartBody.cls
+++ b/force-app/main/default/classes/IBMWatsonMultipartBody.cls
@@ -134,28 +134,29 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
     }
     String headerEncoded = EncodingUtil.base64Encode(Blob.valueOf(header + HeaderCRLF));
     while (headerEncoded.endsWith('=')) {
-      header+=' ';
+      header += ' ';
       headerEncoded = EncodingUtil.base64Encode(Blob.valueOf(header + HeaderCRLF));
     }
 
     String footer;
     if (isEndingPart) {
      footer = CRLF + '--' + this.boundary + '--';
-    }else{
+    } else {
      footer = CRLF;
     }
 
     String footerEncoded = EncodingUtil.base64Encode(Blob.valueOf(footer));
 
     Blob bodyBlob = null;
-    String last4Bytes = bodyEncoded.substring(bodyEncoded.length()-4,bodyEncoded.length());
+    String last4Bytes = bodyEncoded.substring(bodyEncoded.length() - 4, bodyEncoded.length());
 
     if (last4Bytes.endsWith('=')) {
       Blob decoded4Bytes = EncodingUtil.base64Decode(last4Bytes);
       HttpRequest tmp = new HttpRequest();
       tmp.setBodyAsBlob(decoded4Bytes);
-      String last4BytesFooter = tmp.getBody()+footer;
-      bodyBlob = EncodingUtil.base64Decode(headerEncoded+bodyEncoded.substring(0,bodyEncoded.length()-4)
+      String last4BytesFooter = tmp.getBody() + footer;
+      bodyBlob = EncodingUtil.base64Decode(headerEncoded
+        + bodyEncoded.substring(0, bodyEncoded.length() - 4)
         + EncodingUtil.base64Encode(Blob.valueOf(last4BytesFooter)));
     } else {
       bodyBlob = EncodingUtil.base64Decode(headerEncoded + bodyEncoded + footerEncoded);
@@ -240,9 +241,9 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
       if (name == null) {
         throw new IBMWatsonServiceExceptions.IllegalArgumentException('name == null');
       }
-      String disposition = 'form-data; name="' +name+'"';
+      String disposition = 'form-data; name="' + name + '"';
       if (String.isNotBlank(filename)) {
-        disposition+='; filename="' +filename+'"';
+        disposition += '; filename="' + filename + '"';
       }
       this.headers.put('Content-Disposition', disposition);
       return create(this.headers, body);
@@ -256,10 +257,10 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
   private static String UUID() {
     Blob b = Crypto.GenerateAESKey(128);
     String h = EncodingUtil.ConvertTohex(b);
-    String UUID = h.substring(0,8) + '-'
-      + h.substring(8,12) + '-'
-      + h.substring(12,16) + '-'
-      + h.substring(16,20) + '-'
+    String UUID = h.substring(0, 8) + '-'
+      + h.substring(8, 12) + '-'
+      + h.substring(12, 16) + '-'
+      + h.substring(16, 20) + '-'
       + h.substring(20);
     return UUID.toUpperCase();
   }


### PR DESCRIPTION
Fixes #130 

This PR fixes a recurring issue the SDK has had uploading files. Testing for reproduction showed that files would upload successfully with certain filenames but not others (although any filename worked in my tests with `text/html` and `application/json` files).

The if-statement changed in this PR was identified as the only diverging point between uploading the above file types and something like `application/pdf`, which is the file type the bug was originally found with. After the change, I was able to successfully upload files of various types and names while retaining prior functionality.