### PR TITLE
Support loading ICP4D credentials from file

### DIFF
--- a/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtils.cls
@@ -6,6 +6,7 @@ public class IBMWatsonCredentialUtils {
   private static final String IAM_API_KEY = 'iam_apikey';
   private static final String API_KEY = 'apikey';
   private static final String IAM_URL = 'iam_url';
+  private static final String ACCESS_TOKEN = 'access_token';
   private static final String CREDENTIAL_FILE_NAME = 'ibm_credentials';
 
   /**
@@ -26,6 +27,7 @@ public class IBMWatsonCredentialUtils {
     private String url;
     private String iamApiKey;
     private String iamUrl;
+    private String accessToken;
 
     private ServiceCredentials() { }
 
@@ -47,6 +49,10 @@ public class IBMWatsonCredentialUtils {
 
     public String getIamUrl() {
       return this.iamUrl;
+    }
+
+    public String getAccessToken() {
+      return this.accessToken;
     }
 
     public boolean isEmpty() {
@@ -110,6 +116,8 @@ public class IBMWatsonCredentialUtils {
           serviceCredentials.iamApiKey = credentialValue;
         } else if (credentialType.contains(IAM_URL)) {
           serviceCredentials.iamUrl = credentialValue;
+        } else if (credentialType.contains(ACCESS_TOKEN)) {
+          serviceCredentials.accessToken = credentialValue;
         } else {
           System.debug(System.LoggingLevel.WARN, 'Unknown credential key found in credential file: ' + credentialType);
         }

--- a/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls
+++ b/force-app/main/default/classes/IBMWatsonCredentialUtilsTest.cls
@@ -4,7 +4,10 @@ private class IBMWatsonCredentialUtilsTest {
     + 'DISCOVERY_PASSWORD=disco_password\r\n'
     + 'DISCOVERY_URL=https://gateway.watsonplatform.net/discovery/api\r\n'
     + 'NATURAL_LANGUAGE_CLASSIFIER_URL=https://gateway-s.watsonplatform.net/natural-language-classifier/api\r\n'
-    + 'NATURAL_LANGUAGE_CLASSIFIER_IAM_APIKEY=nlc_apikey';
+    + 'NATURAL_LANGUAGE_CLASSIFIER_IAM_APIKEY=nlc_apikey\r\n'
+    + 'ASSISTANT_ACCESS_TOKEN=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTU1OTMyODk1NSwiZXhwIjo5OTk5OTk5OTk5OTk5OTk5OTl9.GE-ML3JWmI3oB0z5mjMG3jFtYVVA5bQCsOTOOj9ab7PcgJc1mA5hn1sONkO0JAFADhUoAgpG4KgQef5tjnCSrtl1tbnDuhaP1DH4QKMCZOkWrKyfQ2X8P1jhyJmV-KpE4wuTrGdMoMVj4wVRZwnxMRSK6LhV6pIzyOLLYR21zcW_2KcKWxCYfIC7tiM1d2PSM5nWa_5Vb068F8PtdiFUElEYHYKrvmwpV57_k2jpXoY6zw8PDcIiWQe3g20w6vCB6zWhxbcFWyjMg1tPOZHgTNNskPShHQBbtZFsSrc7rkNPzttKF70m7_JqrRYUZDNN8TmuR9uyitwxEFkr2L0WDQ\r\n'
+    + 'ASSISTANT_CLOUD_TYPE=icp\r\n'
+    + 'ASSISTANT_URL=https://icp.cluster:31843/assistant/test/instances/1560453115/api';
 
   static testMethod void testHasBadStartOrEndChar() {
     // valid
@@ -29,7 +32,7 @@ private class IBMWatsonCredentialUtilsTest {
 
   static testMethod void testParsingCredentialFileNoService() {
     IBMWatsonCredentialUtils.ServiceCredentials serviceCredentials
-      = IBMWatsonCredentialUtils.parseCredentialFile('assistant', testCredentialFileContents);
+      = IBMWatsonCredentialUtils.parseCredentialFile('language_translator', testCredentialFileContents);
     System.assert(serviceCredentials.isEmpty());
   }
 
@@ -52,6 +55,16 @@ private class IBMWatsonCredentialUtilsTest {
     IBMWatsonCredentialUtils.ServiceCredentials serviceCredentials
       = IBMWatsonCredentialUtils.parseCredentialFile('natural_language_classifier', testCredentialFileContents);
     System.assertEquals(expectedApikey, serviceCredentials.getIamApiKey());
+    System.assertEquals(expectedUrl, serviceCredentials.getUrl());
+  }
+
+  static testMethod void testParsingCredentialFileIcp4d() {
+    String expectedAccessToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluIiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIiwiYWNjZXNzX2NhdGFsb2ciLCJtYW5hZ2VfcG9saWNpZXMiLCJhY2Nlc3NfcG9saWNpZXMiLCJ2aXJ0dWFsaXplX3RyYW5zZm9ybSIsImNhbl9wcm92aXNpb24iLCJkZXBsb3ltZW50X2FkbWluIl0sInN1YiI6ImFkbWluIiwiaXNzIjoiS05PWFNTTyIsImF1ZCI6IkRTWCIsInVpZCI6Ijk5OSIsImlhdCI6MTU1OTMyODk1NSwiZXhwIjo5OTk5OTk5OTk5OTk5OTk5OTl9.GE-ML3JWmI3oB0z5mjMG3jFtYVVA5bQCsOTOOj9ab7PcgJc1mA5hn1sONkO0JAFADhUoAgpG4KgQef5tjnCSrtl1tbnDuhaP1DH4QKMCZOkWrKyfQ2X8P1jhyJmV-KpE4wuTrGdMoMVj4wVRZwnxMRSK6LhV6pIzyOLLYR21zcW_2KcKWxCYfIC7tiM1d2PSM5nWa_5Vb068F8PtdiFUElEYHYKrvmwpV57_k2jpXoY6zw8PDcIiWQe3g20w6vCB6zWhxbcFWyjMg1tPOZHgTNNskPShHQBbtZFsSrc7rkNPzttKF70m7_JqrRYUZDNN8TmuR9uyitwxEFkr2L0WDQ';
+    String expectedUrl = 'https://icp.cluster:31843/assistant/test/instances/1560453115/api';
+
+    IBMWatsonCredentialUtils.ServiceCredentials serviceCredentials
+      = IBMWatsonCredentialUtils.parseCredentialFile('assistant', testCredentialFileContents);
+    System.assertEquals(expectedAccessToken, serviceCredentials.getAccessToken());
     System.assertEquals(expectedUrl, serviceCredentials.getUrl());
   }
 }

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -60,6 +60,13 @@ public abstract class IBMWatsonService {
         .build();
       setAuthenticator(iamOptions);
    }
+
+    if (serviceCredentials.getAccessToken() != null) {
+      IBMWatsonICP4DConfig config = new IBMWatsonICP4DConfig.Builder()
+        .userManagedAccessToken(serviceCredentials.getAccessToken())
+        .build();
+      setAuthenticator(config);
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds the ICP4D `access_token` to the list of keys the core looks for when loading credentials from a file. If it finds one, it'll set up an `IBMWatsonICP4DAuthenticator` instance.

For reference, downloading a credential file for a service instance in ICP4D results in the following file structure (using an Assistant instance as an example):
```
ASSISTANT_ACCESS_TOKEN=<token>
ASSISTANT_CLOUD_TYPE=icp
ASSISTANT_URL=<api_url>
```