### PR TITLE
Limit SOQL call for user agent to one Apex class

### DIFF
--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -33,7 +33,7 @@ public abstract class IBMWatsonService {
   }
 
   private static String buildUserAgent() {
-    ApexClass ac = [Select ApiVersion From ApexClass Where Name = 'IBMWatsonService'];
+    ApexClass ac = [Select ApiVersion From ApexClass Where Name = 'IBMWatsonService' LIMIT 1];
     Organization org = [Select OrganizationType, InstanceName From Organization];
     return String.format(USER_AGENT_FORMAT, new List<String>{SDK_VERSION, 'APEX_API_VERSION=' + ac.ApiVersion + ';ORG_TYPE=' + org.OrganizationType + ';INSTANCE=' + org.InstanceName });
   }


### PR DESCRIPTION
Fixes #129 and fixes #138 

This PR limits the SOQL query to build the user agent to just one record in the case that the SDK is deployed in multiple namespaces. This will fix errors for now, and it can be tweaked in the future if necessary.