### PR TITLE
Fix illegal assignment from Object to String

### DIFF
--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
@@ -164,7 +164,7 @@ public class IBMWatsonIAMTokenManager {
       return (IBMWatsonIAMToken) ((IBMWatsonGenericModel) IBMWatsonIAMToken.class.newInstance()).deserialize(jsonString, safeJsonMap, IBMWatsonIAMToken.class);
     } else {
       Map<String, Object> responseMap = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
-      String errorMessage = responseMap.get('errorMessage');
+      String errorMessage = responseMap.get('errorMessage').toString();
       if (errorMessage == null) {
         errorMessage = DEFAULT_ERROR_MESSAGE;
       }


### PR DESCRIPTION
This PR fixes an issue where we were trying to use an `Object` as a `String` while doing error handling in the `IBMWatsonIAMTokenManager` class.