### PR TITLE
Make content type optional in createJob() and recognize()

### DIFF
--- a/force-app/main/default/classes/IBMSpeechToTextV1.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1.cls
@@ -176,7 +176,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     IBMWatsonValidator.notNull(recognizeOptions, 'recognizeOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/recognize');
     builder.addHeader('Accept', 'application/json');
-    builder.addHeader('Content-Type', recognizeOptions.contentType());
+    if (recognizeOptions.contentType() != null) {
+      builder.addHeader('Content-Type', recognizeOptions.contentType());
+    }
     Map<String, String> requestHeaders = (recognizeOptions != null) ? recognizeOptions.requestHeaders() : null;
     if (requestHeaders != null && requestHeaders.size() > 0) {
       for (String name : requestHeaders.keySet()) {
@@ -378,7 +380,9 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     IBMWatsonValidator.notNull(createJobOptions, 'createJobOptions cannot be null');
     IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(getEndPoint() + '/v1/recognitions');
     builder.addHeader('Accept', 'application/json');
-    builder.addHeader('Content-Type', createJobOptions.contentType());
+    if (createJobOptions.contentType() != null) {
+      builder.addHeader('Content-Type', createJobOptions.contentType());
+    }
     Map<String, String> requestHeaders = (createJobOptions != null) ? createJobOptions.requestHeaders() : null;
     if (requestHeaders != null && requestHeaders.size() > 0) {
       for (String name : requestHeaders.keySet()) {

--- a/force-app/main/default/classes/IBMSpeechToTextV1.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1.cls
@@ -106,10 +106,10 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   /**
    * Recognize audio.
    *
-   * Sends audio and returns transcription results for a recognition request. Returns only the final results; to enable
-   * interim results, use the WebSocket API. The service imposes a data size limit of 100 MB. It automatically detects
-   * the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to
-   * one-channel mono during transcoding.
+   * Sends audio and returns transcription results for a recognition request. You can pass a maximum of 100 MB and a
+   * minimum of 100 bytes of audio with a request. The service automatically detects the endianness of the incoming
+   * audio and, for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding.
+   * The method returns only final results; to enable interim results, use the WebSocket API.
    *
    * **See also:** [Making a basic HTTP
    * request](https://console.bluemix.net/docs/services/speech-to-text/http.html#HTTP-basic).
@@ -124,7 +124,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
    *
    * **See also:**
    * * [Audio transmission](https://console.bluemix.net/docs/services/speech-to-text/input.html#transmission)
-   * * [Timeouts](https://console.bluemix.net/docs/services/speech-to-text/input.html#timeouts).
+   * * [Timeouts](https://console.bluemix.net/docs/services/speech-to-text/input.html#timeouts)
    *
    * ### Audio formats (content types)
    *
@@ -154,14 +154,13 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
    *
    * **See also:** [Audio formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
    *
-   * **Note:** You must pass a content type when using any of the Watson SDKs. The SDKs require the content-type
-   * parameter for all audio formats.
-   *
    * ### Multipart speech recognition
    *
-   *  The method also supports multipart recognition requests. With multipart requests, you pass all audio data as
-   * multipart form data. You specify some parameters as request headers and query parameters, but you pass JSON
-   * metadata as form data to control most aspects of the transcription.
+   *  **Note:** The Watson SDKs do not support multipart speech recognition.
+   *
+   * The HTTP `POST` method of the service also supports multipart speech recognition. With multipart requests, you pass
+   * all audio data as multipart form data. You specify some parameters as request headers and query parameters, but you
+   * pass JSON metadata as form data to control most aspects of the transcription.
    *
    * The multipart approach is intended for use with browsers for which JavaScript is disabled or when the parameters
    * used with the request are greater than the 8 KB limit imposed by most HTTP servers and proxies. You can encounter
@@ -325,8 +324,10 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
    * * `user_token`
    * * `results_ttl`
    *
-   * The service imposes a data size limit of 100 MB. It automatically detects the endianness of the incoming audio and,
-   * for audio that includes multiple channels, downmixes the audio to one-channel mono during transcoding.
+   * You can pass a maximum of 100 MB and a minimum of 100 bytes of audio with a request. The service automatically
+   * detects the endianness of the incoming audio and, for audio that includes multiple channels, downmixes the audio to
+   * one-channel mono during transcoding. The method returns only final results; to enable interim results, use the
+   * WebSocket API.
    *
    * **See also:** [Creating a job](https://console.bluemix.net/docs/services/speech-to-text/async.html#create).
    *
@@ -369,9 +370,6 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
    * * `audio/webm;codecs=vorbis`
    *
    * **See also:** [Audio formats](https://console.bluemix.net/docs/services/speech-to-text/audio-formats.html).
-   *
-   * **Note:** You must pass a content type when using any of the Watson SDKs. The SDKs require the content-type
-   * parameter for all audio formats.
    *
    * @param createJobOptions the {@link IBMSpeechToTextV1Models.CreateJobOptions} containing the options for the call
    * @return the {@link IBMSpeechToTextV1Models.RecognitionJob} with the response

--- a/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
@@ -464,6 +464,22 @@ public class IBMSpeechToTextV1Models {
     }
 
     /**
+     * Instantiates a new builder.
+     *
+     * NOTE: audioResource and contentType are now required, so this constructor will be removed. Please use
+     * the constructor with 4 parameters.
+     *
+     * @param customizationId the customizationId
+     * @param audioName the audioName
+     */
+    public AddAudioOptionsBuilder(String customizationId, String audioName) {
+      this.customizationId = customizationId;
+      this.audioName = audioName;
+      this.audioResource = audioResource;
+      this.contentType = contentType;
+    }
+
+    /**
      * Instantiates a new builder with required properties.
      *
      * @param customizationId the customizationId
@@ -2493,7 +2509,6 @@ public class IBMSpeechToTextV1Models {
 
     private CreateJobOptions(CreateJobOptionsBuilder builder) {
       IBMWatsonValidator.notNull(builder.audio, 'audio cannot be null');
-      IBMWatsonValidator.notNull(builder.contentType, 'contentType cannot be null');
       audio = builder.audio;
       contentType = builder.contentType;
       model = builder.model;
@@ -6134,7 +6149,6 @@ public class IBMSpeechToTextV1Models {
 
     private RecognizeOptions(RecognizeOptionsBuilder builder) {
       IBMWatsonValidator.notNull(builder.audio, 'audio cannot be null');
-      IBMWatsonValidator.notNull(builder.contentType, 'contentType cannot be null');
       audio = builder.audio;
       contentType = builder.contentType;
       model = builder.model;
@@ -7179,8 +7193,8 @@ public class IBMSpeechToTextV1Models {
   public class SpeechRecognitionAlternative extends IBMWatsonGenericModel {
     private String transcript_serialized_name;
     private Double confidence_serialized_name;
-    private List<String> timestamps_serialized_name;
-    private List<String> word_confidence_serialized_name;
+    private List<List<String>> timestamps_serialized_name;
+    private List<List<String>> word_confidence_serialized_name;
  
     /**
      * Gets the transcript.
@@ -7217,7 +7231,7 @@ public class IBMSpeechToTextV1Models {
      * @return the timestamps
      */
     @AuraEnabled
-    public List<String> getTimestamps() {
+    public List<List<String>> getTimestamps() {
       return timestamps_serialized_name;
     }
  
@@ -7231,7 +7245,7 @@ public class IBMSpeechToTextV1Models {
      * @return the wordConfidence
      */
     @AuraEnabled
-    public List<String> getWordConfidence() {
+    public List<List<String>> getWordConfidence() {
       return word_confidence_serialized_name;
     }
 
@@ -7258,7 +7272,7 @@ public class IBMSpeechToTextV1Models {
      *
      * @param timestamps the new timestamps
      */
-    public void setTimestamps(final List<String> timestamps) {
+    public void setTimestamps(final List<List<String>> timestamps) {
       this.timestamps_serialized_name = timestamps;
     }
 
@@ -7267,7 +7281,7 @@ public class IBMSpeechToTextV1Models {
      *
      * @param wordConfidence the new wordConfidence
      */
-    public void setWordConfidence(final List<String> wordConfidence) {
+    public void setWordConfidence(final List<List<String>> wordConfidence) {
       this.word_confidence_serialized_name = wordConfidence;
     }
 

--- a/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
@@ -464,22 +464,6 @@ public class IBMSpeechToTextV1Models {
     }
 
     /**
-     * Instantiates a new builder.
-     *
-     * NOTE: audioResource and contentType are now required, so this constructor will be removed. Please use
-     * the constructor with 4 parameters.
-     *
-     * @param customizationId the customizationId
-     * @param audioName the audioName
-     */
-    public AddAudioOptionsBuilder(String customizationId, String audioName) {
-      this.customizationId = customizationId;
-      this.audioName = audioName;
-      this.audioResource = audioResource;
-      this.contentType = contentType;
-    }
-
-    /**
      * Instantiates a new builder with required properties.
      *
      * @param customizationId the customizationId
@@ -7195,8 +7179,8 @@ public class IBMSpeechToTextV1Models {
   public class SpeechRecognitionAlternative extends IBMWatsonGenericModel {
     private String transcript_serialized_name;
     private Double confidence_serialized_name;
-    private List<List<String>> timestamps_serialized_name;
-    private List<List<String>> word_confidence_serialized_name;
+    private List<String> timestamps_serialized_name;
+    private List<String> word_confidence_serialized_name;
  
     /**
      * Gets the transcript.
@@ -7233,7 +7217,7 @@ public class IBMSpeechToTextV1Models {
      * @return the timestamps
      */
     @AuraEnabled
-    public List<List<String>> getTimestamps() {
+    public List<String> getTimestamps() {
       return timestamps_serialized_name;
     }
  
@@ -7247,7 +7231,7 @@ public class IBMSpeechToTextV1Models {
      * @return the wordConfidence
      */
     @AuraEnabled
-    public List<List<String>> getWordConfidence() {
+    public List<String> getWordConfidence() {
       return word_confidence_serialized_name;
     }
 
@@ -7274,7 +7258,7 @@ public class IBMSpeechToTextV1Models {
      *
      * @param timestamps the new timestamps
      */
-    public void setTimestamps(final List<List<String>> timestamps) {
+    public void setTimestamps(final List<String> timestamps) {
       this.timestamps_serialized_name = timestamps;
     }
 
@@ -7283,7 +7267,7 @@ public class IBMSpeechToTextV1Models {
      *
      * @param wordConfidence the new wordConfidence
      */
-    public void setWordConfidence(final List<List<String>> wordConfidence) {
+    public void setWordConfidence(final List<String> wordConfidence) {
       this.word_confidence_serialized_name = wordConfidence;
     }
 

--- a/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
@@ -625,8 +625,13 @@ public class IBMSpeechToTextV1Models {
      * Gets the corpusFile.
      *
      * A plain text file that contains the training data for the corpus. Encode the file in UTF-8 if it contains
-     * non-ASCII characters; the service assumes UTF-8 encoding if it encounters non-ASCII characters. With the `curl`
-     * command, use the `--data-binary` option to upload the file for the request.
+     * non-ASCII characters; the service assumes UTF-8 encoding if it encounters non-ASCII characters.
+     *
+     * Make sure that you know the character encoding of the file. You must use that encoding when working with the
+     * words in the custom language model. For more information, see [Character
+     * encoding](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#charEncoding).
+     *
+     * With the `curl` command, use the `--data-binary` option to upload the file for the request.
      *
      * @return the corpusFile
      */
@@ -821,9 +826,10 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the wordName.
      *
-     * The custom word for the custom language model. When you add or update a custom word with the **Add a custom
-     * word** method, do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
-     * compound words.
+     * The custom word that is to be added to or updated in the custom language model. Do not include spaces in the
+     * word. Use a `-` (dash) or `_` (underscore) to connect the tokens of compound words. URL-encode the word if it
+     * includes non-ASCII characters. For more information, see [Character
+     * encoding](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#charEncoding).
      *
      * @return the wordName
      */
@@ -838,7 +844,7 @@ public class IBMSpeechToTextV1Models {
      * custom model. Do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
      * compound words.
      *
-     * Omit this field for the **Add a custom word** method.
+     * Omit this parameter for the **Add a custom word** method.
      *
      * @return the word
      */
@@ -2018,8 +2024,9 @@ public class IBMSpeechToTextV1Models {
      * Gets the baseModelName.
      *
      * The name of the base language model that is to be customized by the new custom acoustic model. The new custom
-     * model can be used only with the base model that it customizes. To determine whether a base model supports
-     * acoustic model customization, refer to [Language support for
+     * model can be used only with the base model that it customizes.
+     *
+     * To determine whether a base model supports acoustic model customization, refer to [Language support for
      * customization](https://console.bluemix.net/docs/services/speech-to-text/custom.html#languageSupport).
      *
      * @return the baseModelName
@@ -2462,7 +2469,7 @@ public class IBMSpeechToTextV1Models {
      * If `true`, the service converts dates, times, series of digits and numbers, phone numbers, currency values, and
      * internet addresses into more readable, conventional representations in the final transcript of a recognition
      * request. For US English, the service also converts certain keyword strings to punctuation symbols. By default, no
-     * smart formatting is performed. Applies to US English and Spanish transcription only. See [Smart
+     * smart formatting is performed. Applies to US English, Japanese, and Spanish transcription only. See [Smart
      * formatting](https://console.bluemix.net/docs/services/speech-to-text/output.html#smart_formatting).
      *
      * @return the smartFormatting
@@ -2476,9 +2483,10 @@ public class IBMSpeechToTextV1Models {
      *
      * If `true`, the response includes labels that identify which words were spoken by which participants in a
      * multi-person exchange. By default, no speaker labels are returned. Setting `speaker_labels` to `true` forces the
-     * `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter. To determine
-     * whether a language model supports speaker labels, use the **Get models** method and check that the attribute
-     * `speaker_labels` is set to `true`. See [Speaker
+     * `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.
+     *
+     * To determine whether a language model supports speaker labels, use the **Get a model** method and check that the
+     * attribute `speaker_labels` is set to `true`. See [Speaker
      * labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
      *
      * @return the speakerLabels
@@ -2914,9 +2922,10 @@ public class IBMSpeechToTextV1Models {
      * Gets the baseModelName.
      *
      * The name of the base language model that is to be customized by the new custom language model. The new custom
-     * model can be used only with the base model that it customizes. To determine whether a base model supports
-     * language model customization, request information about the base model and check that the attribute
-     * `custom_language_model` is set to `true`, or refer to [Language support for
+     * model can be used only with the base model that it customizes.
+     *
+     * To determine whether a base model supports language model customization, use the **Get a model** method and check
+     * that the attribute `custom_language_model` is set to `true`. You can also refer to [Language support for
      * customization](https://console.bluemix.net/docs/services/speech-to-text/custom.html#languageSupport).
      *
      * @return the baseModelName
@@ -3092,7 +3101,7 @@ public class IBMSpeechToTextV1Models {
      * custom model. Do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
      * compound words.
      *
-     * Omit this field for the **Add a custom word** method.
+     * Omit this parameter for the **Add a custom word** method.
      *
      * @return the word
      */
@@ -3804,9 +3813,9 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the wordName.
      *
-     * The custom word for the custom language model. When you add or update a custom word with the **Add a custom
-     * word** method, do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
-     * compound words.
+     * The custom word that is to be deleted from the custom language model. URL-encode the word if it includes
+     * non-ASCII characters. For more information, see [Character
+     * encoding](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#charEncoding).
      *
      * @return the wordName
      */
@@ -4350,7 +4359,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the modelId.
      *
-     * The identifier of the model in the form of its name from the output of the **Get models** method.
+     * The identifier of the model in the form of its name from the output of the **Get a model** method.
      *
      * @return the modelId
      */
@@ -4456,9 +4465,9 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the wordName.
      *
-     * The custom word for the custom language model. When you add or update a custom word with the **Add a custom
-     * word** method, do not include spaces in the word. Use a `-` (dash) or `_` (underscore) to connect the tokens of
-     * compound words.
+     * The custom word that is to be read from the custom language model. URL-encode the word if it includes non-ASCII
+     * characters. For more information, see [Character
+     * encoding](https://console.bluemix.net/docs/services/speech-to-text/language-resource.html#charEncoding).
      *
      * @return the wordName
      */
@@ -6101,7 +6110,7 @@ public class IBMSpeechToTextV1Models {
      * If `true`, the service converts dates, times, series of digits and numbers, phone numbers, currency values, and
      * internet addresses into more readable, conventional representations in the final transcript of a recognition
      * request. For US English, the service also converts certain keyword strings to punctuation symbols. By default, no
-     * smart formatting is performed. Applies to US English and Spanish transcription only. See [Smart
+     * smart formatting is performed. Applies to US English, Japanese, and Spanish transcription only. See [Smart
      * formatting](https://console.bluemix.net/docs/services/speech-to-text/output.html#smart_formatting).
      *
      * @return the smartFormatting
@@ -6115,9 +6124,10 @@ public class IBMSpeechToTextV1Models {
      *
      * If `true`, the response includes labels that identify which words were spoken by which participants in a
      * multi-person exchange. By default, no speaker labels are returned. Setting `speaker_labels` to `true` forces the
-     * `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter. To determine
-     * whether a language model supports speaker labels, use the **Get models** method and check that the attribute
-     * `speaker_labels` is set to `true`. See [Speaker
+     * `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.
+     *
+     * To determine whether a language model supports speaker labels, use the **Get a model** method and check that the
+     * attribute `speaker_labels` is set to `true`. See [Speaker
      * labels](https://console.bluemix.net/docs/services/speech-to-text/output.html#speaker_labels).
      *
      * @return the speakerLabels
@@ -7038,7 +7048,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the supportedFeatures.
      *
-     * Describes the additional service features supported with the model.
+     * Describes the additional service features that are supported with the model.
      *
      * @return the supportedFeatures
      */
@@ -7050,7 +7060,7 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the description.
      *
-     * Brief description of the model.
+     * A brief description of the model.
      *
      * @return the description
      */
@@ -7501,7 +7511,7 @@ public class IBMSpeechToTextV1Models {
      * An array of warning messages associated with the request:
      * * Warnings for invalid parameters or fields can include a descriptive message and a list of invalid argument
      * strings, for example, `"Unknown arguments:"` or `"Unknown url query arguments:"` followed by a list of the form
-     * `"invalid_arg_1, invalid_arg_2."`
+     * `"{invalid_arg_1}, {invalid_arg_2}."`
      * * The following warning is returned if the request passes a custom model that is based on an older version of a
      * base model for which an updated version is available: `"Using previous version of base model, because your custom
      * model has been built with it. Please note that this version will be supported only for a limited time. Consider
@@ -7591,7 +7601,7 @@ public class IBMSpeechToTextV1Models {
   }
 
   /**
-   * SupportedFeatures.
+   * Describes the additional service features that are supported with the model.
    */
   public class SupportedFeatures extends IBMWatsonGenericModel {
     private Boolean custom_language_model_serialized_name;


### PR DESCRIPTION
This PR is a small patch to ensure that the `Content-Type` header in `createJob()` and `recognize()` are not required, since the service allows them not to be specified.