### PR TITLE
Add support for ICP4D auth

### DIFF
--- a/force-app/main/default/classes/IBMAssistantV1.cls
+++ b/force-app/main/default/classes/IBMAssistantV1.cls
@@ -33,6 +33,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMAssistantV1(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMAssistantV1(String versionDate, String username, String password) {
     this(versionDate);
@@ -40,18 +41,15 @@ public class IBMAssistantV1 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMAssistantV1` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMAssistantV1` with the specified authentication configuration.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMAssistantV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+  public IBMAssistantV1(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this(versionDate);
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMAssistantV2.cls
+++ b/force-app/main/default/classes/IBMAssistantV2.cls
@@ -33,6 +33,7 @@ public class IBMAssistantV2 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMAssistantV2(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMAssistantV2(String versionDate, String username, String password) {
     this(versionDate);
@@ -40,18 +41,15 @@ public class IBMAssistantV2 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMAssistantV2` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMAssistantV2` with the specified authentication configuration.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMAssistantV2(String versionDate, IBMWatsonIAMOptions iamOptions) {
+  public IBMAssistantV2(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this(versionDate);
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMCompareComplyV1.cls
+++ b/force-app/main/default/classes/IBMCompareComplyV1.cls
@@ -27,18 +27,15 @@ public class IBMCompareComplyV1 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMCompareComplyV1` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMCompareComplyV1` with the specified authentication configuration.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMCompareComplyV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+  public IBMCompareComplyV1(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this(versionDate);
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMDiscoveryV1.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1.cls
@@ -35,6 +35,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMDiscoveryV1(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMDiscoveryV1(String versionDate, String username, String password) {
     this(versionDate);
@@ -42,18 +43,15 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMDiscoveryV1` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMDiscoveryV1` with the specified authentication configuration.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMDiscoveryV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+  public IBMDiscoveryV1(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this(versionDate);
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMLanguageTranslatorV3.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV3.cls
@@ -35,6 +35,7 @@ public class IBMLanguageTranslatorV3 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMLanguageTranslatorV3(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMLanguageTranslatorV3(String versionDate, String username, String password) {
     this(versionDate);
@@ -42,18 +43,15 @@ public class IBMLanguageTranslatorV3 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMLanguageTranslatorV3` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMLanguageTranslatorV3` with the specified authentication configuration.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMLanguageTranslatorV3(String versionDate, IBMWatsonIAMOptions iamOptions) {
+  public IBMLanguageTranslatorV3(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this(versionDate);
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
@@ -12,7 +12,6 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
 
   /**
    * Instantiates a new `IBMNaturalLanguageClassifierV1`.
-   *
    */
   public IBMNaturalLanguageClassifierV1() {
     super('natural_language_classifier', 'v1');
@@ -23,6 +22,7 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
    *
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMNaturalLanguageClassifierV1(IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMNaturalLanguageClassifierV1(String username, String password) {
     this();
@@ -30,16 +30,13 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMNaturalLanguageClassifierV1` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMNaturalLanguageClassifierV1` with the specified authentication configuration.
    *
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMNaturalLanguageClassifierV1(IBMWatsonIAMOptions iamOptions) {
+  public IBMNaturalLanguageClassifierV1(IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this();
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
@@ -37,6 +37,7 @@ public class IBMNaturalLanguageUnderstandingV1 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMNaturalLanguageUnderstandingV1(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMNaturalLanguageUnderstandingV1(String versionDate, String username, String password) {
     this(versionDate);
@@ -44,18 +45,15 @@ public class IBMNaturalLanguageUnderstandingV1 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMNaturalLanguageUnderstandingV1` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMNaturalLanguageUnderstandingV1` with the specified authentication configuration.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMNaturalLanguageUnderstandingV1(String versionDate, IBMWatsonIAMOptions iamOptions) {
+  public IBMNaturalLanguageUnderstandingV1(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this(versionDate);
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3.cls
@@ -46,6 +46,7 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMPersonalityInsightsV3(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMPersonalityInsightsV3(String versionDate, String username, String password) {
     this(versionDate);
@@ -53,18 +54,15 @@ public class IBMPersonalityInsightsV3 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMPersonalityInsightsV3` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMPersonalityInsightsV3` with the specified authentication configuration.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMPersonalityInsightsV3(String versionDate, IBMWatsonIAMOptions iamOptions) {
+  public IBMPersonalityInsightsV3(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this(versionDate);
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMSpeechToTextV1.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1.cls
@@ -26,7 +26,6 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
 
   /**
    * Instantiates a new `IBMSpeechToTextV1`.
-   *
    */
   public IBMSpeechToTextV1() {
     super('speech_to_text', 'v1');
@@ -37,6 +36,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
    *
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMSpeechToTextV1(IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMSpeechToTextV1(String username, String password) {
     this();
@@ -44,16 +44,13 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMSpeechToTextV1` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMSpeechToTextV1` with the specified authentication configuration.
    *
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMSpeechToTextV1(IBMWatsonIAMOptions iamOptions) {
+  public IBMSpeechToTextV1(IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this();
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMTextToSpeechV1.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1.cls
@@ -24,7 +24,6 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
 
   /**
    * Instantiates a new `IBMTextToSpeechV1`.
-   *
    */
   public IBMTextToSpeechV1() {
     super('text_to_speech', 'v1');
@@ -35,6 +34,7 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    *
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMTextToSpeechV1(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMTextToSpeechV1(String username, String password) {
     this();
@@ -42,16 +42,13 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMTextToSpeechV1` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMTextToSpeechV1` with the specified authentication configuration.
    *
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMTextToSpeechV1(IBMWatsonIAMOptions iamOptions) {
+  public IBMTextToSpeechV1(IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this();
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMToneAnalyzerV3.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3.cls
@@ -39,6 +39,7 @@ public class IBMToneAnalyzerV3 extends IBMWatsonService {
    *        calls from failing when the service introduces breaking changes.
    * @param username the username
    * @param password the password
+   * @deprecated Use IBMToneAnalyzerV3(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) instead
    */
   public IBMToneAnalyzerV3(String versionDate, String username, String password) {
     this(versionDate);
@@ -46,18 +47,15 @@ public class IBMToneAnalyzerV3 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMToneAnalyzerV3` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMToneAnalyzerV3` with the specified authentication configuration.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMToneAnalyzerV3(String versionDate, IBMWatsonIAMOptions iamOptions) {
+  public IBMToneAnalyzerV3(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this(versionDate);
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMVisualRecognitionV3.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3.cls
@@ -28,18 +28,15 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
   }
 
   /**
-   * Instantiates a new `IBMVisualRecognitionV3` with IAM. Note that if the access token is specified in the
-   * iamOptions, you accept responsibility for managing the access token yourself. You must set a new access token before this
-   * one expires or after receiving a 401 error from the service. Failing to do so will result in authentication errors
-   * after this token expires.
+   * Instantiates a new `IBMVisualRecognitionV3` with the specified authentication configuration.
    *
    * @param versionDate The version date (yyyy-MM-dd) of the REST API to use. Specifying this value will keep your API
    *        calls from failing when the service introduces breaking changes.
-   * @param iamOptions the options for authenticating through IAM
+   * @param authenticatorConfig the authentication configuration for this service
    */
-  public IBMVisualRecognitionV3(String versionDate, IBMWatsonIAMOptions iamOptions) {
+  public IBMVisualRecognitionV3(String versionDate, IBMWatsonAuthenticatorConfig authenticatorConfig) {
     this(versionDate);
-    setIamCredentials(iamOptions);
+    setAuthenticator(authenticatorConfig);
   }
 
   /**

--- a/force-app/main/default/classes/IBMWatsonAuthenticator.cls
+++ b/force-app/main/default/classes/IBMWatsonAuthenticator.cls
@@ -1,0 +1,4 @@
+public interface IBMWatsonAuthenticator {
+  String authenticationType();
+  void authenticate(IBMWatsonRequest.Builder requestBuilder);
+}

--- a/force-app/main/default/classes/IBMWatsonAuthenticator.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonAuthenticator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonAuthenticatorConfig.cls
+++ b/force-app/main/default/classes/IBMWatsonAuthenticatorConfig.cls
@@ -1,0 +1,4 @@
+public interface IBMWatsonAuthenticatorConfig {
+  String authenticationType();
+  void validate();
+}

--- a/force-app/main/default/classes/IBMWatsonAuthenticatorConfig.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonAuthenticatorConfig.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonAuthenticatorFactory.cls
+++ b/force-app/main/default/classes/IBMWatsonAuthenticatorFactory.cls
@@ -1,0 +1,20 @@
+public class IBMWatsonAuthenticatorFactory {
+  private IBMWatsonAuthenticatorFactory() {}
+
+  public static IBMWatsonAuthenticator getAuthenticator(IBMWatsonAuthenticatorConfig config) {
+    config.validate();
+
+    String authType = config.authenticationType();
+    if (authType.equals(IBMWatsonCredentialUtils.AUTHTYPE_IAM)) {
+      return new IBMWatsonIAMTokenManager((IBMWatsonIAMOptions) config);
+    } else if (authType.equals(IBMWatsonCredentialUtils.AUTHTYPE_ICP4D)) {
+      return new IBMWatsonICP4DAuthenticator((IBMWatsonICP4DConfig) config);
+    } else if (authType.equals(IBMWatsonCredentialUtils.AUTHTYPE_BASIC)) {
+      return new IBMWatsonBasicAuthenticator((IBMWatsonBasicAuthConfig) config);
+    } else if (authType.equals(IBMWatsonCredentialUtils.AUTHTYPE_NOAUTH)) {
+      return new IBMWatsonNoauthAuthenticator((IBMWatsonNoauthConfig) config);
+    } else {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('Unrecognized AuthenticatorConfig type');
+    }
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonAuthenticatorFactory.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonAuthenticatorFactory.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonAuthenticatorFactoryTest.cls
+++ b/force-app/main/default/classes/IBMWatsonAuthenticatorFactoryTest.cls
@@ -1,0 +1,59 @@
+@isTest
+private class IBMWatsonAuthenticatorFactoryTest {
+  private class UnknownConfig implements IBMWatsonAuthenticatorConfig {
+    public String authenticationType() {
+      return 'unknown';
+    }
+
+    public void validate() { }
+  }
+
+  static testMethod void testGetAuthenticatorIam() {
+    Test.startTest();
+    IBMWatsonIAMOptions config = new IBMWatsonIAMOptions.Builder()
+      .apiKey('test-key')
+      .build();
+    IBMWatsonAuthenticator authenticator = IBMWatsonAuthenticatorFactory.getAuthenticator(config);
+    System.assert(authenticator instanceof IBMWatsonIAMTokenManager);
+    Test.stopTest();
+  }
+
+  static testMethod void testGetAuthenticatorIcp4d() {
+    Test.startTest();
+    IBMWatsonICP4DConfig config = new IBMWatsonICP4DConfig.Builder()
+      .url('https://test.com')
+      .userManagedAccessToken('test-token')
+      .build();
+    IBMWatsonAuthenticator authenticator = IBMWatsonAuthenticatorFactory.getAuthenticator(config);
+    System.assert(authenticator instanceof IBMWatsonICP4DAuthenticator);
+    Test.stopTest();
+  }
+
+  static testMethod void testGetAuthenticatorBasic() {
+    Test.startTest();
+    IBMWatsonBasicAuthConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('test-username')
+      .password('test-password')
+      .build();
+    IBMWatsonAuthenticator authenticator = IBMWatsonAuthenticatorFactory.getAuthenticator(config);
+    System.assert(authenticator instanceof IBMWatsonBasicAuthenticator);
+    Test.stopTest();
+  }
+
+  static testMethod void testGetAuthenticatorNoauth() {
+    Test.startTest();
+    IBMWatsonAuthenticator authenticator = IBMWatsonAuthenticatorFactory.getAuthenticator(new IBMWatsonNoauthConfig());
+    System.assert(authenticator instanceof IBMWatsonNoauthAuthenticator);
+    Test.stopTest();
+  }
+
+  static testMethod void testGetAuthenticatorUnknown() {
+    Test.startTest();
+    try {
+      IBMWatsonAuthenticatorFactory.getAuthenticator(new UnknownConfig());
+    } catch (Exception e) {
+      System.assert(e.getMessage().contains('Unrecognized AuthenticatorConfig type'));
+    }
+    Test.stopTest();
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonAuthenticatorFactoryTest.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonAuthenticatorFactoryTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonBasicAuthConfig.cls
+++ b/force-app/main/default/classes/IBMWatsonBasicAuthConfig.cls
@@ -1,0 +1,49 @@
+public class IBMWatsonBasicAuthConfig implements IBMWatsonAuthenticatorConfig {
+  private String username;
+  private String password;
+
+  public String authenticationType() {
+    return IBMWatsonCredentialUtils.AUTHTYPE_BASIC;
+  }
+
+  public void validate() {
+    if (IBMWatsonCredentialUtils.hasBadStartOrEndChar(username) || IBMWatsonCredentialUtils.hasBadStartOrEndChar(password)) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('The username and password shouldn\'t start or end with curly brackets or '
+          + 'quotes. Please remove any surrounding {, }, or " characters.');
+    }
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public class Builder {
+    private String username;
+    private String password;
+
+    public IBMWatsonBasicAuthConfig build() {
+      IBMWatsonBasicAuthConfig config = new IBMWatsonBasicAuthConfig(this);
+      config.validate();
+      return config;
+    }
+
+    public Builder username(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public Builder password(String password) {
+      this.password = password;
+      return this;
+    }
+  }
+
+  private IBMWatsonBasicAuthConfig(Builder builder) {
+    this.username = builder.username;
+    this.password = builder.password;
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonBasicAuthConfig.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonBasicAuthConfig.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonBasicAuthConfigTest.cls
+++ b/force-app/main/default/classes/IBMWatsonBasicAuthConfigTest.cls
@@ -1,0 +1,34 @@
+@isTest
+private class IBMWatsonBasicAuthConfigTest {
+  static testMethod void testBuildSuccess() {
+    Test.startTest();
+    String username = 'test-username';
+    String password = 'test-password';
+
+    IBMWatsonBasicAuthConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username(username)
+      .password(password)
+      .build();
+
+    System.assertEquals(username, config.getUsername());
+    System.assertEquals(password, config.getPassword());
+    System.assertEquals(IBMWatsonCredentialUtils.AUTHTYPE_BASIC, config.authenticationType());
+    Test.stopTest();
+  }
+
+  static testMethod void testBuildInvalid() {
+    Test.startTest();
+    String username = '{test-username}'; 
+    String password = 'test-password';
+
+    try {
+      IBMWatsonBasicAuthConfig config = new IBMWatsonBasicAuthConfig.Builder()
+        .username(username)
+        .password(password)
+        .build();
+    } catch (Exception e) {
+      System.assert(e instanceof IBMWatsonServiceExceptions.IllegalArgumentException);
+    }
+    Test.stopTest();
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonBasicAuthConfigTest.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonBasicAuthConfigTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonBasicAuthenticator.cls
+++ b/force-app/main/default/classes/IBMWatsonBasicAuthenticator.cls
@@ -1,0 +1,16 @@
+public class IBMWatsonBasicAuthenticator implements IBMWatsonAuthenticator {
+  private String authHeader;
+
+  public IBMWatsonBasicAuthenticator(IBMWatsonBasicAuthConfig config) {
+    Blob authBlob = Blob.valueOf(config.getUsername() + ':' + config.getPassword());
+    this.authHeader = 'Basic ' + EncodingUtil.base64Encode(authBlob);
+  }
+
+  public String authenticationType() {
+    return IBMWatsonCredentialUtils.AUTHTYPE_BASIC;
+  }
+
+  public void authenticate(IBMWatsonRequest.Builder requestBuilder) {
+    requestBuilder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, this.authHeader);
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonBasicAuthenticator.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonBasicAuthenticator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonBasicAuthenticatorTest.cls
+++ b/force-app/main/default/classes/IBMWatsonBasicAuthenticatorTest.cls
@@ -1,0 +1,23 @@
+@isTest
+private class IBMWatsonBasicAuthenticatorTest {
+  static testMethod void testAuthenticate() {
+    Test.startTest();
+    String username = 'test-username';
+    String password = 'test-password';
+
+    IBMWatsonBasicAuthConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username(username)
+      .password(password)
+      .build();
+    IBMWatsonBasicAuthenticator authenticator = new IBMWatsonBasicAuthenticator(config);
+
+    IBMWatsonRequest.Builder builder = new IBMWatsonRequest.Builder().url('https://test.com');
+    authenticator.authenticate(builder);
+    IBMWatsonRequest request = builder.build();
+
+    String authHeader = request.header(IBMWatsonHttpHeaders.AUTHORIZATION);
+    System.assert(authHeader != null);
+    System.assertEquals('Basic ' + EncodingUtil.base64Encode(Blob.valueOf(username + ':' + password)), authHeader);
+    Test.stopTest();
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonBasicAuthenticatorTest.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonBasicAuthenticatorTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
@@ -8,6 +8,14 @@ public class IBMWatsonCredentialUtils {
   private static final String IAM_URL = 'iam_url';
   private static final String CREDENTIAL_FILE_NAME = 'ibm_credentials';
 
+  /**
+   * Valid authentication types.
+   */
+  public static final String AUTHTYPE_BASIC = 'basic';
+  public static final String AUTHTYPE_NOAUTH = 'noauth';
+  public static final String AUTHTYPE_IAM = 'iam';
+  public static final String AUTHTYPE_ICP4D = 'icp4d';
+
   private IBMWatsonCredentialUtils() {
     // This is a utility class - no instantiation allowed.
   }

--- a/force-app/main/default/classes/IBMWatsonIAMOptions.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMOptions.cls
@@ -14,6 +14,11 @@ public class IBMWatsonIAMOptions implements IBMWatsonAuthenticatorConfig {
     if (String.isBlank(this.apiKey) && String.isBlank(this.accessToken)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException('You must provide either the apiKey or accessToken properties.');
     }
+
+    if (IBMWatsonCredentialUtils.hasBadStartOrEndChar(this.apiKey)) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('The API key shouldn\'t start or end with curly brackets or '
+          + 'quotes. Please remove any surrounding {, }, or " characters.');
+    }
   }
 
   public String getApiKey() {

--- a/force-app/main/default/classes/IBMWatsonIAMOptions.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMOptions.cls
@@ -1,10 +1,20 @@
 /**
  * Options for authenticating using IAM.
  */
-public class IBMWatsonIAMOptions {
+public class IBMWatsonIAMOptions implements IBMWatsonAuthenticatorConfig {
   private String apiKey;
   private String accessToken;
   private String url;
+
+  public String authenticationType() {
+    return IBMWatsonCredentialUtils.AUTHTYPE_IAM;
+  }
+
+  public void validate() {
+    if (String.isBlank(this.apiKey) && String.isBlank(this.accessToken)) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('You must provide either the apiKey or accessToken properties.');
+    }
+  }
 
   public String getApiKey() {
     return apiKey;
@@ -24,7 +34,9 @@ public class IBMWatsonIAMOptions {
     private String url;
 
     public IBMWatsonIAMOptions build() {
-      return new IBMWatsonIAMOptions(this);
+      IBMWatsonIAMOptions config = new IBMWatsonIAMOptions(this);
+      config.validate();
+      return config;
     }
 
     public Builder apiKey(String apiKey) {

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
@@ -1,7 +1,7 @@
 /**
  * Retrieves, stores, and refreshes IAM tokens.
  */
-public class IBMWatsonIAMTokenManager {
+public class IBMWatsonIAMTokenManager implements IBMWatsonAuthenticator {
   private String userManagedAccessToken;
   private String apiKey;
   private String url;
@@ -34,12 +34,19 @@ public class IBMWatsonIAMTokenManager {
     tokenData = new IBMWatsonIAMToken();
   }
 
+  public String authenticationType() {
+    return IBMWatsonCredentialUtils.AUTHTYPE_IAM;
+  }
+
+  public void authenticate(IBMWatsonRequest.Builder requestBuilder) {
+    requestBuilder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, 'Bearer ' + getToken());
+  }
+
   /**
    * This function returns an access token. The source of the token is determined by the following logic:
    * 1. If user provides their own managed access token, assume it is valid and send it
-   * 2. If this class is managing tokens and does not yet have one, or the refresh token is expired, make a request
+   * 2. If this class is managing tokens and does not yet have one, or the token is expired, make a request
    * for one
-   * 3. If this class is managing tokens and the token has expired, refresh it
    * 4. If this class is managing tokens and has a valid token stored, send it
    *
    * @return the valid access token
@@ -50,12 +57,9 @@ public class IBMWatsonIAMTokenManager {
     if (userManagedAccessToken != null) {
       // use user-managed access token
       token = userManagedAccessToken;
-    } else if (tokenData.getAccessToken() == null || isRefreshTokenExpired()) {
+    } else if (tokenData.getAccessToken() == null || isAccessTokenExpired()) {
       // request new token
       token = requestToken();
-    } else if (isAccessTokenExpired()) {
-      // refresh current token
-      token = refreshToken();
     } else {
       // use valid managed token
       token = tokenData.getAccessToken();
@@ -86,26 +90,6 @@ public class IBMWatsonIAMTokenManager {
   }
 
   /**
-   * Refresh an IAM token using a refresh token. Also updates internal managed IAM token information.
-   *
-   * @return the new access token
-   */
-  private String refreshToken() {
-    IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpPost(url);
-
-    builder.addHeader(IBMWatsonHttpHeaders.CONTENT_TYPE, IBMWatsonHttpMediaType.APPLICATION_FORM_URLENCODED);
-
-    IBMWatsonFormBody formBody = new IBMWatsonFormBody.Builder()
-      .add(GRANT_TYPE, REFRESH_GRANT_TYPE)
-      .add(REFRESH_TOKEN, tokenData.getRefreshToken())
-      .build();
-    builder.body(formBody);
-
-    tokenData = callIamApi(builder.build());
-    return tokenData.getAccessToken();
-  }
-
-  /**
    * Check if currently stored access token is expired.
    *
    * Using a buffer to prevent the edge case of the
@@ -127,25 +111,6 @@ public class IBMWatsonIAMTokenManager {
     Double currentTime = Math.floor(System.now().getTime() / 1000);
 
     return refreshTime < currentTime;
-  }
-
-  /**
-   * Used as a fail-safe to prevent the condition of a refresh token expiring,
-   * which could happen after around 30 days. This function will return true
-   * if it has been at least 7 days and 1 hour since the last token was
-   * retrieved.
-   *
-   * @returns whether the current managed refresh token is expired or not
-   */
-  private boolean isRefreshTokenExpired() {
-    if (tokenData.getExpiration() == null) {
-      return true;
-    }
-
-    Integer sevenDays = 7 * 24 * 3600;
-    Double currentTime = Math.floor(System.now().getTime() / 1000);
-    Long newTokenTime = tokenData.getExpiration() + sevenDays;
-    return newTokenTime < currentTime;
   }
 
   /**

--- a/force-app/main/default/classes/IBMWatsonICP4DAuthenticator.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DAuthenticator.cls
@@ -1,0 +1,99 @@
+public class IBMWatsonICP4DAuthenticator implements IBMWatsonAuthenticator {
+  // This is the suffix we'll need to add to the user-supplied URL to retrieve an access token.
+  private static final String URL_SUFFIX = '/v1/preauth/validateAuth';
+  private static final String DEFAULT_ERROR_MESSAGE = 'Error while retrieving access token from ICP4D token service';
+
+  // Configuration properties for this authenticator.
+  private IBMWatsonICP4DConfig config;
+
+  // This field holds an access token and its expiration time.
+  private IBMWatsonICP4DToken tokenData;
+
+  public IBMWatsonICP4DAuthenticator(IBMWatsonICP4DConfig config) {
+    this.config = config;
+  }
+
+  public String authenticationType() {
+    return IBMWatsonCredentialUtils.AUTHTYPE_ICP4D;
+  }
+
+  public void authenticate(IBMWatsonRequest.Builder requestBuilder) {
+    requestBuilder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, 'Bearer ' + getToken());
+  }
+
+  /**
+   * This function returns an access token. The source of the token is determined by the following logic:
+   * 1. If user provides their own managed access token, assume it is valid and send it
+   * 2. If this class is managing tokens and does not yet have one, or the token is expired, make a request
+   * for one
+   * 3. If this class is managing tokens and has a valid token stored, send it
+   *
+   * @return the valid access token
+   */
+  public String getToken() {
+    String token;
+
+    if (!String.isBlank(config.getUserManagedAccessToken())) {
+      // If the user set their own access token, then use it.
+      token = config.getUserManagedAccessToken();
+    } else {
+      // Request a new token if necessary.
+      if (this.tokenData == null || !this.tokenData.isTokenValid()) {
+        this.tokenData = requestToken();
+      }
+
+      // Return the access token from our IBMWatsonICP4DToken object.
+      token = this.tokenData.accessToken;
+    }
+
+    return token;
+  }
+
+  /**
+   * Obtains an ICP4D access token for the username/password combination using the configured URL.
+   * @return an IBMWatsonICP4DToken instance that contains the access token
+   */
+  private IBMWatsonICP4DToken requestToken() {
+    // Form a GET request to retrieve the access token.
+    String requestUrl = config.getUrl() + URL_SUFFIX;
+    requestUrl = requestUrl.replace('//', '/');
+    IBMWatsonRequestBuilder builder = IBMWatsonRequestBuilder.httpGet(requestUrl);
+    builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, buildBasicAuthHeader());
+
+    // Invoke the GET request.
+    IBMWatsonICP4DTokenResponse response = invokeRequest(builder.build());
+
+    // Construct a new IBMWatsonICP4DToken object from the response and return it.
+    return new IBMWatsonICP4DToken(response);
+  }
+
+  private String buildBasicAuthHeader() {
+    Blob authBlob = Blob.valueOf(this.config.getUsername() + ':' + this.config.getPassword());
+    return 'Basic ' + EncodingUtil.base64Encode(authBlob);
+  }
+
+  /**
+   * Executes the specified request and returns the response object containing the ICP4D token.
+   *
+   * @param request the request for obtaining an ICP4D access token
+   * @return an IBMWatsonICP4DTokenResponse instance that contains the requested access token and related info
+   */
+  private IBMWatsonICP4DTokenResponse invokeRequest(IBMWatsonRequest request) {
+    IBMWatsonResponse response = IBMWatsonClient.executeRequest(request);
+
+    if (response.isSuccessful() && String.isNotBlank(response.getBody())) {
+      Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
+      Map<String, Object> safeJsonMap = IBMWatsonJSONUtil.prepareResponse(jsonMap);
+      String jsonString = JSON.serialize(safeJsonMap);
+      return (IBMWatsonICP4DTokenResponse)JSON.deserialize(jsonString, IBMWatsonICP4DTokenResponse.class);
+    } else {
+      Map<String, Object> responseMap = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
+      String errorMessage = responseMap.get('errorMessage').toString();
+      if (errorMessage == null) {
+        errorMessage = DEFAULT_ERROR_MESSAGE;
+      }
+      Integer statusCode = response.getStatusCode();
+      throw new IBMWatsonServiceExceptions.ResponseException(statusCode, errorMessage, response);
+    }
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonICP4DAuthenticator.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonICP4DAuthenticator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonICP4DAuthenticatorTest.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DAuthenticatorTest.cls
@@ -1,0 +1,86 @@
+@isTest
+private class IBMWatsonICP4DAuthenticatorTest {
+  private String url;
+
+  private static final String ACCESS_TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTU1OTMyODk1NSwiZXhwIjo5OTk5OTk5OTk5OTk5OTk5OTl9.GE-ML3JWmI3oB0z5mjMG3jFtYVVA5bQCsOTOOj9ab7PcgJc1mA5hn1sONkO0JAFADhUoAgpG4KgQef5tjnCSrtl1tbnDuhaP1DH4QKMCZOkWrKyfQ2X8P1jhyJmV-KpE4wuTrGdMoMVj4wVRZwnxMRSK6LhV6pIzyOLLYR21zcW_2KcKWxCYfIC7tiM1d2PSM5nWa_5Vb068F8PtdiFUElEYHYKrvmwpV57_k2jpXoY6zw8PDcIiWQe3g20w6vCB6zWhxbcFWyjMg1tPOZHgTNNskPShHQBbtZFsSrc7rkNPzttKF70m7_JqrRYUZDNN8TmuR9uyitwxEFkr2L0WDQ';
+  private static final String USERNAME = '123456789';
+  private static final String PASSWORD = 'password';
+  private static final String URL = 'https://test.url';
+
+  static testMethod void testAuthenticateUserManagedToken() {
+    Test.startTest();
+    IBMWatsonICP4DConfig config = new IBMWatsonICP4DConfig.Builder()
+      .userManagedAccessToken(ACCESS_TOKEN)
+      .url(URL)
+      .build();
+    IBMWatsonICP4DAuthenticator authenticator = new IBMWatsonICP4DAuthenticator(config);
+
+    IBMWatsonRequest.Builder builder = new IBMWatsonRequest.Builder().url(URL);
+    authenticator.authenticate(builder);
+    IBMWatsonRequest request = builder.build();
+
+    String authHeader = request.header(IBMWatsonHttpHeaders.AUTHORIZATION);
+    System.assert(authHeader != null);
+    System.assertEquals('Bearer ' + ACCESS_TOKEN, authHeader);
+    Test.stopTest();
+  }
+
+  static testMethod void getTokenFromUsernameAndPassword() {
+    String body = IBMWatsonMockResponses.validICP4DToken();
+    IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(
+      200,
+      'Success',
+      body,
+      null);
+    Test.setMock(HttpCalloutMock.class, mockResponse);
+    Test.startTest();
+
+    IBMWatsonICP4DConfig config = new IBMWatsonICP4DConfig.Builder()
+      .username(USERNAME)
+      .password(PASSWORD)
+      .url(URL)
+      .build();
+    IBMWatsonICP4DAuthenticator authenticator = new IBMWatsonICP4DAuthenticator(config);
+
+    String token = authenticator.getToken();
+    System.assertEquals(ACCESS_TOKEN, token);
+    Test.stopTest();
+  }
+
+  /**
+   * Tests that if the stored access token is expired, it can be refreshed properly.
+   */
+  static testMethod void getTokenAfterRefresh() {
+    String body = IBMWatsonMockResponses.expiredICP4DToken();
+    IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(
+      200,
+      'Success',
+      body,
+      null);
+    Test.setMock(HttpCalloutMock.class, mockResponse);
+    Test.startTest();
+
+    IBMWatsonICP4DConfig config = new IBMWatsonICP4DConfig.Builder()
+      .username(USERNAME)
+      .password(PASSWORD)
+      .url(URL)
+      .build();
+    IBMWatsonICP4DAuthenticator authenticator = new IBMWatsonICP4DAuthenticator(config);
+
+    // setting expired token
+    authenticator.getToken();
+
+    // getting valid token
+    String newBody = IBMWatsonMockResponses.validICP4DToken();
+    IBMWatsonMockHttpResponse newMockResponse = new IBMWatsonMockHttpResponse(
+      200,
+      'Success',
+      newBody,
+      null);
+    Test.setMock(HttpCalloutMock.class, newMockResponse);
+    String newToken = authenticator.getToken();
+
+    System.assertEquals(ACCESS_TOKEN, newToken);
+    Test.stopTest();
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonICP4DAuthenticatorTest.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonICP4DAuthenticatorTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonICP4DConfig.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DConfig.cls
@@ -1,0 +1,82 @@
+public class IBMWatsonICP4DConfig implements IBMWatsonAuthenticatorConfig {
+  private String url;
+  private String username;
+  private String password;
+  private String userManagedAccessToken;
+
+  public String authenticationType() {
+    return IBMWatsonCredentialUtils.AUTHTYPE_ICP4D;
+  }
+
+  public void validate() {
+    if (String.isBlank(url)) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('You must provide a URL.');
+    }
+
+    // If the user specifies their own access token, then username/password are not required.
+    if (!String.isBlank(userManagedAccessToken)) {
+      return;
+    }
+
+    if (String.isBlank(username) || String.isBlank(password)) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException(
+        'You must provide both username and password values.');
+    }
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public String getUserManagedAccessToken() {
+    return userManagedAccessToken;
+  }
+
+  public class Builder {
+    private String url;
+    private String username;
+    private String password;
+    private String userManagedAccessToken;
+
+    public IBMWatsonICP4DConfig build() {
+      IBMWatsonICP4DConfig config = new IBMWatsonICP4DConfig(this);
+      config.validate();
+      return config;
+    }
+
+    public Builder url(String url) {
+      this.url = url;
+      return this;
+    }
+
+    public Builder username(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public Builder password(String password) {
+      this.password = password;
+      return this;
+    }
+
+    public Builder userManagedAccessToken(String userManagedAccessToken) {
+      this.userManagedAccessToken = userManagedAccessToken;
+      return this;
+    }
+  }
+
+  private IBMWatsonICP4DConfig(Builder builder) {
+    this.url = builder.url;
+    this.username = builder.username;
+    this.password = builder.password;
+    this.userManagedAccessToken = builder.userManagedAccessToken;
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonICP4DConfig.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DConfig.cls
@@ -9,18 +9,23 @@ public class IBMWatsonICP4DConfig implements IBMWatsonAuthenticatorConfig {
   }
 
   public void validate() {
-    if (String.isBlank(url)) {
-      throw new IBMWatsonServiceExceptions.IllegalArgumentException('You must provide a URL.');
-    }
-
     // If the user specifies their own access token, then username/password are not required.
     if (!String.isBlank(userManagedAccessToken)) {
       return;
     }
 
+    if (String.isBlank(url)) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('You must provide a URL.');
+    }
+
     if (String.isBlank(username) || String.isBlank(password)) {
       throw new IBMWatsonServiceExceptions.IllegalArgumentException(
         'You must provide both username and password values.');
+    }
+
+    if (IBMWatsonCredentialUtils.hasBadStartOrEndChar(username) || IBMWatsonCredentialUtils.hasBadStartOrEndChar(password)) {
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('The username and password shouldn\'t start or end with curly brackets or '
+          + 'quotes. Please remove any surrounding {, }, or " characters.');
     }
   }
 

--- a/force-app/main/default/classes/IBMWatsonICP4DConfig.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonICP4DConfig.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonICP4DConfigTest.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DConfigTest.cls
@@ -1,0 +1,36 @@
+@isTest
+private class IBMWatsonICP4DConfigTest {
+  static testMethod void testBuildSuccess() {
+    Test.startTest();
+    String url = 'https://test.com';
+    String username = 'test-username';
+    String password = 'test-password';
+    String accessToken = 'test-token';
+
+    IBMWatsonICP4DConfig config = new IBMWatsonICP4DConfig.Builder()
+      .url(url)
+      .username(username)
+      .password(password)
+      .userManagedAccessToken(accessToken)
+      .build();
+
+    System.assertEquals(url, config.getUrl());
+    System.assertEquals(username, config.getUsername());
+    System.assertEquals(password, config.getPassword());
+    System.assertEquals(accessToken, config.getUserManagedAccessToken());
+    System.assertEquals(IBMWatsonCredentialUtils.AUTHTYPE_ICP4D, config.authenticationType());
+    Test.stopTest();
+  }
+
+  static testMethod void testBuildInvalid() {
+    Test.startTest();
+    try {
+      IBMWatsonICP4DConfig config = new IBMWatsonICP4DConfig.Builder()
+        .username('test-username')
+        .build();
+    } catch (Exception e) {
+      System.assert(e instanceof IBMWatsonServiceExceptions.IllegalArgumentException);
+    }
+    Test.stopTest();
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonICP4DConfigTest.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonICP4DConfigTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonICP4DToken.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DToken.cls
@@ -1,0 +1,48 @@
+/**
+ * This class holds relevant info re: an ICP4D access token for use by the IBMWatsonICP4DAuthenticator class.
+ */
+public class IBMWatsonICP4DToken {
+  public String accessToken;
+  public Long expirationTimeInMillis;
+
+  /**
+   * This ctor is used to store a user-managed access token which will never expire.
+   * @param accessToken the user-managed access token
+   */
+  public IBMWatsonICP4DToken(String accessToken) {
+    this.accessToken = accessToken;
+    this.expirationTimeInMillis = -1;
+  }
+
+  /**
+   * This ctor will extract the ICP4D access token from the specified IBMWatsonICP4DTokenResponse instance,
+   * and compute the expiration time as "80% of the timeToLive added to the issued-at time".
+   * This means that we'll trigger the acquisition of a new token shortly before it is set to expire.
+   * @param response the IBMWatsonICP4DTokenResponse instance
+   */
+  public IBMWatsonICP4DToken(IBMWatsonICP4DTokenResponse response) {
+    this.accessToken = response.getAccessToken();
+
+    // To compute the expiration time, we'll need to crack open the accessToken value
+    // which is a JWToken (Json Web Token) instance.
+    IBMWatsonJSONWebToken jwt = new IBMWatsonJSONWebToken(this.accessToken);
+
+    Long iat = jwt.getPayload().getIssuedAt();
+    Long exp = jwt.getPayload().getExpiresAt();
+    if (iat != null && exp != null) {
+      Long ttl = exp - iat;
+      this.expirationTimeInMillis = (iat + (Long) (0.8 * ttl)) * 1000;
+    } else {
+      throw new IBMWatsonServiceExceptions.ResponseException('Properties "iat" and "exp" MUST be present within the encoded access token');
+    }
+  }
+
+  /**
+   * Returns true iff this object holds a valid non-expired access token.
+   * @return true if token is valid and not expired, false otherwise
+   */
+  public boolean isTokenValid() {
+    return !String.isBlank(this.accessToken)
+        && (this.expirationTimeInMillis < 0 || System.now().getTime() <= this.expirationTimeInMillis);
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonICP4DToken.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonICP4DToken.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls
@@ -1,0 +1,69 @@
+/**
+ * This class models a response received from the ICP4D "get token" API.
+ */
+public class IBMWatsonICP4DTokenResponse extends IBMWatsonGenericModel {
+  private String username_serialized_name;
+  private String role_serialized_name;
+  private String[] permissions_serialized_name;
+  private String sub_serialized_name;
+  private String iss_serialized_name;
+  private String aud_serialized_name;
+  private String uid_serialized_name;
+  private String accessToken_serialized_name;
+  private String message_serialized_name;
+
+  public String getUsername() {
+    return username_serialized_name;
+  }
+  public void setUsername(String username) {
+    this.username_serialized_name = username;
+  }
+  public String getRole() {
+    return role_serialized_name;
+  }
+  public void setRole(String role) {
+    this.role_serialized_name = role;
+  }
+  public String[] getPermissions() {
+    return permissions_serialized_name;
+  }
+  public void setPermissions(String[] permissions) {
+    this.permissions_serialized_name = permissions;
+  }
+  public String getSub() {
+    return sub_serialized_name;
+  }
+  public void setSub(String sub) {
+    this.sub_serialized_name = sub;
+  }
+  public String getIss() {
+    return iss_serialized_name;
+  }
+  public void setIss(String iss) {
+    this.iss_serialized_name = iss;
+  }
+  public String getAud() {
+    return aud_serialized_name;
+  }
+  public void setAud(String aud) {
+    this.aud_serialized_name = aud;
+  }
+  public String getUid() {
+    return uid_serialized_name;
+  }
+  public void setUid(String uid) {
+    this.uid_serialized_name = uid;
+  }
+  public String getAccessToken() {
+    return accessToken_serialized_name;
+  }
+  public void setAccessToken(String accessToken) {
+    this.accessToken_serialized_name = accessToken;
+  }
+  public String getMessage() {
+    return message_serialized_name;
+  }
+  public void setMessage(String message) {
+    this.message_serialized_name = message;
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonJSONWebToken.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONWebToken.cls
@@ -1,0 +1,109 @@
+public class IBMWatsonJSONWebToken {
+  private Map<String, Object> header;
+  private Payload payload;
+
+  /**
+   * Ctor which accepts the encoded JWT as a string.  This ctor will parse
+   * the JWT into its header and payload parts
+   * @param encodedToken a string representing the encoded JWT.
+   */
+  public IBMWatsonJSONWebToken(String encodedToken) {
+    // Split the encoded jwt string into the header, payload, and signature
+    String[] decodedParts = encodedToken.split('\\.');
+
+    String tokenJson;
+
+    // Decode and parse the header.
+    tokenJson = EncodingUtil.base64Decode(decodedParts[0]).toString();
+    header = (Map<String, Object>) JSON.deserializeUntyped(tokenJson);
+
+    // Decode and parse the body.
+    tokenJson = EncodingUtil.base64Decode(decodedParts[1]).toString();
+    payload = (Payload) JSON.deserialize(tokenJson, Payload.class);
+  }
+
+  public Map<String, Object> getHeader() {
+    return header;
+  }
+
+  public Payload getPayload() {
+    return payload;
+  }
+
+  public class Payload {
+    private Long iat;
+    private Long exp;
+    private String sub;
+    private String iss;
+    private String aud;
+    private String uid;
+    private String username;
+    private String role;
+
+    public Payload() {}
+
+    /**
+     * Returns the "Issued At" ("iat") value within this JsonWebToken.
+     * @return the iat value
+     */
+    public Long getIssuedAt() {
+      return iat;
+    }
+
+    /**
+     * Returns the "Expires At" ("exp") value within this JsonWebToken.
+     * @return the exp value
+     */
+    public Long getExpiresAt() {
+      return exp;
+    }
+
+    /**
+     * Returns the "Subject" ("sub") value with this JsonWebToken.
+     * @return the sub value
+     */
+    public String getSubject() {
+      return sub;
+    }
+
+    /**
+     * Returns the "Issuer" ("iss") value with this JsonWebToken.
+     * @return the iss value
+     */
+    public String getIssuer() {
+      return iss;
+    }
+
+    /**
+     * Returns the "Audience" ("aud") value with this JsonWebToken.
+     * @return the aud value
+     */
+    public String getAudience() {
+      return aud;
+    }
+
+    /**
+     * Returns the "Userid" ("uid") value with this JsonWebToken.
+     * @return the uid value
+     */
+    public String getUserId() {
+      return uid;
+    }
+
+    /**
+     * Returns the "Username" ("username") value with this JsonWebToken.
+     * @return the username value
+     */
+    public String getUsername() {
+      return username;
+    }
+
+    /**
+     * Returns the "Role" ("role") value with this JsonWebToken.
+     * @return the role value
+     */
+    public String getRole() {
+      return role;
+    }
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonJSONWebToken.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonJSONWebToken.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonJSONWebTokenTest.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONWebTokenTest.cls
@@ -1,0 +1,18 @@
+@isTest
+private class IBMWatsonJSONWebTokenTest {
+  private static String encodedToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTU1OTMyODk1NSwiZXhwIjo5OTk5OTk5OTk5OTk5OTk5OTl9.GE-ML3JWmI3oB0z5mjMG3jFtYVVA5bQCsOTOOj9ab7PcgJc1mA5hn1sONkO0JAFADhUoAgpG4KgQef5tjnCSrtl1tbnDuhaP1DH4QKMCZOkWrKyfQ2X8P1jhyJmV-KpE4wuTrGdMoMVj4wVRZwnxMRSK6LhV6pIzyOLLYR21zcW_2KcKWxCYfIC7tiM1d2PSM5nWa_5Vb068F8PtdiFUElEYHYKrvmwpV57_k2jpXoY6zw8PDcIiWQe3g20w6vCB6zWhxbcFWyjMg1tPOZHgTNNskPShHQBbtZFsSrc7rkNPzttKF70m7_JqrRYUZDNN8TmuR9uyitwxEFkr2L0WDQ';
+
+  static testMethod void testConstructor() {
+    IBMWatsonJSONWebToken jwt = new IBMWatsonJSONWebToken(encodedToken);
+    System.assert(jwt.getHeader() != null);
+    System.assert(jwt.getPayload() != null);
+    System.assert(jwt.getPayload().getExpiresAt() != null);
+    System.assert(jwt.getPayload().getIssuedAt() != null);
+    System.assert(jwt.getPayload().getAudience() != null);
+    System.assert(jwt.getPayload().getIssuer() != null);
+    System.assert(jwt.getPayload().getRole() != null);
+    System.assert(jwt.getPayload().getSubject() != null);
+    System.assert(jwt.getPayload().getUserId() != null);
+    System.assert(jwt.getPayload().getUsername() != null);
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonJSONWebTokenTest.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonJSONWebTokenTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonMockResponses.cls
+++ b/force-app/main/default/classes/IBMWatsonMockResponses.cls
@@ -3858,4 +3858,52 @@ public class IBMWatsonMockResponses {
       '"status": "analyzed"' +
     '}';
   }
+
+  public static testMethod String validICP4DToken() {
+    return '{' +
+      '"username": "admin",' +
+      '"role": "Admin",' +
+      '"permissions": [' +
+        '"administrator",' +
+        '"manage_catalog",' +
+        '"access_catalog",' +
+        '"manage_policies",' +
+        '"access_policies",' +
+        '"virtualize_transform",' +
+        '"can_provision",' +
+        '"deployment_admin"' +
+      '],' +
+      '"sub": "admin",' +
+      '"iss": "test",' +
+      '"aud": "DSX",' +
+      '"uid": "999",' +
+      '"accessToken": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTU1OTMyODk1NSwiZXhwIjo5OTk5OTk5OTk5OTk5OTk5OTl9.GE-ML3JWmI3oB0z5mjMG3jFtYVVA5bQCsOTOOj9ab7PcgJc1mA5hn1sONkO0JAFADhUoAgpG4KgQef5tjnCSrtl1tbnDuhaP1DH4QKMCZOkWrKyfQ2X8P1jhyJmV-KpE4wuTrGdMoMVj4wVRZwnxMRSK6LhV6pIzyOLLYR21zcW_2KcKWxCYfIC7tiM1d2PSM5nWa_5Vb068F8PtdiFUElEYHYKrvmwpV57_k2jpXoY6zw8PDcIiWQe3g20w6vCB6zWhxbcFWyjMg1tPOZHgTNNskPShHQBbtZFsSrc7rkNPzttKF70m7_JqrRYUZDNN8TmuR9uyitwxEFkr2L0WDQ",' +
+      '"_messageCode_": "success",' +
+      '"message": "success"' +
+    '}'; 
+  }
+
+  public static testMethod String expiredICP4DToken() {
+    return '{' +
+      '"username": "admin",' +
+      '"role": "Admin",' +
+      '"permissions": [' +
+        '"administrator",' +
+        '"manage_catalog",' +
+        '"access_catalog",' +
+        '"manage_policies",' +
+        '"access_policies",' +
+        '"virtualize_transform",' +
+        '"can_provision",' +
+        '"deployment_admin"' +
+      '],' +
+      '"sub": "admin",' +
+      '"iss": "test",' +
+      '"aud": "DSX",' +
+      '"uid": "999",' +
+      '"accessToken": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTU1OTMyODk1NSwiZXhwIjoxNTU5MzI4OTU1fQ==.GE-ML3JWmI3oB0z5mjMG3jFtYVVA5bQCsOTOOj9ab7PcgJc1mA5hn1sONkO0JAFADhUoAgpG4KgQef5tjnCSrtl1tbnDuhaP1DH4QKMCZOkWrKyfQ2X8P1jhyJmV-KpE4wuTrGdMoMVj4wVRZwnxMRSK6LhV6pIzyOLLYR21zcW_2KcKWxCYfIC7tiM1d2PSM5nWa_5Vb068F8PtdiFUElEYHYKrvmwpV57_k2jpXoY6zw8PDcIiWQe3g20w6vCB6zWhxbcFWyjMg1tPOZHgTNNskPShHQBbtZFsSrc7rkNPzttKF70m7_JqrRYUZDNN8TmuR9uyitwxEFkr2L0WDQ",' +
+      '"_messageCode_": "success",' +
+      '"message": "success"' +
+    '}';
+  }
 }

--- a/force-app/main/default/classes/IBMWatsonNoauthAuthenticator.cls
+++ b/force-app/main/default/classes/IBMWatsonNoauthAuthenticator.cls
@@ -1,0 +1,11 @@
+public class IBMWatsonNoauthAuthenticator implements IBMWatsonAuthenticator {
+  public IBMWatsonNoauthAuthenticator(IBMWatsonNoauthConfig config) { }
+
+  public String authenticationType() {
+    return IBMWatsonCredentialUtils.AUTHTYPE_NOAUTH;
+  }
+
+  public void authenticate(IBMWatsonRequest.Builder requestBuilder) {
+    // do nothing
+  }
+}

--- a/force-app/main/default/classes/IBMWatsonNoauthAuthenticator.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonNoauthAuthenticator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonNoauthConfig.cls
+++ b/force-app/main/default/classes/IBMWatsonNoauthConfig.cls
@@ -1,0 +1,9 @@
+public class IBMWatsonNoauthConfig implements IBMWatsonAuthenticatorConfig {
+  public IBMWatsonNoauthConfig() { }
+
+  public String authenticationType() {
+    return IBMWatsonCredentialUtils.AUTHTYPE_NOAUTH;
+  }
+
+  public void validate() { }
+}

--- a/force-app/main/default/classes/IBMWatsonNoauthConfig.cls-meta.xml
+++ b/force-app/main/default/classes/IBMWatsonNoauthConfig.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>41.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/IBMWatsonRequest.cls
+++ b/force-app/main/default/classes/IBMWatsonRequest.cls
@@ -14,7 +14,9 @@ public class IBMWatsonRequest {
     this.method = builder.method;
     this.headers = new Map<String, String>();
     this.headers.putAll(builder.headers);
-    this.body = builder.body.clone();
+    if (builder.body != null) {
+      this.body = builder.body.clone();
+    }
   }
 
   public URL getUrl() {

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -324,8 +324,6 @@ public abstract class IBMWatsonService {
   public void setSkipAuthentication(boolean skipAuthentication) {
     this.skipAuthentication = skipAuthentication;
     if (this.skipAuthentication) {
-      /* IBMWatsonAuthenticatorConfig noauthConfig = (IBMWatsonAuthenticatorConfig) new IBMWatsonNoauthConfig();
-      setAuthenticator(noauthConfig); */
       setAuthenticator(new IBMWatsonNoauthConfig());
     }
   }

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -5,7 +5,6 @@ public abstract class IBMWatsonService {
   private String userAgent;
   private String name;
   private IBMWatsonAuthenticator authenticator;
-  private boolean skipAuthentication = false;
   private Map<String, String> defaultHeaders = null;
 
   private static final String CALLOUT = 'callout:';
@@ -241,10 +240,6 @@ public abstract class IBMWatsonService {
    * @param builder the new authentication
    */
   protected virtual void setAuthentication(IBMWatsonRequest.Builder builder) {
-    if (skipAuthentication) {
-      return;
-    }
-
     if (this.authenticator != null) {
       this.authenticator.authenticate(builder);
     } else {
@@ -313,18 +308,8 @@ public abstract class IBMWatsonService {
   public void setAuthenticator(IBMWatsonAuthenticatorConfig authConfig) {
     try {
       this.authenticator = IBMWatsonAuthenticatorFactory.getAuthenticator(authConfig);
-      if (this.authenticator instanceof IBMWatsonNoauthAuthenticator) {
-        this.skipAuthentication = true;
-      }
     } catch (Exception e) {
       throw new IBMWatsonServiceExceptions.ResponseException(e.getMessage());
-    }
-  }
-
-  public void setSkipAuthentication(boolean skipAuthentication) {
-    this.skipAuthentication = skipAuthentication;
-    if (this.skipAuthentication) {
-      setAuthenticator(new IBMWatsonNoauthConfig());
     }
   }
 

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -4,15 +4,11 @@ public abstract class IBMWatsonService {
   private String endPoint;
   private String userAgent;
   private String name;
-  private IBMWatsonIAMTokenManager tokenManager;
+  private IBMWatsonAuthenticator authenticator;
   private boolean skipAuthentication = false;
   private Map<String, String> defaultHeaders = null;
 
-  private static final String URL = 'url';
-  private static final String PATH_AUTHORIZATION_V1_TOKEN = '/v1/token';
   private static final String CALLOUT = 'callout:';
-  private static final String BASIC = 'Basic ';
-  private static final String BEARER = 'Bearer ';
   private static final String VERSION = 'version';
   private static final String USER_AGENT_FORMAT = 'watson-apis-salesforce-sdk-{0} {1}';
   private static final String SDK_VERSION = '4.0.2';
@@ -63,7 +59,7 @@ public abstract class IBMWatsonService {
         .apiKey(serviceCredentials.getIamApiKey())
         .url(serviceCredentials.getIamUrl())
         .build();
-      setIamCredentials(iamOptions);
+      setAuthenticator(iamOptions);
    }
   }
 
@@ -245,20 +241,14 @@ public abstract class IBMWatsonService {
    * @param builder the new authentication
    */
   protected virtual void setAuthentication(IBMWatsonRequest.Builder builder) {
-    if (tokenManager != null) {
-      String accessToken = tokenManager.getToken();
-      builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, BEARER + accessToken);
-    } else if (getApiKey() == null) {
-      if (skipAuthentication) {
-        Map<String, String> currentHeaders = builder.build().getAllHeaders();
-        if (currentHeaders.containsKey(IBMWatsonHttpHeaders.X_WATSON_AUTHORIZATION_TOKEN)) {
-          System.debug(System.LoggingLevel.WARN, AUTH_HEADER_DEPRECATION_MESSAGE);
-        }
-        return;
-      }
-      throw new IBMWatsonServiceExceptions.IllegalArgumentException('apiKey or username and password were not specified');
+    if (skipAuthentication) {
+      return;
+    }
+
+    if (this.authenticator != null) {
+      this.authenticator.authenticate(builder);
     } else {
-      builder.addHeader(IBMWatsonHttpHeaders.AUTHORIZATION, apiKey.startsWith(BASIC) ? apiKey : BASIC + apiKey);
+      throw new IBMWatsonServiceExceptions.IllegalArgumentException('Authentication information was not properly configured.');
     }
   }
 
@@ -269,19 +259,19 @@ public abstract class IBMWatsonService {
    * @param password the password
    */
   public void setUsernameAndPassword(final String username, final String password) {
-    if (IBMWatsonCredentialUtils.hasBadStartOrEndChar(username) || IBMWatsonCredentialUtils.hasBadStartOrEndChar(password)) {
-      throw new IBMWatsonServiceExceptions.IllegalArgumentException('The username and password shouldn\'t start or end with curly brackets or '
-          + 'quotes. Please remove any surrounding {, }, or " characters.');
-    }
-
     // we'll perform the token exchange for users UNLESS they're on ICP
     if (username.equals(APIKEY_AS_USERNAME) && !password.startsWith(ICP_PREFIX)) {
       IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
         .apiKey(password)
         .build();
-      setIamCredentials(iamOptions);
+      setAuthenticator(iamOptions);
     } else {
-      apiKey = IBMWatsonCredentialUtils.toBasicAuth(username, password);
+      this.apiKey = IBMWatsonCredentialUtils.toBasicAuth(username, password);
+      IBMWatsonBasicAuthConfig basicAuthConfig = new IBMWatsonBasicAuthConfig.Builder()
+        .username(username)
+        .password(password)
+        .build();
+      setAuthenticator(basicAuthConfig);
     }
   }
 
@@ -317,7 +307,27 @@ public abstract class IBMWatsonService {
    * @param iamOptions object containing values to be used for authenticating with IAM
    */
   public void setIamCredentials(IBMWatsonIAMOptions iamOptions) {
-    this.tokenManager = new IBMWatsonIAMTokenManager(iamOptions);
+    setAuthenticator(iamOptions);
+  }
+
+  protected void setAuthenticator(IBMWatsonAuthenticatorConfig authConfig) {
+    try {
+      this.authenticator = IBMWatsonAuthenticatorFactory.getAuthenticator(authConfig);
+      if (this.authenticator instanceof IBMWatsonNoauthAuthenticator) {
+        this.skipAuthentication = true;
+      }
+    } catch (Exception e) {
+      throw new IBMWatsonServiceExceptions.ResponseException(e.getMessage());
+    }
+  }
+
+  public void setSkipAuthentication(boolean skipAuthentication) {
+    this.skipAuthentication = skipAuthentication;
+    if (this.skipAuthentication) {
+      /* IBMWatsonAuthenticatorConfig noauthConfig = (IBMWatsonAuthenticatorConfig) new IBMWatsonNoauthConfig();
+      setAuthenticator(noauthConfig); */
+      setAuthenticator(new IBMWatsonNoauthConfig());
+    }
   }
 
   /**
@@ -335,6 +345,7 @@ public abstract class IBMWatsonService {
    *
    *
    * @return the apiKey
+   * @deprecated
    */
   protected String getApiKey() {
     return apiKey;
@@ -346,6 +357,7 @@ public abstract class IBMWatsonService {
    * @return true if the tokenManager has been set
    */
   public Boolean isTokenManagerSet() {
-    return tokenManager != null;
+    return this.authenticator != null
+      && this.authenticator.authenticationType().equals(IBMWatsonCredentialUtils.AUTHTYPE_IAM);
   }
 }

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -310,7 +310,7 @@ public abstract class IBMWatsonService {
     setAuthenticator(iamOptions);
   }
 
-  protected void setAuthenticator(IBMWatsonAuthenticatorConfig authConfig) {
+  public void setAuthenticator(IBMWatsonAuthenticatorConfig authConfig) {
     try {
       this.authenticator = IBMWatsonAuthenticatorFactory.getAuthenticator(authConfig);
       if (this.authenticator instanceof IBMWatsonNoauthAuthenticator) {


### PR DESCRIPTION
This PR adds support for authentication through ICP4D. Along with that core change, constructors have been changed to allow for a unified authentication framework for all supported formats (basic, IAM, ICP4D, none). This model is identical to the one implemented in the Java SDK here: https://github.com/IBM/java-sdk-core/pull/37