### PR TITLE
Remove hardcoded basic auth from token manager

### DIFF
--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
@@ -7,7 +7,6 @@ public class IBMWatsonIAMTokenManager {
   private String url;
   private IBMWatsonIAMToken tokenData;
 
-  private static final String DEFAULT_AUTHORIZATION = 'Basic Yng6Yng=';
   private static final String DEFAULT_IAM_URL = 'https://iam.bluemix.net/identity/token';
   private static final String GRANT_TYPE = 'grant_type';
   private static final String REQUEST_GRANT_TYPE = 'urn:ibm:params:oauth:grant-type:apikey';
@@ -67,7 +66,6 @@ public class IBMWatsonIAMTokenManager {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(url);
 
     builder.addHeader(IBMWatsonHttpHeaders.CONTENT_TYPE, IBMWatsonHttpMediaType.APPLICATION_FORM_URLENCODED);
-    builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
 
     IBMWatsonFormBody formBody = new IBMWatsonFormBody.Builder()
       .add(GRANT_TYPE, REQUEST_GRANT_TYPE)
@@ -89,7 +87,6 @@ public class IBMWatsonIAMTokenManager {
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(url);
 
     builder.addHeader(IBMWatsonHttpHeaders.CONTENT_TYPE, IBMWatsonHttpMediaType.APPLICATION_FORM_URLENCODED);
-    builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, DEFAULT_AUTHORIZATION);
 
     IBMWatsonFormBody formBody = new IBMWatsonFormBody.Builder()
       .add(GRANT_TYPE, REFRESH_GRANT_TYPE)


### PR DESCRIPTION
## Summary

Removes the basic authentication header from the IAM token request because it is not necessary. If it is necessary, it needs to be stored in a secure way because currently it generated a security violation in the source code scanner when used in managed packages.