### PR TITLE
Look for iam_apikey for IAM auth in credential file

### DIFF
--- a/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
@@ -3,7 +3,7 @@ public class IBMWatsonCredentialUtils {
   private static final String USERNAME = 'username';
   private static final String PASSWORD = 'password';
   private static final String URL = 'url';
-  private static final String IAM_API_KEY = 'apikey';
+  private static final String IAM_API_KEY = 'iam_apikey';
   private static final String IAM_URL = 'iam_url';
   private static final String CREDENTIAL_FILE_NAME = 'ibm_credentials';
 

--- a/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
@@ -4,6 +4,7 @@ public class IBMWatsonCredentialUtils {
   private static final String PASSWORD = 'password';
   private static final String URL = 'url';
   private static final String IAM_API_KEY = 'iam_apikey';
+  private static final String API_KEY = 'apikey';
   private static final String IAM_URL = 'iam_url';
   private static final String CREDENTIAL_FILE_NAME = 'ibm_credentials';
 
@@ -97,7 +98,7 @@ public class IBMWatsonCredentialUtils {
           serviceCredentials.password = credentialValue;
         } else if (credentialType.contains(URL)) {
           serviceCredentials.url = credentialValue;
-        } else if (credentialType.contains(IAM_API_KEY)) {
+        } else if (credentialType.contains(IAM_API_KEY) || credentialType.contains(API_KEY)) {
           serviceCredentials.iamApiKey = credentialValue;
         } else if (credentialType.contains(IAM_URL)) {
           serviceCredentials.iamUrl = credentialValue;

--- a/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls
@@ -4,7 +4,7 @@ private class IBMWatsonCredentialUtilsTest {
     + 'DISCOVERY_PASSWORD=disco_password\r\n'
     + 'DISCOVERY_URL=https://gateway.watsonplatform.net/discovery/api\r\n'
     + 'NATURAL_LANGUAGE_CLASSIFIER_URL=https://gateway-s.watsonplatform.net/natural-language-classifier/api\r\n'
-    + 'NATURAL_LANGUAGE_CLASSIFIER_APIKEY=nlc_apikey';
+    + 'NATURAL_LANGUAGE_CLASSIFIER_IAM_APIKEY=nlc_apikey';
 
   static testMethod void testHasBadStartOrEndChar() {
     // valid

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
@@ -15,6 +15,7 @@ public class IBMWatsonIAMTokenManager {
   private static final String RESPONSE_TYPE = 'response_type';
   private static final String CLOUD_IAM = 'cloud_iam';
   private static final String REFRESH_TOKEN = 'refresh_token';
+  private static final String DEFAULT_ERROR_MESSAGE = 'There was a problem calling the IAM API.';
 
   public IBMWatsonIAMTokenManager(IBMWatsonIAMOptions options) {
     if (options.getApiKey() != null) {
@@ -162,9 +163,13 @@ public class IBMWatsonIAMTokenManager {
       String jsonString = JSON.serialize(safeJsonMap);
       return (IBMWatsonIAMToken) ((IBMWatsonGenericModel) IBMWatsonIAMToken.class.newInstance()).deserialize(jsonString, safeJsonMap, IBMWatsonIAMToken.class);
     } else {
-      String error = response.getBody();
+      Map<String, Object> responseMap = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
+      String errorMessage = responseMap.get('errorMessage');
+      if (errorMessage == null) {
+        errorMessage = DEFAULT_ERROR_MESSAGE;
+      }
       Integer statusCode = response.getStatusCode();
-      throw new IBMWatsonServiceExceptions.ResponseException(statusCode, error, response);
+      throw new IBMWatsonServiceExceptions.ResponseException(statusCode, errorMessage, response);
     }
   }
 }


### PR DESCRIPTION
Related to an internal naming debate. Basically, we've decided we should be using `iam_apikey` for IAM keys and are updating code on the IBM Cloud side to adhere to this. This will then require updating on the SDK side to capture those changes.

In this PR, we still do look for the old `apikey` name so as not to break anyone who may have been using an old credential file.

Lastly, I also included a change to try and pull the error message from bad IAM responses, which use the key `errorMessage`. This is a small change just to try and make those problems more readable.