### PR TITLE
Support credential file

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,37 @@ Finally, you can also install or update the SDK using the Ant Build Tool. This m
     Valid service names are all services listed [here](https://cloud.ibm.com/catalog/?category=watson) written as one word (e.g. Visual Recognition becomes visualrecognition). The parameter is case-insensitive. To deploy multiple services, just run the command again with the next desired service flag.
 
 ## Authentication
-To access your Watson services through Apex, you'll need to authenticate with your service credentials. There are two ways to do this: [using named credentials](#using-named-credentials) or [specifying credentials in the Apex code](#specifying-credentials-in-the-apex-code).
+To access your Watson services through Apex, you'll need to authenticate with your service credentials. There are three ways to do this: [using a credential file](#using-a-credential-file), [using named credentials](#using-named-credentials) or [specifying credentials in the Apex code](#specifying-credentials-in-the-apex-code).
 
 **Note:** Previously, it was possible to authenticate using a token in a header called `X-Watson-Authorization-Token`. This method is deprecated. The token continues to work with Cloud Foundry services, but is not supported for services that use Identity and Access Management (IAM) authentication. See [here](#using-iam) for details.
 
+### Using a credential file
+
+With a credential file, you just need to put the file in the right place and the SDK will do the work of parsing it and authenticating. You can get this file by clicking the **Download** button for the credentials in the **Manage** tab of your service instance.
+
+Once you've downloaded your file, you'll need to do the following:
+
+1. Log in to your Salesforce dashboard
+1. Go to _Setup_ by clicking on the gear icon on the top right of the page
+1. Enter _Static Resources_ in the quick find box and select the highlighted entry
+1. Create a new static resource
+1. Enter the name **ibm_credentials** (:point_left: this must be the name!)
+1. Upload the file you downloaded from the service dashboard page
+1. Set the cache control to **Public**
+
+Once this is done, you're good to go! As an example, if you uploaded a credential file for your Discovery service, you just need to do the following in your code
+
+```java
+IBMDiscoveryV1 discovery = new IBMDiscoveryV1('2017-11-07');
+```
+
+and you'll be authenticated :white_check_mark:
+
+If you're using more than one service at a time in your code and get two different credetnial files, just put the contents together in one file and upload it to your Static Resources with the same name as above. The SDK will handle assigning credentials to their appropriate services.
+
 ### Using `Named Credentials`
 
-`Named Credentials` are the preferred way of authentication, since they allow you to keep sensitive information out of your code. However, they only work when using a **username and password**, so if you'd like to authenticate with an API key or IAM, you'll need to [set that up in your Apex code](#specifying-credentials-in-the-apex-code).
+`Named Credentials` are the next preferred way of authentication, since they allow you to keep sensitive information out of your code. However, they only work when using a **username and password**, so if you'd like to authenticate with an API key or IAM, you'll need to either use the credential file method [above](#using-a-credential-file) or [set that up in your Apex code](#specifying-credentials-in-the-apex-code).
 
 When creating a service instance like with `new Discovery()`, each service loads the credentials from `Named Credentials`. The SDK will use the service name and API version to build the `Named Credentials` name.
 
@@ -148,9 +172,7 @@ In order to create **Named Credentials**:
 
 ### Specifying credentials in the Apex code
 
-Setting credentials in the code is always an option, and in fact, it's the only option if you're authenticating with IAM.
-
-You can always set these values directly in the constructor or with a method call after instantiating your service.
+If the methods above don't work for you, setting credentials in the code is always an option. You can always set these values directly in the constructor or with a method call after instantiating your service.
 
 _Note: You must set the service endpoint manually when setting your credentials this way. Otherwise, the SDK will default to searching for `Named Credentials` that you won't have set up._
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ The IBM Watson Salesforce SDK uses the [Watson API](http://www.ibm.com/watson/de
 ### Getting credentials
 To find out which authentication to use, view the service credentials. You find the service credentials for authentication the same way for all Watson services:
 
-1. Go to the IBM Cloud [Dashboard](https://console.bluemix.net/dashboard/apps?category=ai) page.
-1. Either click an existing Watson service instance or click [**Create resource > AI**](https://console.bluemix.net/catalog/?category=ai) and create a service instance.
-1. Copy the credentials you need for authentication. Click **Show** if the credentials are masked.
+1. Go to the IBM Cloud [Dashboard](https://cloud.ibm.com) page.
+1. Either click an existing Watson service instance in your [resource list](https://cloud.ibm.com/resources) or click [**Create resource > AI**](https://cloud.ibm.com/catalog?category=ai) and create a service instance.
+1. Click on the **Manage** item in the left nav bar of your service instance.
+
+On this page, you should be able to see your credentials for accessing your service instance.
 
 You'll also need a Salesforce account to run your Apex code. To get one, you can visit [this link](https://developer.salesforce.com/signup).
 
@@ -102,7 +104,7 @@ Finally, you can also install or update the SDK using the Ant Build Tool. This m
     ant deployWatson -Dservice=assistant
     ```
 
-    Valid service names are all services listed [here](https://console.bluemix.net/catalog/?category=watson) written as one word (e.g. Visual Recognition becomes visualrecognition). The parameter is case-insensitive. To deploy multiple services, just run the command again with the next desired service flag.
+    Valid service names are all services listed [here](https://cloud.ibm.com/catalog/?category=watson) written as one word (e.g. Visual Recognition becomes visualrecognition). The parameter is case-insensitive. To deploy multiple services, just run the command again with the next desired service flag.
 
 ## Authentication
 To access your Watson services through Apex, you'll need to authenticate with your service credentials. There are two ways to do this: [using named credentials](#using-named-credentials) or [specifying credentials in the Apex code](#specifying-credentials-in-the-apex-code).
@@ -361,4 +363,4 @@ If you're interested in helping to make this project better, see [Contributing.m
 This library is licensed under the MIT license. Full license text is
 available in [LICENSE](LICENSE).
 
-[ibm-cloud-onboarding]: http://console.bluemix.net/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-SalesForce
+[ibm-cloud-onboarding]: http://cloud.ibm.com/registration?target=/developer/watson&cm_sp=WatsonPlatform-WatsonServices-_-OnPageNavLink-IBMWatson_SDKs-_-SalesForce

--- a/force-app/main/default/classes/IBMAssistantV1.cls
+++ b/force-app/main/default/classes/IBMAssistantV1.cls
@@ -18,7 +18,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    */
   public IBMAssistantV1(String versionDate) {
-    super('watson_assistant_v1');
+    super('assistant', 'v1');
 
     if (String.isBlank(versionDate)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('versionDate cannot be null.');

--- a/force-app/main/default/classes/IBMAssistantV2.cls
+++ b/force-app/main/default/classes/IBMAssistantV2.cls
@@ -18,7 +18,7 @@ public class IBMAssistantV2 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    */
   public IBMAssistantV2(String versionDate) {
-    super('watson_assistant_v2');
+    super('assistant', 'v2');
 
     if (String.isBlank(versionDate)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('versionDate cannot be null.');

--- a/force-app/main/default/classes/IBMCompareComplyV1.cls
+++ b/force-app/main/default/classes/IBMCompareComplyV1.cls
@@ -18,7 +18,7 @@ public class IBMCompareComplyV1 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    */
   public IBMCompareComplyV1(String versionDate) {
-    super('watson_compare_comply_v1');
+    super('compare_comply' , 'v1');
 
     if (String.isBlank(versionDate)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('versionDate cannot be null.');

--- a/force-app/main/default/classes/IBMDiscoveryV1.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1.cls
@@ -20,7 +20,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    */
   public IBMDiscoveryV1(String versionDate) {
-    super('watson_discovery_v1');
+    super('discovery', 'v1');
 
     if (String.isBlank(versionDate)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('versionDate cannot be null.');

--- a/force-app/main/default/classes/IBMLanguageTranslatorV3.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV3.cls
@@ -20,7 +20,7 @@ public class IBMLanguageTranslatorV3 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    */
   public IBMLanguageTranslatorV3(String versionDate) {
-    super('watson_language_translator_v3');
+    super('language_translator', 'v3');
 
     if (String.isBlank(versionDate)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('versionDate cannot be null.');

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
@@ -15,7 +15,7 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
    *
    */
   public IBMNaturalLanguageClassifierV1() {
-    super('watson_natural_language_classifier_v1');
+    super('natural_language_classifier', 'v1');
   }
 
   /**

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
@@ -3,8 +3,8 @@
  * Language Understanding will give you results for the features you request. The service cleans HTML content before
  * analysis by default, so the results can ignore most advertisements and other unwanted content.
  *
- * You can create [custom models](https://cloud.ibm.com/docs/services/natural-language-understanding/customizing.html) with Watson Knowledge
- * Studio to detect custom entities and relations in Natural Language Understanding.
+ * You can create [custom models](https://cloud.ibm.com/docs/services/natural-language-understanding/customizing.html)
+ * with Watson Knowledge Studio to detect custom entities and relations in Natural Language Understanding.
  *
  * @version V1
  * @see <a href="http://www.ibm.com/watson/developercloud/natural-language-understanding.html">Natural Language Understanding</a>
@@ -22,7 +22,7 @@ public class IBMNaturalLanguageUnderstandingV1 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    */
   public IBMNaturalLanguageUnderstandingV1(String versionDate) {
-    super('watson_natural_language_understanding_v1');
+    super('natural_language_understanding', 'v1');
 
     if (String.isBlank(versionDate)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('versionDate cannot be null.');
@@ -146,8 +146,9 @@ public class IBMNaturalLanguageUnderstandingV1 extends IBMWatsonService {
   /**
    * List models.
    *
-   * Lists Watson Knowledge Studio [custom models](https://cloud.ibm.com/docs/services/natural-language-understanding/customizing.html) that
-   * are deployed to your Natural Language Understanding service.
+   * Lists Watson Knowledge Studio [custom
+   * models](https://cloud.ibm.com/docs/services/natural-language-understanding/customizing.html) that are deployed to
+   * your Natural Language Understanding service.
    *
    * @param listModelsOptions the {@link IBMNaturalLanguageUnderstandingV1Models.ListModelsOptions} containing the options for the call
    * @return the {@link IBMNaturalLanguageUnderstandingV1Models.ListModelsResults} with the response

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3.cls
@@ -31,7 +31,7 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    */
   public IBMPersonalityInsightsV3(String versionDate) {
-    super('watson_personality_insights_v3');
+    super('personality_insights', 'v3');
 
     if (String.isBlank(versionDate)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('versionDate cannot be null.');
@@ -89,7 +89,8 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
    * When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the character
    * encoding of the input text; for example, `Content-Type: text/plain;charset=utf-8`.
    *
-   * **See also:** [Specifying request and response formats](https://cloud.ibm.com/docs/services/personality-insights/input.html#formats)
+   * **See also:** [Specifying request and response
+   * formats](https://cloud.ibm.com/docs/services/personality-insights/input.html#formats)
    *
    * ### Accept types
    *
@@ -160,7 +161,8 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
    * When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the character
    * encoding of the input text; for example, `Content-Type: text/plain;charset=utf-8`.
    *
-   * **See also:** [Specifying request and response formats](https://cloud.ibm.com/docs/services/personality-insights/input.html#formats)
+   * **See also:** [Specifying request and response
+   * formats](https://cloud.ibm.com/docs/services/personality-insights/input.html#formats)
    *
    * ### Accept types
    *

--- a/force-app/main/default/classes/IBMSpeechToTextV1.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1.cls
@@ -1,6 +1,6 @@
 /**
  * The IBM&reg; Speech to Text service provides APIs that use IBM's speech-recognition capabilities to produce
- * transcripts of spoken audio. The service can transcribe speech from various languages and audio formats. It addition
+ * transcripts of spoken audio. The service can transcribe speech from various languages and audio formats. In addition
  * to basic transcription, the service can produce detailed information about many different aspects of the audio. For
  * most languages, the service supports two sampling rates, broadband and narrowband. It returns all JSON response
  * content in the UTF-8 character set.
@@ -29,7 +29,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
    *
    */
   public IBMSpeechToTextV1() {
-    super('watson_speech_to_text_v1');
+    super('speech_to_text', 'v1');
   }
 
   /**

--- a/force-app/main/default/classes/IBMTextToSpeechV1.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1.cls
@@ -27,7 +27,7 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    *
    */
   public IBMTextToSpeechV1() {
-    super('watson_text_to_speech_v1');
+    super('text_to_speech', 'v1');
   }
 
   /**
@@ -116,7 +116,8 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    * The service returns the synthesized audio stream as an array of bytes. You can pass a maximum of 5 KB of text to
    * the service.
    *
-   * **See also:** [Synthesizing text to audio](https://cloud.ibm.com/docs/services/text-to-speech/http.html#synthesize).
+   * **See also:** [Synthesizing text to
+   * audio](https://cloud.ibm.com/docs/services/text-to-speech/http.html#synthesize).
    *
    * ### Audio formats (accept types)
    *
@@ -260,7 +261,8 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    *
    * **Note:** This method is currently a beta release.
    *
-   * **See also:** [Creating a custom model](https://cloud.ibm.com/docs/services/text-to-speech/custom-models.html#cuModelsCreate).
+   * **See also:** [Creating a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech/custom-models.html#cuModelsCreate).
    *
    * @param createVoiceModelOptions the {@link IBMTextToSpeechV1Models.CreateVoiceModelOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.VoiceModel} with the response
@@ -296,7 +298,8 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    *
    * **Note:** This method is currently a beta release.
    *
-   * **See also:** [Deleting a custom model](https://cloud.ibm.com/docs/services/text-to-speech/custom-models.html#cuModelsDelete).
+   * **See also:** [Deleting a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech/custom-models.html#cuModelsDelete).
    *
    * @param deleteVoiceModelOptions the {@link IBMTextToSpeechV1Models.DeleteVoiceModelOptions} containing the options for the call
    * @return the service call
@@ -323,7 +326,8 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    *
    * **Note:** This method is currently a beta release.
    *
-   * **See also:** [Querying a custom model](https://cloud.ibm.com/docs/services/text-to-speech/custom-models.html#cuModelsQuery).
+   * **See also:** [Querying a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech/custom-models.html#cuModelsQuery).
    *
    * @param getVoiceModelOptions the {@link IBMTextToSpeechV1Models.GetVoiceModelOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.VoiceModel} with the response
@@ -352,7 +356,8 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    *
    * **Note:** This method is currently a beta release.
    *
-   * **See also:** [Querying all custom models](https://cloud.ibm.com/docs/services/text-to-speech/custom-models.html#cuModelsQueryAll).
+   * **See also:** [Querying all custom
+   * models](https://cloud.ibm.com/docs/services/text-to-speech/custom-models.html#cuModelsQueryAll).
    *
    * @param listVoiceModelsOptions the {@link IBMTextToSpeechV1Models.ListVoiceModelsOptions} containing the options for the call
    * @return the {@link IBMTextToSpeechV1Models.VoiceModels} with the response
@@ -396,7 +401,8 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    *
    * **See also:**
    * * [Updating a custom model](https://cloud.ibm.com/docs/services/text-to-speech/custom-models.html#cuModelsUpdate)
-   * * [Adding words to a Japanese custom model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuJapaneseAdd)
+   * * [Adding words to a Japanese custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuJapaneseAdd)
    * * [Understanding customization](https://cloud.ibm.com/docs/services/text-to-speech/custom-intro.html).
    *
    * @param updateVoiceModelOptions the {@link IBMTextToSpeechV1Models.UpdateVoiceModelOptions} containing the options for the call
@@ -448,8 +454,10 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    * **Note:** This method is currently a beta release.
    *
    * **See also:**
-   * * [Adding a single word to a custom model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuWordAdd)
-   * * [Adding words to a Japanese custom model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuJapaneseAdd)
+   * * [Adding a single word to a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuWordAdd)
+   * * [Adding words to a Japanese custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuJapaneseAdd)
    * * [Understanding customization](https://cloud.ibm.com/docs/services/text-to-speech/custom-intro.html).
    *
    * @param addWordOptions the {@link IBMTextToSpeechV1Models.AddWordOptions} containing the options for the call
@@ -497,8 +505,10 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    * **Note:** This method is currently a beta release.
    *
    * **See also:**
-   * * [Adding multiple words to a custom model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuWordsAdd)
-   * * [Adding words to a Japanese custom model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuJapaneseAdd)
+   * * [Adding multiple words to a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuWordsAdd)
+   * * [Adding words to a Japanese custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech/custom-entries.html#cuJapaneseAdd)
    * * [Understanding customization](https://cloud.ibm.com/docs/services/text-to-speech/custom-intro.html).
    *
    * @param addWordsOptions the {@link IBMTextToSpeechV1Models.AddWordsOptions} containing the options for the call

--- a/force-app/main/default/classes/IBMToneAnalyzerV3.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3.cls
@@ -24,7 +24,7 @@ public class IBMToneAnalyzerV3 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    */
   public IBMToneAnalyzerV3(String versionDate) {
-    super('watson_tone_analyzer_v3');
+    super('tone_analyzer', 'v3');
 
     if (String.isBlank(versionDate)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('versionDate cannot be null.');

--- a/force-app/main/default/classes/IBMVisualRecognitionV3.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3.cls
@@ -19,7 +19,7 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    */
   public IBMVisualRecognitionV3(String versionDate) {
-    super('watson_visual_recognition_v3');
+    super('visual_recognition', 'v3');
 
     if (String.isBlank(versionDate)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('versionDate cannot be null.');
@@ -102,7 +102,8 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
    * recognition.
    *
    * Supported image formats include .gif, .jpg, .png, and .tif. The maximum image size is 10 MB. The minimum
-   * recommended pixel density is 32X32 pixels per inch.
+   * recommended pixel density is 32X32 pixels, but the service tends to perform better with images that are at least
+   * 224 x 224 pixels.
    *
    * @param detectFacesOptions the {@link IBMVisualRecognitionV3Models.DetectFacesOptions} containing the options for the call
    * @return the {@link IBMVisualRecognitionV3Models.DetectedFaces} with the response
@@ -251,9 +252,8 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   /**
    * Update a classifier.
    *
-   * Update a custom classifier by adding new positive or negative classes (examples) or by adding new images to
-   * existing classes. You must supply at least one set of positive or negative examples. For details, see [Updating
-   * custom
+   * Update a custom classifier by adding new positive or negative classes or by adding new images to existing classes.
+   * You must supply at least one set of positive or negative examples. For details, see [Updating custom
    * classifiers](https://cloud.ibm.com/docs/services/visual-recognition/customizing.html#updating-custom-classifiers).
    *
    * Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image file names, and classifier and class

--- a/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
@@ -78,7 +78,7 @@ public class IBMWatsonCredentialUtils {
     return fileContents;
   }
 
-  private static ServiceCredentials parseCredentialFile(String serviceName, String contents) {
+  public static ServiceCredentials parseCredentialFile(String serviceName, String fileContents) {
     ServiceCredentials serviceCredentials = new ServiceCredentials();
 
     String[] lineList = fileContents.split('\r\n');

--- a/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
@@ -1,8 +1,52 @@
 public class IBMWatsonCredentialUtils {
   private static final String BASIC = 'Basic ';
+  private static final String USERNAME = 'username';
+  private static final String PASSWORD = 'password';
+  private static final String URL = 'url';
+  private static final String IAM_API_KEY = 'apikey';
+  private static final String IAM_URL = 'iam_url';
+  private static final String CREDENTIAL_FILE_NAME = 'ibm_credentials';
 
   private IBMWatsonCredentialUtils() {
     // This is a utility class - no instantiation allowed.
+  }
+
+  public class ServiceCredentials {
+    private String username;
+    private String password;
+    private String url;
+    private String iamApiKey;
+    private String iamUrl;
+
+    private ServiceCredentials() { }
+
+    public String getUsername() {
+      return this.username;
+    }
+
+    public String getPassword() {
+      return this.password;
+    }
+
+    public String getUrl() {
+      return this.url;
+    }
+
+    public String getIamApiKey() {
+      return this.iamApiKey;
+    }
+
+    public String getIamUrl() {
+      return this.iamUrl;
+    }
+
+    public boolean isEmpty() {
+      return (username == null
+          && password == null
+          && url == null
+          && iamApiKey == null
+          && iamUrl == null);
+    }
   }
 
   public static String toBasicAuth(String username, String password) {
@@ -21,5 +65,46 @@ public class IBMWatsonCredentialUtils {
       || credentialValue.startsWith('"')
       || credentialValue.endsWith('}')
       || credentialValue.endsWith('"');
+  }
+
+  public static ServiceCredentials loadCredentialFileValues(String serviceName) {
+    ServiceCredentials serviceCredentials = new ServiceCredentials();
+    String body;
+
+    try {
+      StaticResource credentialFileResource = [SELECT Id, Body FROM StaticResource WHERE Name = :CREDENTIAL_FILE_NAME LIMIT 1];
+      fileContents = credentialFileResource.Body.toString();
+    } catch (QueryException e) {
+      System.debug(System.LoggingLevel.INFO, 'Could not find credential file in Static Resources');
+      return serviceCredentials;
+    }
+
+    String[] lineList = fileContents.split('\r\n');
+    for (String line : lineList) {
+      String[] keyAndVal = line.split('=');
+      String lowercaseKey = keyAndVal[0].toLowerCase();
+      Integer serviceNameLength = serviceName.length();
+
+      if (lowercaseKey.contains(serviceName)) {
+        String credentialType = lowercaseKey.substring(serviceNameLength + 1);
+        String credentialValue = keyAndVal[1];
+
+        if (credentialType.contains(USERNAME)) {
+          serviceCredentials.username = credentialValue;
+        } else if (credentialType.contains(PASSWORD)) {
+          serviceCredentials.password = credentialValue;
+        } else if (credentialType.contains(URL)) {
+          serviceCredentials.url = credentialValue;
+        } else if (credentialType.contains(IAM_API_KEY)) {
+          serviceCredentials.iamApiKey = credentialValue;
+        } else if (credentialType.contains(IAM_URL)) {
+          serviceCredentials.iamUrl = credentialValue;
+        } else {
+          System.debug(System.LoggingLevel.WARN, 'Unknown credential key found in credential file: ' + credentialType);
+        }
+      }
+    }
+
+    return serviceCredentials;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
@@ -67,17 +67,19 @@ public class IBMWatsonCredentialUtils {
       || credentialValue.endsWith('"');
   }
 
-  public static ServiceCredentials loadCredentialFileValues(String serviceName) {
-    ServiceCredentials serviceCredentials = new ServiceCredentials();
-    String body;
-
+  private static String getCredentialFileBody() {
+    String fileContents = null;
     try {
       StaticResource credentialFileResource = [SELECT Id, Body FROM StaticResource WHERE Name = :CREDENTIAL_FILE_NAME LIMIT 1];
       fileContents = credentialFileResource.Body.toString();
     } catch (QueryException e) {
       System.debug(System.LoggingLevel.INFO, 'Could not find credential file in Static Resources');
-      return serviceCredentials;
     }
+    return fileContents;
+  }
+
+  private static ServiceCredentials parseCredentialFile(String serviceName, String contents) {
+    ServiceCredentials serviceCredentials = new ServiceCredentials();
 
     String[] lineList = fileContents.split('\r\n');
     for (String line : lineList) {
@@ -103,6 +105,17 @@ public class IBMWatsonCredentialUtils {
           System.debug(System.LoggingLevel.WARN, 'Unknown credential key found in credential file: ' + credentialType);
         }
       }
+    }
+
+    return serviceCredentials;
+  }
+
+  public static ServiceCredentials loadCredentialFileValues(String serviceName) {
+    ServiceCredentials serviceCredentials = new ServiceCredentials();
+    String fileContents = getCredentialFileBody();
+
+    if (fileContents != null) {
+      serviceCredentials = parseCredentialFile(serviceName, fileContents);
     }
 
     return serviceCredentials;

--- a/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls
@@ -1,5 +1,11 @@
 @isTest
 private class IBMWatsonCredentialUtilsTest {
+  private static String testCredentialFileContents = 'DISCOVERY_USERNAME=disco_username\r\n'
+    + 'DISCOVERY_PASSWORD=disco_password\r\n'
+    + 'DISCOVERY_URL=https://gateway.watsonplatform.net/discovery/api\r\n'
+    + 'NATURAL_LANGUAGE_CLASSIFIER_URL=https://gateway-s.watsonplatform.net/natural-language-classifier/api\r\n'
+    + 'NATURAL_LANGUAGE_CLASSIFIER_APIKEY=nlc_apikey';
+
   static testMethod void testHasBadStartOrEndChar() {
     // valid
     System.assert(!IBMWatsonCredentialUtils.hasBadStartOrEndChar('this_is_fine'));
@@ -19,5 +25,33 @@ private class IBMWatsonCredentialUtilsTest {
     // ending quote
     System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('nope"'));
     System.assert(IBMWatsonCredentialUtils.hasBadStartOrEndChar('sorry""'));
+  }
+
+  static testMethod void testParsingCredentialFileNoService() {
+    IBMWatsonCredentialUtils.ServiceCredentials serviceCredentials
+      = IBMWatsonCredentialUtils.parseCredentialFile('assistant', testCredentialFileContents);
+    System.assert(serviceCredentials.isEmpty());
+  }
+
+  static testMethod void testParsingCredentialFileUsernameAndPassword() {
+    String expectedUsername = 'disco_username';
+    String expectedPassword = 'disco_password';
+    String expectedUrl = 'https://gateway.watsonplatform.net/discovery/api';
+
+    IBMWatsonCredentialUtils.ServiceCredentials serviceCredentials
+      = IBMWatsonCredentialUtils.parseCredentialFile('discovery', testCredentialFileContents);
+    System.assertEquals(expectedUsername, serviceCredentials.getUsername());
+    System.assertEquals(expectedPassword, serviceCredentials.getPassword());
+    System.assertEquals(expectedUrl, serviceCredentials.getUrl());
+  }
+
+  static testMethod void testParsingCredentialFileApikey() {
+    String expectedApikey = 'nlc_apikey';
+    String expectedUrl = 'https://gateway-s.watsonplatform.net/natural-language-classifier/api';
+
+    IBMWatsonCredentialUtils.ServiceCredentials serviceCredentials
+      = IBMWatsonCredentialUtils.parseCredentialFile('natural_language_classifier', testCredentialFileContents);
+    System.assertEquals(expectedApikey, serviceCredentials.getIamApiKey());
+    System.assertEquals(expectedUrl, serviceCredentials.getUrl());
   }
 }

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -1,7 +1,4 @@
 public abstract class IBMWatsonService {
-
-  protected String serviceName {get;set;}
-
   private String apiKey;
   private String defaultEndPoint;
   private String endPoint;
@@ -37,12 +34,37 @@ public abstract class IBMWatsonService {
    * Instantiates a new Watson service.
    *
    * @param name the service name
+   * @param version the service version
    */
-  protected IBMWatsonService(String name) {
+  protected IBMWatsonService(String name, String version) {
     this.name = name;
     this.userAgent = buildUserAgent(); // initialize the `User-Agent` value
 
-    setEndPoint(CALLOUT + name);
+    IBMWatsonCredentialUtils.ServiceCredentials fileCredentials = IBMWatsonCredentialUtils.loadCredentialFileValues(name);
+    if (!fileCredentials.isEmpty()) {
+      setCredentialFields(fileCredentials);
+    } else {
+      String namedCredentialsKey = String.format('watson_{0}_{1}', new String[]{ name, version });
+      setEndPoint(CALLOUT + namedCredentialsKey);
+    }
+  }
+
+  private void setCredentialFields(IBMWatsonCredentialUtils.ServiceCredentials serviceCredentials) {
+    if (serviceCredentials.getUrl() != null) {
+      setEndPoint(serviceCredentials.getUrl());
+    }
+
+    if ((serviceCredentials.getUsername() != null) && (serviceCredentials.getPassword() != null)) {
+      setUsernameAndPassword(serviceCredentials.getUsername(), serviceCredentials.getPassword());
+    }
+
+    if (serviceCredentials.getIamApiKey() != null) {
+      IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
+        .apiKey(serviceCredentials.getIamApiKey())
+        .url(serviceCredentials.getIamUrl())
+        .build();
+      setIamCredentials(iamOptions);
+   }
   }
 
   /**

--- a/force-app/main/default/classes/IBMWatsonServiceTest.cls
+++ b/force-app/main/default/classes/IBMWatsonServiceTest.cls
@@ -6,7 +6,7 @@ private class IBMWatsonServiceTest {
    */
   class TestService extends IBMWatsonService {
     public TestService() {
-      super('test_service_v1');
+      super('service', 'v1');
     }
 
     public TestClass testingMethod() {


### PR DESCRIPTION
This PR adds support for a credential file downloaded from IBM Cloud. Due to restrictions of the Salesforce platform, the file will only be searched for in the **Static Resources** section of the user's Salesforce dashboard. The resource must be named `ibm_credentials*. Documentation has been added to the README to explain these steps.

Otherwise, this functionality behaves in the same way as the other SDKs.