### PR TITLE
Add CF token deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Finally, you can also install or update the SDK using the Ant Build Tool. This m
     Valid service names are all services listed [here](https://console.bluemix.net/catalog/?category=watson) written as one word (e.g. Visual Recognition becomes visualrecognition). The parameter is case-insensitive. To deploy multiple services, just run the command again with the next desired service flag.
 
 ## Authentication
-To access your Watson services through Apex, you'll need to authenticate with your service credentials. There are two ways to do this: [using named credentials](#using-named-credentials) or [specifying credentials in the Apex code](#specifying-credentials-in-the-apex-code)
+To access your Watson services through Apex, you'll need to authenticate with your service credentials. There are two ways to do this: [using named credentials](#using-named-credentials) or [specifying credentials in the Apex code](#specifying-credentials-in-the-apex-code).
+
+**Note:** Previously, it was possible to authenticate using a token in a header called `X-Watson-Authorization-Token`. This method is deprecated. The token continues to work with Cloud Foundry services, but is not supported for services that use Identity and Access Management (IAM) authentication. See [here](#using-iam) for details.
 
 ### Using `Named Credentials`
 

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -19,6 +19,10 @@ public abstract class IBMWatsonService {
   private static final String VERSION = 'version';
   private static final String USER_AGENT_FORMAT = 'watson-apis-salesforce-sdk/{0}/({1})';
   private static final String SDK_VERSION = '2.3.2';
+  private static final String AUTH_HEADER_DEPRECATION_MESSAGE = 'Authenticating with the X-Watson-Authorization-Token'
+    + 'header is deprecated. The token continues to work with Cloud Foundry services, but is not supported for '
+    + 'services that use Identity and Access Management (IAM) authentication. For details see the IAM '
+    + 'authentication section in the README.';
 
   /**
    * Instantiates a new Watson service.
@@ -196,7 +200,11 @@ public abstract class IBMWatsonService {
       builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, BEARER + accessToken);
     } else if (getApiKey() == null) {
       if (skipAuthentication) {
-        return; // chosen to skip authentication with the service
+        Map<String, String> currentHeaders = builder.build().getAllHeaders();
+        if (currentHeaders.containsKey(IBMWatsonHttpHeaders.X_WATSON_AUTHORIZATION_TOKEN)) {
+          System.debug(System.LoggingLevel.WARN, AUTH_HEADER_DEPRECATION_MESSAGE);
+        }
+        return;
       }
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('apiKey or username and password were not specified');
     } else {


### PR DESCRIPTION
This PR adds deprecation warnings for the `X-Watson-Authorization-Token` header: once in the main README and once in the code. The method of warning in the code should behave identically to the proposed change in the Java SDK: https://github.com/watson-developer-cloud/java-sdk/pull/964