### PR TITLE
Gracefully handle common errors in credential values

### DIFF
--- a/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
@@ -9,4 +9,17 @@ public class IBMWatsonCredentialUtils {
     Blob blobValue = Blob.valueOf(username + ':' + password);
     return BASIC + EncodingUtil.base64Encode(blobValue);
   }
+
+  /**
+   * Returns true if the supplied value begins or ends with curly brackets or quotation marks.
+   *
+   * @param credentialValue the credential value to check
+   * @return true if the value starts or ends with these characters and is therefore invalid
+   */
+  public static Boolean hasBadStartOrEndChar(String credentialValue) {
+    return credentialValue.startsWith('{')
+      || credentialValue.startsWith('"')
+      || credentialValue.endsWith('}')
+      || credentialValue.endsWith('"');
+  }
 }

--- a/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls
@@ -1,0 +1,23 @@
+@isTest
+private class IBMWatsonCredentialUtilsTest {
+  static testMethod void testHasBadStartOrEndChar() {
+    // valid
+    System.assert(!IBMWatsonCredentialUtils.hasBadStartOrEndChar('this_is_fine'));
+
+    // starting bracket
+    System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('{bad_username'));
+    System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('{{still_bad'));
+
+    // ending bracket
+    System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('invalid}'));
+    System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('also_invalid}}'));
+
+    // starting quote
+    System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('"not_allowed_either'));
+    System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('""still_not'));
+
+    // ending quote
+    System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('nope"'));
+    System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('sorry""'));
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
@@ -17,6 +17,11 @@ public class IBMWatsonIAMTokenManager {
   private static final String REFRESH_TOKEN = 'refresh_token';
 
   public IBMWatsonIAMTokenManager(IBMWatsonIAMOptions options) {
+    if (IBMWatsonCredentialUtils.hasBadStartOrEndChar(options.getApiKey())) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('The IAM API key shouldn\'t start or end with curly brackets or '
+          + 'quotes. Please remove any surrounding {, }, or " characters.');
+    }
+
     this.apiKey = options.getApiKey();
     if (options.getUrl() != null) {
       this.url = options.getUrl();

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
@@ -17,12 +17,13 @@ public class IBMWatsonIAMTokenManager {
   private static final String REFRESH_TOKEN = 'refresh_token';
 
   public IBMWatsonIAMTokenManager(IBMWatsonIAMOptions options) {
-    if (IBMWatsonCredentialUtils.hasBadStartOrEndChar(options.getApiKey())) {
-      throw new IBMWatsonServiceExceptions.IllegalArgumentException('The IAM API key shouldn\'t start or end with curly brackets or '
-          + 'quotes. Please remove any surrounding {, }, or " characters.');
+    if (options.getApiKey() != null) {
+      if (IBMWatsonCredentialUtils.hasBadStartOrEndChar(options.getApiKey())) {
+        throw new IBMWatsonServiceExceptions.IllegalArgumentException('The IAM API key shouldn\'t start or end with curly brackets or '
+            + 'quotes. Please remove any surrounding {, }, or " characters.');
+      }
+      this.apiKey = options.getApiKey();
     }
-
-    this.apiKey = options.getApiKey();
     if (options.getUrl() != null) {
       this.url = options.getUrl();
     } else {

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -248,6 +248,11 @@ public abstract class IBMWatsonService {
    * @param password the password
    */
   public void setUsernameAndPassword(final String username, final String password) {
+    if (IBMWatsonCredentialUtils.hasBadStartOrEndChar(username) || IBMWatsonCredentialUtils.hasBadStartOrEndChar(password)) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('The username and password shouldn\'t start or end with curly brackets or '
+          + 'quotes. Please remove any surrounding {, }, or " characters.');
+    }
+
     // we'll perform the token exchange for users UNLESS they're on ICP
     if (username.equals(APIKEY_AS_USERNAME) && !password.startsWith(ICP_PREFIX)) {
       IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
@@ -265,6 +270,11 @@ public abstract class IBMWatsonService {
    * @param endPoint the new end point. Will be ignored if empty or null
    */
   public void setEndPoint(String endPointParam) {
+    if (IBMWatsonCredentialUtils.hasBadStartOrEndChar(endPointParam)) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('The URL shouldn\'t start or end with curly brackets or '
+          + 'quotes. Please remove any surrounding {, }, or " characters.');
+    }
+
     if (String.isNotBlank(endPointParam)) {
       String newEndPoint = endPointParam.endsWith('/') ? endPointParam.removeEnd('/') : endPointParam;
       if (this.endPoint == null) {


### PR DESCRIPTION
This PR ensures that exceptions are thrown for credential values surrounded by `{}` or `""` characters. This prevents making a call to the service and provides a more helpful error message.