### PR TITLE
Add support for ICP auth

### DIFF
--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -20,6 +20,7 @@ public abstract class IBMWatsonService {
   private static final String USER_AGENT_FORMAT = 'watson-apis-salesforce-sdk/{0}/({1})';
   private static final String SDK_VERSION = '2.6.0';
   private static final String APIKEY_AS_USERNAME = 'apikey';
+  private static final String ICP_PREFIX = 'icp-';
   private static final String AUTH_HEADER_DEPRECATION_MESSAGE = 'Authenticating with the X-Watson-Authorization-Token'
     + 'header is deprecated. The token continues to work with Cloud Foundry services, but is not supported for '
     + 'services that use Identity and Access Management (IAM) authentication. For details see the IAM '
@@ -220,7 +221,8 @@ public abstract class IBMWatsonService {
    * @param password the password
    */
   public void setUsernameAndPassword(final String username, final String password) {
-    if (username.equals(APIKEY_AS_USERNAME)) {
+    // we'll perform the token exchange for users UNLESS they're on ICP
+    if (username.equals(APIKEY_AS_USERNAME) && !password.startsWith(ICP_PREFIX)) {
       IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
         .apiKey(password)
         .build();

--- a/force-app/main/default/classes/IBMWatsonServiceTest.cls
+++ b/force-app/main/default/classes/IBMWatsonServiceTest.cls
@@ -398,4 +398,13 @@ private class IBMWatsonServiceTest {
     System.assert(testService.isTokenManagerSet() == true);
     Test.stopTest();
   }
+
+  static testMethod void testAuthenticationWithIcp() {
+    Test.startTest();
+    String testApiKey = 'icp-12345';
+    TestService testService = new TestService();
+    testService.setUsernameAndPassword('apikey', testApiKey);
+    System.assert(testService.isTokenManagerSet() == false);
+    Test.stopTest();
+  }
 }


### PR DESCRIPTION
This PR ensures that users authenticating with an API key on ICP do not perform the usual token exchange, instead going through basic auth.