### PR TITLE
Fix issues with Assistant models

### DIFF
--- a/force-app/main/default/classes/IBMAssistantV1Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Models.cls
@@ -532,6 +532,7 @@ public class IBMAssistantV1Models {
     private String digress_out_serialized_name;
     private String digress_out_slots_serialized_name;
     private String user_label_serialized_name;
+    private Boolean disabled_serialized_name;
  
     /**
      * Gets the dialogNode.
@@ -738,6 +739,17 @@ public class IBMAssistantV1Models {
     public String userLabel() {
       return user_label_serialized_name;
     }
+
+    /**
+     * Gets the disabled.
+     *
+     * Whether to consider the dialog node during runtime evaluation.  Set to `true` to ignore the dialog node.
+     *
+     * @return the disabled
+     */
+    public Boolean disabled() {
+      return disabled_serialized_name;
+    }
   
     private CreateDialogNode(CreateDialogNodeBuilder builder) {
       IBMWatsonValidator.notNull(builder.dialogNode, 'dialogNode cannot be null');
@@ -759,6 +771,7 @@ public class IBMAssistantV1Models {
       digress_out_serialized_name = builder.digressOut;
       digress_out_slots_serialized_name = builder.digressOutSlots;
       user_label_serialized_name = builder.userLabel;
+      disabled_serialized_name = builder.disabled;
     }
 
     /**
@@ -794,6 +807,7 @@ public class IBMAssistantV1Models {
     private String digressOut;
     private String digressOutSlots;
     private String userLabel;
+    private Boolean disabled;
 
     private CreateDialogNodeBuilder(CreateDialogNode createDialogNode) {
       dialogNode = createDialogNode.dialog_node_serialized_name;
@@ -814,6 +828,7 @@ public class IBMAssistantV1Models {
       digressOut = createDialogNode.digress_out_serialized_name;
       digressOutSlots = createDialogNode.digress_out_slots_serialized_name;
       userLabel = createDialogNode.user_label_serialized_name;
+      disabled = createDialogNode.disabled_serialized_name;
     }
 
     /**
@@ -1051,6 +1066,17 @@ public class IBMAssistantV1Models {
      */
     public CreateDialogNodeBuilder userLabel(String userLabel) {
       this.userLabel = userLabel;
+      return this;
+    }
+
+    /**
+     * Set the disabled.
+     *
+     * @param disabled the disabled
+     * @return the CreateDialogNode builder
+     */
+    public CreateDialogNodeBuilder disabled(Boolean disabled) {
+      this.disabled = disabled;
       return this;
     }
   }

--- a/force-app/main/default/classes/IBMAssistantV2Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV2Models.cls
@@ -1904,12 +1904,13 @@ public class IBMAssistantV2Models {
   /**
    * Assistant output to be rendered or processed by the client.
    */
-  public class MessageOutput extends IBMWatsonGenericModel {
+  public class MessageOutput extends IBMWatsonDynamicModel {
     private List<DialogRuntimeResponseGeneric> generic_serialized_name;
     private List<RuntimeIntent> intents_serialized_name;
     private List<RuntimeEntity> entities_serialized_name;
     private List<DialogNodeAction> actions_serialized_name;
     private MessageOutputDebug debug_serialized_name;
+    private Map<String, Object> additional_properties_serialized_name;
  
     /**
      * Gets the generic.
@@ -1970,6 +1971,16 @@ public class IBMAssistantV2Models {
     @AuraEnabled
     public MessageOutputDebug getDebug() {
       return debug_serialized_name;
+    }
+
+    /**
+     * Gets the dynamic properties attached to MessageOutput.
+     *
+     * @return the dynamic properties
+     */
+    @AuraEnabled
+    public Map<String, Object> getAdditionalProperties() {
+      return this.getDynamicProperties();
     }
 
     /**
@@ -2079,6 +2090,14 @@ public class IBMAssistantV2Models {
       // calling custom deserializer for debug
       MessageOutputDebug newDebug = (MessageOutputDebug) new MessageOutputDebug().deserialize(JSON.serialize(ret.getDebug()), (Map<String, Object>) jsonMap.get('debug_serialized_name'), MessageOutputDebug.class);
       ret.setDebug(newDebug);
+
+      Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
+
+      for (String key : jsonMap.keySet()) {
+        if (!baseProps.contains(key)) {
+          ret.put(key, jsonMap.get(key));
+        }
+      }
 
       return ret;
     }


### PR DESCRIPTION
This PR has a fix each for Assistant v1 and v2.

For Assistant v1, a missing property has been manually added to the `CreateDialogNode` model. This will be automated soon (hopefully in the next release).

For Assistant v2, the `MessageOutput` model has been made dynamic to capture additional properties that aren't currently documented. These will be added properly in the next release as well.