### PR TITLE
Move to standard camelCase

### DIFF
--- a/force-app/main/default/classes/IBMAssistantV1.cls
+++ b/force-app/main/default/classes/IBMAssistantV1.cls
@@ -100,7 +100,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (messageOptions.output() != null) {
       contentJson.put('output', messageOptions.output());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, messageOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.MessageResponse) createServiceCall(builder.build(), IBMAssistantV1Models.MessageResponse.class);
   }
@@ -198,7 +198,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (createWorkspaceOptions.counterexamples() != null) {
       contentJson.put('counterexamples', createWorkspaceOptions.counterexamples());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createWorkspaceOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Workspace) createServiceCall(builder.build(), IBMAssistantV1Models.Workspace.class);
   }
@@ -296,7 +296,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (updateWorkspaceOptions.counterexamples() != null) {
       contentJson.put('counterexamples', updateWorkspaceOptions.counterexamples());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateWorkspaceOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Workspace) createServiceCall(builder.build(), IBMAssistantV1Models.Workspace.class);
   }
@@ -405,7 +405,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (createIntentOptions.examples() != null) {
       contentJson.put('examples', createIntentOptions.examples());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createIntentOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Intent) createServiceCall(builder.build(), IBMAssistantV1Models.Intent.class);
   }
@@ -479,7 +479,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (updateIntentOptions.newExamples() != null) {
       contentJson.put('examples', updateIntentOptions.newExamples());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateIntentOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Intent) createServiceCall(builder.build(), IBMAssistantV1Models.Intent.class);
   }
@@ -581,7 +581,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (createExampleOptions.mentions() != null) {
       contentJson.put('mentions', createExampleOptions.mentions());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createExampleOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Example) createServiceCall(builder.build(), IBMAssistantV1Models.Example.class);
   }
@@ -647,7 +647,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (updateExampleOptions.newMentions() != null) {
       contentJson.put('mentions', updateExampleOptions.newMentions());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateExampleOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Example) createServiceCall(builder.build(), IBMAssistantV1Models.Example.class);
   }
@@ -746,7 +746,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('text', createCounterexampleOptions.text());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createCounterexampleOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Counterexample) createServiceCall(builder.build(), IBMAssistantV1Models.Counterexample.class);
   }
@@ -809,7 +809,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (updateCounterexampleOptions.newText() != null) {
       contentJson.put('text', updateCounterexampleOptions.newText());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateCounterexampleOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Counterexample) createServiceCall(builder.build(), IBMAssistantV1Models.Counterexample.class);
   }
@@ -924,7 +924,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (createEntityOptions.values() != null) {
       contentJson.put('values', createEntityOptions.values());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createEntityOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Entity) createServiceCall(builder.build(), IBMAssistantV1Models.Entity.class);
   }
@@ -1004,7 +1004,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (updateEntityOptions.newValues() != null) {
       contentJson.put('values', updateEntityOptions.newValues());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateEntityOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Entity) createServiceCall(builder.build(), IBMAssistantV1Models.Entity.class);
   }
@@ -1151,7 +1151,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (createValueOptions.patterns() != null) {
       contentJson.put('patterns', createValueOptions.patterns());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createValueOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Value) createServiceCall(builder.build(), IBMAssistantV1Models.Value.class);
   }
@@ -1230,7 +1230,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (updateValueOptions.newPatterns() != null) {
       contentJson.put('patterns', updateValueOptions.newPatterns());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateValueOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Value) createServiceCall(builder.build(), IBMAssistantV1Models.Value.class);
   }
@@ -1329,7 +1329,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('synonym', createSynonymOptions.synonym());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createSynonymOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Synonym) createServiceCall(builder.build(), IBMAssistantV1Models.Synonym.class);
   }
@@ -1392,7 +1392,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (updateSynonymOptions.newSynonym() != null) {
       contentJson.put('synonym', updateSynonymOptions.newSynonym());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateSynonymOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.Synonym) createServiceCall(builder.build(), IBMAssistantV1Models.Synonym.class);
   }
@@ -1542,7 +1542,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (createDialogNodeOptions.userLabel() != null) {
       contentJson.put('user_label', createDialogNodeOptions.userLabel());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createDialogNodeOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.DialogNode) createServiceCall(builder.build(), IBMAssistantV1Models.DialogNode.class);
   }
@@ -1656,7 +1656,7 @@ public class IBMAssistantV1 extends IBMWatsonService {
     if (updateDialogNodeOptions.newUserLabel() != null) {
       contentJson.put('user_label', updateDialogNodeOptions.newUserLabel());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateDialogNodeOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV1Models.DialogNode) createServiceCall(builder.build(), IBMAssistantV1Models.DialogNode.class);
   }

--- a/force-app/main/default/classes/IBMAssistantV1Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Models.cls
@@ -3,8 +3,14 @@ public class IBMAssistantV1Models {
    * A recognized capture group for a pattern-based entity.
    */
   public class CaptureGroup extends IBMWatsonGenericModel {
-    private String group_serialized_name;
-    private List<Long> location_serialized_name;
+    private String xgroup;
+    private List<Long> location;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public CaptureGroup() { }
  
     /**
      * Gets the xgroup.
@@ -15,7 +21,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getXgroup() {
-      return group_serialized_name;
+      return xgroup;
     }
  
     /**
@@ -27,37 +33,126 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
+    }
+  
+    private CaptureGroup(CaptureGroupBuilder builder) {
+      IBMWatsonValidator.notNull(builder.xgroup, 'xgroup cannot be null');
+      this.xgroup = builder.xgroup;
+      this.location = builder.location;
     }
 
     /**
-     * Sets the xgroup.
+     * New builder.
      *
-     * @param xgroup the new xgroup
+     * @return a CaptureGroup builder
      */
-    public void setXgroup(final String xgroup) {
-      this.group_serialized_name = xgroup;
+    public CaptureGroupBuilder newBuilder() {
+      return new CaptureGroupBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xgroup', 'group');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('group', 'xgroup');
+      return mapping;
+    }
+  }
+
+  /**
+   * CaptureGroup Builder.
+   */
+  public class CaptureGroupBuilder {
+    private String xgroup;
+    private List<Long> location;
+
+    private CaptureGroupBuilder(CaptureGroup captureGroup) {
+      this.xgroup = captureGroup.xgroup;
+      this.location = captureGroup.location;
     }
 
     /**
-     * Sets the location.
+     * Instantiates a new builder.
+     */
+    public CaptureGroupBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param xgroup the xgroup
+     */
+    public CaptureGroupBuilder(String xgroup) {
+      this.xgroup = xgroup;
+    }
+
+    /**
+     * Builds a CaptureGroup.
+     *
+     * @return the captureGroup
+     */
+    public CaptureGroup build() {
+      return new CaptureGroup(this);
+    }
+
+    /**
+     * Adds an location to location.
      *
      * @param location the new location
+     * @return the CaptureGroup builder
      */
-    public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
+    public CaptureGroupBuilder addLocation(Long location) {
+      IBMWatsonValidator.notNull(location, 'location cannot be null');
+      if (this.location == null) {
+        this.location = new List<Long>();
+      }
+      this.location.add(location);
+      return this;
     }
 
+    /**
+     * Set the xgroup.
+     *
+     * @param xgroup the xgroup
+     * @return the CaptureGroup builder
+     */
+    public CaptureGroupBuilder setXgroup(String xgroup) {
+      this.xgroup = xgroup;
+      return this;
+    }
+
+    /**
+     * Set the location.
+     * Existing location will be replaced.
+     *
+     * @param location the location
+     * @return the CaptureGroup builder
+     */
+    public CaptureGroupBuilder setLocation(List<Long> location) {
+      this.location = location;
+      return this;
+    }
   }
 
   /**
    * State information for the conversation. To maintain state, include the context from the previous response.
    */
   public class Context extends IBMWatsonDynamicModel {
-    private String conversation_id_serialized_name;
-    private SystemResponse system_serialized_name;
-    private MessageContextMetadata metadata_serialized_name;
+    private String conversationId;
+    private SystemResponse xsystem;
+    private MessageContextMetadata metadata;
     private Map<String, Object> additional_properties_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Context() { }
 
     /**
      * Gets the conversationId.
@@ -66,7 +161,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getConversationId() {
-      return conversation_id_serialized_name;
+      return conversationId;
     }
 
     /**
@@ -76,7 +171,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public SystemResponse getXsystem() {
-      return system_serialized_name;
+      return xsystem;
     }
 
     /**
@@ -86,7 +181,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public MessageContextMetadata getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
 
     /**
@@ -99,31 +194,19 @@ public class IBMAssistantV1Models {
       return this.getDynamicProperties();
     }
 
-    /**
-     * Sets the conversationId.
-     *
-     * @param conversationId the new conversationId
-     */
-    public void setConversationId(final String conversationId) {
-      this.conversation_id_serialized_name = conversationId;
+    private Context(ContextBuilder builder) {
+      this.conversationId = builder.conversationId;
+      this.xsystem = builder.xsystem;
+      this.metadata = builder.metadata;
     }
 
     /**
-     * Sets the xsystem.
+     * New builder.
      *
-     * @param xsystem the new xsystem
+     * @return a Context builder
      */
-    public void setXsystem(final SystemResponse xsystem) {
-      this.system_serialized_name = xsystem;
-    }
-
-    /**
-     * Sets the metadata.
-     *
-     * @param metadata the new metadata
-     */
-    public void setMetadata(final MessageContextMetadata metadata) {
-      this.metadata_serialized_name = metadata;
+    public ContextBuilder newBuilder() {
+      return new ContextBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -132,24 +215,108 @@ public class IBMAssistantV1Models {
       }
 
       Context ret = (Context) super.deserialize(jsonString, jsonMap, classType);
+      ContextBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for xsystem
-      SystemResponse newXsystem = (SystemResponse) new SystemResponse().deserialize(JSON.serialize(ret.getXsystem()), (Map<String, Object>) jsonMap.get('system_serialized_name'), SystemResponse.class);
-      ret.setXsystem(newXsystem);
+      SystemResponse newXsystem = (SystemResponse) new SystemResponse().deserialize(JSON.serialize(ret.getXsystem()), (Map<String, Object>) jsonMap.get('xsystem'), SystemResponse.class);
+      retBuilder.setXsystem(newXsystem);
 
       // calling custom deserializer for metadata
-      MessageContextMetadata newMetadata = (MessageContextMetadata) new MessageContextMetadata().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), MessageContextMetadata.class);
-      ret.setMetadata(newMetadata);
+      MessageContextMetadata newMetadata = (MessageContextMetadata) new MessageContextMetadata().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), MessageContextMetadata.class);
+      retBuilder.setMetadata(newMetadata);
 
+      Context builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
 
       for (String key : jsonMap.keySet()) {
         if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
+          builderResult.put(key, jsonMap.get(key));
         }
       }
 
-      return ret;
+      return builderResult;
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('conversationId', 'conversation_id');
+      mapping.put('xsystem', 'system');
+      if (metadata != null) {
+        mapping.putAll(metadata.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('conversation_id', 'conversationId');
+      mapping.put('system', 'xsystem');
+      if (metadata != null) {
+        mapping.putAll(metadata.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * Context Builder.
+   */
+  public class ContextBuilder {
+    private String conversationId;
+    private SystemResponse xsystem;
+    private MessageContextMetadata metadata;
+
+    private ContextBuilder(Context context) {
+      this.conversationId = context.conversationId;
+      this.xsystem = context.xsystem;
+      this.metadata = context.metadata;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public ContextBuilder() { }
+
+    /**
+     * Builds a Context.
+     *
+     * @return the context
+     */
+    public Context build() {
+      return new Context(this);
+    }
+
+    /**
+     * Set the conversationId.
+     *
+     * @param conversationId the conversationId
+     * @return the Context builder
+     */
+    public ContextBuilder setConversationId(String conversationId) {
+      this.conversationId = conversationId;
+      return this;
+    }
+
+    /**
+     * Set the xsystem.
+     *
+     * @param xsystem the xsystem
+     * @return the Context builder
+     */
+    public ContextBuilder setXsystem(SystemResponse xsystem) {
+      this.xsystem = xsystem;
+      return this;
+    }
+
+    /**
+     * Set the metadata.
+     *
+     * @param metadata the metadata
+     * @return the Context builder
+     */
+    public ContextBuilder setMetadata(MessageContextMetadata metadata) {
+      this.metadata = metadata;
+      return this;
     }
   }
 
@@ -157,9 +324,9 @@ public class IBMAssistantV1Models {
    * Counterexample.
    */
   public class Counterexample extends IBMWatsonResponseModel {
-    private String text_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
+    private String text;
+    private Datetime created;
+    private Datetime updated;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -178,7 +345,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -190,7 +357,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -202,14 +369,14 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
   
     private Counterexample(CounterexampleBuilder builder) {
       IBMWatsonValidator.notNull(builder.text, 'text cannot be null');
-      this.text_serialized_name = builder.text;
-      this.created_serialized_name = builder.created;
-      this.updated_serialized_name = builder.updated;
+      this.text = builder.text;
+      this.created = builder.created;
+      this.updated = builder.updated;
     }
 
     /**
@@ -220,7 +387,6 @@ public class IBMAssistantV1Models {
     public CounterexampleBuilder newBuilder() {
       return new CounterexampleBuilder(this);
     }
-
   }
 
   /**
@@ -232,9 +398,9 @@ public class IBMAssistantV1Models {
     private Datetime updated;
 
     private CounterexampleBuilder(Counterexample counterexample) {
-      this.text = counterexample.text_serialized_name;
-      this.created = counterexample.created_serialized_name;
-      this.updated = counterexample.updated_serialized_name;
+      this.text = counterexample.text;
+      this.created = counterexample.created;
+      this.updated = counterexample.updated;
     }
 
     /**
@@ -299,8 +465,8 @@ public class IBMAssistantV1Models {
    * CounterexampleCollection.
    */
   public class CounterexampleCollection extends IBMWatsonResponseModel {
-    private List<Counterexample> counterexamples_serialized_name;
-    private Pagination pagination_serialized_name;
+    private List<Counterexample> counterexamples;
+    private Pagination pagination;
  
     /**
      * Gets the counterexamples.
@@ -311,7 +477,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Counterexample> getCounterexamples() {
-      return counterexamples_serialized_name;
+      return counterexamples;
     }
  
     /**
@@ -323,7 +489,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -332,7 +498,7 @@ public class IBMAssistantV1Models {
      * @param counterexamples the new counterexamples
      */
     public void setCounterexamples(final List<Counterexample> counterexamples) {
-      this.counterexamples_serialized_name = counterexamples;
+      this.counterexamples = counterexamples;
     }
 
     /**
@@ -341,7 +507,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -357,18 +523,26 @@ public class IBMAssistantV1Models {
       if (deserializedCounterexamples != null) {
         for (Integer i = 0; i < deserializedCounterexamples.size(); i++) {
           Counterexample currentItem = ret.getCounterexamples().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('counterexamples_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('counterexamples');
           Counterexample newItem = (Counterexample) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Counterexample.class);
           newCounterexamples.add(newItem);
         }
-        ret.counterexamples_serialized_name = newCounterexamples;
+        ret.counterexamples = newCounterexamples;
       }
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -378,7 +552,7 @@ public class IBMAssistantV1Models {
   public class CreateCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspaceId;
     private String text;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -389,7 +563,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -420,6 +594,11 @@ public class IBMAssistantV1Models {
       return new CreateCounterexampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -530,7 +709,7 @@ public class IBMAssistantV1Models {
     private String digressOut;
     private String digressOutSlots;
     private String userLabel;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -541,7 +720,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -553,7 +732,7 @@ public class IBMAssistantV1Models {
     public String dialogNode() {
       return dialogNode;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -564,7 +743,7 @@ public class IBMAssistantV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the conditions.
      *
@@ -576,7 +755,7 @@ public class IBMAssistantV1Models {
     public String conditions() {
       return conditions;
     }
- 
+
     /**
      * Gets the parent.
      *
@@ -587,7 +766,7 @@ public class IBMAssistantV1Models {
     public String parent() {
       return parent;
     }
- 
+
     /**
      * Gets the previousSibling.
      *
@@ -598,7 +777,7 @@ public class IBMAssistantV1Models {
     public String previousSibling() {
       return previousSibling;
     }
- 
+
     /**
      * Gets the output.
      *
@@ -610,7 +789,7 @@ public class IBMAssistantV1Models {
     public DialogNodeOutput output() {
       return output;
     }
- 
+
     /**
      * Gets the context.
      *
@@ -621,7 +800,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel context() {
       return context;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -632,7 +811,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the nextStep.
      *
@@ -643,7 +822,7 @@ public class IBMAssistantV1Models {
     public DialogNodeNextStep nextStep() {
       return nextStep;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -655,7 +834,7 @@ public class IBMAssistantV1Models {
     public String title() {
       return title;
     }
- 
+
     /**
      * Gets the nodeType.
      *
@@ -666,7 +845,7 @@ public class IBMAssistantV1Models {
     public String nodeType() {
       return nodeType;
     }
- 
+
     /**
      * Gets the eventName.
      *
@@ -677,7 +856,7 @@ public class IBMAssistantV1Models {
     public String eventName() {
       return eventName;
     }
- 
+
     /**
      * Gets the variable.
      *
@@ -688,7 +867,7 @@ public class IBMAssistantV1Models {
     public String variable() {
       return variable;
     }
- 
+
     /**
      * Gets the actions.
      *
@@ -699,7 +878,7 @@ public class IBMAssistantV1Models {
     public List<DialogNodeAction> actions() {
       return actions;
     }
- 
+
     /**
      * Gets the digressIn.
      *
@@ -710,7 +889,7 @@ public class IBMAssistantV1Models {
     public String digressIn() {
       return digressIn;
     }
- 
+
     /**
      * Gets the digressOut.
      *
@@ -721,7 +900,7 @@ public class IBMAssistantV1Models {
     public String digressOut() {
       return digressOut;
     }
- 
+
     /**
      * Gets the digressOutSlots.
      *
@@ -732,7 +911,7 @@ public class IBMAssistantV1Models {
     public String digressOutSlots() {
       return digressOutSlots;
     }
- 
+
     /**
      * Gets the userLabel.
      *
@@ -778,6 +957,29 @@ public class IBMAssistantV1Models {
       return new CreateDialogNodeOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('dialogNode', 'dialog_node');
+      mapping.put('previousSibling', 'previous_sibling');
+      if (output != null) {
+        mapping.putAll(output.getSdkToApiMapping());
+      }
+      mapping.put('nextStep', 'next_step');
+      if (nextStep != null) {
+        mapping.putAll(nextStep.getSdkToApiMapping());
+      }
+      mapping.put('nodeType', 'type');
+      mapping.put('eventName', 'event_name');
+      if (actions != null && actions[0] != null) {
+        mapping.putAll(actions[0].getSdkToApiMapping());
+      }
+      mapping.put('digressIn', 'digress_in');
+      mapping.put('digressOut', 'digress_out');
+      mapping.put('digressOutSlots', 'digress_out_slots');
+      mapping.put('userLabel', 'user_label');
+      return mapping;
+    }
   }
 
   /**
@@ -1122,14 +1324,14 @@ public class IBMAssistantV1Models {
   /**
    * CreateEntity.
    */
-  public class CreateEntity {
-    private String entity_serialized_name;
-    private String description_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private Boolean fuzzy_match_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
-    private List<CreateValue> values_serialized_name;
+  public class CreateEntity extends IBMWatsonGenericModel {
+    private String entity;
+    private String description;
+    private IBMWatsonMapModel metadata;
+    private Boolean fuzzyMatch;
+    private Datetime created;
+    private Datetime updated;
+    private List<CreateValue> values;
  
     /**
      * Gets the entity.
@@ -1142,7 +1344,7 @@ public class IBMAssistantV1Models {
      * @return the entity
      */
     public String entity() {
-      return entity_serialized_name;
+      return entity;
     }
  
     /**
@@ -1153,7 +1355,7 @@ public class IBMAssistantV1Models {
      * @return the description
      */
     public String description() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -1164,7 +1366,7 @@ public class IBMAssistantV1Models {
      * @return the metadata
      */
     public IBMWatsonMapModel metadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
  
     /**
@@ -1175,7 +1377,7 @@ public class IBMAssistantV1Models {
      * @return the fuzzyMatch
      */
     public Boolean fuzzyMatch() {
-      return fuzzy_match_serialized_name;
+      return fuzzyMatch;
     }
  
     /**
@@ -1186,7 +1388,7 @@ public class IBMAssistantV1Models {
      * @return the created
      */
     public Datetime created() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -1197,7 +1399,7 @@ public class IBMAssistantV1Models {
      * @return the updated
      */
     public Datetime updated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -1208,18 +1410,18 @@ public class IBMAssistantV1Models {
      * @return the values
      */
     public List<CreateValue> values() {
-      return values_serialized_name;
+      return values;
     }
   
     private CreateEntity(CreateEntityBuilder builder) {
       IBMWatsonValidator.notNull(builder.entity, 'entity cannot be null');
-      this.entity_serialized_name = builder.entity;
-      this.description_serialized_name = builder.description;
-      this.metadata_serialized_name = builder.metadata;
-      this.fuzzy_match_serialized_name = builder.fuzzyMatch;
-      this.created_serialized_name = builder.created;
-      this.updated_serialized_name = builder.updated;
-      this.values_serialized_name = builder.values;
+      this.entity = builder.entity;
+      this.description = builder.description;
+      this.metadata = builder.metadata;
+      this.fuzzyMatch = builder.fuzzyMatch;
+      this.created = builder.created;
+      this.updated = builder.updated;
+      this.values = builder.values;
     }
 
     /**
@@ -1231,6 +1433,14 @@ public class IBMAssistantV1Models {
       return new CreateEntityBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('fuzzyMatch', 'fuzzy_match');
+      if (values != null && values[0] != null) {
+        mapping.putAll(values[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -1246,13 +1456,13 @@ public class IBMAssistantV1Models {
     private List<CreateValue> values;
 
     private CreateEntityBuilder(CreateEntity createEntity) {
-      this.entity = createEntity.entity_serialized_name;
-      this.description = createEntity.description_serialized_name;
-      this.metadata = createEntity.metadata_serialized_name;
-      this.fuzzyMatch = createEntity.fuzzy_match_serialized_name;
-      this.created = createEntity.created_serialized_name;
-      this.updated = createEntity.updated_serialized_name;
-      this.values = createEntity.values_serialized_name;
+      this.entity = createEntity.entity;
+      this.description = createEntity.description;
+      this.metadata = createEntity.metadata;
+      this.fuzzyMatch = createEntity.fuzzyMatch;
+      this.created = createEntity.created;
+      this.updated = createEntity.updated;
+      this.values = createEntity.values;
     }
 
     /**
@@ -1383,7 +1593,7 @@ public class IBMAssistantV1Models {
     private IBMWatsonMapModel metadata;
     private Boolean fuzzyMatch;
     private List<CreateValue> values;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -1394,7 +1604,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -1408,7 +1618,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -1419,7 +1629,7 @@ public class IBMAssistantV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -1430,7 +1640,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the fuzzyMatch.
      *
@@ -1441,7 +1651,7 @@ public class IBMAssistantV1Models {
     public Boolean fuzzyMatch() {
       return fuzzyMatch;
     }
- 
+
     /**
      * Gets the values.
      *
@@ -1474,6 +1684,15 @@ public class IBMAssistantV1Models {
       return new CreateEntityOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('fuzzyMatch', 'fuzzy_match');
+      if (values != null && values[0] != null) {
+        mapping.putAll(values[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -1626,7 +1845,7 @@ public class IBMAssistantV1Models {
     private String intent;
     private String text;
     private List<Mention> mentions;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -1637,7 +1856,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -1648,7 +1867,7 @@ public class IBMAssistantV1Models {
     public String intent() {
       return intent;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -1661,7 +1880,7 @@ public class IBMAssistantV1Models {
     public String text() {
       return text;
     }
- 
+
     /**
      * Gets the mentions.
      *
@@ -1693,6 +1912,11 @@ public class IBMAssistantV1Models {
       return new CreateExampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1828,12 +2052,12 @@ public class IBMAssistantV1Models {
   /**
    * CreateIntent.
    */
-  public class CreateIntent {
-    private String intent_serialized_name;
-    private String description_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
-    private List<Example> examples_serialized_name;
+  public class CreateIntent extends IBMWatsonGenericModel {
+    private String intent;
+    private String description;
+    private Datetime created;
+    private Datetime updated;
+    private List<Example> examples;
  
     /**
      * Gets the intent.
@@ -1845,7 +2069,7 @@ public class IBMAssistantV1Models {
      * @return the intent
      */
     public String intent() {
-      return intent_serialized_name;
+      return intent;
     }
  
     /**
@@ -1856,7 +2080,7 @@ public class IBMAssistantV1Models {
      * @return the description
      */
     public String description() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -1867,7 +2091,7 @@ public class IBMAssistantV1Models {
      * @return the created
      */
     public Datetime created() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -1878,7 +2102,7 @@ public class IBMAssistantV1Models {
      * @return the updated
      */
     public Datetime updated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -1889,16 +2113,16 @@ public class IBMAssistantV1Models {
      * @return the examples
      */
     public List<Example> examples() {
-      return examples_serialized_name;
+      return examples;
     }
   
     private CreateIntent(CreateIntentBuilder builder) {
       IBMWatsonValidator.notNull(builder.intent, 'intent cannot be null');
-      this.intent_serialized_name = builder.intent;
-      this.description_serialized_name = builder.description;
-      this.created_serialized_name = builder.created;
-      this.updated_serialized_name = builder.updated;
-      this.examples_serialized_name = builder.examples;
+      this.intent = builder.intent;
+      this.description = builder.description;
+      this.created = builder.created;
+      this.updated = builder.updated;
+      this.examples = builder.examples;
     }
 
     /**
@@ -1909,7 +2133,6 @@ public class IBMAssistantV1Models {
     public CreateIntentBuilder newBuilder() {
       return new CreateIntentBuilder(this);
     }
-
   }
 
   /**
@@ -1923,11 +2146,11 @@ public class IBMAssistantV1Models {
     private List<Example> examples;
 
     private CreateIntentBuilder(CreateIntent createIntent) {
-      this.intent = createIntent.intent_serialized_name;
-      this.description = createIntent.description_serialized_name;
-      this.created = createIntent.created_serialized_name;
-      this.updated = createIntent.updated_serialized_name;
-      this.examples = createIntent.examples_serialized_name;
+      this.intent = createIntent.intent;
+      this.description = createIntent.description;
+      this.created = createIntent.created;
+      this.updated = createIntent.updated;
+      this.examples = createIntent.examples;
     }
 
     /**
@@ -2034,7 +2257,7 @@ public class IBMAssistantV1Models {
     private String intent;
     private String description;
     private List<Example> examples;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -2045,7 +2268,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -2058,7 +2281,7 @@ public class IBMAssistantV1Models {
     public String intent() {
       return intent;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -2069,7 +2292,7 @@ public class IBMAssistantV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the examples.
      *
@@ -2100,6 +2323,11 @@ public class IBMAssistantV1Models {
       return new CreateIntentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -2226,7 +2454,7 @@ public class IBMAssistantV1Models {
     private String entity;
     private String value;
     private String synonym;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -2237,7 +2465,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -2248,7 +2476,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -2259,7 +2487,7 @@ public class IBMAssistantV1Models {
     public String value() {
       return value;
     }
- 
+
     /**
      * Gets the synonym.
      *
@@ -2294,6 +2522,11 @@ public class IBMAssistantV1Models {
       return new CreateSynonymOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -2415,19 +2648,13 @@ public class IBMAssistantV1Models {
    * CreateValue.
    */
   public class CreateValue extends IBMWatsonGenericModel {
-    private String value_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private String type_serialized_name;
-    private List<String> synonyms_serialized_name;
-    private List<String> patterns_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
-
-    /**
-     * This constructor is strictly for internal serialization/deserialization purposes
-     * and should not be called by the client.
-     */
-    public CreateValue() { }
+    private String value;
+    private IBMWatsonMapModel metadata;
+    private String valueType;
+    private List<String> synonyms;
+    private List<String> patterns;
+    private Datetime created;
+    private Datetime updated;
  
     /**
      * Gets the value.
@@ -2438,9 +2665,8 @@ public class IBMAssistantV1Models {
      *
      * @return the value
      */
-    @AuraEnabled
-    public String getValue() {
-      return value_serialized_name;
+    public String value() {
+      return value;
     }
  
     /**
@@ -2450,9 +2676,8 @@ public class IBMAssistantV1Models {
      *
      * @return the metadata
      */
-    @AuraEnabled
-    public IBMWatsonMapModel getMetadata() {
-      return metadata_serialized_name;
+    public IBMWatsonMapModel metadata() {
+      return metadata;
     }
  
     /**
@@ -2462,9 +2687,8 @@ public class IBMAssistantV1Models {
      *
      * @return the valueType
      */
-    @AuraEnabled
-    public String getValueType() {
-      return type_serialized_name;
+    public String valueType() {
+      return valueType;
     }
  
     /**
@@ -2477,9 +2701,8 @@ public class IBMAssistantV1Models {
      *
      * @return the synonyms
      */
-    @AuraEnabled
-    public List<String> getSynonyms() {
-      return synonyms_serialized_name;
+    public List<String> synonyms() {
+      return synonyms;
     }
  
     /**
@@ -2492,9 +2715,8 @@ public class IBMAssistantV1Models {
      *
      * @return the patterns
      */
-    @AuraEnabled
-    public List<String> getPatterns() {
-      return patterns_serialized_name;
+    public List<String> patterns() {
+      return patterns;
     }
  
     /**
@@ -2504,9 +2726,8 @@ public class IBMAssistantV1Models {
      *
      * @return the created
      */
-    @AuraEnabled
-    public Datetime getCreated() {
-      return created_serialized_name;
+    public Datetime created() {
+      return created;
     }
  
     /**
@@ -2516,20 +2737,19 @@ public class IBMAssistantV1Models {
      *
      * @return the updated
      */
-    @AuraEnabled
-    public Datetime getUpdated() {
-      return updated_serialized_name;
+    public Datetime updated() {
+      return updated;
     }
   
     private CreateValue(CreateValueBuilder builder) {
       IBMWatsonValidator.notNull(builder.value, 'value cannot be null');
-      this.value_serialized_name = builder.value;
-      this.metadata_serialized_name = builder.metadata;
-      this.type_serialized_name = builder.valueType;
-      this.synonyms_serialized_name = builder.synonyms;
-      this.patterns_serialized_name = builder.patterns;
-      this.created_serialized_name = builder.created;
-      this.updated_serialized_name = builder.updated;
+      this.value = builder.value;
+      this.metadata = builder.metadata;
+      this.valueType = builder.valueType;
+      this.synonyms = builder.synonyms;
+      this.patterns = builder.patterns;
+      this.created = builder.created;
+      this.updated = builder.updated;
     }
 
     /**
@@ -2541,19 +2761,10 @@ public class IBMAssistantV1Models {
       return new CreateValueBuilder(this);
     }
 
-    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-      if (jsonMap == null) {
-        return null;
-      }
-
-      CreateValue ret = (CreateValue) super.deserialize(jsonString, jsonMap, classType);
-      CreateValueBuilder retBuilder = ret.newBuilder();
-
-      // calling custom deserializer for metadata
-      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), IBMWatsonMapModel.class);
-      retBuilder.metadata(newMetadata);
-
-      return retBuilder.build();
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('valueType', 'type');
+      return mapping;
     }
   }
 
@@ -2570,13 +2781,13 @@ public class IBMAssistantV1Models {
     private Datetime updated;
 
     private CreateValueBuilder(CreateValue createValue) {
-      this.value = createValue.value_serialized_name;
-      this.metadata = createValue.metadata_serialized_name;
-      this.valueType = createValue.type_serialized_name;
-      this.synonyms = createValue.synonyms_serialized_name;
-      this.patterns = createValue.patterns_serialized_name;
-      this.created = createValue.created_serialized_name;
-      this.updated = createValue.updated_serialized_name;
+      this.value = createValue.value;
+      this.metadata = createValue.metadata;
+      this.valueType = createValue.valueType;
+      this.synonyms = createValue.synonyms;
+      this.patterns = createValue.patterns;
+      this.created = createValue.created;
+      this.updated = createValue.updated;
     }
 
     /**
@@ -2724,7 +2935,7 @@ public class IBMAssistantV1Models {
     private String valueType;
     private List<String> synonyms;
     private List<String> patterns;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -2735,7 +2946,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -2746,7 +2957,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -2759,7 +2970,7 @@ public class IBMAssistantV1Models {
     public String value() {
       return value;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -2770,7 +2981,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the valueType.
      *
@@ -2781,7 +2992,7 @@ public class IBMAssistantV1Models {
     public String valueType() {
       return valueType;
     }
- 
+
     /**
      * Gets the synonyms.
      *
@@ -2795,7 +3006,7 @@ public class IBMAssistantV1Models {
     public List<String> synonyms() {
       return synonyms;
     }
- 
+
     /**
      * Gets the patterns.
      *
@@ -2833,6 +3044,12 @@ public class IBMAssistantV1Models {
       return new CreateValueOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('valueType', 'type');
+      return mapping;
+    }
   }
 
   /**
@@ -2996,21 +3213,6 @@ public class IBMAssistantV1Models {
     }
 
     /**
-     * Set the createValue.
-     *
-     * @param createValue the createValue
-     * @return the CreateValueOptions builder
-     */
-    public CreateValueOptionsBuilder createValue(CreateValue createValue) {
-      this.value = createValue.getValue();
-      this.metadata = createValue.getMetadata();
-      this.valueType = createValue.getValueType();
-      this.synonyms = createValue.getSynonyms();
-      this.patterns = createValue.getPatterns();
-      return this;
-    }
-
-    /**
      * Add a request header.
      *
      * @param name the header name
@@ -3037,7 +3239,7 @@ public class IBMAssistantV1Models {
     private List<CreateEntity> entities;
     private List<DialogNode> dialogNodes;
     private List<Counterexample> counterexamples;
- 
+
     /**
      * Gets the name.
      *
@@ -3048,7 +3250,7 @@ public class IBMAssistantV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -3059,7 +3261,7 @@ public class IBMAssistantV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -3070,7 +3272,7 @@ public class IBMAssistantV1Models {
     public String language() {
       return language;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -3081,7 +3283,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the learningOptOut.
      *
@@ -3093,7 +3295,7 @@ public class IBMAssistantV1Models {
     public Boolean learningOptOut() {
       return learningOptOut;
     }
- 
+
     /**
      * Gets the systemSettings.
      *
@@ -3104,7 +3306,7 @@ public class IBMAssistantV1Models {
     public WorkspaceSystemSettings systemSettings() {
       return systemSettings;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -3115,7 +3317,7 @@ public class IBMAssistantV1Models {
     public List<CreateIntent> intents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -3126,7 +3328,7 @@ public class IBMAssistantV1Models {
     public List<CreateEntity> entities() {
       return entities;
     }
- 
+
     /**
      * Gets the dialogNodes.
      *
@@ -3137,7 +3339,7 @@ public class IBMAssistantV1Models {
     public List<DialogNode> dialogNodes() {
       return dialogNodes;
     }
- 
+
     /**
      * Gets the counterexamples.
      *
@@ -3172,6 +3374,22 @@ public class IBMAssistantV1Models {
       return new CreateWorkspaceOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('learningOptOut', 'learning_opt_out');
+      mapping.put('systemSettings', 'system_settings');
+      if (systemSettings != null) {
+        mapping.putAll(systemSettings.getSdkToApiMapping());
+      }
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getSdkToApiMapping());
+      }
+      mapping.put('dialogNodes', 'dialog_nodes');
+      if (dialogNodes != null && dialogNodes[0] != null) {
+        mapping.putAll(dialogNodes[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -3411,7 +3629,7 @@ public class IBMAssistantV1Models {
   public class DeleteCounterexampleOptions extends IBMWatsonOptionsModel {
     private String workspaceId;
     private String text;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -3422,7 +3640,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -3451,6 +3669,11 @@ public class IBMAssistantV1Models {
       return new DeleteCounterexampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -3533,7 +3756,7 @@ public class IBMAssistantV1Models {
   public class DeleteDialogNodeOptions extends IBMWatsonOptionsModel {
     private String workspaceId;
     private String dialogNode;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -3544,7 +3767,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -3573,6 +3796,12 @@ public class IBMAssistantV1Models {
       return new DeleteDialogNodeOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('dialogNode', 'dialog_node');
+      return mapping;
+    }
   }
 
   /**
@@ -3655,7 +3884,7 @@ public class IBMAssistantV1Models {
   public class DeleteEntityOptions extends IBMWatsonOptionsModel {
     private String workspaceId;
     private String entity;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -3666,7 +3895,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -3695,6 +3924,11 @@ public class IBMAssistantV1Models {
       return new DeleteEntityOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -3778,7 +4012,7 @@ public class IBMAssistantV1Models {
     private String workspaceId;
     private String intent;
     private String text;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -3789,7 +4023,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -3800,7 +4034,7 @@ public class IBMAssistantV1Models {
     public String intent() {
       return intent;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -3831,6 +4065,11 @@ public class IBMAssistantV1Models {
       return new DeleteExampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -3928,7 +4167,7 @@ public class IBMAssistantV1Models {
   public class DeleteIntentOptions extends IBMWatsonOptionsModel {
     private String workspaceId;
     private String intent;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -3939,7 +4178,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -3968,6 +4207,11 @@ public class IBMAssistantV1Models {
       return new DeleteIntentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4052,7 +4296,7 @@ public class IBMAssistantV1Models {
     private String entity;
     private String value;
     private String synonym;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -4063,7 +4307,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -4074,7 +4318,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -4085,7 +4329,7 @@ public class IBMAssistantV1Models {
     public String value() {
       return value;
     }
- 
+
     /**
      * Gets the synonym.
      *
@@ -4118,6 +4362,11 @@ public class IBMAssistantV1Models {
       return new DeleteSynonymOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4229,7 +4478,7 @@ public class IBMAssistantV1Models {
    */
   public class DeleteUserDataOptions extends IBMWatsonOptionsModel {
     private String customerId;
- 
+
     /**
      * Gets the customerId.
      *
@@ -4256,6 +4505,11 @@ public class IBMAssistantV1Models {
       return new DeleteUserDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customerId', 'customer_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4324,7 +4578,7 @@ public class IBMAssistantV1Models {
     private String workspaceId;
     private String entity;
     private String value;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -4335,7 +4589,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -4346,7 +4600,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -4377,6 +4631,11 @@ public class IBMAssistantV1Models {
       return new DeleteValueOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4473,7 +4732,7 @@ public class IBMAssistantV1Models {
    */
   public class DeleteWorkspaceOptions extends IBMWatsonOptionsModel {
     private String workspaceId;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -4500,6 +4759,11 @@ public class IBMAssistantV1Models {
       return new DeleteWorkspaceOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4565,27 +4829,27 @@ public class IBMAssistantV1Models {
    * DialogNode.
    */
   public class DialogNode extends IBMWatsonResponseModel {
-    private String dialog_node_serialized_name;
-    private String description_serialized_name;
-    private String conditions_serialized_name;
-    private String parent_serialized_name;
-    private String previous_sibling_serialized_name;
-    private DialogNodeOutput output_serialized_name;
-    private IBMWatsonMapModel context_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private DialogNodeNextStep next_step_serialized_name;
-    private String title_serialized_name;
-    private String type_serialized_name;
-    private String event_name_serialized_name;
-    private String variable_serialized_name;
-    private List<DialogNodeAction> actions_serialized_name;
-    private String digress_in_serialized_name;
-    private String digress_out_serialized_name;
-    private String digress_out_slots_serialized_name;
-    private String user_label_serialized_name;
-    private Boolean disabled_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
+    private String dialogNode;
+    private String description;
+    private String conditions;
+    private String parent;
+    private String previousSibling;
+    private DialogNodeOutput output;
+    private IBMWatsonMapModel context;
+    private IBMWatsonMapModel metadata;
+    private DialogNodeNextStep nextStep;
+    private String title;
+    private String nodeType;
+    private String eventName;
+    private String variable;
+    private List<DialogNodeAction> actions;
+    private String digressIn;
+    private String digressOut;
+    private String digressOutSlots;
+    private String userLabel;
+    private Boolean disabled;
+    private Datetime created;
+    private Datetime updated;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -4603,7 +4867,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDialogNode() {
-      return dialog_node_serialized_name;
+      return dialogNode;
     }
  
     /**
@@ -4615,7 +4879,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -4628,7 +4892,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getConditions() {
-      return conditions_serialized_name;
+      return conditions;
     }
  
     /**
@@ -4640,7 +4904,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getParent() {
-      return parent_serialized_name;
+      return parent;
     }
  
     /**
@@ -4652,7 +4916,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getPreviousSibling() {
-      return previous_sibling_serialized_name;
+      return previousSibling;
     }
  
     /**
@@ -4665,7 +4929,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public DialogNodeOutput getOutput() {
-      return output_serialized_name;
+      return output;
     }
  
     /**
@@ -4677,7 +4941,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getContext() {
-      return context_serialized_name;
+      return context;
     }
  
     /**
@@ -4689,7 +4953,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
  
     /**
@@ -4701,7 +4965,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public DialogNodeNextStep getNextStep() {
-      return next_step_serialized_name;
+      return nextStep;
     }
  
     /**
@@ -4714,7 +4978,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -4726,7 +4990,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getNodeType() {
-      return type_serialized_name;
+      return nodeType;
     }
  
     /**
@@ -4738,7 +5002,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getEventName() {
-      return event_name_serialized_name;
+      return eventName;
     }
  
     /**
@@ -4750,7 +5014,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getVariable() {
-      return variable_serialized_name;
+      return variable;
     }
  
     /**
@@ -4762,7 +5026,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNodeAction> getActions() {
-      return actions_serialized_name;
+      return actions;
     }
  
     /**
@@ -4774,7 +5038,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDigressIn() {
-      return digress_in_serialized_name;
+      return digressIn;
     }
  
     /**
@@ -4786,7 +5050,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDigressOut() {
-      return digress_out_serialized_name;
+      return digressOut;
     }
  
     /**
@@ -4798,7 +5062,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDigressOutSlots() {
-      return digress_out_slots_serialized_name;
+      return digressOutSlots;
     }
  
     /**
@@ -4810,7 +5074,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getUserLabel() {
-      return user_label_serialized_name;
+      return userLabel;
     }
  
     /**
@@ -4822,7 +5086,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getDisabled() {
-      return disabled_serialized_name;
+      return disabled;
     }
  
     /**
@@ -4834,7 +5098,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -4846,32 +5110,32 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
   
     private DialogNode(DialogNodeBuilder builder) {
       IBMWatsonValidator.notNull(builder.dialogNode, 'dialogNode cannot be null');
-      this.dialog_node_serialized_name = builder.dialogNode;
-      this.description_serialized_name = builder.description;
-      this.conditions_serialized_name = builder.conditions;
-      this.parent_serialized_name = builder.parent;
-      this.previous_sibling_serialized_name = builder.previousSibling;
-      this.output_serialized_name = builder.output;
-      this.context_serialized_name = builder.context;
-      this.metadata_serialized_name = builder.metadata;
-      this.next_step_serialized_name = builder.nextStep;
-      this.title_serialized_name = builder.title;
-      this.type_serialized_name = builder.nodeType;
-      this.event_name_serialized_name = builder.eventName;
-      this.variable_serialized_name = builder.variable;
-      this.actions_serialized_name = builder.actions;
-      this.digress_in_serialized_name = builder.digressIn;
-      this.digress_out_serialized_name = builder.digressOut;
-      this.digress_out_slots_serialized_name = builder.digressOutSlots;
-      this.user_label_serialized_name = builder.userLabel;
-      this.disabled_serialized_name = builder.disabled;
-      this.created_serialized_name = builder.created;
-      this.updated_serialized_name = builder.updated;
+      this.dialogNode = builder.dialogNode;
+      this.description = builder.description;
+      this.conditions = builder.conditions;
+      this.parent = builder.parent;
+      this.previousSibling = builder.previousSibling;
+      this.output = builder.output;
+      this.context = builder.context;
+      this.metadata = builder.metadata;
+      this.nextStep = builder.nextStep;
+      this.title = builder.title;
+      this.nodeType = builder.nodeType;
+      this.eventName = builder.eventName;
+      this.variable = builder.variable;
+      this.actions = builder.actions;
+      this.digressIn = builder.digressIn;
+      this.digressOut = builder.digressOut;
+      this.digressOutSlots = builder.digressOutSlots;
+      this.userLabel = builder.userLabel;
+      this.disabled = builder.disabled;
+      this.created = builder.created;
+      this.updated = builder.updated;
     }
 
     /**
@@ -4892,19 +5156,19 @@ public class IBMAssistantV1Models {
       DialogNodeBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for output
-      DialogNodeOutput newOutput = (DialogNodeOutput) new DialogNodeOutput().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output_serialized_name'), DialogNodeOutput.class);
+      DialogNodeOutput newOutput = (DialogNodeOutput) new DialogNodeOutput().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output'), DialogNodeOutput.class);
       retBuilder.output(newOutput);
 
       // calling custom deserializer for context
-      IBMWatsonMapModel newContext = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newContext = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context'), IBMWatsonMapModel.class);
       retBuilder.context(newContext);
 
       // calling custom deserializer for metadata
-      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
       retBuilder.metadata(newMetadata);
 
       // calling custom deserializer for nextStep
-      DialogNodeNextStep newNextStep = (DialogNodeNextStep) new DialogNodeNextStep().deserialize(JSON.serialize(ret.getNextStep()), (Map<String, Object>) jsonMap.get('next_step_serialized_name'), DialogNodeNextStep.class);
+      DialogNodeNextStep newNextStep = (DialogNodeNextStep) new DialogNodeNextStep().deserialize(JSON.serialize(ret.getNextStep()), (Map<String, Object>) jsonMap.get('nextStep'), DialogNodeNextStep.class);
       retBuilder.nextStep(newNextStep);
 
       // calling custom deserializer for actions
@@ -4913,7 +5177,7 @@ public class IBMAssistantV1Models {
       if (deserializedActions != null) {
         for (Integer i = 0; i < deserializedActions.size(); i++) {
           DialogNodeAction currentItem = ret.getActions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('actions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('actions');
           DialogNodeAction newItem = (DialogNodeAction) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeAction.class);
           newActions.add(newItem);
         }
@@ -4921,6 +5185,52 @@ public class IBMAssistantV1Models {
       }
 
       return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dialogNode', 'dialog_node');
+      mapping.put('previousSibling', 'previous_sibling');
+      if (output != null) {
+        mapping.putAll(output.getSdkToApiMapping());
+      }
+      mapping.put('nextStep', 'next_step');
+      if (nextStep != null) {
+        mapping.putAll(nextStep.getSdkToApiMapping());
+      }
+      mapping.put('nodeType', 'type');
+      mapping.put('eventName', 'event_name');
+      if (actions != null && actions[0] != null) {
+        mapping.putAll(actions[0].getSdkToApiMapping());
+      }
+      mapping.put('digressIn', 'digress_in');
+      mapping.put('digressOut', 'digress_out');
+      mapping.put('digressOutSlots', 'digress_out_slots');
+      mapping.put('userLabel', 'user_label');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dialog_node', 'dialogNode');
+      mapping.put('previous_sibling', 'previousSibling');
+      if (output != null) {
+        mapping.putAll(output.getApiToSdkMapping());
+      }
+      mapping.put('next_step', 'nextStep');
+      if (nextStep != null) {
+        mapping.putAll(nextStep.getApiToSdkMapping());
+      }
+      mapping.put('type', 'nodeType');
+      mapping.put('event_name', 'eventName');
+      if (actions != null && actions[0] != null) {
+        mapping.putAll(actions[0].getApiToSdkMapping());
+      }
+      mapping.put('digress_in', 'digressIn');
+      mapping.put('digress_out', 'digressOut');
+      mapping.put('digress_out_slots', 'digressOutSlots');
+      mapping.put('user_label', 'userLabel');
+      return mapping;
     }
   }
 
@@ -4951,27 +5261,27 @@ public class IBMAssistantV1Models {
     private Datetime updated;
 
     private DialogNodeBuilder(DialogNode dialogNode) {
-      this.dialogNode = dialogNode.dialog_node_serialized_name;
-      this.description = dialogNode.description_serialized_name;
-      this.conditions = dialogNode.conditions_serialized_name;
-      this.parent = dialogNode.parent_serialized_name;
-      this.previousSibling = dialogNode.previous_sibling_serialized_name;
-      this.output = dialogNode.output_serialized_name;
-      this.context = dialogNode.context_serialized_name;
-      this.metadata = dialogNode.metadata_serialized_name;
-      this.nextStep = dialogNode.next_step_serialized_name;
-      this.title = dialogNode.title_serialized_name;
-      this.nodeType = dialogNode.type_serialized_name;
-      this.eventName = dialogNode.event_name_serialized_name;
-      this.variable = dialogNode.variable_serialized_name;
-      this.actions = dialogNode.actions_serialized_name;
-      this.digressIn = dialogNode.digress_in_serialized_name;
-      this.digressOut = dialogNode.digress_out_serialized_name;
-      this.digressOutSlots = dialogNode.digress_out_slots_serialized_name;
-      this.userLabel = dialogNode.user_label_serialized_name;
-      this.disabled = dialogNode.disabled_serialized_name;
-      this.created = dialogNode.created_serialized_name;
-      this.updated = dialogNode.updated_serialized_name;
+      this.dialogNode = dialogNode.dialogNode;
+      this.description = dialogNode.description;
+      this.conditions = dialogNode.conditions;
+      this.parent = dialogNode.parent;
+      this.previousSibling = dialogNode.previousSibling;
+      this.output = dialogNode.output;
+      this.context = dialogNode.context;
+      this.metadata = dialogNode.metadata;
+      this.nextStep = dialogNode.nextStep;
+      this.title = dialogNode.title;
+      this.nodeType = dialogNode.nodeType;
+      this.eventName = dialogNode.eventName;
+      this.variable = dialogNode.variable;
+      this.actions = dialogNode.actions;
+      this.digressIn = dialogNode.digressIn;
+      this.digressOut = dialogNode.digressOut;
+      this.digressOutSlots = dialogNode.digressOutSlots;
+      this.userLabel = dialogNode.userLabel;
+      this.disabled = dialogNode.disabled;
+      this.created = dialogNode.created;
+      this.updated = dialogNode.updated;
     }
 
     /**
@@ -5250,11 +5560,17 @@ public class IBMAssistantV1Models {
    * DialogNodeAction.
    */
   public class DialogNodeAction extends IBMWatsonGenericModel {
-    private String name_serialized_name;
-    private String type_serialized_name;
-    private IBMWatsonMapModel parameters_serialized_name;
-    private String result_variable_serialized_name;
-    private String credentials_serialized_name;
+    private String name;
+    private String actionType;
+    private IBMWatsonMapModel parameters;
+    private String resultVariable;
+    private String credentials;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogNodeAction() { }
  
     /**
      * Gets the name.
@@ -5265,7 +5581,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -5277,7 +5593,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getActionType() {
-      return type_serialized_name;
+      return actionType;
     }
  
     /**
@@ -5289,7 +5605,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getParameters() {
-      return parameters_serialized_name;
+      return parameters;
     }
  
     /**
@@ -5301,7 +5617,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getResultVariable() {
-      return result_variable_serialized_name;
+      return resultVariable;
     }
  
     /**
@@ -5313,52 +5629,26 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getCredentials() {
-      return credentials_serialized_name;
+      return credentials;
+    }
+  
+    private DialogNodeAction(DialogNodeActionBuilder builder) {
+      IBMWatsonValidator.notNull(builder.name, 'name cannot be null');
+      IBMWatsonValidator.notNull(builder.resultVariable, 'resultVariable cannot be null');
+      this.name = builder.name;
+      this.actionType = builder.actionType;
+      this.parameters = builder.parameters;
+      this.resultVariable = builder.resultVariable;
+      this.credentials = builder.credentials;
     }
 
     /**
-     * Sets the name.
+     * New builder.
      *
-     * @param name the new name
+     * @return a DialogNodeAction builder
      */
-    public void setName(final String name) {
-      this.name_serialized_name = name;
-    }
-
-    /**
-     * Sets the actionType.
-     *
-     * @param actionType the new actionType
-     */
-    public void setActionType(final String actionType) {
-      this.type_serialized_name = actionType;
-    }
-
-    /**
-     * Sets the parameters.
-     *
-     * @param parameters the new parameters
-     */
-    public void setParameters(final IBMWatsonMapModel parameters) {
-      this.parameters_serialized_name = parameters;
-    }
-
-    /**
-     * Sets the resultVariable.
-     *
-     * @param resultVariable the new resultVariable
-     */
-    public void setResultVariable(final String resultVariable) {
-      this.result_variable_serialized_name = resultVariable;
-    }
-
-    /**
-     * Sets the credentials.
-     *
-     * @param credentials the new credentials
-     */
-    public void setCredentials(final String credentials) {
-      this.credentials_serialized_name = credentials;
+    public DialogNodeActionBuilder newBuilder() {
+      return new DialogNodeActionBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5367,12 +5657,127 @@ public class IBMAssistantV1Models {
       }
 
       DialogNodeAction ret = (DialogNodeAction) super.deserialize(jsonString, jsonMap, classType);
+      DialogNodeActionBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for parameters
-      IBMWatsonMapModel newParameters = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getParameters()), (Map<String, Object>) jsonMap.get('parameters_serialized_name'), IBMWatsonMapModel.class);
-      ret.setParameters(newParameters);
+      IBMWatsonMapModel newParameters = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getParameters()), (Map<String, Object>) jsonMap.get('parameters'), IBMWatsonMapModel.class);
+      retBuilder.setParameters(newParameters);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('actionType', 'type');
+      mapping.put('resultVariable', 'result_variable');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'actionType');
+      mapping.put('result_variable', 'resultVariable');
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogNodeAction Builder.
+   */
+  public class DialogNodeActionBuilder {
+    private String name;
+    private String actionType;
+    private IBMWatsonMapModel parameters;
+    private String resultVariable;
+    private String credentials;
+
+    private DialogNodeActionBuilder(DialogNodeAction dialogNodeAction) {
+      this.name = dialogNodeAction.name;
+      this.actionType = dialogNodeAction.actionType;
+      this.parameters = dialogNodeAction.parameters;
+      this.resultVariable = dialogNodeAction.resultVariable;
+      this.credentials = dialogNodeAction.credentials;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogNodeActionBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param name the name
+     * @param resultVariable the resultVariable
+     */
+    public DialogNodeActionBuilder(String name, String resultVariable) {
+      this.name = name;
+      this.resultVariable = resultVariable;
+    }
+
+    /**
+     * Builds a DialogNodeAction.
+     *
+     * @return the dialogNodeAction
+     */
+    public DialogNodeAction build() {
+      return new DialogNodeAction(this);
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the DialogNodeAction builder
+     */
+    public DialogNodeActionBuilder setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the actionType.
+     *
+     * @param actionType the actionType
+     * @return the DialogNodeAction builder
+     */
+    public DialogNodeActionBuilder setActionType(String actionType) {
+      this.actionType = actionType;
+      return this;
+    }
+
+    /**
+     * Set the parameters.
+     *
+     * @param parameters the parameters
+     * @return the DialogNodeAction builder
+     */
+    public DialogNodeActionBuilder setParameters(IBMWatsonMapModel parameters) {
+      this.parameters = parameters;
+      return this;
+    }
+
+    /**
+     * Set the resultVariable.
+     *
+     * @param resultVariable the resultVariable
+     * @return the DialogNodeAction builder
+     */
+    public DialogNodeActionBuilder setResultVariable(String resultVariable) {
+      this.resultVariable = resultVariable;
+      return this;
+    }
+
+    /**
+     * Set the credentials.
+     *
+     * @param credentials the credentials
+     * @return the DialogNodeAction builder
+     */
+    public DialogNodeActionBuilder setCredentials(String credentials) {
+      this.credentials = credentials;
+      return this;
     }
   }
 
@@ -5380,8 +5785,8 @@ public class IBMAssistantV1Models {
    * An array of dialog nodes.
    */
   public class DialogNodeCollection extends IBMWatsonResponseModel {
-    private List<DialogNode> dialog_nodes_serialized_name;
-    private Pagination pagination_serialized_name;
+    private List<DialogNode> dialogNodes;
+    private Pagination pagination;
  
     /**
      * Gets the dialogNodes.
@@ -5392,7 +5797,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNode> getDialogNodes() {
-      return dialog_nodes_serialized_name;
+      return dialogNodes;
     }
  
     /**
@@ -5404,7 +5809,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -5413,7 +5818,7 @@ public class IBMAssistantV1Models {
      * @param dialogNodes the new dialogNodes
      */
     public void setDialogNodes(final List<DialogNode> dialogNodes) {
-      this.dialog_nodes_serialized_name = dialogNodes;
+      this.dialogNodes = dialogNodes;
     }
 
     /**
@@ -5422,7 +5827,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5438,18 +5843,30 @@ public class IBMAssistantV1Models {
       if (deserializedDialogNodes != null) {
         for (Integer i = 0; i < deserializedDialogNodes.size(); i++) {
           DialogNode currentItem = ret.getDialogNodes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('dialog_nodes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('dialogNodes');
           DialogNode newItem = (DialogNode) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNode.class);
           newDialogNodes.add(newItem);
         }
-        ret.dialog_nodes_serialized_name = newDialogNodes;
+        ret.dialogNodes = newDialogNodes;
       }
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dialog_nodes', 'dialogNodes');
+      if (dialogNodes != null && dialogNodes[0] != null) {
+        mapping.putAll(dialogNodes[0].getApiToSdkMapping());
+      }
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5457,9 +5874,15 @@ public class IBMAssistantV1Models {
    * The next step to execute following this dialog node.
    */
   public class DialogNodeNextStep extends IBMWatsonGenericModel {
-    private String behavior_serialized_name;
-    private String dialog_node_serialized_name;
-    private String selector_serialized_name;
+    private String behavior;
+    private String dialogNode;
+    private String selector;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogNodeNextStep() { }
  
     /**
      * Gets the behavior.
@@ -5489,7 +5912,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getBehavior() {
-      return behavior_serialized_name;
+      return behavior;
     }
  
     /**
@@ -5501,7 +5924,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDialogNode() {
-      return dialog_node_serialized_name;
+      return dialogNode;
     }
  
     /**
@@ -5513,45 +5936,123 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getSelector() {
-      return selector_serialized_name;
+      return selector;
+    }
+  
+    private DialogNodeNextStep(DialogNodeNextStepBuilder builder) {
+      IBMWatsonValidator.notNull(builder.behavior, 'behavior cannot be null');
+      this.behavior = builder.behavior;
+      this.dialogNode = builder.dialogNode;
+      this.selector = builder.selector;
     }
 
     /**
-     * Sets the behavior.
+     * New builder.
      *
-     * @param behavior the new behavior
+     * @return a DialogNodeNextStep builder
      */
-    public void setBehavior(final String behavior) {
-      this.behavior_serialized_name = behavior;
+    public DialogNodeNextStepBuilder newBuilder() {
+      return new DialogNodeNextStepBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dialogNode', 'dialog_node');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dialog_node', 'dialogNode');
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogNodeNextStep Builder.
+   */
+  public class DialogNodeNextStepBuilder {
+    private String behavior;
+    private String dialogNode;
+    private String selector;
+
+    private DialogNodeNextStepBuilder(DialogNodeNextStep dialogNodeNextStep) {
+      this.behavior = dialogNodeNextStep.behavior;
+      this.dialogNode = dialogNodeNextStep.dialogNode;
+      this.selector = dialogNodeNextStep.selector;
     }
 
     /**
-     * Sets the dialogNode.
-     *
-     * @param dialogNode the new dialogNode
+     * Instantiates a new builder.
      */
-    public void setDialogNode(final String dialogNode) {
-      this.dialog_node_serialized_name = dialogNode;
+    public DialogNodeNextStepBuilder() {
     }
 
     /**
-     * Sets the selector.
+     * Instantiates a new builder with required properties.
      *
-     * @param selector the new selector
+     * @param behavior the behavior
      */
-    public void setSelector(final String selector) {
-      this.selector_serialized_name = selector;
+    public DialogNodeNextStepBuilder(String behavior) {
+      this.behavior = behavior;
     }
 
+    /**
+     * Builds a DialogNodeNextStep.
+     *
+     * @return the dialogNodeNextStep
+     */
+    public DialogNodeNextStep build() {
+      return new DialogNodeNextStep(this);
+    }
+
+    /**
+     * Set the behavior.
+     *
+     * @param behavior the behavior
+     * @return the DialogNodeNextStep builder
+     */
+    public DialogNodeNextStepBuilder setBehavior(String behavior) {
+      this.behavior = behavior;
+      return this;
+    }
+
+    /**
+     * Set the dialogNode.
+     *
+     * @param dialogNode the dialogNode
+     * @return the DialogNodeNextStep builder
+     */
+    public DialogNodeNextStepBuilder setDialogNode(String dialogNode) {
+      this.dialogNode = dialogNode;
+      return this;
+    }
+
+    /**
+     * Set the selector.
+     *
+     * @param selector the selector
+     * @return the DialogNodeNextStep builder
+     */
+    public DialogNodeNextStepBuilder setSelector(String selector) {
+      this.selector = selector;
+      return this;
+    }
   }
 
   /**
    * The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-dialog-overview#dialog-overview-responses).
    */
   public class DialogNodeOutput extends IBMWatsonDynamicModel {
-    private List<DialogNodeOutputGeneric> generic_serialized_name;
-    private DialogNodeOutputModifiers modifiers_serialized_name;
+    private List<DialogNodeOutputGeneric> generic;
+    private DialogNodeOutputModifiers modifiers;
     private Map<String, Object> additional_properties_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogNodeOutput() { }
 
     /**
      * Gets the generic.
@@ -5560,7 +6061,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNodeOutputGeneric> getGeneric() {
-      return generic_serialized_name;
+      return generic;
     }
 
     /**
@@ -5570,7 +6071,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public DialogNodeOutputModifiers getModifiers() {
-      return modifiers_serialized_name;
+      return modifiers;
     }
 
     /**
@@ -5583,22 +6084,18 @@ public class IBMAssistantV1Models {
       return this.getDynamicProperties();
     }
 
-    /**
-     * Sets the generic.
-     *
-     * @param generic the new generic
-     */
-    public void setGeneric(final List<DialogNodeOutputGeneric> generic) {
-      this.generic_serialized_name = generic;
+    private DialogNodeOutput(DialogNodeOutputBuilder builder) {
+      this.generic = builder.generic;
+      this.modifiers = builder.modifiers;
     }
 
     /**
-     * Sets the modifiers.
+     * New builder.
      *
-     * @param modifiers the new modifiers
+     * @return a DialogNodeOutput builder
      */
-    public void setModifiers(final DialogNodeOutputModifiers modifiers) {
-      this.modifiers_serialized_name = modifiers;
+    public DialogNodeOutputBuilder newBuilder() {
+      return new DialogNodeOutputBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5607,6 +6104,7 @@ public class IBMAssistantV1Models {
       }
 
       DialogNodeOutput ret = (DialogNodeOutput) super.deserialize(jsonString, jsonMap, classType);
+      DialogNodeOutputBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for generic
       List<DialogNodeOutputGeneric> newGeneric = new List<DialogNodeOutputGeneric>();
@@ -5614,26 +6112,108 @@ public class IBMAssistantV1Models {
       if (deserializedGeneric != null) {
         for (Integer i = 0; i < deserializedGeneric.size(); i++) {
           DialogNodeOutputGeneric currentItem = ret.getGeneric().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('generic_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('generic');
           DialogNodeOutputGeneric newItem = (DialogNodeOutputGeneric) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeOutputGeneric.class);
           newGeneric.add(newItem);
         }
-        ret.setGeneric(newGeneric);
+        retBuilder.setGeneric(newGeneric);
       }
 
       // calling custom deserializer for modifiers
-      DialogNodeOutputModifiers newModifiers = (DialogNodeOutputModifiers) new DialogNodeOutputModifiers().deserialize(JSON.serialize(ret.getModifiers()), (Map<String, Object>) jsonMap.get('modifiers_serialized_name'), DialogNodeOutputModifiers.class);
-      ret.setModifiers(newModifiers);
+      DialogNodeOutputModifiers newModifiers = (DialogNodeOutputModifiers) new DialogNodeOutputModifiers().deserialize(JSON.serialize(ret.getModifiers()), (Map<String, Object>) jsonMap.get('modifiers'), DialogNodeOutputModifiers.class);
+      retBuilder.setModifiers(newModifiers);
 
+      DialogNodeOutput builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
 
       for (String key : jsonMap.keySet()) {
         if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
+          builderResult.put(key, jsonMap.get(key));
         }
       }
 
-      return ret;
+      return builderResult;
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (generic != null && generic[0] != null) {
+        mapping.putAll(generic[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (generic != null && generic[0] != null) {
+        mapping.putAll(generic[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogNodeOutput Builder.
+   */
+  public class DialogNodeOutputBuilder {
+    private List<DialogNodeOutputGeneric> generic;
+    private DialogNodeOutputModifiers modifiers;
+
+    private DialogNodeOutputBuilder(DialogNodeOutput dialogNodeOutput) {
+      this.generic = dialogNodeOutput.generic;
+      this.modifiers = dialogNodeOutput.modifiers;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogNodeOutputBuilder() { }
+
+    /**
+     * Builds a DialogNodeOutput.
+     *
+     * @return the dialogNodeOutput
+     */
+    public DialogNodeOutput build() {
+      return new DialogNodeOutput(this);
+    }
+
+    /**
+     * Adds an generic to generic.
+     *
+     * @param generic the new generic
+     * @return the DialogNodeOutput builder
+     */
+    public DialogNodeOutputBuilder addGeneric(DialogNodeOutputGeneric generic) {
+      IBMWatsonValidator.notNull(generic, 'generic cannot be null');
+      if (this.generic == null) {
+        this.generic = new List<DialogNodeOutputGeneric>();
+      }
+      this.generic.add(generic);
+      return this;
+    }
+
+    /**
+     * Set the generic.
+     * Existing generic will be replaced.
+     *
+     * @param generic the generic
+     * @return the DialogNodeOutput builder
+     */
+    public DialogNodeOutputBuilder setGeneric(List<DialogNodeOutputGeneric> generic) {
+      this.generic = generic;
+      return this;
+    }
+
+    /**
+     * Set the modifiers.
+     *
+     * @param modifiers the modifiers
+     * @return the DialogNodeOutput builder
+     */
+    public DialogNodeOutputBuilder setModifiers(DialogNodeOutputModifiers modifiers) {
+      this.modifiers = modifiers;
+      return this;
     }
   }
 
@@ -5641,18 +6221,24 @@ public class IBMAssistantV1Models {
    * DialogNodeOutputGeneric.
    */
   public class DialogNodeOutputGeneric extends IBMWatsonGenericModel {
-    private String response_type_serialized_name;
-    private List<DialogNodeOutputTextValuesElement> values_serialized_name;
-    private String selection_policy_serialized_name;
-    private String delimiter_serialized_name;
-    private Long time_serialized_name;
-    private Boolean typing_serialized_name;
-    private String source_serialized_name;
-    private String title_serialized_name;
-    private String description_serialized_name;
-    private String preference_serialized_name;
-    private List<DialogNodeOutputOptionsElement> options_serialized_name;
-    private String message_to_human_agent_serialized_name;
+    private String responseType;
+    private List<DialogNodeOutputTextValuesElement> values;
+    private String selectionPolicy;
+    private String delimiter;
+    private Long xtime;
+    private Boolean typing;
+    private String source;
+    private String title;
+    private String description;
+    private String preference;
+    private List<DialogNodeOutputOptionsElement> options;
+    private String messageToHumanAgent;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogNodeOutputGeneric() { }
  
     /**
      * Gets the responseType.
@@ -5664,7 +6250,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getResponseType() {
-      return response_type_serialized_name;
+      return responseType;
     }
  
     /**
@@ -5676,7 +6262,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNodeOutputTextValuesElement> getValues() {
-      return values_serialized_name;
+      return values;
     }
  
     /**
@@ -5689,7 +6275,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getSelectionPolicy() {
-      return selection_policy_serialized_name;
+      return selectionPolicy;
     }
  
     /**
@@ -5701,7 +6287,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDelimiter() {
-      return delimiter_serialized_name;
+      return delimiter;
     }
  
     /**
@@ -5714,7 +6300,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Long getXtime() {
-      return time_serialized_name;
+      return xtime;
     }
  
     /**
@@ -5727,7 +6313,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getTyping() {
-      return typing_serialized_name;
+      return typing;
     }
  
     /**
@@ -5739,7 +6325,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getSource() {
-      return source_serialized_name;
+      return source;
     }
  
     /**
@@ -5751,7 +6337,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -5763,7 +6349,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -5776,7 +6362,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getPreference() {
-      return preference_serialized_name;
+      return preference;
     }
  
     /**
@@ -5789,7 +6375,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNodeOutputOptionsElement> getOptions() {
-      return options_serialized_name;
+      return options;
     }
  
     /**
@@ -5802,115 +6388,32 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getMessageToHumanAgent() {
-      return message_to_human_agent_serialized_name;
+      return messageToHumanAgent;
+    }
+  
+    private DialogNodeOutputGeneric(DialogNodeOutputGenericBuilder builder) {
+      IBMWatsonValidator.notNull(builder.responseType, 'responseType cannot be null');
+      this.responseType = builder.responseType;
+      this.values = builder.values;
+      this.selectionPolicy = builder.selectionPolicy;
+      this.delimiter = builder.delimiter;
+      this.xtime = builder.xtime;
+      this.typing = builder.typing;
+      this.source = builder.source;
+      this.title = builder.title;
+      this.description = builder.description;
+      this.preference = builder.preference;
+      this.options = builder.options;
+      this.messageToHumanAgent = builder.messageToHumanAgent;
     }
 
     /**
-     * Sets the responseType.
+     * New builder.
      *
-     * @param responseType the new responseType
+     * @return a DialogNodeOutputGeneric builder
      */
-    public void setResponseType(final String responseType) {
-      this.response_type_serialized_name = responseType;
-    }
-
-    /**
-     * Sets the values.
-     *
-     * @param values the new values
-     */
-    public void setValues(final List<DialogNodeOutputTextValuesElement> values) {
-      this.values_serialized_name = values;
-    }
-
-    /**
-     * Sets the selectionPolicy.
-     *
-     * @param selectionPolicy the new selectionPolicy
-     */
-    public void setSelectionPolicy(final String selectionPolicy) {
-      this.selection_policy_serialized_name = selectionPolicy;
-    }
-
-    /**
-     * Sets the delimiter.
-     *
-     * @param delimiter the new delimiter
-     */
-    public void setDelimiter(final String delimiter) {
-      this.delimiter_serialized_name = delimiter;
-    }
-
-    /**
-     * Sets the xtime.
-     *
-     * @param xtime the new xtime
-     */
-    public void setXtime(final long xtime) {
-      this.time_serialized_name = xtime;
-    }
-
-    /**
-     * Sets the typing.
-     *
-     * @param typing the new typing
-     */
-    public void setTyping(final Boolean typing) {
-      this.typing_serialized_name = typing;
-    }
-
-    /**
-     * Sets the source.
-     *
-     * @param source the new source
-     */
-    public void setSource(final String source) {
-      this.source_serialized_name = source;
-    }
-
-    /**
-     * Sets the title.
-     *
-     * @param title the new title
-     */
-    public void setTitle(final String title) {
-      this.title_serialized_name = title;
-    }
-
-    /**
-     * Sets the description.
-     *
-     * @param description the new description
-     */
-    public void setDescription(final String description) {
-      this.description_serialized_name = description;
-    }
-
-    /**
-     * Sets the preference.
-     *
-     * @param preference the new preference
-     */
-    public void setPreference(final String preference) {
-      this.preference_serialized_name = preference;
-    }
-
-    /**
-     * Sets the options.
-     *
-     * @param options the new options
-     */
-    public void setOptions(final List<DialogNodeOutputOptionsElement> options) {
-      this.options_serialized_name = options;
-    }
-
-    /**
-     * Sets the messageToHumanAgent.
-     *
-     * @param messageToHumanAgent the new messageToHumanAgent
-     */
-    public void setMessageToHumanAgent(final String messageToHumanAgent) {
-      this.message_to_human_agent_serialized_name = messageToHumanAgent;
+    public DialogNodeOutputGenericBuilder newBuilder() {
+      return new DialogNodeOutputGenericBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5919,6 +6422,7 @@ public class IBMAssistantV1Models {
       }
 
       DialogNodeOutputGeneric ret = (DialogNodeOutputGeneric) super.deserialize(jsonString, jsonMap, classType);
+      DialogNodeOutputGenericBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for values
       List<DialogNodeOutputTextValuesElement> newValues = new List<DialogNodeOutputTextValuesElement>();
@@ -5926,11 +6430,11 @@ public class IBMAssistantV1Models {
       if (deserializedValues != null) {
         for (Integer i = 0; i < deserializedValues.size(); i++) {
           DialogNodeOutputTextValuesElement currentItem = ret.getValues().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('values_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('values');
           DialogNodeOutputTextValuesElement newItem = (DialogNodeOutputTextValuesElement) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeOutputTextValuesElement.class);
           newValues.add(newItem);
         }
-        ret.values_serialized_name = newValues;
+        retBuilder.setValues(newValues);
       }
 
       // calling custom deserializer for options
@@ -5939,14 +6443,259 @@ public class IBMAssistantV1Models {
       if (deserializedOptions != null) {
         for (Integer i = 0; i < deserializedOptions.size(); i++) {
           DialogNodeOutputOptionsElement currentItem = ret.getOptions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('options_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('options');
           DialogNodeOutputOptionsElement newItem = (DialogNodeOutputOptionsElement) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeOutputOptionsElement.class);
           newOptions.add(newItem);
         }
-        ret.options_serialized_name = newOptions;
+        retBuilder.setOptions(newOptions);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('responseType', 'response_type');
+      mapping.put('selectionPolicy', 'selection_policy');
+      mapping.put('xtime', 'time');
+      if (options != null && options[0] != null) {
+        mapping.putAll(options[0].getSdkToApiMapping());
+      }
+      mapping.put('messageToHumanAgent', 'message_to_human_agent');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('response_type', 'responseType');
+      mapping.put('selection_policy', 'selectionPolicy');
+      mapping.put('time', 'xtime');
+      if (options != null && options[0] != null) {
+        mapping.putAll(options[0].getApiToSdkMapping());
+      }
+      mapping.put('message_to_human_agent', 'messageToHumanAgent');
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogNodeOutputGeneric Builder.
+   */
+  public class DialogNodeOutputGenericBuilder {
+    private String responseType;
+    private List<DialogNodeOutputTextValuesElement> values;
+    private String selectionPolicy;
+    private String delimiter;
+    private Long xtime;
+    private Boolean typing;
+    private String source;
+    private String title;
+    private String description;
+    private String preference;
+    private List<DialogNodeOutputOptionsElement> options;
+    private String messageToHumanAgent;
+
+    private DialogNodeOutputGenericBuilder(DialogNodeOutputGeneric dialogNodeOutputGeneric) {
+      this.responseType = dialogNodeOutputGeneric.responseType;
+      this.values = dialogNodeOutputGeneric.values;
+      this.selectionPolicy = dialogNodeOutputGeneric.selectionPolicy;
+      this.delimiter = dialogNodeOutputGeneric.delimiter;
+      this.xtime = dialogNodeOutputGeneric.xtime;
+      this.typing = dialogNodeOutputGeneric.typing;
+      this.source = dialogNodeOutputGeneric.source;
+      this.title = dialogNodeOutputGeneric.title;
+      this.description = dialogNodeOutputGeneric.description;
+      this.preference = dialogNodeOutputGeneric.preference;
+      this.options = dialogNodeOutputGeneric.options;
+      this.messageToHumanAgent = dialogNodeOutputGeneric.messageToHumanAgent;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogNodeOutputGenericBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param responseType the responseType
+     */
+    public DialogNodeOutputGenericBuilder(String responseType) {
+      this.responseType = responseType;
+    }
+
+    /**
+     * Builds a DialogNodeOutputGeneric.
+     *
+     * @return the dialogNodeOutputGeneric
+     */
+    public DialogNodeOutputGeneric build() {
+      return new DialogNodeOutputGeneric(this);
+    }
+
+    /**
+     * Adds an values to values.
+     *
+     * @param values the new values
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder addValues(DialogNodeOutputTextValuesElement values) {
+      IBMWatsonValidator.notNull(values, 'values cannot be null');
+      if (this.values == null) {
+        this.values = new List<DialogNodeOutputTextValuesElement>();
+      }
+      this.values.add(values);
+      return this;
+    }
+
+    /**
+     * Adds an options to options.
+     *
+     * @param options the new options
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder addOptions(DialogNodeOutputOptionsElement options) {
+      IBMWatsonValidator.notNull(options, 'options cannot be null');
+      if (this.options == null) {
+        this.options = new List<DialogNodeOutputOptionsElement>();
+      }
+      this.options.add(options);
+      return this;
+    }
+
+    /**
+     * Set the responseType.
+     *
+     * @param responseType the responseType
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setResponseType(String responseType) {
+      this.responseType = responseType;
+      return this;
+    }
+
+    /**
+     * Set the values.
+     * Existing values will be replaced.
+     *
+     * @param values the values
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setValues(List<DialogNodeOutputTextValuesElement> values) {
+      this.values = values;
+      return this;
+    }
+
+    /**
+     * Set the selectionPolicy.
+     *
+     * @param selectionPolicy the selectionPolicy
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setSelectionPolicy(String selectionPolicy) {
+      this.selectionPolicy = selectionPolicy;
+      return this;
+    }
+
+    /**
+     * Set the delimiter.
+     *
+     * @param delimiter the delimiter
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setDelimiter(String delimiter) {
+      this.delimiter = delimiter;
+      return this;
+    }
+
+    /**
+     * Set the xtime.
+     *
+     * @param xtime the xtime
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setXtime(Long xtime) {
+      this.xtime = xtime;
+      return this;
+    }
+
+    /**
+     * Set the typing.
+     *
+     * @param typing the typing
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setTyping(Boolean typing) {
+      this.typing = typing;
+      return this;
+    }
+
+    /**
+     * Set the source.
+     *
+     * @param source the source
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setSource(String source) {
+      this.source = source;
+      return this;
+    }
+
+    /**
+     * Set the title.
+     *
+     * @param title the title
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setTitle(String title) {
+      this.title = title;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the preference.
+     *
+     * @param preference the preference
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setPreference(String preference) {
+      this.preference = preference;
+      return this;
+    }
+
+    /**
+     * Set the options.
+     * Existing options will be replaced.
+     *
+     * @param options the options
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setOptions(List<DialogNodeOutputOptionsElement> options) {
+      this.options = options;
+      return this;
+    }
+
+    /**
+     * Set the messageToHumanAgent.
+     *
+     * @param messageToHumanAgent the messageToHumanAgent
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder setMessageToHumanAgent(String messageToHumanAgent) {
+      this.messageToHumanAgent = messageToHumanAgent;
+      return this;
     }
   }
 
@@ -5954,7 +6703,13 @@ public class IBMAssistantV1Models {
    * Options that modify how specified output is handled.
    */
   public class DialogNodeOutputModifiers extends IBMWatsonGenericModel {
-    private Boolean overwrite_serialized_name;
+    private Boolean overwrite;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogNodeOutputModifiers() { }
  
     /**
      * Gets the overwrite.
@@ -5966,26 +6721,72 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getOverwrite() {
-      return overwrite_serialized_name;
+      return overwrite;
+    }
+  
+    private DialogNodeOutputModifiers(DialogNodeOutputModifiersBuilder builder) {
+      this.overwrite = builder.overwrite;
     }
 
     /**
-     * Sets the overwrite.
+     * New builder.
      *
-     * @param overwrite the new overwrite
+     * @return a DialogNodeOutputModifiers builder
      */
-    public void setOverwrite(final Boolean overwrite) {
-      this.overwrite_serialized_name = overwrite;
+    public DialogNodeOutputModifiersBuilder newBuilder() {
+      return new DialogNodeOutputModifiersBuilder(this);
+    }
+  }
+
+  /**
+   * DialogNodeOutputModifiers Builder.
+   */
+  public class DialogNodeOutputModifiersBuilder {
+    private Boolean overwrite;
+
+    private DialogNodeOutputModifiersBuilder(DialogNodeOutputModifiers dialogNodeOutputModifiers) {
+      this.overwrite = dialogNodeOutputModifiers.overwrite;
     }
 
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogNodeOutputModifiersBuilder() {
+    }
+
+    /**
+     * Builds a DialogNodeOutputModifiers.
+     *
+     * @return the dialogNodeOutputModifiers
+     */
+    public DialogNodeOutputModifiers build() {
+      return new DialogNodeOutputModifiers(this);
+    }
+
+    /**
+     * Set the overwrite.
+     *
+     * @param overwrite the overwrite
+     * @return the DialogNodeOutputModifiers builder
+     */
+    public DialogNodeOutputModifiersBuilder setOverwrite(Boolean overwrite) {
+      this.overwrite = overwrite;
+      return this;
+    }
   }
 
   /**
    * DialogNodeOutputOptionsElement.
    */
   public class DialogNodeOutputOptionsElement extends IBMWatsonGenericModel {
-    private String label_serialized_name;
-    private DialogNodeOutputOptionsElementValue value_serialized_name;
+    private String label;
+    private DialogNodeOutputOptionsElementValue value;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogNodeOutputOptionsElement() { }
  
     /**
      * Gets the label.
@@ -5996,7 +6797,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getLabel() {
-      return label_serialized_name;
+      return label;
     }
  
     /**
@@ -6009,25 +6810,23 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public DialogNodeOutputOptionsElementValue getValue() {
-      return value_serialized_name;
+      return value;
+    }
+  
+    private DialogNodeOutputOptionsElement(DialogNodeOutputOptionsElementBuilder builder) {
+      IBMWatsonValidator.notNull(builder.label, 'label cannot be null');
+      IBMWatsonValidator.notNull(builder.value, 'value cannot be null');
+      this.label = builder.label;
+      this.value = builder.value;
     }
 
     /**
-     * Sets the label.
+     * New builder.
      *
-     * @param label the new label
+     * @return a DialogNodeOutputOptionsElement builder
      */
-    public void setLabel(final String label) {
-      this.label_serialized_name = label;
-    }
-
-    /**
-     * Sets the value.
-     *
-     * @param value the new value
-     */
-    public void setValue(final DialogNodeOutputOptionsElementValue value) {
-      this.value_serialized_name = value;
+    public DialogNodeOutputOptionsElementBuilder newBuilder() {
+      return new DialogNodeOutputOptionsElementBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6036,12 +6835,90 @@ public class IBMAssistantV1Models {
       }
 
       DialogNodeOutputOptionsElement ret = (DialogNodeOutputOptionsElement) super.deserialize(jsonString, jsonMap, classType);
+      DialogNodeOutputOptionsElementBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for value
-      DialogNodeOutputOptionsElementValue newValue = (DialogNodeOutputOptionsElementValue) new DialogNodeOutputOptionsElementValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value_serialized_name'), DialogNodeOutputOptionsElementValue.class);
-      ret.setValue(newValue);
+      DialogNodeOutputOptionsElementValue newValue = (DialogNodeOutputOptionsElementValue) new DialogNodeOutputOptionsElementValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value'), DialogNodeOutputOptionsElementValue.class);
+      retBuilder.setValue(newValue);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (value != null) {
+        mapping.putAll(value.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (value != null) {
+        mapping.putAll(value.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogNodeOutputOptionsElement Builder.
+   */
+  public class DialogNodeOutputOptionsElementBuilder {
+    private String label;
+    private DialogNodeOutputOptionsElementValue value;
+
+    private DialogNodeOutputOptionsElementBuilder(DialogNodeOutputOptionsElement dialogNodeOutputOptionsElement) {
+      this.label = dialogNodeOutputOptionsElement.label;
+      this.value = dialogNodeOutputOptionsElement.value;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogNodeOutputOptionsElementBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param label the label
+     * @param value the value
+     */
+    public DialogNodeOutputOptionsElementBuilder(String label, DialogNodeOutputOptionsElementValue value) {
+      this.label = label;
+      this.value = value;
+    }
+
+    /**
+     * Builds a DialogNodeOutputOptionsElement.
+     *
+     * @return the dialogNodeOutputOptionsElement
+     */
+    public DialogNodeOutputOptionsElement build() {
+      return new DialogNodeOutputOptionsElement(this);
+    }
+
+    /**
+     * Set the label.
+     *
+     * @param label the label
+     * @return the DialogNodeOutputOptionsElement builder
+     */
+    public DialogNodeOutputOptionsElementBuilder setLabel(String label) {
+      this.label = label;
+      return this;
+    }
+
+    /**
+     * Set the value.
+     *
+     * @param value the value
+     * @return the DialogNodeOutputOptionsElement builder
+     */
+    public DialogNodeOutputOptionsElementBuilder setValue(DialogNodeOutputOptionsElementValue value) {
+      this.value = value;
+      return this;
     }
   }
 
@@ -6050,9 +6927,15 @@ public class IBMAssistantV1Models {
    * corresponding option.
    */
   public class DialogNodeOutputOptionsElementValue extends IBMWatsonGenericModel {
-    private MessageInput input_serialized_name;
-    private List<RuntimeIntent> intents_serialized_name;
-    private List<RuntimeEntity> entities_serialized_name;
+    private MessageInput input;
+    private List<RuntimeIntent> intents;
+    private List<RuntimeEntity> entities;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogNodeOutputOptionsElementValue() { }
  
     /**
      * Gets the input.
@@ -6063,7 +6946,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public MessageInput getInput() {
-      return input_serialized_name;
+      return input;
     }
  
     /**
@@ -6078,7 +6961,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<RuntimeIntent> getIntents() {
-      return intents_serialized_name;
+      return intents;
     }
  
     /**
@@ -6093,34 +6976,22 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<RuntimeEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
+    }
+  
+    private DialogNodeOutputOptionsElementValue(DialogNodeOutputOptionsElementValueBuilder builder) {
+      this.input = builder.input;
+      this.intents = builder.intents;
+      this.entities = builder.entities;
     }
 
     /**
-     * Sets the input.
+     * New builder.
      *
-     * @param input the new input
+     * @return a DialogNodeOutputOptionsElementValue builder
      */
-    public void setInput(final MessageInput input) {
-      this.input_serialized_name = input;
-    }
-
-    /**
-     * Sets the intents.
-     *
-     * @param intents the new intents
-     */
-    public void setIntents(final List<RuntimeIntent> intents) {
-      this.intents_serialized_name = intents;
-    }
-
-    /**
-     * Sets the entities.
-     *
-     * @param entities the new entities
-     */
-    public void setEntities(final List<RuntimeEntity> entities) {
-      this.entities_serialized_name = entities;
+    public DialogNodeOutputOptionsElementValueBuilder newBuilder() {
+      return new DialogNodeOutputOptionsElementValueBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6129,10 +7000,11 @@ public class IBMAssistantV1Models {
       }
 
       DialogNodeOutputOptionsElementValue ret = (DialogNodeOutputOptionsElementValue) super.deserialize(jsonString, jsonMap, classType);
+      DialogNodeOutputOptionsElementValueBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for input
-      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input_serialized_name'), MessageInput.class);
-      ret.setInput(newInput);
+      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input'), MessageInput.class);
+      retBuilder.setInput(newInput);
 
       // calling custom deserializer for intents
       List<RuntimeIntent> newIntents = new List<RuntimeIntent>();
@@ -6140,11 +7012,11 @@ public class IBMAssistantV1Models {
       if (deserializedIntents != null) {
         for (Integer i = 0; i < deserializedIntents.size(); i++) {
           RuntimeIntent currentItem = ret.getIntents().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('intents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('intents');
           RuntimeIntent newItem = (RuntimeIntent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeIntent.class);
           newIntents.add(newItem);
         }
-        ret.intents_serialized_name = newIntents;
+        retBuilder.setIntents(newIntents);
       }
 
       // calling custom deserializer for entities
@@ -6153,14 +7025,125 @@ public class IBMAssistantV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           RuntimeEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           RuntimeEntity newItem = (RuntimeEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeEntity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        retBuilder.setEntities(newEntities);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogNodeOutputOptionsElementValue Builder.
+   */
+  public class DialogNodeOutputOptionsElementValueBuilder {
+    private MessageInput input;
+    private List<RuntimeIntent> intents;
+    private List<RuntimeEntity> entities;
+
+    private DialogNodeOutputOptionsElementValueBuilder(DialogNodeOutputOptionsElementValue dialogNodeOutputOptionsElementValue) {
+      this.input = dialogNodeOutputOptionsElementValue.input;
+      this.intents = dialogNodeOutputOptionsElementValue.intents;
+      this.entities = dialogNodeOutputOptionsElementValue.entities;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogNodeOutputOptionsElementValueBuilder() {
+    }
+
+    /**
+     * Builds a DialogNodeOutputOptionsElementValue.
+     *
+     * @return the dialogNodeOutputOptionsElementValue
+     */
+    public DialogNodeOutputOptionsElementValue build() {
+      return new DialogNodeOutputOptionsElementValue(this);
+    }
+
+    /**
+     * Adds an intents to intents.
+     *
+     * @param intents the new intents
+     * @return the DialogNodeOutputOptionsElementValue builder
+     */
+    public DialogNodeOutputOptionsElementValueBuilder addIntents(RuntimeIntent intents) {
+      IBMWatsonValidator.notNull(intents, 'intents cannot be null');
+      if (this.intents == null) {
+        this.intents = new List<RuntimeIntent>();
+      }
+      this.intents.add(intents);
+      return this;
+    }
+
+    /**
+     * Adds an entities to entities.
+     *
+     * @param entities the new entities
+     * @return the DialogNodeOutputOptionsElementValue builder
+     */
+    public DialogNodeOutputOptionsElementValueBuilder addEntities(RuntimeEntity entities) {
+      IBMWatsonValidator.notNull(entities, 'entities cannot be null');
+      if (this.entities == null) {
+        this.entities = new List<RuntimeEntity>();
+      }
+      this.entities.add(entities);
+      return this;
+    }
+
+    /**
+     * Set the input.
+     *
+     * @param input the input
+     * @return the DialogNodeOutputOptionsElementValue builder
+     */
+    public DialogNodeOutputOptionsElementValueBuilder setInput(MessageInput input) {
+      this.input = input;
+      return this;
+    }
+
+    /**
+     * Set the intents.
+     * Existing intents will be replaced.
+     *
+     * @param intents the intents
+     * @return the DialogNodeOutputOptionsElementValue builder
+     */
+    public DialogNodeOutputOptionsElementValueBuilder setIntents(List<RuntimeIntent> intents) {
+      this.intents = intents;
+      return this;
+    }
+
+    /**
+     * Set the entities.
+     * Existing entities will be replaced.
+     *
+     * @param entities the entities
+     * @return the DialogNodeOutputOptionsElementValue builder
+     */
+    public DialogNodeOutputOptionsElementValueBuilder setEntities(List<RuntimeEntity> entities) {
+      this.entities = entities;
+      return this;
     }
   }
 
@@ -6168,7 +7151,13 @@ public class IBMAssistantV1Models {
    * DialogNodeOutputTextValuesElement.
    */
   public class DialogNodeOutputTextValuesElement extends IBMWatsonGenericModel {
-    private String text_serialized_name;
+    private String text;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogNodeOutputTextValuesElement() { }
  
     /**
      * Gets the text.
@@ -6180,27 +7169,73 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
+    }
+  
+    private DialogNodeOutputTextValuesElement(DialogNodeOutputTextValuesElementBuilder builder) {
+      this.text = builder.text;
     }
 
     /**
-     * Sets the text.
+     * New builder.
      *
-     * @param text the new text
+     * @return a DialogNodeOutputTextValuesElement builder
      */
-    public void setText(final String text) {
-      this.text_serialized_name = text;
+    public DialogNodeOutputTextValuesElementBuilder newBuilder() {
+      return new DialogNodeOutputTextValuesElementBuilder(this);
+    }
+  }
+
+  /**
+   * DialogNodeOutputTextValuesElement Builder.
+   */
+  public class DialogNodeOutputTextValuesElementBuilder {
+    private String text;
+
+    private DialogNodeOutputTextValuesElementBuilder(DialogNodeOutputTextValuesElement dialogNodeOutputTextValuesElement) {
+      this.text = dialogNodeOutputTextValuesElement.text;
     }
 
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogNodeOutputTextValuesElementBuilder() {
+    }
+
+    /**
+     * Builds a DialogNodeOutputTextValuesElement.
+     *
+     * @return the dialogNodeOutputTextValuesElement
+     */
+    public DialogNodeOutputTextValuesElement build() {
+      return new DialogNodeOutputTextValuesElement(this);
+    }
+
+    /**
+     * Set the text.
+     *
+     * @param text the text
+     * @return the DialogNodeOutputTextValuesElement builder
+     */
+    public DialogNodeOutputTextValuesElementBuilder setText(String text) {
+      this.text = text;
+      return this;
+    }
   }
 
   /**
    * DialogNodeVisitedDetails.
    */
   public class DialogNodeVisitedDetails extends IBMWatsonGenericModel {
-    private String dialog_node_serialized_name;
-    private String title_serialized_name;
-    private String conditions_serialized_name;
+    private String dialogNode;
+    private String title;
+    private String conditions;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogNodeVisitedDetails() { }
  
     /**
      * Gets the dialogNode.
@@ -6211,7 +7246,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDialogNode() {
-      return dialog_node_serialized_name;
+      return dialogNode;
     }
  
     /**
@@ -6223,7 +7258,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -6235,55 +7270,123 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getConditions() {
-      return conditions_serialized_name;
+      return conditions;
+    }
+  
+    private DialogNodeVisitedDetails(DialogNodeVisitedDetailsBuilder builder) {
+      this.dialogNode = builder.dialogNode;
+      this.title = builder.title;
+      this.conditions = builder.conditions;
     }
 
     /**
-     * Sets the dialogNode.
+     * New builder.
      *
-     * @param dialogNode the new dialogNode
+     * @return a DialogNodeVisitedDetails builder
      */
-    public void setDialogNode(final String dialogNode) {
-      this.dialog_node_serialized_name = dialogNode;
+    public DialogNodeVisitedDetailsBuilder newBuilder() {
+      return new DialogNodeVisitedDetailsBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dialogNode', 'dialog_node');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dialog_node', 'dialogNode');
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogNodeVisitedDetails Builder.
+   */
+  public class DialogNodeVisitedDetailsBuilder {
+    private String dialogNode;
+    private String title;
+    private String conditions;
+
+    private DialogNodeVisitedDetailsBuilder(DialogNodeVisitedDetails dialogNodeVisitedDetails) {
+      this.dialogNode = dialogNodeVisitedDetails.dialogNode;
+      this.title = dialogNodeVisitedDetails.title;
+      this.conditions = dialogNodeVisitedDetails.conditions;
     }
 
     /**
-     * Sets the title.
-     *
-     * @param title the new title
+     * Instantiates a new builder.
      */
-    public void setTitle(final String title) {
-      this.title_serialized_name = title;
+    public DialogNodeVisitedDetailsBuilder() {
     }
 
     /**
-     * Sets the conditions.
+     * Builds a DialogNodeVisitedDetails.
      *
-     * @param conditions the new conditions
+     * @return the dialogNodeVisitedDetails
      */
-    public void setConditions(final String conditions) {
-      this.conditions_serialized_name = conditions;
+    public DialogNodeVisitedDetails build() {
+      return new DialogNodeVisitedDetails(this);
     }
 
+    /**
+     * Set the dialogNode.
+     *
+     * @param dialogNode the dialogNode
+     * @return the DialogNodeVisitedDetails builder
+     */
+    public DialogNodeVisitedDetailsBuilder setDialogNode(String dialogNode) {
+      this.dialogNode = dialogNode;
+      return this;
+    }
+
+    /**
+     * Set the title.
+     *
+     * @param title the title
+     * @return the DialogNodeVisitedDetails builder
+     */
+    public DialogNodeVisitedDetailsBuilder setTitle(String title) {
+      this.title = title;
+      return this;
+    }
+
+    /**
+     * Set the conditions.
+     *
+     * @param conditions the conditions
+     * @return the DialogNodeVisitedDetails builder
+     */
+    public DialogNodeVisitedDetailsBuilder setConditions(String conditions) {
+      this.conditions = conditions;
+      return this;
+    }
   }
 
   /**
    * DialogRuntimeResponseGeneric.
    */
   public class DialogRuntimeResponseGeneric extends IBMWatsonGenericModel {
-    private String response_type_serialized_name;
-    private String text_serialized_name;
-    private Long time_serialized_name;
-    private Boolean typing_serialized_name;
-    private String source_serialized_name;
-    private String title_serialized_name;
-    private String description_serialized_name;
-    private String preference_serialized_name;
-    private List<DialogNodeOutputOptionsElement> options_serialized_name;
-    private String message_to_human_agent_serialized_name;
-    private String topic_serialized_name;
-    private String dialog_node_serialized_name;
-    private List<DialogSuggestion> suggestions_serialized_name;
+    private String responseType;
+    private String text;
+    private Long xtime;
+    private Boolean typing;
+    private String source;
+    private String title;
+    private String description;
+    private String preference;
+    private List<DialogNodeOutputOptionsElement> options;
+    private String messageToHumanAgent;
+    private String topic;
+    private String dialogNode;
+    private List<DialogSuggestion> suggestions;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogRuntimeResponseGeneric() { }
  
     /**
      * Gets the responseType.
@@ -6298,7 +7401,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getResponseType() {
-      return response_type_serialized_name;
+      return responseType;
     }
  
     /**
@@ -6310,7 +7413,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -6322,7 +7425,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Long getXtime() {
-      return time_serialized_name;
+      return xtime;
     }
  
     /**
@@ -6334,7 +7437,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getTyping() {
-      return typing_serialized_name;
+      return typing;
     }
  
     /**
@@ -6346,7 +7449,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getSource() {
-      return source_serialized_name;
+      return source;
     }
  
     /**
@@ -6358,7 +7461,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -6370,7 +7473,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -6382,7 +7485,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getPreference() {
-      return preference_serialized_name;
+      return preference;
     }
  
     /**
@@ -6394,7 +7497,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNodeOutputOptionsElement> getOptions() {
-      return options_serialized_name;
+      return options;
     }
  
     /**
@@ -6406,7 +7509,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getMessageToHumanAgent() {
-      return message_to_human_agent_serialized_name;
+      return messageToHumanAgent;
     }
  
     /**
@@ -6418,7 +7521,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getTopic() {
-      return topic_serialized_name;
+      return topic;
     }
  
     /**
@@ -6431,7 +7534,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDialogNode() {
-      return dialog_node_serialized_name;
+      return dialogNode;
     }
  
     /**
@@ -6446,115 +7549,33 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogSuggestion> getSuggestions() {
-      return suggestions_serialized_name;
+      return suggestions;
+    }
+  
+    private DialogRuntimeResponseGeneric(DialogRuntimeResponseGenericBuilder builder) {
+      IBMWatsonValidator.notNull(builder.responseType, 'responseType cannot be null');
+      this.responseType = builder.responseType;
+      this.text = builder.text;
+      this.xtime = builder.xtime;
+      this.typing = builder.typing;
+      this.source = builder.source;
+      this.title = builder.title;
+      this.description = builder.description;
+      this.preference = builder.preference;
+      this.options = builder.options;
+      this.messageToHumanAgent = builder.messageToHumanAgent;
+      this.topic = builder.topic;
+      this.dialogNode = builder.dialogNode;
+      this.suggestions = builder.suggestions;
     }
 
     /**
-     * Sets the responseType.
+     * New builder.
      *
-     * @param responseType the new responseType
+     * @return a DialogRuntimeResponseGeneric builder
      */
-    public void setResponseType(final String responseType) {
-      this.response_type_serialized_name = responseType;
-    }
-
-    /**
-     * Sets the text.
-     *
-     * @param text the new text
-     */
-    public void setText(final String text) {
-      this.text_serialized_name = text;
-    }
-
-    /**
-     * Sets the xtime.
-     *
-     * @param xtime the new xtime
-     */
-    public void setXtime(final long xtime) {
-      this.time_serialized_name = xtime;
-    }
-
-    /**
-     * Sets the typing.
-     *
-     * @param typing the new typing
-     */
-    public void setTyping(final Boolean typing) {
-      this.typing_serialized_name = typing;
-    }
-
-    /**
-     * Sets the source.
-     *
-     * @param source the new source
-     */
-    public void setSource(final String source) {
-      this.source_serialized_name = source;
-    }
-
-    /**
-     * Sets the title.
-     *
-     * @param title the new title
-     */
-    public void setTitle(final String title) {
-      this.title_serialized_name = title;
-    }
-
-    /**
-     * Sets the description.
-     *
-     * @param description the new description
-     */
-    public void setDescription(final String description) {
-      this.description_serialized_name = description;
-    }
-
-    /**
-     * Sets the preference.
-     *
-     * @param preference the new preference
-     */
-    public void setPreference(final String preference) {
-      this.preference_serialized_name = preference;
-    }
-
-    /**
-     * Sets the options.
-     *
-     * @param options the new options
-     */
-    public void setOptions(final List<DialogNodeOutputOptionsElement> options) {
-      this.options_serialized_name = options;
-    }
-
-    /**
-     * Sets the messageToHumanAgent.
-     *
-     * @param messageToHumanAgent the new messageToHumanAgent
-     */
-    public void setMessageToHumanAgent(final String messageToHumanAgent) {
-      this.message_to_human_agent_serialized_name = messageToHumanAgent;
-    }
-
-    /**
-     * Sets the dialogNode.
-     *
-     * @param dialogNode the new dialogNode
-     */
-    public void setDialogNode(final String dialogNode) {
-      this.dialog_node_serialized_name = dialogNode;
-    }
-
-    /**
-     * Sets the suggestions.
-     *
-     * @param suggestions the new suggestions
-     */
-    public void setSuggestions(final List<DialogSuggestion> suggestions) {
-      this.suggestions_serialized_name = suggestions;
+    public DialogRuntimeResponseGenericBuilder newBuilder() {
+      return new DialogRuntimeResponseGenericBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6563,6 +7584,7 @@ public class IBMAssistantV1Models {
       }
 
       DialogRuntimeResponseGeneric ret = (DialogRuntimeResponseGeneric) super.deserialize(jsonString, jsonMap, classType);
+      DialogRuntimeResponseGenericBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for options
       List<DialogNodeOutputOptionsElement> newOptions = new List<DialogNodeOutputOptionsElement>();
@@ -6570,11 +7592,11 @@ public class IBMAssistantV1Models {
       if (deserializedOptions != null) {
         for (Integer i = 0; i < deserializedOptions.size(); i++) {
           DialogNodeOutputOptionsElement currentItem = ret.getOptions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('options_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('options');
           DialogNodeOutputOptionsElement newItem = (DialogNodeOutputOptionsElement) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeOutputOptionsElement.class);
           newOptions.add(newItem);
         }
-        ret.options_serialized_name = newOptions;
+        retBuilder.setOptions(newOptions);
       }
 
       // calling custom deserializer for suggestions
@@ -6583,14 +7605,278 @@ public class IBMAssistantV1Models {
       if (deserializedSuggestions != null) {
         for (Integer i = 0; i < deserializedSuggestions.size(); i++) {
           DialogSuggestion currentItem = ret.getSuggestions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('suggestions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('suggestions');
           DialogSuggestion newItem = (DialogSuggestion) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogSuggestion.class);
           newSuggestions.add(newItem);
         }
-        ret.suggestions_serialized_name = newSuggestions;
+        retBuilder.setSuggestions(newSuggestions);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('responseType', 'response_type');
+      mapping.put('xtime', 'time');
+      if (options != null && options[0] != null) {
+        mapping.putAll(options[0].getSdkToApiMapping());
+      }
+      mapping.put('messageToHumanAgent', 'message_to_human_agent');
+      mapping.put('dialogNode', 'dialog_node');
+      if (suggestions != null && suggestions[0] != null) {
+        mapping.putAll(suggestions[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('response_type', 'responseType');
+      mapping.put('time', 'xtime');
+      if (options != null && options[0] != null) {
+        mapping.putAll(options[0].getApiToSdkMapping());
+      }
+      mapping.put('message_to_human_agent', 'messageToHumanAgent');
+      mapping.put('dialog_node', 'dialogNode');
+      if (suggestions != null && suggestions[0] != null) {
+        mapping.putAll(suggestions[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogRuntimeResponseGeneric Builder.
+   */
+  public class DialogRuntimeResponseGenericBuilder {
+    private String responseType;
+    private String text;
+    private Long xtime;
+    private Boolean typing;
+    private String source;
+    private String title;
+    private String description;
+    private String preference;
+    private List<DialogNodeOutputOptionsElement> options;
+    private String messageToHumanAgent;
+    private String topic;
+    private String dialogNode;
+    private List<DialogSuggestion> suggestions;
+
+    private DialogRuntimeResponseGenericBuilder(DialogRuntimeResponseGeneric dialogRuntimeResponseGeneric) {
+      this.responseType = dialogRuntimeResponseGeneric.responseType;
+      this.text = dialogRuntimeResponseGeneric.text;
+      this.xtime = dialogRuntimeResponseGeneric.xtime;
+      this.typing = dialogRuntimeResponseGeneric.typing;
+      this.source = dialogRuntimeResponseGeneric.source;
+      this.title = dialogRuntimeResponseGeneric.title;
+      this.description = dialogRuntimeResponseGeneric.description;
+      this.preference = dialogRuntimeResponseGeneric.preference;
+      this.options = dialogRuntimeResponseGeneric.options;
+      this.messageToHumanAgent = dialogRuntimeResponseGeneric.messageToHumanAgent;
+      this.topic = dialogRuntimeResponseGeneric.topic;
+      this.dialogNode = dialogRuntimeResponseGeneric.dialogNode;
+      this.suggestions = dialogRuntimeResponseGeneric.suggestions;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogRuntimeResponseGenericBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param responseType the responseType
+     */
+    public DialogRuntimeResponseGenericBuilder(String responseType) {
+      this.responseType = responseType;
+    }
+
+    /**
+     * Builds a DialogRuntimeResponseGeneric.
+     *
+     * @return the dialogRuntimeResponseGeneric
+     */
+    public DialogRuntimeResponseGeneric build() {
+      return new DialogRuntimeResponseGeneric(this);
+    }
+
+    /**
+     * Adds an options to options.
+     *
+     * @param options the new options
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder addOptions(DialogNodeOutputOptionsElement options) {
+      IBMWatsonValidator.notNull(options, 'options cannot be null');
+      if (this.options == null) {
+        this.options = new List<DialogNodeOutputOptionsElement>();
+      }
+      this.options.add(options);
+      return this;
+    }
+
+    /**
+     * Adds an suggestions to suggestions.
+     *
+     * @param suggestions the new suggestions
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder addSuggestions(DialogSuggestion suggestions) {
+      IBMWatsonValidator.notNull(suggestions, 'suggestions cannot be null');
+      if (this.suggestions == null) {
+        this.suggestions = new List<DialogSuggestion>();
+      }
+      this.suggestions.add(suggestions);
+      return this;
+    }
+
+    /**
+     * Set the responseType.
+     *
+     * @param responseType the responseType
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setResponseType(String responseType) {
+      this.responseType = responseType;
+      return this;
+    }
+
+    /**
+     * Set the text.
+     *
+     * @param text the text
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setText(String text) {
+      this.text = text;
+      return this;
+    }
+
+    /**
+     * Set the xtime.
+     *
+     * @param xtime the xtime
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setXtime(Long xtime) {
+      this.xtime = xtime;
+      return this;
+    }
+
+    /**
+     * Set the typing.
+     *
+     * @param typing the typing
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setTyping(Boolean typing) {
+      this.typing = typing;
+      return this;
+    }
+
+    /**
+     * Set the source.
+     *
+     * @param source the source
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setSource(String source) {
+      this.source = source;
+      return this;
+    }
+
+    /**
+     * Set the title.
+     *
+     * @param title the title
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setTitle(String title) {
+      this.title = title;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the preference.
+     *
+     * @param preference the preference
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setPreference(String preference) {
+      this.preference = preference;
+      return this;
+    }
+
+    /**
+     * Set the options.
+     * Existing options will be replaced.
+     *
+     * @param options the options
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setOptions(List<DialogNodeOutputOptionsElement> options) {
+      this.options = options;
+      return this;
+    }
+
+    /**
+     * Set the messageToHumanAgent.
+     *
+     * @param messageToHumanAgent the messageToHumanAgent
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setMessageToHumanAgent(String messageToHumanAgent) {
+      this.messageToHumanAgent = messageToHumanAgent;
+      return this;
+    }
+
+    /**
+     * Set the topic.
+     *
+     * @param topic the topic
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setTopic(String topic) {
+      this.topic = topic;
+      return this;
+    }
+
+    /**
+     * Set the dialogNode.
+     *
+     * @param dialogNode the dialogNode
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setDialogNode(String dialogNode) {
+      this.dialogNode = dialogNode;
+      return this;
+    }
+
+    /**
+     * Set the suggestions.
+     * Existing suggestions will be replaced.
+     *
+     * @param suggestions the suggestions
+     * @return the DialogRuntimeResponseGeneric builder
+     */
+    public DialogRuntimeResponseGenericBuilder setSuggestions(List<DialogSuggestion> suggestions) {
+      this.suggestions = suggestions;
+      return this;
     }
   }
 
@@ -6598,10 +7884,16 @@ public class IBMAssistantV1Models {
    * DialogSuggestion.
    */
   public class DialogSuggestion extends IBMWatsonGenericModel {
-    private String label_serialized_name;
-    private DialogSuggestionValue value_serialized_name;
-    private IBMWatsonMapModel output_serialized_name;
-    private String dialog_node_serialized_name;
+    private String label;
+    private DialogSuggestionValue value;
+    private IBMWatsonMapModel output;
+    private String dialogNode;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogSuggestion() { }
  
     /**
      * Gets the label.
@@ -6613,7 +7905,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getLabel() {
-      return label_serialized_name;
+      return label;
     }
  
     /**
@@ -6626,7 +7918,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public DialogSuggestionValue getValue() {
-      return value_serialized_name;
+      return value;
     }
  
     /**
@@ -6639,7 +7931,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getOutput() {
-      return output_serialized_name;
+      return output;
     }
  
     /**
@@ -6652,43 +7944,25 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDialogNode() {
-      return dialog_node_serialized_name;
+      return dialogNode;
+    }
+  
+    private DialogSuggestion(DialogSuggestionBuilder builder) {
+      IBMWatsonValidator.notNull(builder.label, 'label cannot be null');
+      IBMWatsonValidator.notNull(builder.value, 'value cannot be null');
+      this.label = builder.label;
+      this.value = builder.value;
+      this.output = builder.output;
+      this.dialogNode = builder.dialogNode;
     }
 
     /**
-     * Sets the label.
+     * New builder.
      *
-     * @param label the new label
+     * @return a DialogSuggestion builder
      */
-    public void setLabel(final String label) {
-      this.label_serialized_name = label;
-    }
-
-    /**
-     * Sets the value.
-     *
-     * @param value the new value
-     */
-    public void setValue(final DialogSuggestionValue value) {
-      this.value_serialized_name = value;
-    }
-
-    /**
-     * Sets the output.
-     *
-     * @param output the new output
-     */
-    public void setOutput(final IBMWatsonMapModel output) {
-      this.output_serialized_name = output;
-    }
-
-    /**
-     * Sets the dialogNode.
-     *
-     * @param dialogNode the new dialogNode
-     */
-    public void setDialogNode(final String dialogNode) {
-      this.dialog_node_serialized_name = dialogNode;
+    public DialogSuggestionBuilder newBuilder() {
+      return new DialogSuggestionBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6697,16 +7971,122 @@ public class IBMAssistantV1Models {
       }
 
       DialogSuggestion ret = (DialogSuggestion) super.deserialize(jsonString, jsonMap, classType);
+      DialogSuggestionBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for value
-      DialogSuggestionValue newValue = (DialogSuggestionValue) new DialogSuggestionValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value_serialized_name'), DialogSuggestionValue.class);
-      ret.setValue(newValue);
+      DialogSuggestionValue newValue = (DialogSuggestionValue) new DialogSuggestionValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value'), DialogSuggestionValue.class);
+      retBuilder.setValue(newValue);
 
       // calling custom deserializer for output
-      IBMWatsonMapModel newOutput = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output_serialized_name'), IBMWatsonMapModel.class);
-      ret.setOutput(newOutput);
+      IBMWatsonMapModel newOutput = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output'), IBMWatsonMapModel.class);
+      retBuilder.setOutput(newOutput);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (value != null) {
+        mapping.putAll(value.getSdkToApiMapping());
+      }
+      mapping.put('dialogNode', 'dialog_node');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (value != null) {
+        mapping.putAll(value.getApiToSdkMapping());
+      }
+      mapping.put('dialog_node', 'dialogNode');
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogSuggestion Builder.
+   */
+  public class DialogSuggestionBuilder {
+    private String label;
+    private DialogSuggestionValue value;
+    private IBMWatsonMapModel output;
+    private String dialogNode;
+
+    private DialogSuggestionBuilder(DialogSuggestion dialogSuggestion) {
+      this.label = dialogSuggestion.label;
+      this.value = dialogSuggestion.value;
+      this.output = dialogSuggestion.output;
+      this.dialogNode = dialogSuggestion.dialogNode;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogSuggestionBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param label the label
+     * @param value the value
+     */
+    public DialogSuggestionBuilder(String label, DialogSuggestionValue value) {
+      this.label = label;
+      this.value = value;
+    }
+
+    /**
+     * Builds a DialogSuggestion.
+     *
+     * @return the dialogSuggestion
+     */
+    public DialogSuggestion build() {
+      return new DialogSuggestion(this);
+    }
+
+    /**
+     * Set the label.
+     *
+     * @param label the label
+     * @return the DialogSuggestion builder
+     */
+    public DialogSuggestionBuilder setLabel(String label) {
+      this.label = label;
+      return this;
+    }
+
+    /**
+     * Set the value.
+     *
+     * @param value the value
+     * @return the DialogSuggestion builder
+     */
+    public DialogSuggestionBuilder setValue(DialogSuggestionValue value) {
+      this.value = value;
+      return this;
+    }
+
+    /**
+     * Set the output.
+     *
+     * @param output the output
+     * @return the DialogSuggestion builder
+     */
+    public DialogSuggestionBuilder setOutput(IBMWatsonMapModel output) {
+      this.output = output;
+      return this;
+    }
+
+    /**
+     * Set the dialogNode.
+     *
+     * @param dialogNode the dialogNode
+     * @return the DialogSuggestion builder
+     */
+    public DialogSuggestionBuilder setDialogNode(String dialogNode) {
+      this.dialogNode = dialogNode;
+      return this;
     }
   }
 
@@ -6715,9 +8095,15 @@ public class IBMAssistantV1Models {
    * selects the corresponding disambiguation option.
    */
   public class DialogSuggestionValue extends IBMWatsonGenericModel {
-    private MessageInput input_serialized_name;
-    private List<RuntimeIntent> intents_serialized_name;
-    private List<RuntimeEntity> entities_serialized_name;
+    private MessageInput input;
+    private List<RuntimeIntent> intents;
+    private List<RuntimeEntity> entities;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public DialogSuggestionValue() { }
  
     /**
      * Gets the input.
@@ -6728,7 +8114,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public MessageInput getInput() {
-      return input_serialized_name;
+      return input;
     }
  
     /**
@@ -6740,7 +8126,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<RuntimeIntent> getIntents() {
-      return intents_serialized_name;
+      return intents;
     }
  
     /**
@@ -6752,34 +8138,22 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<RuntimeEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
+    }
+  
+    private DialogSuggestionValue(DialogSuggestionValueBuilder builder) {
+      this.input = builder.input;
+      this.intents = builder.intents;
+      this.entities = builder.entities;
     }
 
     /**
-     * Sets the input.
+     * New builder.
      *
-     * @param input the new input
+     * @return a DialogSuggestionValue builder
      */
-    public void setInput(final MessageInput input) {
-      this.input_serialized_name = input;
-    }
-
-    /**
-     * Sets the intents.
-     *
-     * @param intents the new intents
-     */
-    public void setIntents(final List<RuntimeIntent> intents) {
-      this.intents_serialized_name = intents;
-    }
-
-    /**
-     * Sets the entities.
-     *
-     * @param entities the new entities
-     */
-    public void setEntities(final List<RuntimeEntity> entities) {
-      this.entities_serialized_name = entities;
+    public DialogSuggestionValueBuilder newBuilder() {
+      return new DialogSuggestionValueBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6788,10 +8162,11 @@ public class IBMAssistantV1Models {
       }
 
       DialogSuggestionValue ret = (DialogSuggestionValue) super.deserialize(jsonString, jsonMap, classType);
+      DialogSuggestionValueBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for input
-      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input_serialized_name'), MessageInput.class);
-      ret.setInput(newInput);
+      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input'), MessageInput.class);
+      retBuilder.setInput(newInput);
 
       // calling custom deserializer for intents
       List<RuntimeIntent> newIntents = new List<RuntimeIntent>();
@@ -6799,11 +8174,11 @@ public class IBMAssistantV1Models {
       if (deserializedIntents != null) {
         for (Integer i = 0; i < deserializedIntents.size(); i++) {
           RuntimeIntent currentItem = ret.getIntents().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('intents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('intents');
           RuntimeIntent newItem = (RuntimeIntent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeIntent.class);
           newIntents.add(newItem);
         }
-        ret.intents_serialized_name = newIntents;
+        retBuilder.setIntents(newIntents);
       }
 
       // calling custom deserializer for entities
@@ -6812,14 +8187,125 @@ public class IBMAssistantV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           RuntimeEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           RuntimeEntity newItem = (RuntimeEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeEntity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        retBuilder.setEntities(newEntities);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * DialogSuggestionValue Builder.
+   */
+  public class DialogSuggestionValueBuilder {
+    private MessageInput input;
+    private List<RuntimeIntent> intents;
+    private List<RuntimeEntity> entities;
+
+    private DialogSuggestionValueBuilder(DialogSuggestionValue dialogSuggestionValue) {
+      this.input = dialogSuggestionValue.input;
+      this.intents = dialogSuggestionValue.intents;
+      this.entities = dialogSuggestionValue.entities;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public DialogSuggestionValueBuilder() {
+    }
+
+    /**
+     * Builds a DialogSuggestionValue.
+     *
+     * @return the dialogSuggestionValue
+     */
+    public DialogSuggestionValue build() {
+      return new DialogSuggestionValue(this);
+    }
+
+    /**
+     * Adds an intents to intents.
+     *
+     * @param intents the new intents
+     * @return the DialogSuggestionValue builder
+     */
+    public DialogSuggestionValueBuilder addIntents(RuntimeIntent intents) {
+      IBMWatsonValidator.notNull(intents, 'intents cannot be null');
+      if (this.intents == null) {
+        this.intents = new List<RuntimeIntent>();
+      }
+      this.intents.add(intents);
+      return this;
+    }
+
+    /**
+     * Adds an entities to entities.
+     *
+     * @param entities the new entities
+     * @return the DialogSuggestionValue builder
+     */
+    public DialogSuggestionValueBuilder addEntities(RuntimeEntity entities) {
+      IBMWatsonValidator.notNull(entities, 'entities cannot be null');
+      if (this.entities == null) {
+        this.entities = new List<RuntimeEntity>();
+      }
+      this.entities.add(entities);
+      return this;
+    }
+
+    /**
+     * Set the input.
+     *
+     * @param input the input
+     * @return the DialogSuggestionValue builder
+     */
+    public DialogSuggestionValueBuilder setInput(MessageInput input) {
+      this.input = input;
+      return this;
+    }
+
+    /**
+     * Set the intents.
+     * Existing intents will be replaced.
+     *
+     * @param intents the intents
+     * @return the DialogSuggestionValue builder
+     */
+    public DialogSuggestionValueBuilder setIntents(List<RuntimeIntent> intents) {
+      this.intents = intents;
+      return this;
+    }
+
+    /**
+     * Set the entities.
+     * Existing entities will be replaced.
+     *
+     * @param entities the entities
+     * @return the DialogSuggestionValue builder
+     */
+    public DialogSuggestionValueBuilder setEntities(List<RuntimeEntity> entities) {
+      this.entities = entities;
+      return this;
     }
   }
 
@@ -6827,13 +8313,13 @@ public class IBMAssistantV1Models {
    * Entity.
    */
   public class Entity extends IBMWatsonResponseModel {
-    private String entity_serialized_name;
-    private String description_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private Boolean fuzzy_match_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
-    private List<Value> values_serialized_name;
+    private String entity;
+    private String description;
+    private IBMWatsonMapModel metadata;
+    private Boolean fuzzyMatch;
+    private Datetime created;
+    private Datetime updated;
+    private List<Value> values;
  
     /**
      * Gets the entity.
@@ -6847,7 +8333,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getEntity() {
-      return entity_serialized_name;
+      return entity;
     }
  
     /**
@@ -6859,7 +8345,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -6871,7 +8357,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
  
     /**
@@ -6883,7 +8369,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getFuzzyMatch() {
-      return fuzzy_match_serialized_name;
+      return fuzzyMatch;
     }
  
     /**
@@ -6895,7 +8381,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -6907,7 +8393,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -6919,7 +8405,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Value> getValues() {
-      return values_serialized_name;
+      return values;
     }
 
     /**
@@ -6928,7 +8414,7 @@ public class IBMAssistantV1Models {
      * @param entity the new entity
      */
     public void setEntity(final String entity) {
-      this.entity_serialized_name = entity;
+      this.entity = entity;
     }
 
     /**
@@ -6937,7 +8423,7 @@ public class IBMAssistantV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -6946,7 +8432,7 @@ public class IBMAssistantV1Models {
      * @param metadata the new metadata
      */
     public void setMetadata(final IBMWatsonMapModel metadata) {
-      this.metadata_serialized_name = metadata;
+      this.metadata = metadata;
     }
 
     /**
@@ -6955,7 +8441,7 @@ public class IBMAssistantV1Models {
      * @param fuzzyMatch the new fuzzyMatch
      */
     public void setFuzzyMatch(final Boolean fuzzyMatch) {
-      this.fuzzy_match_serialized_name = fuzzyMatch;
+      this.fuzzyMatch = fuzzyMatch;
     }
 
     /**
@@ -6964,7 +8450,7 @@ public class IBMAssistantV1Models {
      * @param values the new values
      */
     public void setValues(final List<Value> values) {
-      this.values_serialized_name = values;
+      this.values = values;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6975,7 +8461,7 @@ public class IBMAssistantV1Models {
       Entity ret = (Entity) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for metadata
-      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
       ret.setMetadata(newMetadata);
 
       // calling custom deserializer for values
@@ -6984,14 +8470,23 @@ public class IBMAssistantV1Models {
       if (deserializedValues != null) {
         for (Integer i = 0; i < deserializedValues.size(); i++) {
           Value currentItem = ret.getValues().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('values_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('values');
           Value newItem = (Value) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Value.class);
           newValues.add(newItem);
         }
-        ret.values_serialized_name = newValues;
+        ret.values = newValues;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('fuzzy_match', 'fuzzyMatch');
+      if (values != null && values[0] != null) {
+        mapping.putAll(values[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -6999,8 +8494,8 @@ public class IBMAssistantV1Models {
    * An array of objects describing the entities for the workspace.
    */
   public class EntityCollection extends IBMWatsonResponseModel {
-    private List<Entity> entities_serialized_name;
-    private Pagination pagination_serialized_name;
+    private List<Entity> entities;
+    private Pagination pagination;
  
     /**
      * Gets the entities.
@@ -7011,7 +8506,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Entity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -7023,7 +8518,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -7032,7 +8527,7 @@ public class IBMAssistantV1Models {
      * @param entities the new entities
      */
     public void setEntities(final List<Entity> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     /**
@@ -7041,7 +8536,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7057,18 +8552,29 @@ public class IBMAssistantV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           Entity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           Entity newItem = (Entity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Entity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7076,9 +8582,9 @@ public class IBMAssistantV1Models {
    * An object describing a contextual entity mention.
    */
   public class EntityMention extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private String intent_serialized_name;
-    private List<Long> location_serialized_name;
+    private String text;
+    private String intent;
+    private List<Long> location;
  
     /**
      * Gets the text.
@@ -7089,7 +8595,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -7101,7 +8607,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getIntent() {
-      return intent_serialized_name;
+      return intent;
     }
  
     /**
@@ -7113,7 +8619,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -7122,7 +8628,7 @@ public class IBMAssistantV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -7131,7 +8637,7 @@ public class IBMAssistantV1Models {
      * @param intent the new intent
      */
     public void setIntent(final String intent) {
-      this.intent_serialized_name = intent;
+      this.intent = intent;
     }
 
     /**
@@ -7140,17 +8646,16 @@ public class IBMAssistantV1Models {
      * @param location the new location
      */
     public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
-
   }
 
   /**
    * EntityMentionCollection.
    */
   public class EntityMentionCollection extends IBMWatsonResponseModel {
-    private List<EntityMention> examples_serialized_name;
-    private Pagination pagination_serialized_name;
+    private List<EntityMention> examples;
+    private Pagination pagination;
  
     /**
      * Gets the examples.
@@ -7161,7 +8666,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<EntityMention> getExamples() {
-      return examples_serialized_name;
+      return examples;
     }
  
     /**
@@ -7173,7 +8678,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -7182,7 +8687,7 @@ public class IBMAssistantV1Models {
      * @param examples the new examples
      */
     public void setExamples(final List<EntityMention> examples) {
-      this.examples_serialized_name = examples;
+      this.examples = examples;
     }
 
     /**
@@ -7191,7 +8696,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7207,18 +8712,26 @@ public class IBMAssistantV1Models {
       if (deserializedExamples != null) {
         for (Integer i = 0; i < deserializedExamples.size(); i++) {
           EntityMention currentItem = ret.getExamples().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('examples_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('examples');
           EntityMention newItem = (EntityMention) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), EntityMention.class);
           newExamples.add(newItem);
         }
-        ret.examples_serialized_name = newExamples;
+        ret.examples = newExamples;
       }
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7226,10 +8739,10 @@ public class IBMAssistantV1Models {
    * Example.
    */
   public class Example extends IBMWatsonResponseModel {
-    private String text_serialized_name;
-    private List<Mention> mentions_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
+    private String text;
+    private List<Mention> mentions;
+    private Datetime created;
+    private Datetime updated;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -7248,7 +8761,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -7260,7 +8773,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Mention> getMentions() {
-      return mentions_serialized_name;
+      return mentions;
     }
  
     /**
@@ -7272,7 +8785,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -7284,15 +8797,15 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
   
     private Example(ExampleBuilder builder) {
       IBMWatsonValidator.notNull(builder.text, 'text cannot be null');
-      this.text_serialized_name = builder.text;
-      this.mentions_serialized_name = builder.mentions;
-      this.created_serialized_name = builder.created;
-      this.updated_serialized_name = builder.updated;
+      this.text = builder.text;
+      this.mentions = builder.mentions;
+      this.created = builder.created;
+      this.updated = builder.updated;
     }
 
     /**
@@ -7318,7 +8831,7 @@ public class IBMAssistantV1Models {
       if (deserializedMentions != null) {
         for (Integer i = 0; i < deserializedMentions.size(); i++) {
           Mention currentItem = ret.getMentions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('mentions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('mentions');
           Mention newItem = (Mention) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Mention.class);
           newMentions.add(newItem);
         }
@@ -7339,10 +8852,10 @@ public class IBMAssistantV1Models {
     private Datetime updated;
 
     private ExampleBuilder(Example example) {
-      this.text = example.text_serialized_name;
-      this.mentions = example.mentions_serialized_name;
-      this.created = example.created_serialized_name;
-      this.updated = example.updated_serialized_name;
+      this.text = example.text;
+      this.mentions = example.mentions;
+      this.created = example.created;
+      this.updated = example.updated;
     }
 
     /**
@@ -7434,8 +8947,8 @@ public class IBMAssistantV1Models {
    * ExampleCollection.
    */
   public class ExampleCollection extends IBMWatsonResponseModel {
-    private List<Example> examples_serialized_name;
-    private Pagination pagination_serialized_name;
+    private List<Example> examples;
+    private Pagination pagination;
  
     /**
      * Gets the examples.
@@ -7446,7 +8959,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Example> getExamples() {
-      return examples_serialized_name;
+      return examples;
     }
  
     /**
@@ -7458,7 +8971,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -7467,7 +8980,7 @@ public class IBMAssistantV1Models {
      * @param examples the new examples
      */
     public void setExamples(final List<Example> examples) {
-      this.examples_serialized_name = examples;
+      this.examples = examples;
     }
 
     /**
@@ -7476,7 +8989,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7492,18 +9005,26 @@ public class IBMAssistantV1Models {
       if (deserializedExamples != null) {
         for (Integer i = 0; i < deserializedExamples.size(); i++) {
           Example currentItem = ret.getExamples().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('examples_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('examples');
           Example newItem = (Example) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Example.class);
           newExamples.add(newItem);
         }
-        ret.examples_serialized_name = newExamples;
+        ret.examples = newExamples;
       }
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7514,7 +9035,7 @@ public class IBMAssistantV1Models {
     private String workspaceId;
     private String text;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -7525,7 +9046,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -7536,7 +9057,7 @@ public class IBMAssistantV1Models {
     public String text() {
       return text;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -7566,6 +9087,12 @@ public class IBMAssistantV1Models {
       return new GetCounterexampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -7662,7 +9189,7 @@ public class IBMAssistantV1Models {
     private String workspaceId;
     private String dialogNode;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -7673,7 +9200,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -7684,7 +9211,7 @@ public class IBMAssistantV1Models {
     public String dialogNode() {
       return dialogNode;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -7714,6 +9241,13 @@ public class IBMAssistantV1Models {
       return new GetDialogNodeOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('dialogNode', 'dialog_node');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -7811,7 +9345,7 @@ public class IBMAssistantV1Models {
     private String entity;
     private Boolean xexport;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -7822,7 +9356,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -7833,7 +9367,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the xexport.
      *
@@ -7845,7 +9379,7 @@ public class IBMAssistantV1Models {
     public Boolean xexport() {
       return xexport;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -7876,6 +9410,13 @@ public class IBMAssistantV1Models {
       return new GetEntityOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('xexport', 'export');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -7986,7 +9527,7 @@ public class IBMAssistantV1Models {
     private String intent;
     private String text;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -7997,7 +9538,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -8008,7 +9549,7 @@ public class IBMAssistantV1Models {
     public String intent() {
       return intent;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -8019,7 +9560,7 @@ public class IBMAssistantV1Models {
     public String text() {
       return text;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -8051,6 +9592,12 @@ public class IBMAssistantV1Models {
       return new GetExampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -8163,7 +9710,7 @@ public class IBMAssistantV1Models {
     private String intent;
     private Boolean xexport;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -8174,7 +9721,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -8185,7 +9732,7 @@ public class IBMAssistantV1Models {
     public String intent() {
       return intent;
     }
- 
+
     /**
      * Gets the xexport.
      *
@@ -8197,7 +9744,7 @@ public class IBMAssistantV1Models {
     public Boolean xexport() {
       return xexport;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -8228,6 +9775,13 @@ public class IBMAssistantV1Models {
       return new GetIntentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('xexport', 'export');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -8339,7 +9893,7 @@ public class IBMAssistantV1Models {
     private String value;
     private String synonym;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -8350,7 +9904,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -8361,7 +9915,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -8372,7 +9926,7 @@ public class IBMAssistantV1Models {
     public String value() {
       return value;
     }
- 
+
     /**
      * Gets the synonym.
      *
@@ -8383,7 +9937,7 @@ public class IBMAssistantV1Models {
     public String synonym() {
       return synonym;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -8417,6 +9971,12 @@ public class IBMAssistantV1Models {
       return new GetSynonymOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -8545,7 +10105,7 @@ public class IBMAssistantV1Models {
     private String value;
     private Boolean xexport;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -8556,7 +10116,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -8567,7 +10127,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -8578,7 +10138,7 @@ public class IBMAssistantV1Models {
     public String value() {
       return value;
     }
- 
+
     /**
      * Gets the xexport.
      *
@@ -8590,7 +10150,7 @@ public class IBMAssistantV1Models {
     public Boolean xexport() {
       return xexport;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -8623,6 +10183,13 @@ public class IBMAssistantV1Models {
       return new GetValueOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('xexport', 'export');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -8748,7 +10315,7 @@ public class IBMAssistantV1Models {
     private Boolean xexport;
     private Boolean includeAudit;
     private String xsort;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -8759,7 +10326,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the xexport.
      *
@@ -8771,7 +10338,7 @@ public class IBMAssistantV1Models {
     public Boolean xexport() {
       return xexport;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -8782,7 +10349,7 @@ public class IBMAssistantV1Models {
     public Boolean includeAudit() {
       return includeAudit;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -8813,6 +10380,14 @@ public class IBMAssistantV1Models {
       return new GetWorkspaceOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('xexport', 'export');
+      mapping.put('includeAudit', 'include_audit');
+      mapping.put('xsort', 'sort');
+      return mapping;
+    }
   }
 
   /**
@@ -8917,11 +10492,11 @@ public class IBMAssistantV1Models {
    * Intent.
    */
   public class Intent extends IBMWatsonResponseModel {
-    private String intent_serialized_name;
-    private String description_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
-    private List<Example> examples_serialized_name;
+    private String intent;
+    private String description;
+    private Datetime created;
+    private Datetime updated;
+    private List<Example> examples;
  
     /**
      * Gets the intent.
@@ -8934,7 +10509,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getIntent() {
-      return intent_serialized_name;
+      return intent;
     }
  
     /**
@@ -8946,7 +10521,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -8958,7 +10533,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -8970,7 +10545,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -8982,7 +10557,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Example> getExamples() {
-      return examples_serialized_name;
+      return examples;
     }
 
     /**
@@ -8991,7 +10566,7 @@ public class IBMAssistantV1Models {
      * @param intent the new intent
      */
     public void setIntent(final String intent) {
-      this.intent_serialized_name = intent;
+      this.intent = intent;
     }
 
     /**
@@ -9000,7 +10575,7 @@ public class IBMAssistantV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -9009,7 +10584,7 @@ public class IBMAssistantV1Models {
      * @param examples the new examples
      */
     public void setExamples(final List<Example> examples) {
-      this.examples_serialized_name = examples;
+      this.examples = examples;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -9025,11 +10600,11 @@ public class IBMAssistantV1Models {
       if (deserializedExamples != null) {
         for (Integer i = 0; i < deserializedExamples.size(); i++) {
           Example currentItem = ret.getExamples().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('examples_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('examples');
           Example newItem = (Example) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Example.class);
           newExamples.add(newItem);
         }
-        ret.examples_serialized_name = newExamples;
+        ret.examples = newExamples;
       }
 
       return ret;
@@ -9040,8 +10615,8 @@ public class IBMAssistantV1Models {
    * IntentCollection.
    */
   public class IntentCollection extends IBMWatsonResponseModel {
-    private List<Intent> intents_serialized_name;
-    private Pagination pagination_serialized_name;
+    private List<Intent> intents;
+    private Pagination pagination;
  
     /**
      * Gets the intents.
@@ -9052,7 +10627,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Intent> getIntents() {
-      return intents_serialized_name;
+      return intents;
     }
  
     /**
@@ -9064,7 +10639,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -9073,7 +10648,7 @@ public class IBMAssistantV1Models {
      * @param intents the new intents
      */
     public void setIntents(final List<Intent> intents) {
-      this.intents_serialized_name = intents;
+      this.intents = intents;
     }
 
     /**
@@ -9082,7 +10657,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -9098,18 +10673,26 @@ public class IBMAssistantV1Models {
       if (deserializedIntents != null) {
         for (Integer i = 0; i < deserializedIntents.size(); i++) {
           Intent currentItem = ret.getIntents().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('intents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('intents');
           Intent newItem = (Intent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Intent.class);
           newIntents.add(newItem);
         }
-        ret.intents_serialized_name = newIntents;
+        ret.intents = newIntents;
       }
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -9121,7 +10704,7 @@ public class IBMAssistantV1Models {
     private String xsort;
     private Long pageLimit;
     private String cursor;
- 
+
     /**
      * Gets the filter.
      *
@@ -9135,7 +10718,7 @@ public class IBMAssistantV1Models {
     public String filter() {
       return filter;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -9147,7 +10730,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -9158,7 +10741,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -9188,6 +10771,12 @@ public class IBMAssistantV1Models {
       return new ListAllLogsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xsort', 'sort');
+      mapping.put('pageLimit', 'page_limit');
+      return mapping;
+    }
   }
 
   /**
@@ -9298,7 +10887,7 @@ public class IBMAssistantV1Models {
     private String xsort;
     private String cursor;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -9309,7 +10898,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -9320,7 +10909,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the includeCount.
      *
@@ -9331,7 +10920,7 @@ public class IBMAssistantV1Models {
     public Boolean includeCount() {
       return includeCount;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -9343,7 +10932,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -9354,7 +10943,7 @@ public class IBMAssistantV1Models {
     public String cursor() {
       return cursor;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -9386,6 +10975,15 @@ public class IBMAssistantV1Models {
       return new ListCounterexamplesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('pageLimit', 'page_limit');
+      mapping.put('includeCount', 'include_count');
+      mapping.put('xsort', 'sort');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -9522,7 +11120,7 @@ public class IBMAssistantV1Models {
     private String xsort;
     private String cursor;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -9533,7 +11131,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -9544,7 +11142,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the includeCount.
      *
@@ -9555,7 +11153,7 @@ public class IBMAssistantV1Models {
     public Boolean includeCount() {
       return includeCount;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -9567,7 +11165,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -9578,7 +11176,7 @@ public class IBMAssistantV1Models {
     public String cursor() {
       return cursor;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -9610,6 +11208,15 @@ public class IBMAssistantV1Models {
       return new ListDialogNodesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('pageLimit', 'page_limit');
+      mapping.put('includeCount', 'include_count');
+      mapping.put('xsort', 'sort');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -9747,7 +11354,7 @@ public class IBMAssistantV1Models {
     private String xsort;
     private String cursor;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -9758,7 +11365,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the xexport.
      *
@@ -9770,7 +11377,7 @@ public class IBMAssistantV1Models {
     public Boolean xexport() {
       return xexport;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -9781,7 +11388,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the includeCount.
      *
@@ -9792,7 +11399,7 @@ public class IBMAssistantV1Models {
     public Boolean includeCount() {
       return includeCount;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -9804,7 +11411,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -9815,7 +11422,7 @@ public class IBMAssistantV1Models {
     public String cursor() {
       return cursor;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -9848,6 +11455,16 @@ public class IBMAssistantV1Models {
       return new ListEntitiesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('xexport', 'export');
+      mapping.put('pageLimit', 'page_limit');
+      mapping.put('includeCount', 'include_count');
+      mapping.put('xsort', 'sort');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -9998,7 +11615,7 @@ public class IBMAssistantV1Models {
     private String xsort;
     private String cursor;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -10009,7 +11626,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -10020,7 +11637,7 @@ public class IBMAssistantV1Models {
     public String intent() {
       return intent;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -10031,7 +11648,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the includeCount.
      *
@@ -10042,7 +11659,7 @@ public class IBMAssistantV1Models {
     public Boolean includeCount() {
       return includeCount;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -10054,7 +11671,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -10065,7 +11682,7 @@ public class IBMAssistantV1Models {
     public String cursor() {
       return cursor;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -10099,6 +11716,15 @@ public class IBMAssistantV1Models {
       return new ListExamplesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('pageLimit', 'page_limit');
+      mapping.put('includeCount', 'include_count');
+      mapping.put('xsort', 'sort');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -10251,7 +11877,7 @@ public class IBMAssistantV1Models {
     private String xsort;
     private String cursor;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -10262,7 +11888,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the xexport.
      *
@@ -10274,7 +11900,7 @@ public class IBMAssistantV1Models {
     public Boolean xexport() {
       return xexport;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -10285,7 +11911,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the includeCount.
      *
@@ -10296,7 +11922,7 @@ public class IBMAssistantV1Models {
     public Boolean includeCount() {
       return includeCount;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -10308,7 +11934,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -10319,7 +11945,7 @@ public class IBMAssistantV1Models {
     public String cursor() {
       return cursor;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -10352,6 +11978,16 @@ public class IBMAssistantV1Models {
       return new ListIntentsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('xexport', 'export');
+      mapping.put('pageLimit', 'page_limit');
+      mapping.put('includeCount', 'include_count');
+      mapping.put('xsort', 'sort');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -10500,7 +12136,7 @@ public class IBMAssistantV1Models {
     private String filter;
     private Long pageLimit;
     private String cursor;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -10511,7 +12147,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -10523,7 +12159,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the filter.
      *
@@ -10536,7 +12172,7 @@ public class IBMAssistantV1Models {
     public String filter() {
       return filter;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -10547,7 +12183,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -10578,6 +12214,13 @@ public class IBMAssistantV1Models {
       return new ListLogsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('xsort', 'sort');
+      mapping.put('pageLimit', 'page_limit');
+      return mapping;
+    }
   }
 
   /**
@@ -10699,7 +12342,7 @@ public class IBMAssistantV1Models {
     private String entity;
     private Boolean xexport;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -10710,7 +12353,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -10721,7 +12364,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the xexport.
      *
@@ -10733,7 +12376,7 @@ public class IBMAssistantV1Models {
     public Boolean xexport() {
       return xexport;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -10764,6 +12407,13 @@ public class IBMAssistantV1Models {
       return new ListMentionsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('xexport', 'export');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -10878,7 +12528,7 @@ public class IBMAssistantV1Models {
     private String xsort;
     private String cursor;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -10889,7 +12539,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -10900,7 +12550,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -10911,7 +12561,7 @@ public class IBMAssistantV1Models {
     public String value() {
       return value;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -10922,7 +12572,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the includeCount.
      *
@@ -10933,7 +12583,7 @@ public class IBMAssistantV1Models {
     public Boolean includeCount() {
       return includeCount;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -10945,7 +12595,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -10956,7 +12606,7 @@ public class IBMAssistantV1Models {
     public String cursor() {
       return cursor;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -10992,6 +12642,15 @@ public class IBMAssistantV1Models {
       return new ListSynonymsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('pageLimit', 'page_limit');
+      mapping.put('includeCount', 'include_count');
+      mapping.put('xsort', 'sort');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -11160,7 +12819,7 @@ public class IBMAssistantV1Models {
     private String xsort;
     private String cursor;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -11171,7 +12830,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -11182,7 +12841,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the xexport.
      *
@@ -11194,7 +12853,7 @@ public class IBMAssistantV1Models {
     public Boolean xexport() {
       return xexport;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -11205,7 +12864,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the includeCount.
      *
@@ -11216,7 +12875,7 @@ public class IBMAssistantV1Models {
     public Boolean includeCount() {
       return includeCount;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -11228,7 +12887,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -11239,7 +12898,7 @@ public class IBMAssistantV1Models {
     public String cursor() {
       return cursor;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -11274,6 +12933,16 @@ public class IBMAssistantV1Models {
       return new ListValuesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('xexport', 'export');
+      mapping.put('pageLimit', 'page_limit');
+      mapping.put('includeCount', 'include_count');
+      mapping.put('xsort', 'sort');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -11437,7 +13106,7 @@ public class IBMAssistantV1Models {
     private String xsort;
     private String cursor;
     private Boolean includeAudit;
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -11448,7 +13117,7 @@ public class IBMAssistantV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the includeCount.
      *
@@ -11459,7 +13128,7 @@ public class IBMAssistantV1Models {
     public Boolean includeCount() {
       return includeCount;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -11471,7 +13140,7 @@ public class IBMAssistantV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -11482,7 +13151,7 @@ public class IBMAssistantV1Models {
     public String cursor() {
       return cursor;
     }
- 
+
     /**
      * Gets the includeAudit.
      *
@@ -11512,6 +13181,14 @@ public class IBMAssistantV1Models {
       return new ListWorkspacesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('pageLimit', 'page_limit');
+      mapping.put('includeCount', 'include_count');
+      mapping.put('xsort', 'sort');
+      mapping.put('includeAudit', 'include_audit');
+      return mapping;
+    }
   }
 
   /**
@@ -11620,13 +13297,13 @@ public class IBMAssistantV1Models {
    * Log.
    */
   public class Log extends IBMWatsonGenericModel {
-    private MessageRequest request_serialized_name;
-    private MessageResponse response_serialized_name;
-    private String log_id_serialized_name;
-    private String request_timestamp_serialized_name;
-    private String response_timestamp_serialized_name;
-    private String workspace_id_serialized_name;
-    private String language_serialized_name;
+    private MessageRequest request;
+    private MessageResponse response;
+    private String logId;
+    private String requestTimestamp;
+    private String responseTimestamp;
+    private String workspaceId;
+    private String language;
  
     /**
      * Gets the request.
@@ -11637,7 +13314,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public MessageRequest getRequest() {
-      return request_serialized_name;
+      return request;
     }
  
     /**
@@ -11649,7 +13326,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public MessageResponse getResponse() {
-      return response_serialized_name;
+      return response;
     }
  
     /**
@@ -11661,7 +13338,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getLogId() {
-      return log_id_serialized_name;
+      return logId;
     }
  
     /**
@@ -11673,7 +13350,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getRequestTimestamp() {
-      return request_timestamp_serialized_name;
+      return requestTimestamp;
     }
  
     /**
@@ -11685,7 +13362,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getResponseTimestamp() {
-      return response_timestamp_serialized_name;
+      return responseTimestamp;
     }
  
     /**
@@ -11697,7 +13374,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getWorkspaceId() {
-      return workspace_id_serialized_name;
+      return workspaceId;
     }
  
     /**
@@ -11709,7 +13386,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
 
     /**
@@ -11718,7 +13395,7 @@ public class IBMAssistantV1Models {
      * @param request the new request
      */
     public void setRequest(final MessageRequest request) {
-      this.request_serialized_name = request;
+      this.request = request;
     }
 
     /**
@@ -11727,7 +13404,7 @@ public class IBMAssistantV1Models {
      * @param response the new response
      */
     public void setResponse(final MessageResponse response) {
-      this.response_serialized_name = response;
+      this.response = response;
     }
 
     /**
@@ -11736,7 +13413,7 @@ public class IBMAssistantV1Models {
      * @param logId the new logId
      */
     public void setLogId(final String logId) {
-      this.log_id_serialized_name = logId;
+      this.logId = logId;
     }
 
     /**
@@ -11745,7 +13422,7 @@ public class IBMAssistantV1Models {
      * @param requestTimestamp the new requestTimestamp
      */
     public void setRequestTimestamp(final String requestTimestamp) {
-      this.request_timestamp_serialized_name = requestTimestamp;
+      this.requestTimestamp = requestTimestamp;
     }
 
     /**
@@ -11754,7 +13431,7 @@ public class IBMAssistantV1Models {
      * @param responseTimestamp the new responseTimestamp
      */
     public void setResponseTimestamp(final String responseTimestamp) {
-      this.response_timestamp_serialized_name = responseTimestamp;
+      this.responseTimestamp = responseTimestamp;
     }
 
     /**
@@ -11763,7 +13440,7 @@ public class IBMAssistantV1Models {
      * @param workspaceId the new workspaceId
      */
     public void setWorkspaceId(final String workspaceId) {
-      this.workspace_id_serialized_name = workspaceId;
+      this.workspaceId = workspaceId;
     }
 
     /**
@@ -11772,7 +13449,7 @@ public class IBMAssistantV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -11783,14 +13460,29 @@ public class IBMAssistantV1Models {
       Log ret = (Log) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for request
-      MessageRequest newRequest = (MessageRequest) new MessageRequest().deserialize(JSON.serialize(ret.getRequest()), (Map<String, Object>) jsonMap.get('request_serialized_name'), MessageRequest.class);
+      MessageRequest newRequest = (MessageRequest) new MessageRequest().deserialize(JSON.serialize(ret.getRequest()), (Map<String, Object>) jsonMap.get('request'), MessageRequest.class);
       ret.setRequest(newRequest);
 
       // calling custom deserializer for response
-      MessageResponse newResponse = (MessageResponse) new MessageResponse().deserialize(JSON.serialize(ret.getResponse()), (Map<String, Object>) jsonMap.get('response_serialized_name'), MessageResponse.class);
+      MessageResponse newResponse = (MessageResponse) new MessageResponse().deserialize(JSON.serialize(ret.getResponse()), (Map<String, Object>) jsonMap.get('response'), MessageResponse.class);
       ret.setResponse(newResponse);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (request != null) {
+        mapping.putAll(request.getApiToSdkMapping());
+      }
+      if (response != null) {
+        mapping.putAll(response.getApiToSdkMapping());
+      }
+      mapping.put('log_id', 'logId');
+      mapping.put('request_timestamp', 'requestTimestamp');
+      mapping.put('response_timestamp', 'responseTimestamp');
+      mapping.put('workspace_id', 'workspaceId');
+      return mapping;
     }
   }
 
@@ -11798,8 +13490,8 @@ public class IBMAssistantV1Models {
    * LogCollection.
    */
   public class LogCollection extends IBMWatsonResponseModel {
-    private List<Log> logs_serialized_name;
-    private LogPagination pagination_serialized_name;
+    private List<Log> logs;
+    private LogPagination pagination;
  
     /**
      * Gets the logs.
@@ -11810,7 +13502,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Log> getLogs() {
-      return logs_serialized_name;
+      return logs;
     }
  
     /**
@@ -11822,7 +13514,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public LogPagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -11831,7 +13523,7 @@ public class IBMAssistantV1Models {
      * @param logs the new logs
      */
     public void setLogs(final List<Log> logs) {
-      this.logs_serialized_name = logs;
+      this.logs = logs;
     }
 
     /**
@@ -11840,7 +13532,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final LogPagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -11856,18 +13548,29 @@ public class IBMAssistantV1Models {
       if (deserializedLogs != null) {
         for (Integer i = 0; i < deserializedLogs.size(); i++) {
           Log currentItem = ret.getLogs().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('logs_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('logs');
           Log newItem = (Log) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Log.class);
           newLogs.add(newItem);
         }
-        ret.logs_serialized_name = newLogs;
+        ret.logs = newLogs;
       }
 
       // calling custom deserializer for pagination
-      LogPagination newPagination = (LogPagination) new LogPagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), LogPagination.class);
+      LogPagination newPagination = (LogPagination) new LogPagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), LogPagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (logs != null && logs[0] != null) {
+        mapping.putAll(logs[0].getApiToSdkMapping());
+      }
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -11875,9 +13578,15 @@ public class IBMAssistantV1Models {
    * Log message details.
    */
   public class LogMessage extends IBMWatsonDynamicModel {
-    private String level_serialized_name;
-    private String msg_serialized_name;
+    private String level;
+    private String msg;
     private Map<String, Object> additional_properties_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public LogMessage() { }
 
     /**
      * Gets the level.
@@ -11886,7 +13595,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getLevel() {
-      return level_serialized_name;
+      return level;
     }
 
     /**
@@ -11896,7 +13605,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getMsg() {
-      return msg_serialized_name;
+      return msg;
     }
 
     /**
@@ -11909,22 +13618,20 @@ public class IBMAssistantV1Models {
       return this.getDynamicProperties();
     }
 
-    /**
-     * Sets the level.
-     *
-     * @param level the new level
-     */
-    public void setLevel(final String level) {
-      this.level_serialized_name = level;
+    private LogMessage(LogMessageBuilder builder) {
+      IBMWatsonValidator.notNull(builder.level, 'level cannot be null');
+      IBMWatsonValidator.notNull(builder.msg, 'msg cannot be null');
+      this.level = builder.level;
+      this.msg = builder.msg;
     }
 
     /**
-     * Sets the msg.
+     * New builder.
      *
-     * @param msg the new msg
+     * @return a LogMessage builder
      */
-    public void setMsg(final String msg) {
-      this.msg_serialized_name = msg;
+    public LogMessageBuilder newBuilder() {
+      return new LogMessageBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -11933,16 +13640,78 @@ public class IBMAssistantV1Models {
       }
 
       LogMessage ret = (LogMessage) super.deserialize(jsonString, jsonMap, classType);
+      LogMessageBuilder retBuilder = ret.newBuilder();
 
+      LogMessage builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
 
       for (String key : jsonMap.keySet()) {
         if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
+          builderResult.put(key, jsonMap.get(key));
         }
       }
 
-      return ret;
+      return builderResult;
+    }
+  }
+
+  /**
+   * LogMessage Builder.
+   */
+  public class LogMessageBuilder {
+    private String level;
+    private String msg;
+
+    private LogMessageBuilder(LogMessage logMessage) {
+      this.level = logMessage.level;
+      this.msg = logMessage.msg;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public LogMessageBuilder() { }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param level the level
+     * @param msg the msg
+     */
+    public LogMessageBuilder(String level, String msg) {
+      this.level = level;
+      this.msg = msg;
+    }
+
+    /**
+     * Builds a LogMessage.
+     *
+     * @return the logMessage
+     */
+    public LogMessage build() {
+      return new LogMessage(this);
+    }
+
+    /**
+     * Set the level.
+     *
+     * @param level the level
+     * @return the LogMessage builder
+     */
+    public LogMessageBuilder setLevel(String level) {
+      this.level = level;
+      return this;
+    }
+
+    /**
+     * Set the msg.
+     *
+     * @param msg the msg
+     * @return the LogMessage builder
+     */
+    public LogMessageBuilder setMsg(String msg) {
+      this.msg = msg;
+      return this;
     }
   }
 
@@ -11950,9 +13719,9 @@ public class IBMAssistantV1Models {
    * The pagination data for the returned objects.
    */
   public class LogPagination extends IBMWatsonGenericModel {
-    private String next_url_serialized_name;
-    private Long matched_serialized_name;
-    private String next_cursor_serialized_name;
+    private String nextUrl;
+    private Long matched;
+    private String nextCursor;
  
     /**
      * Gets the nextUrl.
@@ -11963,7 +13732,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getNextUrl() {
-      return next_url_serialized_name;
+      return nextUrl;
     }
  
     /**
@@ -11975,7 +13744,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Long getMatched() {
-      return matched_serialized_name;
+      return matched;
     }
  
     /**
@@ -11987,7 +13756,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getNextCursor() {
-      return next_cursor_serialized_name;
+      return nextCursor;
     }
 
     /**
@@ -11996,7 +13765,7 @@ public class IBMAssistantV1Models {
      * @param nextUrl the new nextUrl
      */
     public void setNextUrl(final String nextUrl) {
-      this.next_url_serialized_name = nextUrl;
+      this.nextUrl = nextUrl;
     }
 
     /**
@@ -12005,7 +13774,7 @@ public class IBMAssistantV1Models {
      * @param matched the new matched
      */
     public void setMatched(final long matched) {
-      this.matched_serialized_name = matched;
+      this.matched = matched;
     }
 
     /**
@@ -12014,17 +13783,29 @@ public class IBMAssistantV1Models {
      * @param nextCursor the new nextCursor
      */
     public void setNextCursor(final String nextCursor) {
-      this.next_cursor_serialized_name = nextCursor;
+      this.nextCursor = nextCursor;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('next_url', 'nextUrl');
+      mapping.put('next_cursor', 'nextCursor');
+      return mapping;
+    }
   }
 
   /**
    * A mention of a contextual entity.
    */
   public class Mention extends IBMWatsonGenericModel {
-    private String entity_serialized_name;
-    private List<Long> location_serialized_name;
+    private String entity;
+    private List<Long> location;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Mention() { }
  
     /**
      * Gets the entity.
@@ -12035,7 +13816,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getEntity() {
-      return entity_serialized_name;
+      return entity;
     }
  
     /**
@@ -12047,35 +13828,115 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
+    }
+  
+    private Mention(MentionBuilder builder) {
+      IBMWatsonValidator.notNull(builder.entity, 'entity cannot be null');
+      IBMWatsonValidator.notNull(builder.location, 'location cannot be null');
+      this.entity = builder.entity;
+      this.location = builder.location;
     }
 
     /**
-     * Sets the entity.
+     * New builder.
      *
-     * @param entity the new entity
+     * @return a Mention builder
      */
-    public void setEntity(final String entity) {
-      this.entity_serialized_name = entity;
+    public MentionBuilder newBuilder() {
+      return new MentionBuilder(this);
+    }
+  }
+
+  /**
+   * Mention Builder.
+   */
+  public class MentionBuilder {
+    private String entity;
+    private List<Long> location;
+
+    private MentionBuilder(Mention mention) {
+      this.entity = mention.entity;
+      this.location = mention.location;
     }
 
     /**
-     * Sets the location.
+     * Instantiates a new builder.
+     */
+    public MentionBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param entity the entity
+     * @param location the location
+     */
+    public MentionBuilder(String entity, List<Long> location) {
+      this.entity = entity;
+      this.location = location;
+    }
+
+    /**
+     * Builds a Mention.
+     *
+     * @return the mention
+     */
+    public Mention build() {
+      return new Mention(this);
+    }
+
+    /**
+     * Adds an location to location.
      *
      * @param location the new location
+     * @return the Mention builder
      */
-    public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
+    public MentionBuilder addLocation(Long location) {
+      IBMWatsonValidator.notNull(location, 'location cannot be null');
+      if (this.location == null) {
+        this.location = new List<Long>();
+      }
+      this.location.add(location);
+      return this;
     }
 
+    /**
+     * Set the entity.
+     *
+     * @param entity the entity
+     * @return the Mention builder
+     */
+    public MentionBuilder setEntity(String entity) {
+      this.entity = entity;
+      return this;
+    }
+
+    /**
+     * Set the location.
+     * Existing location will be replaced.
+     *
+     * @param location the location
+     * @return the Mention builder
+     */
+    public MentionBuilder setLocation(List<Long> location) {
+      this.location = location;
+      return this;
+    }
   }
 
   /**
    * Metadata related to the message.
    */
   public class MessageContextMetadata extends IBMWatsonGenericModel {
-    private String deployment_serialized_name;
-    private String user_id_serialized_name;
+    private String deployment;
+    private String userId;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public MessageContextMetadata() { }
  
     /**
      * Gets the deployment.
@@ -12087,7 +13948,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDeployment() {
-      return deployment_serialized_name;
+      return deployment;
     }
  
     /**
@@ -12102,34 +13963,91 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getUserId() {
-      return user_id_serialized_name;
+      return userId;
+    }
+  
+    private MessageContextMetadata(MessageContextMetadataBuilder builder) {
+      this.deployment = builder.deployment;
+      this.userId = builder.userId;
     }
 
     /**
-     * Sets the deployment.
+     * New builder.
      *
-     * @param deployment the new deployment
+     * @return a MessageContextMetadata builder
      */
-    public void setDeployment(final String deployment) {
-      this.deployment_serialized_name = deployment;
+    public MessageContextMetadataBuilder newBuilder() {
+      return new MessageContextMetadataBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('userId', 'user_id');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('user_id', 'userId');
+      return mapping;
+    }
+  }
+
+  /**
+   * MessageContextMetadata Builder.
+   */
+  public class MessageContextMetadataBuilder {
+    private String deployment;
+    private String userId;
+
+    private MessageContextMetadataBuilder(MessageContextMetadata messageContextMetadata) {
+      this.deployment = messageContextMetadata.deployment;
+      this.userId = messageContextMetadata.userId;
     }
 
     /**
-     * Sets the userId.
-     *
-     * @param userId the new userId
+     * Instantiates a new builder.
      */
-    public void setUserId(final String userId) {
-      this.user_id_serialized_name = userId;
+    public MessageContextMetadataBuilder() {
     }
 
+    /**
+     * Builds a MessageContextMetadata.
+     *
+     * @return the messageContextMetadata
+     */
+    public MessageContextMetadata build() {
+      return new MessageContextMetadata(this);
+    }
+
+    /**
+     * Set the deployment.
+     *
+     * @param deployment the deployment
+     * @return the MessageContextMetadata builder
+     */
+    public MessageContextMetadataBuilder setDeployment(String deployment) {
+      this.deployment = deployment;
+      return this;
+    }
+
+    /**
+     * Set the userId.
+     *
+     * @param userId the userId
+     * @return the MessageContextMetadata builder
+     */
+    public MessageContextMetadataBuilder setUserId(String userId) {
+      this.userId = userId;
+      return this;
+    }
   }
 
   /**
    * An input object that includes the input text.
    */
   public class MessageInput extends IBMWatsonDynamicModel {
-    private String text_serialized_name;
+    private String text;
     private Map<String, Object> additional_properties_serialized_name;
 
     /**
@@ -12145,7 +14063,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -12159,7 +14077,7 @@ public class IBMAssistantV1Models {
     }
 
     private MessageInput(MessageInputBuilder builder) {
-      this.text_serialized_name = builder.text;
+      this.text = builder.text;
     }
 
     /**
@@ -12199,7 +14117,7 @@ public class IBMAssistantV1Models {
     private String text;
 
     private MessageInputBuilder(MessageInput messageInput) {
-      this.text = messageInput.text_serialized_name;
+      this.text = messageInput.text;
     }
 
     /**
@@ -12240,7 +14158,7 @@ public class IBMAssistantV1Models {
     private Context context;
     private OutputData output;
     private Boolean nodesVisitedDetails;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -12251,7 +14169,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the input.
      *
@@ -12262,7 +14180,7 @@ public class IBMAssistantV1Models {
     public MessageInput input() {
       return input;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -12274,7 +14192,7 @@ public class IBMAssistantV1Models {
     public List<RuntimeIntent> intents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -12286,7 +14204,7 @@ public class IBMAssistantV1Models {
     public List<RuntimeEntity> entities() {
       return entities;
     }
- 
+
     /**
      * Gets the alternateIntents.
      *
@@ -12297,7 +14215,7 @@ public class IBMAssistantV1Models {
     public Boolean alternateIntents() {
       return alternateIntents;
     }
- 
+
     /**
      * Gets the context.
      *
@@ -12308,7 +14226,7 @@ public class IBMAssistantV1Models {
     public Context context() {
       return context;
     }
- 
+
     /**
      * Gets the output.
      *
@@ -12320,7 +14238,7 @@ public class IBMAssistantV1Models {
     public OutputData output() {
       return output;
     }
- 
+
     /**
      * Gets the nodesVisitedDetails.
      *
@@ -12355,6 +14273,22 @@ public class IBMAssistantV1Models {
       return new MessageOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getSdkToApiMapping());
+      }
+      mapping.put('alternateIntents', 'alternate_intents');
+      if (context != null) {
+        mapping.putAll(context.getSdkToApiMapping());
+      }
+      if (output != null) {
+        mapping.putAll(output.getSdkToApiMapping());
+      }
+      mapping.put('nodesVisitedDetails', 'nodes_visited_details');
+      return mapping;
+    }
   }
 
   /**
@@ -12559,13 +14493,19 @@ public class IBMAssistantV1Models {
    * A request sent to the workspace, including the user input and context.
    */
   public class MessageRequest extends IBMWatsonGenericModel {
-    private MessageInput input_serialized_name;
-    private List<RuntimeIntent> intents_serialized_name;
-    private List<RuntimeEntity> entities_serialized_name;
-    private Boolean alternate_intents_serialized_name;
-    private Context context_serialized_name;
-    private OutputData output_serialized_name;
-    private List<DialogNodeAction> actions_serialized_name;
+    private MessageInput input;
+    private List<RuntimeIntent> intents;
+    private List<RuntimeEntity> entities;
+    private Boolean alternateIntents;
+    private Context context;
+    private OutputData output;
+    private List<DialogNodeAction> actions;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public MessageRequest() { }
  
     /**
      * Gets the input.
@@ -12576,7 +14516,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public MessageInput getInput() {
-      return input_serialized_name;
+      return input;
     }
  
     /**
@@ -12589,7 +14529,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<RuntimeIntent> getIntents() {
-      return intents_serialized_name;
+      return intents;
     }
  
     /**
@@ -12602,7 +14542,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<RuntimeEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -12614,7 +14554,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getAlternateIntents() {
-      return alternate_intents_serialized_name;
+      return alternateIntents;
     }
  
     /**
@@ -12626,7 +14566,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Context getContext() {
-      return context_serialized_name;
+      return context;
     }
  
     /**
@@ -12639,7 +14579,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public OutputData getOutput() {
-      return output_serialized_name;
+      return output;
     }
  
     /**
@@ -12651,61 +14591,26 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNodeAction> getActions() {
-      return actions_serialized_name;
+      return actions;
+    }
+  
+    private MessageRequest(MessageRequestBuilder builder) {
+      this.input = builder.input;
+      this.intents = builder.intents;
+      this.entities = builder.entities;
+      this.alternateIntents = builder.alternateIntents;
+      this.context = builder.context;
+      this.output = builder.output;
+      this.actions = builder.actions;
     }
 
     /**
-     * Sets the input.
+     * New builder.
      *
-     * @param input the new input
+     * @return a MessageRequest builder
      */
-    public void setInput(final MessageInput input) {
-      this.input_serialized_name = input;
-    }
-
-    /**
-     * Sets the intents.
-     *
-     * @param intents the new intents
-     */
-    public void setIntents(final List<RuntimeIntent> intents) {
-      this.intents_serialized_name = intents;
-    }
-
-    /**
-     * Sets the entities.
-     *
-     * @param entities the new entities
-     */
-    public void setEntities(final List<RuntimeEntity> entities) {
-      this.entities_serialized_name = entities;
-    }
-
-    /**
-     * Sets the alternateIntents.
-     *
-     * @param alternateIntents the new alternateIntents
-     */
-    public void setAlternateIntents(final Boolean alternateIntents) {
-      this.alternate_intents_serialized_name = alternateIntents;
-    }
-
-    /**
-     * Sets the context.
-     *
-     * @param context the new context
-     */
-    public void setContext(final Context context) {
-      this.context_serialized_name = context;
-    }
-
-    /**
-     * Sets the output.
-     *
-     * @param output the new output
-     */
-    public void setOutput(final OutputData output) {
-      this.output_serialized_name = output;
+    public MessageRequestBuilder newBuilder() {
+      return new MessageRequestBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -12714,10 +14619,11 @@ public class IBMAssistantV1Models {
       }
 
       MessageRequest ret = (MessageRequest) super.deserialize(jsonString, jsonMap, classType);
+      MessageRequestBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for input
-      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input_serialized_name'), MessageInput.class);
-      ret.setInput(newInput);
+      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input'), MessageInput.class);
+      retBuilder.setInput(newInput);
 
       // calling custom deserializer for intents
       List<RuntimeIntent> newIntents = new List<RuntimeIntent>();
@@ -12725,11 +14631,11 @@ public class IBMAssistantV1Models {
       if (deserializedIntents != null) {
         for (Integer i = 0; i < deserializedIntents.size(); i++) {
           RuntimeIntent currentItem = ret.getIntents().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('intents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('intents');
           RuntimeIntent newItem = (RuntimeIntent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeIntent.class);
           newIntents.add(newItem);
         }
-        ret.intents_serialized_name = newIntents;
+        retBuilder.setIntents(newIntents);
       }
 
       // calling custom deserializer for entities
@@ -12738,20 +14644,20 @@ public class IBMAssistantV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           RuntimeEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           RuntimeEntity newItem = (RuntimeEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeEntity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        retBuilder.setEntities(newEntities);
       }
 
       // calling custom deserializer for context
-      Context newContext = (Context) new Context().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context_serialized_name'), Context.class);
-      ret.setContext(newContext);
+      Context newContext = (Context) new Context().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context'), Context.class);
+      retBuilder.setContext(newContext);
 
       // calling custom deserializer for output
-      OutputData newOutput = (OutputData) new OutputData().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output_serialized_name'), OutputData.class);
-      ret.setOutput(newOutput);
+      OutputData newOutput = (OutputData) new OutputData().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output'), OutputData.class);
+      retBuilder.setOutput(newOutput);
 
       // calling custom deserializer for actions
       List<DialogNodeAction> newActions = new List<DialogNodeAction>();
@@ -12759,14 +14665,213 @@ public class IBMAssistantV1Models {
       if (deserializedActions != null) {
         for (Integer i = 0; i < deserializedActions.size(); i++) {
           DialogNodeAction currentItem = ret.getActions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('actions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('actions');
           DialogNodeAction newItem = (DialogNodeAction) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeAction.class);
           newActions.add(newItem);
         }
-        ret.actions_serialized_name = newActions;
+        retBuilder.setActions(newActions);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getSdkToApiMapping());
+      }
+      mapping.put('alternateIntents', 'alternate_intents');
+      if (context != null) {
+        mapping.putAll(context.getSdkToApiMapping());
+      }
+      if (output != null) {
+        mapping.putAll(output.getSdkToApiMapping());
+      }
+      if (actions != null && actions[0] != null) {
+        mapping.putAll(actions[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      mapping.put('alternate_intents', 'alternateIntents');
+      if (context != null) {
+        mapping.putAll(context.getApiToSdkMapping());
+      }
+      if (output != null) {
+        mapping.putAll(output.getApiToSdkMapping());
+      }
+      if (actions != null && actions[0] != null) {
+        mapping.putAll(actions[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * MessageRequest Builder.
+   */
+  public class MessageRequestBuilder {
+    private MessageInput input;
+    private List<RuntimeIntent> intents;
+    private List<RuntimeEntity> entities;
+    private Boolean alternateIntents;
+    private Context context;
+    private OutputData output;
+    private List<DialogNodeAction> actions;
+
+    private MessageRequestBuilder(MessageRequest messageRequest) {
+      this.input = messageRequest.input;
+      this.intents = messageRequest.intents;
+      this.entities = messageRequest.entities;
+      this.alternateIntents = messageRequest.alternateIntents;
+      this.context = messageRequest.context;
+      this.output = messageRequest.output;
+      this.actions = messageRequest.actions;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public MessageRequestBuilder() {
+    }
+
+    /**
+     * Builds a MessageRequest.
+     *
+     * @return the messageRequest
+     */
+    public MessageRequest build() {
+      return new MessageRequest(this);
+    }
+
+    /**
+     * Adds an intents to intents.
+     *
+     * @param intents the new intents
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder addIntents(RuntimeIntent intents) {
+      IBMWatsonValidator.notNull(intents, 'intents cannot be null');
+      if (this.intents == null) {
+        this.intents = new List<RuntimeIntent>();
+      }
+      this.intents.add(intents);
+      return this;
+    }
+
+    /**
+     * Adds an entities to entities.
+     *
+     * @param entities the new entities
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder addEntities(RuntimeEntity entities) {
+      IBMWatsonValidator.notNull(entities, 'entities cannot be null');
+      if (this.entities == null) {
+        this.entities = new List<RuntimeEntity>();
+      }
+      this.entities.add(entities);
+      return this;
+    }
+
+    /**
+     * Adds an actions to actions.
+     *
+     * @param actions the new actions
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder addActions(DialogNodeAction actions) {
+      IBMWatsonValidator.notNull(actions, 'actions cannot be null');
+      if (this.actions == null) {
+        this.actions = new List<DialogNodeAction>();
+      }
+      this.actions.add(actions);
+      return this;
+    }
+
+    /**
+     * Set the input.
+     *
+     * @param input the input
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder setInput(MessageInput input) {
+      this.input = input;
+      return this;
+    }
+
+    /**
+     * Set the intents.
+     * Existing intents will be replaced.
+     *
+     * @param intents the intents
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder setIntents(List<RuntimeIntent> intents) {
+      this.intents = intents;
+      return this;
+    }
+
+    /**
+     * Set the entities.
+     * Existing entities will be replaced.
+     *
+     * @param entities the entities
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder setEntities(List<RuntimeEntity> entities) {
+      this.entities = entities;
+      return this;
+    }
+
+    /**
+     * Set the alternateIntents.
+     *
+     * @param alternateIntents the alternateIntents
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder setAlternateIntents(Boolean alternateIntents) {
+      this.alternateIntents = alternateIntents;
+      return this;
+    }
+
+    /**
+     * Set the context.
+     *
+     * @param context the context
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder setContext(Context context) {
+      this.context = context;
+      return this;
+    }
+
+    /**
+     * Set the output.
+     *
+     * @param output the output
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder setOutput(OutputData output) {
+      this.output = output;
+      return this;
+    }
+
+    /**
+     * Set the actions.
+     * Existing actions will be replaced.
+     *
+     * @param actions the actions
+     * @return the MessageRequest builder
+     */
+    public MessageRequestBuilder setActions(List<DialogNodeAction> actions) {
+      this.actions = actions;
+      return this;
     }
   }
 
@@ -12774,13 +14879,13 @@ public class IBMAssistantV1Models {
    * The response sent by the workspace, including the output text, detected intents and entities, and context.
    */
   public class MessageResponse extends IBMWatsonResponseModel {
-    private MessageInput input_serialized_name;
-    private List<RuntimeIntent> intents_serialized_name;
-    private List<RuntimeEntity> entities_serialized_name;
-    private Boolean alternate_intents_serialized_name;
-    private Context context_serialized_name;
-    private OutputData output_serialized_name;
-    private List<DialogNodeAction> actions_serialized_name;
+    private MessageInput input;
+    private List<RuntimeIntent> intents;
+    private List<RuntimeEntity> entities;
+    private Boolean alternateIntents;
+    private Context context;
+    private OutputData output;
+    private List<DialogNodeAction> actions;
  
     /**
      * Gets the input.
@@ -12791,7 +14896,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public MessageInput getInput() {
-      return input_serialized_name;
+      return input;
     }
  
     /**
@@ -12803,7 +14908,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<RuntimeIntent> getIntents() {
-      return intents_serialized_name;
+      return intents;
     }
  
     /**
@@ -12815,7 +14920,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<RuntimeEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -12827,7 +14932,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getAlternateIntents() {
-      return alternate_intents_serialized_name;
+      return alternateIntents;
     }
  
     /**
@@ -12839,7 +14944,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Context getContext() {
-      return context_serialized_name;
+      return context;
     }
  
     /**
@@ -12852,7 +14957,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public OutputData getOutput() {
-      return output_serialized_name;
+      return output;
     }
  
     /**
@@ -12864,7 +14969,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNodeAction> getActions() {
-      return actions_serialized_name;
+      return actions;
     }
 
     /**
@@ -12873,7 +14978,7 @@ public class IBMAssistantV1Models {
      * @param input the new input
      */
     public void setInput(final MessageInput input) {
-      this.input_serialized_name = input;
+      this.input = input;
     }
 
     /**
@@ -12882,7 +14987,7 @@ public class IBMAssistantV1Models {
      * @param intents the new intents
      */
     public void setIntents(final List<RuntimeIntent> intents) {
-      this.intents_serialized_name = intents;
+      this.intents = intents;
     }
 
     /**
@@ -12891,7 +14996,7 @@ public class IBMAssistantV1Models {
      * @param entities the new entities
      */
     public void setEntities(final List<RuntimeEntity> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     /**
@@ -12900,7 +15005,7 @@ public class IBMAssistantV1Models {
      * @param alternateIntents the new alternateIntents
      */
     public void setAlternateIntents(final Boolean alternateIntents) {
-      this.alternate_intents_serialized_name = alternateIntents;
+      this.alternateIntents = alternateIntents;
     }
 
     /**
@@ -12909,7 +15014,7 @@ public class IBMAssistantV1Models {
      * @param context the new context
      */
     public void setContext(final Context context) {
-      this.context_serialized_name = context;
+      this.context = context;
     }
 
     /**
@@ -12918,7 +15023,7 @@ public class IBMAssistantV1Models {
      * @param output the new output
      */
     public void setOutput(final OutputData output) {
-      this.output_serialized_name = output;
+      this.output = output;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -12929,7 +15034,7 @@ public class IBMAssistantV1Models {
       MessageResponse ret = (MessageResponse) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for input
-      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input_serialized_name'), MessageInput.class);
+      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input'), MessageInput.class);
       ret.setInput(newInput);
 
       // calling custom deserializer for intents
@@ -12938,11 +15043,11 @@ public class IBMAssistantV1Models {
       if (deserializedIntents != null) {
         for (Integer i = 0; i < deserializedIntents.size(); i++) {
           RuntimeIntent currentItem = ret.getIntents().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('intents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('intents');
           RuntimeIntent newItem = (RuntimeIntent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeIntent.class);
           newIntents.add(newItem);
         }
-        ret.intents_serialized_name = newIntents;
+        ret.intents = newIntents;
       }
 
       // calling custom deserializer for entities
@@ -12951,19 +15056,19 @@ public class IBMAssistantV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           RuntimeEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           RuntimeEntity newItem = (RuntimeEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeEntity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       // calling custom deserializer for context
-      Context newContext = (Context) new Context().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context_serialized_name'), Context.class);
+      Context newContext = (Context) new Context().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context'), Context.class);
       ret.setContext(newContext);
 
       // calling custom deserializer for output
-      OutputData newOutput = (OutputData) new OutputData().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output_serialized_name'), OutputData.class);
+      OutputData newOutput = (OutputData) new OutputData().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output'), OutputData.class);
       ret.setOutput(newOutput);
 
       // calling custom deserializer for actions
@@ -12972,14 +15077,32 @@ public class IBMAssistantV1Models {
       if (deserializedActions != null) {
         for (Integer i = 0; i < deserializedActions.size(); i++) {
           DialogNodeAction currentItem = ret.getActions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('actions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('actions');
           DialogNodeAction newItem = (DialogNodeAction) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeAction.class);
           newActions.add(newItem);
         }
-        ret.actions_serialized_name = newActions;
+        ret.actions = newActions;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      mapping.put('alternate_intents', 'alternateIntents');
+      if (context != null) {
+        mapping.putAll(context.getApiToSdkMapping());
+      }
+      if (output != null) {
+        mapping.putAll(output.getApiToSdkMapping());
+      }
+      if (actions != null && actions[0] != null) {
+        mapping.putAll(actions[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -12987,12 +15110,18 @@ public class IBMAssistantV1Models {
    * An output object that includes the response to the user, the dialog nodes that were triggered, and messages from the log.
    */
   public class OutputData extends IBMWatsonDynamicModel {
-    private List<LogMessage> log_messages_serialized_name;
-    private List<String> text_serialized_name;
-    private List<DialogRuntimeResponseGeneric> generic_serialized_name;
-    private List<String> nodes_visited_serialized_name;
-    private List<DialogNodeVisitedDetails> nodes_visited_details_serialized_name;
+    private List<LogMessage> logMessages;
+    private List<String> text;
+    private List<DialogRuntimeResponseGeneric> generic;
+    private List<String> nodesVisited;
+    private List<DialogNodeVisitedDetails> nodesVisitedDetails;
     private Map<String, Object> additional_properties_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public OutputData() { }
 
     /**
      * Gets the logMessages.
@@ -13001,7 +15130,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<LogMessage> getLogMessages() {
-      return log_messages_serialized_name;
+      return logMessages;
     }
 
     /**
@@ -13011,7 +15140,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<String> getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -13021,7 +15150,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogRuntimeResponseGeneric> getGeneric() {
-      return generic_serialized_name;
+      return generic;
     }
 
     /**
@@ -13031,7 +15160,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<String> getNodesVisited() {
-      return nodes_visited_serialized_name;
+      return nodesVisited;
     }
 
     /**
@@ -13041,7 +15170,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNodeVisitedDetails> getNodesVisitedDetails() {
-      return nodes_visited_details_serialized_name;
+      return nodesVisitedDetails;
     }
 
     /**
@@ -13054,49 +15183,23 @@ public class IBMAssistantV1Models {
       return this.getDynamicProperties();
     }
 
-    /**
-     * Sets the logMessages.
-     *
-     * @param logMessages the new logMessages
-     */
-    public void setLogMessages(final List<LogMessage> logMessages) {
-      this.log_messages_serialized_name = logMessages;
+    private OutputData(OutputDataBuilder builder) {
+      IBMWatsonValidator.notNull(builder.logMessages, 'logMessages cannot be null');
+      IBMWatsonValidator.notNull(builder.text, 'text cannot be null');
+      this.logMessages = builder.logMessages;
+      this.text = builder.text;
+      this.generic = builder.generic;
+      this.nodesVisited = builder.nodesVisited;
+      this.nodesVisitedDetails = builder.nodesVisitedDetails;
     }
 
     /**
-     * Sets the text.
+     * New builder.
      *
-     * @param text the new text
+     * @return a OutputData builder
      */
-    public void setText(final List<String> text) {
-      this.text_serialized_name = text;
-    }
-
-    /**
-     * Sets the generic.
-     *
-     * @param generic the new generic
-     */
-    public void setGeneric(final List<DialogRuntimeResponseGeneric> generic) {
-      this.generic_serialized_name = generic;
-    }
-
-    /**
-     * Sets the nodesVisited.
-     *
-     * @param nodesVisited the new nodesVisited
-     */
-    public void setNodesVisited(final List<String> nodesVisited) {
-      this.nodes_visited_serialized_name = nodesVisited;
-    }
-
-    /**
-     * Sets the nodesVisitedDetails.
-     *
-     * @param nodesVisitedDetails the new nodesVisitedDetails
-     */
-    public void setNodesVisitedDetails(final List<DialogNodeVisitedDetails> nodesVisitedDetails) {
-      this.nodes_visited_details_serialized_name = nodesVisitedDetails;
+    public OutputDataBuilder newBuilder() {
+      return new OutputDataBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -13105,6 +15208,7 @@ public class IBMAssistantV1Models {
       }
 
       OutputData ret = (OutputData) super.deserialize(jsonString, jsonMap, classType);
+      OutputDataBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for logMessages
       List<LogMessage> newLogMessages = new List<LogMessage>();
@@ -13112,11 +15216,11 @@ public class IBMAssistantV1Models {
       if (deserializedLogMessages != null) {
         for (Integer i = 0; i < deserializedLogMessages.size(); i++) {
           LogMessage currentItem = ret.getLogMessages().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('log_messages_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('logMessages');
           LogMessage newItem = (LogMessage) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), LogMessage.class);
           newLogMessages.add(newItem);
         }
-        ret.setLogMessages(newLogMessages);
+        retBuilder.setLogMessages(newLogMessages);
       }
 
       // calling custom deserializer for generic
@@ -13125,11 +15229,11 @@ public class IBMAssistantV1Models {
       if (deserializedGeneric != null) {
         for (Integer i = 0; i < deserializedGeneric.size(); i++) {
           DialogRuntimeResponseGeneric currentItem = ret.getGeneric().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('generic_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('generic');
           DialogRuntimeResponseGeneric newItem = (DialogRuntimeResponseGeneric) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogRuntimeResponseGeneric.class);
           newGeneric.add(newItem);
         }
-        ret.setGeneric(newGeneric);
+        retBuilder.setGeneric(newGeneric);
       }
 
       // calling custom deserializer for nodesVisitedDetails
@@ -13138,22 +15242,230 @@ public class IBMAssistantV1Models {
       if (deserializedNodesVisitedDetails != null) {
         for (Integer i = 0; i < deserializedNodesVisitedDetails.size(); i++) {
           DialogNodeVisitedDetails currentItem = ret.getNodesVisitedDetails().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('nodes_visited_details_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('nodesVisitedDetails');
           DialogNodeVisitedDetails newItem = (DialogNodeVisitedDetails) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeVisitedDetails.class);
           newNodesVisitedDetails.add(newItem);
         }
-        ret.setNodesVisitedDetails(newNodesVisitedDetails);
+        retBuilder.setNodesVisitedDetails(newNodesVisitedDetails);
       }
 
+      OutputData builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
 
       for (String key : jsonMap.keySet()) {
         if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
+          builderResult.put(key, jsonMap.get(key));
         }
       }
 
-      return ret;
+      return builderResult;
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('logMessages', 'log_messages');
+      if (generic != null && generic[0] != null) {
+        mapping.putAll(generic[0].getSdkToApiMapping());
+      }
+      mapping.put('nodesVisited', 'nodes_visited');
+      mapping.put('nodesVisitedDetails', 'nodes_visited_details');
+      if (nodesVisitedDetails != null && nodesVisitedDetails[0] != null) {
+        mapping.putAll(nodesVisitedDetails[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('log_messages', 'logMessages');
+      if (generic != null && generic[0] != null) {
+        mapping.putAll(generic[0].getApiToSdkMapping());
+      }
+      mapping.put('nodes_visited', 'nodesVisited');
+      mapping.put('nodes_visited_details', 'nodesVisitedDetails');
+      if (nodesVisitedDetails != null && nodesVisitedDetails[0] != null) {
+        mapping.putAll(nodesVisitedDetails[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * OutputData Builder.
+   */
+  public class OutputDataBuilder {
+    private List<LogMessage> logMessages;
+    private List<String> text;
+    private List<DialogRuntimeResponseGeneric> generic;
+    private List<String> nodesVisited;
+    private List<DialogNodeVisitedDetails> nodesVisitedDetails;
+
+    private OutputDataBuilder(OutputData outputData) {
+      this.logMessages = outputData.logMessages;
+      this.text = outputData.text;
+      this.generic = outputData.generic;
+      this.nodesVisited = outputData.nodesVisited;
+      this.nodesVisitedDetails = outputData.nodesVisitedDetails;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public OutputDataBuilder() { }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param logMessages the logMessages
+     * @param text the text
+     */
+    public OutputDataBuilder(List<LogMessage> logMessages, List<String> text) {
+      this.logMessages = logMessages;
+      this.text = text;
+    }
+
+    /**
+     * Builds a OutputData.
+     *
+     * @return the outputData
+     */
+    public OutputData build() {
+      return new OutputData(this);
+    }
+
+    /**
+     * Adds an logMessages to logMessages.
+     *
+     * @param logMessages the new logMessages
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder addLogMessages(LogMessage logMessages) {
+      IBMWatsonValidator.notNull(logMessages, 'logMessages cannot be null');
+      if (this.logMessages == null) {
+        this.logMessages = new List<LogMessage>();
+      }
+      this.logMessages.add(logMessages);
+      return this;
+    }
+
+    /**
+     * Adds an text to text.
+     *
+     * @param text the new text
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder addText(String text) {
+      IBMWatsonValidator.notNull(text, 'text cannot be null');
+      if (this.text == null) {
+        this.text = new List<String>();
+      }
+      this.text.add(text);
+      return this;
+    }
+
+    /**
+     * Adds an generic to generic.
+     *
+     * @param generic the new generic
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder addGeneric(DialogRuntimeResponseGeneric generic) {
+      IBMWatsonValidator.notNull(generic, 'generic cannot be null');
+      if (this.generic == null) {
+        this.generic = new List<DialogRuntimeResponseGeneric>();
+      }
+      this.generic.add(generic);
+      return this;
+    }
+
+    /**
+     * Adds an nodesVisited to nodesVisited.
+     *
+     * @param nodesVisited the new nodesVisited
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder addNodesVisited(String nodesVisited) {
+      IBMWatsonValidator.notNull(nodesVisited, 'nodesVisited cannot be null');
+      if (this.nodesVisited == null) {
+        this.nodesVisited = new List<String>();
+      }
+      this.nodesVisited.add(nodesVisited);
+      return this;
+    }
+
+    /**
+     * Adds an nodesVisitedDetails to nodesVisitedDetails.
+     *
+     * @param nodesVisitedDetails the new nodesVisitedDetails
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder addNodesVisitedDetails(DialogNodeVisitedDetails nodesVisitedDetails) {
+      IBMWatsonValidator.notNull(nodesVisitedDetails, 'nodesVisitedDetails cannot be null');
+      if (this.nodesVisitedDetails == null) {
+        this.nodesVisitedDetails = new List<DialogNodeVisitedDetails>();
+      }
+      this.nodesVisitedDetails.add(nodesVisitedDetails);
+      return this;
+    }
+
+    /**
+     * Set the logMessages.
+     * Existing logMessages will be replaced.
+     *
+     * @param logMessages the logMessages
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder setLogMessages(List<LogMessage> logMessages) {
+      this.logMessages = logMessages;
+      return this;
+    }
+
+    /**
+     * Set the text.
+     * Existing text will be replaced.
+     *
+     * @param text the text
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder setText(List<String> text) {
+      this.text = text;
+      return this;
+    }
+
+    /**
+     * Set the generic.
+     * Existing generic will be replaced.
+     *
+     * @param generic the generic
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder setGeneric(List<DialogRuntimeResponseGeneric> generic) {
+      this.generic = generic;
+      return this;
+    }
+
+    /**
+     * Set the nodesVisited.
+     * Existing nodesVisited will be replaced.
+     *
+     * @param nodesVisited the nodesVisited
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder setNodesVisited(List<String> nodesVisited) {
+      this.nodesVisited = nodesVisited;
+      return this;
+    }
+
+    /**
+     * Set the nodesVisitedDetails.
+     * Existing nodesVisitedDetails will be replaced.
+     *
+     * @param nodesVisitedDetails the nodesVisitedDetails
+     * @return the OutputData builder
+     */
+    public OutputDataBuilder setNodesVisitedDetails(List<DialogNodeVisitedDetails> nodesVisitedDetails) {
+      this.nodesVisitedDetails = nodesVisitedDetails;
+      return this;
     }
   }
 
@@ -13161,12 +15473,12 @@ public class IBMAssistantV1Models {
    * The pagination data for the returned objects.
    */
   public class Pagination extends IBMWatsonGenericModel {
-    private String refresh_url_serialized_name;
-    private String next_url_serialized_name;
-    private Long total_serialized_name;
-    private Long matched_serialized_name;
-    private String refresh_cursor_serialized_name;
-    private String next_cursor_serialized_name;
+    private String refreshUrl;
+    private String nextUrl;
+    private Long total;
+    private Long matched;
+    private String refreshCursor;
+    private String nextCursor;
  
     /**
      * Gets the refreshUrl.
@@ -13177,7 +15489,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getRefreshUrl() {
-      return refresh_url_serialized_name;
+      return refreshUrl;
     }
  
     /**
@@ -13189,7 +15501,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getNextUrl() {
-      return next_url_serialized_name;
+      return nextUrl;
     }
  
     /**
@@ -13201,7 +15513,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Long getTotal() {
-      return total_serialized_name;
+      return total;
     }
  
     /**
@@ -13213,7 +15525,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Long getMatched() {
-      return matched_serialized_name;
+      return matched;
     }
  
     /**
@@ -13225,7 +15537,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getRefreshCursor() {
-      return refresh_cursor_serialized_name;
+      return refreshCursor;
     }
  
     /**
@@ -13237,7 +15549,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getNextCursor() {
-      return next_cursor_serialized_name;
+      return nextCursor;
     }
 
     /**
@@ -13246,7 +15558,7 @@ public class IBMAssistantV1Models {
      * @param refreshUrl the new refreshUrl
      */
     public void setRefreshUrl(final String refreshUrl) {
-      this.refresh_url_serialized_name = refreshUrl;
+      this.refreshUrl = refreshUrl;
     }
 
     /**
@@ -13255,7 +15567,7 @@ public class IBMAssistantV1Models {
      * @param nextUrl the new nextUrl
      */
     public void setNextUrl(final String nextUrl) {
-      this.next_url_serialized_name = nextUrl;
+      this.nextUrl = nextUrl;
     }
 
     /**
@@ -13264,7 +15576,7 @@ public class IBMAssistantV1Models {
      * @param total the new total
      */
     public void setTotal(final long total) {
-      this.total_serialized_name = total;
+      this.total = total;
     }
 
     /**
@@ -13273,7 +15585,7 @@ public class IBMAssistantV1Models {
      * @param matched the new matched
      */
     public void setMatched(final long matched) {
-      this.matched_serialized_name = matched;
+      this.matched = matched;
     }
 
     /**
@@ -13282,7 +15594,7 @@ public class IBMAssistantV1Models {
      * @param refreshCursor the new refreshCursor
      */
     public void setRefreshCursor(final String refreshCursor) {
-      this.refresh_cursor_serialized_name = refreshCursor;
+      this.refreshCursor = refreshCursor;
     }
 
     /**
@@ -13291,22 +15603,36 @@ public class IBMAssistantV1Models {
      * @param nextCursor the new nextCursor
      */
     public void setNextCursor(final String nextCursor) {
-      this.next_cursor_serialized_name = nextCursor;
+      this.nextCursor = nextCursor;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('refresh_url', 'refreshUrl');
+      mapping.put('next_url', 'nextUrl');
+      mapping.put('refresh_cursor', 'refreshCursor');
+      mapping.put('next_cursor', 'nextCursor');
+      return mapping;
+    }
   }
 
   /**
    * A term from the request that was identified as an entity.
    */
   public class RuntimeEntity extends IBMWatsonDynamicModel {
-    private String entity_serialized_name;
-    private List<Long> location_serialized_name;
-    private String value_serialized_name;
-    private Double confidence_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private List<CaptureGroup> groups_serialized_name;
+    private String entity;
+    private List<Long> location;
+    private String value;
+    private Double confidence;
+    private IBMWatsonMapModel metadata;
+    private List<CaptureGroup> groups;
     private Map<String, Object> additional_properties_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public RuntimeEntity() { }
 
     /**
      * Gets the entity.
@@ -13315,7 +15641,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getEntity() {
-      return entity_serialized_name;
+      return entity;
     }
 
     /**
@@ -13325,7 +15651,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -13335,7 +15661,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getValue() {
-      return value_serialized_name;
+      return value;
     }
 
     /**
@@ -13345,7 +15671,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
 
     /**
@@ -13355,7 +15681,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
 
     /**
@@ -13365,7 +15691,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<CaptureGroup> getGroups() {
-      return groups_serialized_name;
+      return groups;
     }
 
     /**
@@ -13378,58 +15704,25 @@ public class IBMAssistantV1Models {
       return this.getDynamicProperties();
     }
 
-    /**
-     * Sets the entity.
-     *
-     * @param entity the new entity
-     */
-    public void setEntity(final String entity) {
-      this.entity_serialized_name = entity;
+    private RuntimeEntity(RuntimeEntityBuilder builder) {
+      IBMWatsonValidator.notNull(builder.entity, 'entity cannot be null');
+      IBMWatsonValidator.notNull(builder.location, 'location cannot be null');
+      IBMWatsonValidator.notNull(builder.value, 'value cannot be null');
+      this.entity = builder.entity;
+      this.location = builder.location;
+      this.value = builder.value;
+      this.confidence = builder.confidence;
+      this.metadata = builder.metadata;
+      this.groups = builder.groups;
     }
 
     /**
-     * Sets the location.
+     * New builder.
      *
-     * @param location the new location
+     * @return a RuntimeEntity builder
      */
-    public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
-    }
-
-    /**
-     * Sets the value.
-     *
-     * @param value the new value
-     */
-    public void setValue(final String value) {
-      this.value_serialized_name = value;
-    }
-
-    /**
-     * Sets the confidence.
-     *
-     * @param confidence the new confidence
-     */
-    public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
-    }
-
-    /**
-     * Sets the metadata.
-     *
-     * @param metadata the new metadata
-     */
-    public void setMetadata(final IBMWatsonMapModel metadata) {
-      this.metadata_serialized_name = metadata;
-    }
-
-    /**
-     * Sets the groups.
-     *
-     * @param groups the new groups
-     */
-    public void setGroups(final List<CaptureGroup> groups) {
-      this.groups_serialized_name = groups;
+    public RuntimeEntityBuilder newBuilder() {
+      return new RuntimeEntityBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -13438,10 +15731,11 @@ public class IBMAssistantV1Models {
       }
 
       RuntimeEntity ret = (RuntimeEntity) super.deserialize(jsonString, jsonMap, classType);
+      RuntimeEntityBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for metadata
-      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), IBMWatsonMapModel.class);
-      ret.setMetadata(newMetadata);
+      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
+      retBuilder.setMetadata(newMetadata);
 
       // calling custom deserializer for groups
       List<CaptureGroup> newGroups = new List<CaptureGroup>();
@@ -13449,22 +15743,185 @@ public class IBMAssistantV1Models {
       if (deserializedGroups != null) {
         for (Integer i = 0; i < deserializedGroups.size(); i++) {
           CaptureGroup currentItem = ret.getGroups().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('groups_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('groups');
           CaptureGroup newItem = (CaptureGroup) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CaptureGroup.class);
           newGroups.add(newItem);
         }
-        ret.setGroups(newGroups);
+        retBuilder.setGroups(newGroups);
       }
 
+      RuntimeEntity builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
 
       for (String key : jsonMap.keySet()) {
         if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
+          builderResult.put(key, jsonMap.get(key));
         }
       }
 
-      return ret;
+      return builderResult;
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (groups != null && groups[0] != null) {
+        mapping.putAll(groups[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (groups != null && groups[0] != null) {
+        mapping.putAll(groups[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * RuntimeEntity Builder.
+   */
+  public class RuntimeEntityBuilder {
+    private String entity;
+    private List<Long> location;
+    private String value;
+    private Double confidence;
+    private IBMWatsonMapModel metadata;
+    private List<CaptureGroup> groups;
+
+    private RuntimeEntityBuilder(RuntimeEntity runtimeEntity) {
+      this.entity = runtimeEntity.entity;
+      this.location = runtimeEntity.location;
+      this.value = runtimeEntity.value;
+      this.confidence = runtimeEntity.confidence;
+      this.metadata = runtimeEntity.metadata;
+      this.groups = runtimeEntity.groups;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public RuntimeEntityBuilder() { }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param entity the entity
+     * @param location the location
+     * @param value the value
+     */
+    public RuntimeEntityBuilder(String entity, List<Long> location, String value) {
+      this.entity = entity;
+      this.location = location;
+      this.value = value;
+    }
+
+    /**
+     * Builds a RuntimeEntity.
+     *
+     * @return the runtimeEntity
+     */
+    public RuntimeEntity build() {
+      return new RuntimeEntity(this);
+    }
+
+    /**
+     * Adds an location to location.
+     *
+     * @param location the new location
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder addLocation(Long location) {
+      IBMWatsonValidator.notNull(location, 'location cannot be null');
+      if (this.location == null) {
+        this.location = new List<Long>();
+      }
+      this.location.add(location);
+      return this;
+    }
+
+    /**
+     * Adds an groups to groups.
+     *
+     * @param groups the new groups
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder addGroups(CaptureGroup groups) {
+      IBMWatsonValidator.notNull(groups, 'groups cannot be null');
+      if (this.groups == null) {
+        this.groups = new List<CaptureGroup>();
+      }
+      this.groups.add(groups);
+      return this;
+    }
+
+    /**
+     * Set the entity.
+     *
+     * @param entity the entity
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setEntity(String entity) {
+      this.entity = entity;
+      return this;
+    }
+
+    /**
+     * Set the location.
+     * Existing location will be replaced.
+     *
+     * @param location the location
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setLocation(List<Long> location) {
+      this.location = location;
+      return this;
+    }
+
+    /**
+     * Set the value.
+     *
+     * @param value the value
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setValue(String value) {
+      this.value = value;
+      return this;
+    }
+
+    /**
+     * Set the confidence.
+     *
+     * @param confidence the confidence
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setConfidence(Double confidence) {
+      this.confidence = confidence;
+      return this;
+    }
+
+    /**
+     * Set the metadata.
+     *
+     * @param metadata the metadata
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setMetadata(IBMWatsonMapModel metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+
+    /**
+     * Set the groups.
+     * Existing groups will be replaced.
+     *
+     * @param groups the groups
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setGroups(List<CaptureGroup> groups) {
+      this.groups = groups;
+      return this;
     }
   }
 
@@ -13472,9 +15929,15 @@ public class IBMAssistantV1Models {
    * An intent identified in the user input.
    */
   public class RuntimeIntent extends IBMWatsonDynamicModel {
-    private String intent_serialized_name;
-    private Double confidence_serialized_name;
+    private String intent;
+    private Double confidence;
     private Map<String, Object> additional_properties_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public RuntimeIntent() { }
 
     /**
      * Gets the intent.
@@ -13483,7 +15946,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getIntent() {
-      return intent_serialized_name;
+      return intent;
     }
 
     /**
@@ -13493,7 +15956,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
 
     /**
@@ -13506,22 +15969,20 @@ public class IBMAssistantV1Models {
       return this.getDynamicProperties();
     }
 
-    /**
-     * Sets the intent.
-     *
-     * @param intent the new intent
-     */
-    public void setIntent(final String intent) {
-      this.intent_serialized_name = intent;
+    private RuntimeIntent(RuntimeIntentBuilder builder) {
+      IBMWatsonValidator.notNull(builder.intent, 'intent cannot be null');
+      IBMWatsonValidator.notNull(builder.confidence, 'confidence cannot be null');
+      this.intent = builder.intent;
+      this.confidence = builder.confidence;
     }
 
     /**
-     * Sets the confidence.
+     * New builder.
      *
-     * @param confidence the new confidence
+     * @return a RuntimeIntent builder
      */
-    public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+    public RuntimeIntentBuilder newBuilder() {
+      return new RuntimeIntentBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -13530,16 +15991,78 @@ public class IBMAssistantV1Models {
       }
 
       RuntimeIntent ret = (RuntimeIntent) super.deserialize(jsonString, jsonMap, classType);
+      RuntimeIntentBuilder retBuilder = ret.newBuilder();
 
+      RuntimeIntent builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
 
       for (String key : jsonMap.keySet()) {
         if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
+          builderResult.put(key, jsonMap.get(key));
         }
       }
 
-      return ret;
+      return builderResult;
+    }
+  }
+
+  /**
+   * RuntimeIntent Builder.
+   */
+  public class RuntimeIntentBuilder {
+    private String intent;
+    private Double confidence;
+
+    private RuntimeIntentBuilder(RuntimeIntent runtimeIntent) {
+      this.intent = runtimeIntent.intent;
+      this.confidence = runtimeIntent.confidence;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public RuntimeIntentBuilder() { }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param intent the intent
+     * @param confidence the confidence
+     */
+    public RuntimeIntentBuilder(String intent, Double confidence) {
+      this.intent = intent;
+      this.confidence = confidence;
+    }
+
+    /**
+     * Builds a RuntimeIntent.
+     *
+     * @return the runtimeIntent
+     */
+    public RuntimeIntent build() {
+      return new RuntimeIntent(this);
+    }
+
+    /**
+     * Set the intent.
+     *
+     * @param intent the intent
+     * @return the RuntimeIntent builder
+     */
+    public RuntimeIntentBuilder setIntent(String intent) {
+      this.intent = intent;
+      return this;
+    }
+
+    /**
+     * Set the confidence.
+     *
+     * @param confidence the confidence
+     * @return the RuntimeIntent builder
+     */
+    public RuntimeIntentBuilder setConfidence(Double confidence) {
+      this.confidence = confidence;
+      return this;
     }
   }
 
@@ -13547,9 +16070,9 @@ public class IBMAssistantV1Models {
    * Synonym.
    */
   public class Synonym extends IBMWatsonResponseModel {
-    private String synonym_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
+    private String synonym;
+    private Datetime created;
+    private Datetime updated;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -13568,7 +16091,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getSynonym() {
-      return synonym_serialized_name;
+      return synonym;
     }
  
     /**
@@ -13580,7 +16103,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -13592,14 +16115,14 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
   
     private Synonym(SynonymBuilder builder) {
       IBMWatsonValidator.notNull(builder.synonym, 'synonym cannot be null');
-      this.synonym_serialized_name = builder.synonym;
-      this.created_serialized_name = builder.created;
-      this.updated_serialized_name = builder.updated;
+      this.synonym = builder.synonym;
+      this.created = builder.created;
+      this.updated = builder.updated;
     }
 
     /**
@@ -13610,7 +16133,6 @@ public class IBMAssistantV1Models {
     public SynonymBuilder newBuilder() {
       return new SynonymBuilder(this);
     }
-
   }
 
   /**
@@ -13622,9 +16144,9 @@ public class IBMAssistantV1Models {
     private Datetime updated;
 
     private SynonymBuilder(Synonym synonym) {
-      this.synonym = synonym.synonym_serialized_name;
-      this.created = synonym.created_serialized_name;
-      this.updated = synonym.updated_serialized_name;
+      this.synonym = synonym.synonym;
+      this.created = synonym.created;
+      this.updated = synonym.updated;
     }
 
     /**
@@ -13689,8 +16211,8 @@ public class IBMAssistantV1Models {
    * SynonymCollection.
    */
   public class SynonymCollection extends IBMWatsonResponseModel {
-    private List<Synonym> synonyms_serialized_name;
-    private Pagination pagination_serialized_name;
+    private List<Synonym> synonyms;
+    private Pagination pagination;
  
     /**
      * Gets the synonyms.
@@ -13701,7 +16223,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Synonym> getSynonyms() {
-      return synonyms_serialized_name;
+      return synonyms;
     }
  
     /**
@@ -13713,7 +16235,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -13722,7 +16244,7 @@ public class IBMAssistantV1Models {
      * @param synonyms the new synonyms
      */
     public void setSynonyms(final List<Synonym> synonyms) {
-      this.synonyms_serialized_name = synonyms;
+      this.synonyms = synonyms;
     }
 
     /**
@@ -13731,7 +16253,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -13747,18 +16269,26 @@ public class IBMAssistantV1Models {
       if (deserializedSynonyms != null) {
         for (Integer i = 0; i < deserializedSynonyms.size(); i++) {
           Synonym currentItem = ret.getSynonyms().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('synonyms_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('synonyms');
           Synonym newItem = (Synonym) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Synonym.class);
           newSynonyms.add(newItem);
         }
-        ret.synonyms_serialized_name = newSynonyms;
+        ret.synonyms = newSynonyms;
       }
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -13767,6 +16297,12 @@ public class IBMAssistantV1Models {
    */
   public class SystemResponse extends IBMWatsonDynamicModel {
     private Map<String, Object> additional_properties_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public SystemResponse() { }
 
     /**
      * Gets the dynamic properties attached to SystemResponse.
@@ -13778,22 +16314,59 @@ public class IBMAssistantV1Models {
       return this.getDynamicProperties();
     }
 
+    private SystemResponse(SystemResponseBuilder builder) {
+    }
+
+    /**
+     * New builder.
+     *
+     * @return a SystemResponse builder
+     */
+    public SystemResponseBuilder newBuilder() {
+      return new SystemResponseBuilder(this);
+    }
+
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
       if (jsonMap == null) {
         return null;
       }
 
       SystemResponse ret = (SystemResponse) super.deserialize(jsonString, jsonMap, classType);
+      SystemResponseBuilder retBuilder = ret.newBuilder();
 
+      SystemResponse builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
 
       for (String key : jsonMap.keySet()) {
         if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
+          builderResult.put(key, jsonMap.get(key));
         }
       }
 
-      return ret;
+      return builderResult;
+    }
+  }
+
+  /**
+   * SystemResponse Builder.
+   */
+  public class SystemResponseBuilder {
+
+    private SystemResponseBuilder(SystemResponse systemResponse) {
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public SystemResponseBuilder() { }
+
+    /**
+     * Builds a SystemResponse.
+     *
+     * @return the systemResponse
+     */
+    public SystemResponse build() {
+      return new SystemResponse(this);
     }
   }
 
@@ -13804,7 +16377,7 @@ public class IBMAssistantV1Models {
     private String workspaceId;
     private String text;
     private String newText;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -13815,7 +16388,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -13826,7 +16399,7 @@ public class IBMAssistantV1Models {
     public String text() {
       return text;
     }
- 
+
     /**
      * Gets the newText.
      *
@@ -13858,6 +16431,12 @@ public class IBMAssistantV1Models {
       return new UpdateCounterexampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('newText', 'new_text');
+      return mapping;
+    }
   }
 
   /**
@@ -13971,7 +16550,7 @@ public class IBMAssistantV1Models {
     private String newDigressOut;
     private String newDigressOutSlots;
     private String newUserLabel;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -13982,7 +16561,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -13993,7 +16572,7 @@ public class IBMAssistantV1Models {
     public String dialogNode() {
       return dialogNode;
     }
- 
+
     /**
      * Gets the newDialogNode.
      *
@@ -14005,7 +16584,7 @@ public class IBMAssistantV1Models {
     public String newDialogNode() {
       return newDialogNode;
     }
- 
+
     /**
      * Gets the newDescription.
      *
@@ -14016,7 +16595,7 @@ public class IBMAssistantV1Models {
     public String newDescription() {
       return newDescription;
     }
- 
+
     /**
      * Gets the newConditions.
      *
@@ -14028,7 +16607,7 @@ public class IBMAssistantV1Models {
     public String newConditions() {
       return newConditions;
     }
- 
+
     /**
      * Gets the newParent.
      *
@@ -14039,7 +16618,7 @@ public class IBMAssistantV1Models {
     public String newParent() {
       return newParent;
     }
- 
+
     /**
      * Gets the newPreviousSibling.
      *
@@ -14050,7 +16629,7 @@ public class IBMAssistantV1Models {
     public String newPreviousSibling() {
       return newPreviousSibling;
     }
- 
+
     /**
      * Gets the newOutput.
      *
@@ -14062,7 +16641,7 @@ public class IBMAssistantV1Models {
     public DialogNodeOutput newOutput() {
       return newOutput;
     }
- 
+
     /**
      * Gets the newContext.
      *
@@ -14073,7 +16652,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel newContext() {
       return newContext;
     }
- 
+
     /**
      * Gets the newMetadata.
      *
@@ -14084,7 +16663,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel newMetadata() {
       return newMetadata;
     }
- 
+
     /**
      * Gets the newNextStep.
      *
@@ -14095,7 +16674,7 @@ public class IBMAssistantV1Models {
     public DialogNodeNextStep newNextStep() {
       return newNextStep;
     }
- 
+
     /**
      * Gets the newTitle.
      *
@@ -14107,7 +16686,7 @@ public class IBMAssistantV1Models {
     public String newTitle() {
       return newTitle;
     }
- 
+
     /**
      * Gets the nodeType.
      *
@@ -14118,7 +16697,7 @@ public class IBMAssistantV1Models {
     public String nodeType() {
       return nodeType;
     }
- 
+
     /**
      * Gets the newEventName.
      *
@@ -14129,7 +16708,7 @@ public class IBMAssistantV1Models {
     public String newEventName() {
       return newEventName;
     }
- 
+
     /**
      * Gets the newVariable.
      *
@@ -14140,7 +16719,7 @@ public class IBMAssistantV1Models {
     public String newVariable() {
       return newVariable;
     }
- 
+
     /**
      * Gets the newActions.
      *
@@ -14151,7 +16730,7 @@ public class IBMAssistantV1Models {
     public List<DialogNodeAction> newActions() {
       return newActions;
     }
- 
+
     /**
      * Gets the newDigressIn.
      *
@@ -14162,7 +16741,7 @@ public class IBMAssistantV1Models {
     public String newDigressIn() {
       return newDigressIn;
     }
- 
+
     /**
      * Gets the newDigressOut.
      *
@@ -14173,7 +16752,7 @@ public class IBMAssistantV1Models {
     public String newDigressOut() {
       return newDigressOut;
     }
- 
+
     /**
      * Gets the newDigressOutSlots.
      *
@@ -14184,7 +16763,7 @@ public class IBMAssistantV1Models {
     public String newDigressOutSlots() {
       return newDigressOutSlots;
     }
- 
+
     /**
      * Gets the newUserLabel.
      *
@@ -14231,6 +16810,39 @@ public class IBMAssistantV1Models {
       return new UpdateDialogNodeOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('dialogNode', 'dialog_node');
+      mapping.put('newDialogNode', 'new_dialog_node');
+      mapping.put('newDescription', 'new_description');
+      mapping.put('newConditions', 'new_conditions');
+      mapping.put('newParent', 'new_parent');
+      mapping.put('newPreviousSibling', 'new_previous_sibling');
+      mapping.put('newOutput', 'new_output');
+      if (newOutput != null) {
+        mapping.putAll(newOutput.getSdkToApiMapping());
+      }
+      mapping.put('newContext', 'new_context');
+      mapping.put('newMetadata', 'new_metadata');
+      mapping.put('newNextStep', 'new_next_step');
+      if (newNextStep != null) {
+        mapping.putAll(newNextStep.getSdkToApiMapping());
+      }
+      mapping.put('newTitle', 'new_title');
+      mapping.put('nodeType', 'new_type');
+      mapping.put('newEventName', 'new_event_name');
+      mapping.put('newVariable', 'new_variable');
+      mapping.put('newActions', 'new_actions');
+      if (newActions != null && newActions[0] != null) {
+        mapping.putAll(newActions[0].getSdkToApiMapping());
+      }
+      mapping.put('newDigressIn', 'new_digress_in');
+      mapping.put('newDigressOut', 'new_digress_out');
+      mapping.put('newDigressOutSlots', 'new_digress_out_slots');
+      mapping.put('newUserLabel', 'new_user_label');
+      return mapping;
+    }
   }
 
   /**
@@ -14568,7 +17180,7 @@ public class IBMAssistantV1Models {
     private IBMWatsonMapModel newMetadata;
     private Boolean newFuzzyMatch;
     private List<CreateValue> newValues;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -14579,7 +17191,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -14590,7 +17202,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the newEntity.
      *
@@ -14603,7 +17215,7 @@ public class IBMAssistantV1Models {
     public String newEntity() {
       return newEntity;
     }
- 
+
     /**
      * Gets the newDescription.
      *
@@ -14614,7 +17226,7 @@ public class IBMAssistantV1Models {
     public String newDescription() {
       return newDescription;
     }
- 
+
     /**
      * Gets the newMetadata.
      *
@@ -14625,7 +17237,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel newMetadata() {
       return newMetadata;
     }
- 
+
     /**
      * Gets the newFuzzyMatch.
      *
@@ -14636,7 +17248,7 @@ public class IBMAssistantV1Models {
     public Boolean newFuzzyMatch() {
       return newFuzzyMatch;
     }
- 
+
     /**
      * Gets the newValues.
      *
@@ -14670,6 +17282,19 @@ public class IBMAssistantV1Models {
       return new UpdateEntityOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('newEntity', 'new_entity');
+      mapping.put('newDescription', 'new_description');
+      mapping.put('newMetadata', 'new_metadata');
+      mapping.put('newFuzzyMatch', 'new_fuzzy_match');
+      mapping.put('newValues', 'new_values');
+      if (newValues != null && newValues[0] != null) {
+        mapping.putAll(newValues[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -14836,7 +17461,7 @@ public class IBMAssistantV1Models {
     private String text;
     private String newText;
     private List<Mention> newMentions;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -14847,7 +17472,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -14858,7 +17483,7 @@ public class IBMAssistantV1Models {
     public String intent() {
       return intent;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -14869,7 +17494,7 @@ public class IBMAssistantV1Models {
     public String text() {
       return text;
     }
- 
+
     /**
      * Gets the newText.
      *
@@ -14882,7 +17507,7 @@ public class IBMAssistantV1Models {
     public String newText() {
       return newText;
     }
- 
+
     /**
      * Gets the newMentions.
      *
@@ -14915,6 +17540,13 @@ public class IBMAssistantV1Models {
       return new UpdateExampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('newText', 'new_text');
+      mapping.put('newMentions', 'new_mentions');
+      return mapping;
+    }
   }
 
   /**
@@ -15057,7 +17689,7 @@ public class IBMAssistantV1Models {
     private String newIntent;
     private String newDescription;
     private List<Example> newExamples;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -15068,7 +17700,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -15079,7 +17711,7 @@ public class IBMAssistantV1Models {
     public String intent() {
       return intent;
     }
- 
+
     /**
      * Gets the newIntent.
      *
@@ -15092,7 +17724,7 @@ public class IBMAssistantV1Models {
     public String newIntent() {
       return newIntent;
     }
- 
+
     /**
      * Gets the newDescription.
      *
@@ -15103,7 +17735,7 @@ public class IBMAssistantV1Models {
     public String newDescription() {
       return newDescription;
     }
- 
+
     /**
      * Gets the newExamples.
      *
@@ -15135,6 +17767,14 @@ public class IBMAssistantV1Models {
       return new UpdateIntentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('newIntent', 'new_intent');
+      mapping.put('newDescription', 'new_description');
+      mapping.put('newExamples', 'new_examples');
+      return mapping;
+    }
   }
 
   /**
@@ -15275,7 +17915,7 @@ public class IBMAssistantV1Models {
     private String value;
     private String synonym;
     private String newSynonym;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -15286,7 +17926,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -15297,7 +17937,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -15308,7 +17948,7 @@ public class IBMAssistantV1Models {
     public String value() {
       return value;
     }
- 
+
     /**
      * Gets the synonym.
      *
@@ -15319,7 +17959,7 @@ public class IBMAssistantV1Models {
     public String synonym() {
       return synonym;
     }
- 
+
     /**
      * Gets the newSynonym.
      *
@@ -15355,6 +17995,12 @@ public class IBMAssistantV1Models {
       return new UpdateSynonymOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('newSynonym', 'new_synonym');
+      return mapping;
+    }
   }
 
   /**
@@ -15486,7 +18132,7 @@ public class IBMAssistantV1Models {
     private String valueType;
     private List<String> newSynonyms;
     private List<String> newPatterns;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -15497,7 +18143,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -15508,7 +18154,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -15519,7 +18165,7 @@ public class IBMAssistantV1Models {
     public String value() {
       return value;
     }
- 
+
     /**
      * Gets the newValue.
      *
@@ -15532,7 +18178,7 @@ public class IBMAssistantV1Models {
     public String newValue() {
       return newValue;
     }
- 
+
     /**
      * Gets the newMetadata.
      *
@@ -15543,7 +18189,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel newMetadata() {
       return newMetadata;
     }
- 
+
     /**
      * Gets the valueType.
      *
@@ -15554,7 +18200,7 @@ public class IBMAssistantV1Models {
     public String valueType() {
       return valueType;
     }
- 
+
     /**
      * Gets the newSynonyms.
      *
@@ -15568,7 +18214,7 @@ public class IBMAssistantV1Models {
     public List<String> newSynonyms() {
       return newSynonyms;
     }
- 
+
     /**
      * Gets the newPatterns.
      *
@@ -15607,6 +18253,16 @@ public class IBMAssistantV1Models {
       return new UpdateValueOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('newValue', 'new_value');
+      mapping.put('newMetadata', 'new_metadata');
+      mapping.put('valueType', 'new_type');
+      mapping.put('newSynonyms', 'new_synonyms');
+      mapping.put('newPatterns', 'new_patterns');
+      return mapping;
+    }
   }
 
   /**
@@ -15811,7 +18467,7 @@ public class IBMAssistantV1Models {
     private List<DialogNode> dialogNodes;
     private List<Counterexample> counterexamples;
     private Boolean append;
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -15822,7 +18478,7 @@ public class IBMAssistantV1Models {
     public String workspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -15833,7 +18489,7 @@ public class IBMAssistantV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -15844,7 +18500,7 @@ public class IBMAssistantV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -15855,7 +18511,7 @@ public class IBMAssistantV1Models {
     public String language() {
       return language;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -15866,7 +18522,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the learningOptOut.
      *
@@ -15878,7 +18534,7 @@ public class IBMAssistantV1Models {
     public Boolean learningOptOut() {
       return learningOptOut;
     }
- 
+
     /**
      * Gets the systemSettings.
      *
@@ -15889,7 +18545,7 @@ public class IBMAssistantV1Models {
     public WorkspaceSystemSettings systemSettings() {
       return systemSettings;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -15900,7 +18556,7 @@ public class IBMAssistantV1Models {
     public List<CreateIntent> intents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -15911,7 +18567,7 @@ public class IBMAssistantV1Models {
     public List<CreateEntity> entities() {
       return entities;
     }
- 
+
     /**
      * Gets the dialogNodes.
      *
@@ -15922,7 +18578,7 @@ public class IBMAssistantV1Models {
     public List<DialogNode> dialogNodes() {
       return dialogNodes;
     }
- 
+
     /**
      * Gets the counterexamples.
      *
@@ -15933,7 +18589,7 @@ public class IBMAssistantV1Models {
     public List<Counterexample> counterexamples() {
       return counterexamples;
     }
- 
+
     /**
      * Gets the append.
      *
@@ -15977,6 +18633,23 @@ public class IBMAssistantV1Models {
       return new UpdateWorkspaceOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('workspaceId', 'workspace_id');
+      mapping.put('learningOptOut', 'learning_opt_out');
+      mapping.put('systemSettings', 'system_settings');
+      if (systemSettings != null) {
+        mapping.putAll(systemSettings.getSdkToApiMapping());
+      }
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getSdkToApiMapping());
+      }
+      mapping.put('dialogNodes', 'dialog_nodes');
+      if (dialogNodes != null && dialogNodes[0] != null) {
+        mapping.putAll(dialogNodes[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -16249,13 +18922,13 @@ public class IBMAssistantV1Models {
    * Value.
    */
   public class Value extends IBMWatsonResponseModel {
-    private String value_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private String type_serialized_name;
-    private List<String> synonyms_serialized_name;
-    private List<String> patterns_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
+    private String value;
+    private IBMWatsonMapModel metadata;
+    private String valueType;
+    private List<String> synonyms;
+    private List<String> patterns;
+    private Datetime created;
+    private Datetime updated;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -16274,7 +18947,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getValue() {
-      return value_serialized_name;
+      return value;
     }
  
     /**
@@ -16286,7 +18959,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
  
     /**
@@ -16298,7 +18971,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getValueType() {
-      return type_serialized_name;
+      return valueType;
     }
  
     /**
@@ -16313,7 +18986,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<String> getSynonyms() {
-      return synonyms_serialized_name;
+      return synonyms;
     }
  
     /**
@@ -16328,7 +19001,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<String> getPatterns() {
-      return patterns_serialized_name;
+      return patterns;
     }
  
     /**
@@ -16340,7 +19013,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -16352,19 +19025,19 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
   
     private Value(ValueBuilder builder) {
       IBMWatsonValidator.notNull(builder.value, 'value cannot be null');
       IBMWatsonValidator.notNull(builder.valueType, 'valueType cannot be null');
-      this.value_serialized_name = builder.value;
-      this.metadata_serialized_name = builder.metadata;
-      this.type_serialized_name = builder.valueType;
-      this.synonyms_serialized_name = builder.synonyms;
-      this.patterns_serialized_name = builder.patterns;
-      this.created_serialized_name = builder.created;
-      this.updated_serialized_name = builder.updated;
+      this.value = builder.value;
+      this.metadata = builder.metadata;
+      this.valueType = builder.valueType;
+      this.synonyms = builder.synonyms;
+      this.patterns = builder.patterns;
+      this.created = builder.created;
+      this.updated = builder.updated;
     }
 
     /**
@@ -16385,10 +19058,16 @@ public class IBMAssistantV1Models {
       ValueBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for metadata
-      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
       retBuilder.metadata(newMetadata);
 
       return retBuilder.build();
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'valueType');
+      return mapping;
     }
   }
 
@@ -16405,13 +19084,13 @@ public class IBMAssistantV1Models {
     private Datetime updated;
 
     private ValueBuilder(Value value) {
-      this.value = value.value_serialized_name;
-      this.metadata = value.metadata_serialized_name;
-      this.valueType = value.type_serialized_name;
-      this.synonyms = value.synonyms_serialized_name;
-      this.patterns = value.patterns_serialized_name;
-      this.created = value.created_serialized_name;
-      this.updated = value.updated_serialized_name;
+      this.value = value.value;
+      this.metadata = value.metadata;
+      this.valueType = value.valueType;
+      this.synonyms = value.synonyms;
+      this.patterns = value.patterns;
+      this.created = value.created;
+      this.updated = value.updated;
     }
 
     /**
@@ -16554,8 +19233,8 @@ public class IBMAssistantV1Models {
    * ValueCollection.
    */
   public class ValueCollection extends IBMWatsonResponseModel {
-    private List<Value> values_serialized_name;
-    private Pagination pagination_serialized_name;
+    private List<Value> values;
+    private Pagination pagination;
  
     /**
      * Gets the values.
@@ -16566,7 +19245,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Value> getValues() {
-      return values_serialized_name;
+      return values;
     }
  
     /**
@@ -16578,7 +19257,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -16587,7 +19266,7 @@ public class IBMAssistantV1Models {
      * @param values the new values
      */
     public void setValues(final List<Value> values) {
-      this.values_serialized_name = values;
+      this.values = values;
     }
 
     /**
@@ -16596,7 +19275,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -16612,18 +19291,29 @@ public class IBMAssistantV1Models {
       if (deserializedValues != null) {
         for (Integer i = 0; i < deserializedValues.size(); i++) {
           Value currentItem = ret.getValues().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('values_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('values');
           Value newItem = (Value) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Value.class);
           newValues.add(newItem);
         }
-        ret.values_serialized_name = newValues;
+        ret.values = newValues;
       }
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (values != null && values[0] != null) {
+        mapping.putAll(values[0].getApiToSdkMapping());
+      }
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -16631,20 +19321,20 @@ public class IBMAssistantV1Models {
    * Workspace.
    */
   public class Workspace extends IBMWatsonResponseModel {
-    private String name_serialized_name;
-    private String description_serialized_name;
-    private String language_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private Boolean learning_opt_out_serialized_name;
-    private WorkspaceSystemSettings system_settings_serialized_name;
-    private String workspace_id_serialized_name;
-    private String status_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
-    private List<Intent> intents_serialized_name;
-    private List<Entity> entities_serialized_name;
-    private List<DialogNode> dialog_nodes_serialized_name;
-    private List<Counterexample> counterexamples_serialized_name;
+    private String name;
+    private String description;
+    private String language;
+    private IBMWatsonMapModel metadata;
+    private Boolean learningOptOut;
+    private WorkspaceSystemSettings systemSettings;
+    private String workspaceId;
+    private String status;
+    private Datetime created;
+    private Datetime updated;
+    private List<Intent> intents;
+    private List<Entity> entities;
+    private List<DialogNode> dialogNodes;
+    private List<Counterexample> counterexamples;
  
     /**
      * Gets the name.
@@ -16655,7 +19345,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -16667,7 +19357,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -16679,7 +19369,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -16691,7 +19381,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
  
     /**
@@ -16704,7 +19394,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getLearningOptOut() {
-      return learning_opt_out_serialized_name;
+      return learningOptOut;
     }
  
     /**
@@ -16716,7 +19406,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public WorkspaceSystemSettings getSystemSettings() {
-      return system_settings_serialized_name;
+      return systemSettings;
     }
  
     /**
@@ -16728,7 +19418,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getWorkspaceId() {
-      return workspace_id_serialized_name;
+      return workspaceId;
     }
  
     /**
@@ -16740,7 +19430,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -16752,7 +19442,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -16764,7 +19454,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -16776,7 +19466,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Intent> getIntents() {
-      return intents_serialized_name;
+      return intents;
     }
  
     /**
@@ -16788,7 +19478,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Entity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -16800,7 +19490,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<DialogNode> getDialogNodes() {
-      return dialog_nodes_serialized_name;
+      return dialogNodes;
     }
  
     /**
@@ -16812,7 +19502,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Counterexample> getCounterexamples() {
-      return counterexamples_serialized_name;
+      return counterexamples;
     }
 
     /**
@@ -16821,7 +19511,7 @@ public class IBMAssistantV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -16830,7 +19520,7 @@ public class IBMAssistantV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -16839,7 +19529,7 @@ public class IBMAssistantV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -16848,7 +19538,7 @@ public class IBMAssistantV1Models {
      * @param metadata the new metadata
      */
     public void setMetadata(final IBMWatsonMapModel metadata) {
-      this.metadata_serialized_name = metadata;
+      this.metadata = metadata;
     }
 
     /**
@@ -16857,7 +19547,7 @@ public class IBMAssistantV1Models {
      * @param learningOptOut the new learningOptOut
      */
     public void setLearningOptOut(final Boolean learningOptOut) {
-      this.learning_opt_out_serialized_name = learningOptOut;
+      this.learningOptOut = learningOptOut;
     }
 
     /**
@@ -16866,7 +19556,7 @@ public class IBMAssistantV1Models {
      * @param systemSettings the new systemSettings
      */
     public void setSystemSettings(final WorkspaceSystemSettings systemSettings) {
-      this.system_settings_serialized_name = systemSettings;
+      this.systemSettings = systemSettings;
     }
 
     /**
@@ -16875,7 +19565,7 @@ public class IBMAssistantV1Models {
      * @param intents the new intents
      */
     public void setIntents(final List<Intent> intents) {
-      this.intents_serialized_name = intents;
+      this.intents = intents;
     }
 
     /**
@@ -16884,7 +19574,7 @@ public class IBMAssistantV1Models {
      * @param entities the new entities
      */
     public void setEntities(final List<Entity> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     /**
@@ -16893,7 +19583,7 @@ public class IBMAssistantV1Models {
      * @param dialogNodes the new dialogNodes
      */
     public void setDialogNodes(final List<DialogNode> dialogNodes) {
-      this.dialog_nodes_serialized_name = dialogNodes;
+      this.dialogNodes = dialogNodes;
     }
 
     /**
@@ -16902,7 +19592,7 @@ public class IBMAssistantV1Models {
      * @param counterexamples the new counterexamples
      */
     public void setCounterexamples(final List<Counterexample> counterexamples) {
-      this.counterexamples_serialized_name = counterexamples;
+      this.counterexamples = counterexamples;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -16913,11 +19603,11 @@ public class IBMAssistantV1Models {
       Workspace ret = (Workspace) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for metadata
-      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
       ret.setMetadata(newMetadata);
 
       // calling custom deserializer for systemSettings
-      WorkspaceSystemSettings newSystemSettings = (WorkspaceSystemSettings) new WorkspaceSystemSettings().deserialize(JSON.serialize(ret.getSystemSettings()), (Map<String, Object>) jsonMap.get('system_settings_serialized_name'), WorkspaceSystemSettings.class);
+      WorkspaceSystemSettings newSystemSettings = (WorkspaceSystemSettings) new WorkspaceSystemSettings().deserialize(JSON.serialize(ret.getSystemSettings()), (Map<String, Object>) jsonMap.get('systemSettings'), WorkspaceSystemSettings.class);
       ret.setSystemSettings(newSystemSettings);
 
       // calling custom deserializer for intents
@@ -16926,11 +19616,11 @@ public class IBMAssistantV1Models {
       if (deserializedIntents != null) {
         for (Integer i = 0; i < deserializedIntents.size(); i++) {
           Intent currentItem = ret.getIntents().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('intents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('intents');
           Intent newItem = (Intent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Intent.class);
           newIntents.add(newItem);
         }
-        ret.intents_serialized_name = newIntents;
+        ret.intents = newIntents;
       }
 
       // calling custom deserializer for entities
@@ -16939,11 +19629,11 @@ public class IBMAssistantV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           Entity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           Entity newItem = (Entity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Entity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       // calling custom deserializer for dialogNodes
@@ -16952,11 +19642,11 @@ public class IBMAssistantV1Models {
       if (deserializedDialogNodes != null) {
         for (Integer i = 0; i < deserializedDialogNodes.size(); i++) {
           DialogNode currentItem = ret.getDialogNodes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('dialog_nodes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('dialogNodes');
           DialogNode newItem = (DialogNode) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNode.class);
           newDialogNodes.add(newItem);
         }
-        ret.dialog_nodes_serialized_name = newDialogNodes;
+        ret.dialogNodes = newDialogNodes;
       }
 
       // calling custom deserializer for counterexamples
@@ -16965,14 +19655,32 @@ public class IBMAssistantV1Models {
       if (deserializedCounterexamples != null) {
         for (Integer i = 0; i < deserializedCounterexamples.size(); i++) {
           Counterexample currentItem = ret.getCounterexamples().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('counterexamples_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('counterexamples');
           Counterexample newItem = (Counterexample) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Counterexample.class);
           newCounterexamples.add(newItem);
         }
-        ret.counterexamples_serialized_name = newCounterexamples;
+        ret.counterexamples = newCounterexamples;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('learning_opt_out', 'learningOptOut');
+      mapping.put('system_settings', 'systemSettings');
+      if (systemSettings != null) {
+        mapping.putAll(systemSettings.getApiToSdkMapping());
+      }
+      mapping.put('workspace_id', 'workspaceId');
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      mapping.put('dialog_nodes', 'dialogNodes');
+      if (dialogNodes != null && dialogNodes[0] != null) {
+        mapping.putAll(dialogNodes[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -16980,8 +19688,8 @@ public class IBMAssistantV1Models {
    * WorkspaceCollection.
    */
   public class WorkspaceCollection extends IBMWatsonResponseModel {
-    private List<Workspace> workspaces_serialized_name;
-    private Pagination pagination_serialized_name;
+    private List<Workspace> workspaces;
+    private Pagination pagination;
  
     /**
      * Gets the workspaces.
@@ -16992,7 +19700,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public List<Workspace> getWorkspaces() {
-      return workspaces_serialized_name;
+      return workspaces;
     }
  
     /**
@@ -17004,7 +19712,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -17013,7 +19721,7 @@ public class IBMAssistantV1Models {
      * @param workspaces the new workspaces
      */
     public void setWorkspaces(final List<Workspace> workspaces) {
-      this.workspaces_serialized_name = workspaces;
+      this.workspaces = workspaces;
     }
 
     /**
@@ -17022,7 +19730,7 @@ public class IBMAssistantV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -17038,18 +19746,29 @@ public class IBMAssistantV1Models {
       if (deserializedWorkspaces != null) {
         for (Integer i = 0; i < deserializedWorkspaces.size(); i++) {
           Workspace currentItem = ret.getWorkspaces().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('workspaces_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('workspaces');
           Workspace newItem = (Workspace) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Workspace.class);
           newWorkspaces.add(newItem);
         }
-        ret.workspaces_serialized_name = newWorkspaces;
+        ret.workspaces = newWorkspaces;
       }
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (workspaces != null && workspaces[0] != null) {
+        mapping.putAll(workspaces[0].getApiToSdkMapping());
+      }
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -17057,9 +19776,15 @@ public class IBMAssistantV1Models {
    * Global settings for the workspace.
    */
   public class WorkspaceSystemSettings extends IBMWatsonGenericModel {
-    private WorkspaceSystemSettingsTooling tooling_serialized_name;
-    private WorkspaceSystemSettingsDisambiguation disambiguation_serialized_name;
-    private IBMWatsonMapModel human_agent_assist_serialized_name;
+    private WorkspaceSystemSettingsTooling tooling;
+    private WorkspaceSystemSettingsDisambiguation disambiguation;
+    private IBMWatsonMapModel humanAgentAssist;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public WorkspaceSystemSettings() { }
  
     /**
      * Gets the tooling.
@@ -17070,7 +19795,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public WorkspaceSystemSettingsTooling getTooling() {
-      return tooling_serialized_name;
+      return tooling;
     }
  
     /**
@@ -17084,7 +19809,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public WorkspaceSystemSettingsDisambiguation getDisambiguation() {
-      return disambiguation_serialized_name;
+      return disambiguation;
     }
  
     /**
@@ -17096,34 +19821,22 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getHumanAgentAssist() {
-      return human_agent_assist_serialized_name;
+      return humanAgentAssist;
+    }
+  
+    private WorkspaceSystemSettings(WorkspaceSystemSettingsBuilder builder) {
+      this.tooling = builder.tooling;
+      this.disambiguation = builder.disambiguation;
+      this.humanAgentAssist = builder.humanAgentAssist;
     }
 
     /**
-     * Sets the tooling.
+     * New builder.
      *
-     * @param tooling the new tooling
+     * @return a WorkspaceSystemSettings builder
      */
-    public void setTooling(final WorkspaceSystemSettingsTooling tooling) {
-      this.tooling_serialized_name = tooling;
-    }
-
-    /**
-     * Sets the disambiguation.
-     *
-     * @param disambiguation the new disambiguation
-     */
-    public void setDisambiguation(final WorkspaceSystemSettingsDisambiguation disambiguation) {
-      this.disambiguation_serialized_name = disambiguation;
-    }
-
-    /**
-     * Sets the humanAgentAssist.
-     *
-     * @param humanAgentAssist the new humanAgentAssist
-     */
-    public void setHumanAgentAssist(final IBMWatsonMapModel humanAgentAssist) {
-      this.human_agent_assist_serialized_name = humanAgentAssist;
+    public WorkspaceSystemSettingsBuilder newBuilder() {
+      return new WorkspaceSystemSettingsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -17132,20 +19845,108 @@ public class IBMAssistantV1Models {
       }
 
       WorkspaceSystemSettings ret = (WorkspaceSystemSettings) super.deserialize(jsonString, jsonMap, classType);
+      WorkspaceSystemSettingsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for tooling
-      WorkspaceSystemSettingsTooling newTooling = (WorkspaceSystemSettingsTooling) new WorkspaceSystemSettingsTooling().deserialize(JSON.serialize(ret.getTooling()), (Map<String, Object>) jsonMap.get('tooling_serialized_name'), WorkspaceSystemSettingsTooling.class);
-      ret.setTooling(newTooling);
+      WorkspaceSystemSettingsTooling newTooling = (WorkspaceSystemSettingsTooling) new WorkspaceSystemSettingsTooling().deserialize(JSON.serialize(ret.getTooling()), (Map<String, Object>) jsonMap.get('tooling'), WorkspaceSystemSettingsTooling.class);
+      retBuilder.setTooling(newTooling);
 
       // calling custom deserializer for disambiguation
-      WorkspaceSystemSettingsDisambiguation newDisambiguation = (WorkspaceSystemSettingsDisambiguation) new WorkspaceSystemSettingsDisambiguation().deserialize(JSON.serialize(ret.getDisambiguation()), (Map<String, Object>) jsonMap.get('disambiguation_serialized_name'), WorkspaceSystemSettingsDisambiguation.class);
-      ret.setDisambiguation(newDisambiguation);
+      WorkspaceSystemSettingsDisambiguation newDisambiguation = (WorkspaceSystemSettingsDisambiguation) new WorkspaceSystemSettingsDisambiguation().deserialize(JSON.serialize(ret.getDisambiguation()), (Map<String, Object>) jsonMap.get('disambiguation'), WorkspaceSystemSettingsDisambiguation.class);
+      retBuilder.setDisambiguation(newDisambiguation);
 
       // calling custom deserializer for humanAgentAssist
-      IBMWatsonMapModel newHumanAgentAssist = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getHumanAgentAssist()), (Map<String, Object>) jsonMap.get('human_agent_assist_serialized_name'), IBMWatsonMapModel.class);
-      ret.setHumanAgentAssist(newHumanAgentAssist);
+      IBMWatsonMapModel newHumanAgentAssist = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getHumanAgentAssist()), (Map<String, Object>) jsonMap.get('humanAgentAssist'), IBMWatsonMapModel.class);
+      retBuilder.setHumanAgentAssist(newHumanAgentAssist);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (tooling != null) {
+        mapping.putAll(tooling.getSdkToApiMapping());
+      }
+      if (disambiguation != null) {
+        mapping.putAll(disambiguation.getSdkToApiMapping());
+      }
+      mapping.put('humanAgentAssist', 'human_agent_assist');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (tooling != null) {
+        mapping.putAll(tooling.getApiToSdkMapping());
+      }
+      if (disambiguation != null) {
+        mapping.putAll(disambiguation.getApiToSdkMapping());
+      }
+      mapping.put('human_agent_assist', 'humanAgentAssist');
+      return mapping;
+    }
+  }
+
+  /**
+   * WorkspaceSystemSettings Builder.
+   */
+  public class WorkspaceSystemSettingsBuilder {
+    private WorkspaceSystemSettingsTooling tooling;
+    private WorkspaceSystemSettingsDisambiguation disambiguation;
+    private IBMWatsonMapModel humanAgentAssist;
+
+    private WorkspaceSystemSettingsBuilder(WorkspaceSystemSettings workspaceSystemSettings) {
+      this.tooling = workspaceSystemSettings.tooling;
+      this.disambiguation = workspaceSystemSettings.disambiguation;
+      this.humanAgentAssist = workspaceSystemSettings.humanAgentAssist;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public WorkspaceSystemSettingsBuilder() {
+    }
+
+    /**
+     * Builds a WorkspaceSystemSettings.
+     *
+     * @return the workspaceSystemSettings
+     */
+    public WorkspaceSystemSettings build() {
+      return new WorkspaceSystemSettings(this);
+    }
+
+    /**
+     * Set the tooling.
+     *
+     * @param tooling the tooling
+     * @return the WorkspaceSystemSettings builder
+     */
+    public WorkspaceSystemSettingsBuilder setTooling(WorkspaceSystemSettingsTooling tooling) {
+      this.tooling = tooling;
+      return this;
+    }
+
+    /**
+     * Set the disambiguation.
+     *
+     * @param disambiguation the disambiguation
+     * @return the WorkspaceSystemSettings builder
+     */
+    public WorkspaceSystemSettingsBuilder setDisambiguation(WorkspaceSystemSettingsDisambiguation disambiguation) {
+      this.disambiguation = disambiguation;
+      return this;
+    }
+
+    /**
+     * Set the humanAgentAssist.
+     *
+     * @param humanAgentAssist the humanAgentAssist
+     * @return the WorkspaceSystemSettings builder
+     */
+    public WorkspaceSystemSettingsBuilder setHumanAgentAssist(IBMWatsonMapModel humanAgentAssist) {
+      this.humanAgentAssist = humanAgentAssist;
+      return this;
     }
   }
 
@@ -17155,10 +19956,16 @@ public class IBMAssistantV1Models {
    * **Note:** This feature is available only to Premium users.
    */
   public class WorkspaceSystemSettingsDisambiguation extends IBMWatsonGenericModel {
-    private String prompt_serialized_name;
-    private String none_of_the_above_prompt_serialized_name;
-    private Boolean enabled_serialized_name;
-    private String sensitivity_serialized_name;
+    private String prompt;
+    private String noneOfTheAbovePrompt;
+    private Boolean enabled;
+    private String sensitivity;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public WorkspaceSystemSettingsDisambiguation() { }
  
     /**
      * Gets the prompt.
@@ -17169,7 +19976,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getPrompt() {
-      return prompt_serialized_name;
+      return prompt;
     }
  
     /**
@@ -17182,7 +19989,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getNoneOfTheAbovePrompt() {
-      return none_of_the_above_prompt_serialized_name;
+      return noneOfTheAbovePrompt;
     }
  
     /**
@@ -17194,7 +20001,7 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getEnabled() {
-      return enabled_serialized_name;
+      return enabled;
     }
  
     /**
@@ -17207,52 +20014,125 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public String getSensitivity() {
-      return sensitivity_serialized_name;
+      return sensitivity;
+    }
+  
+    private WorkspaceSystemSettingsDisambiguation(WorkspaceSystemSettingsDisambiguationBuilder builder) {
+      this.prompt = builder.prompt;
+      this.noneOfTheAbovePrompt = builder.noneOfTheAbovePrompt;
+      this.enabled = builder.enabled;
+      this.sensitivity = builder.sensitivity;
     }
 
     /**
-     * Sets the prompt.
+     * New builder.
      *
-     * @param prompt the new prompt
+     * @return a WorkspaceSystemSettingsDisambiguation builder
      */
-    public void setPrompt(final String prompt) {
-      this.prompt_serialized_name = prompt;
+    public WorkspaceSystemSettingsDisambiguationBuilder newBuilder() {
+      return new WorkspaceSystemSettingsDisambiguationBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('noneOfTheAbovePrompt', 'none_of_the_above_prompt');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('none_of_the_above_prompt', 'noneOfTheAbovePrompt');
+      return mapping;
+    }
+  }
+
+  /**
+   * WorkspaceSystemSettingsDisambiguation Builder.
+   */
+  public class WorkspaceSystemSettingsDisambiguationBuilder {
+    private String prompt;
+    private String noneOfTheAbovePrompt;
+    private Boolean enabled;
+    private String sensitivity;
+
+    private WorkspaceSystemSettingsDisambiguationBuilder(WorkspaceSystemSettingsDisambiguation workspaceSystemSettingsDisambiguation) {
+      this.prompt = workspaceSystemSettingsDisambiguation.prompt;
+      this.noneOfTheAbovePrompt = workspaceSystemSettingsDisambiguation.noneOfTheAbovePrompt;
+      this.enabled = workspaceSystemSettingsDisambiguation.enabled;
+      this.sensitivity = workspaceSystemSettingsDisambiguation.sensitivity;
     }
 
     /**
-     * Sets the noneOfTheAbovePrompt.
-     *
-     * @param noneOfTheAbovePrompt the new noneOfTheAbovePrompt
+     * Instantiates a new builder.
      */
-    public void setNoneOfTheAbovePrompt(final String noneOfTheAbovePrompt) {
-      this.none_of_the_above_prompt_serialized_name = noneOfTheAbovePrompt;
+    public WorkspaceSystemSettingsDisambiguationBuilder() {
     }
 
     /**
-     * Sets the enabled.
+     * Builds a WorkspaceSystemSettingsDisambiguation.
      *
-     * @param enabled the new enabled
+     * @return the workspaceSystemSettingsDisambiguation
      */
-    public void setEnabled(final Boolean enabled) {
-      this.enabled_serialized_name = enabled;
+    public WorkspaceSystemSettingsDisambiguation build() {
+      return new WorkspaceSystemSettingsDisambiguation(this);
     }
 
     /**
-     * Sets the sensitivity.
+     * Set the prompt.
      *
-     * @param sensitivity the new sensitivity
+     * @param prompt the prompt
+     * @return the WorkspaceSystemSettingsDisambiguation builder
      */
-    public void setSensitivity(final String sensitivity) {
-      this.sensitivity_serialized_name = sensitivity;
+    public WorkspaceSystemSettingsDisambiguationBuilder setPrompt(String prompt) {
+      this.prompt = prompt;
+      return this;
     }
 
+    /**
+     * Set the noneOfTheAbovePrompt.
+     *
+     * @param noneOfTheAbovePrompt the noneOfTheAbovePrompt
+     * @return the WorkspaceSystemSettingsDisambiguation builder
+     */
+    public WorkspaceSystemSettingsDisambiguationBuilder setNoneOfTheAbovePrompt(String noneOfTheAbovePrompt) {
+      this.noneOfTheAbovePrompt = noneOfTheAbovePrompt;
+      return this;
+    }
+
+    /**
+     * Set the enabled.
+     *
+     * @param enabled the enabled
+     * @return the WorkspaceSystemSettingsDisambiguation builder
+     */
+    public WorkspaceSystemSettingsDisambiguationBuilder setEnabled(Boolean enabled) {
+      this.enabled = enabled;
+      return this;
+    }
+
+    /**
+     * Set the sensitivity.
+     *
+     * @param sensitivity the sensitivity
+     * @return the WorkspaceSystemSettingsDisambiguation builder
+     */
+    public WorkspaceSystemSettingsDisambiguationBuilder setSensitivity(String sensitivity) {
+      this.sensitivity = sensitivity;
+      return this;
+    }
   }
 
   /**
    * Workspace settings related to the Watson Assistant user interface.
    */
   public class WorkspaceSystemSettingsTooling extends IBMWatsonGenericModel {
-    private Boolean store_generic_responses_serialized_name;
+    private Boolean storeGenericResponses;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public WorkspaceSystemSettingsTooling() { }
  
     /**
      * Gets the storeGenericResponses.
@@ -17263,18 +20143,70 @@ public class IBMAssistantV1Models {
      */
     @AuraEnabled
     public Boolean getStoreGenericResponses() {
-      return store_generic_responses_serialized_name;
+      return storeGenericResponses;
+    }
+  
+    private WorkspaceSystemSettingsTooling(WorkspaceSystemSettingsToolingBuilder builder) {
+      this.storeGenericResponses = builder.storeGenericResponses;
     }
 
     /**
-     * Sets the storeGenericResponses.
+     * New builder.
      *
-     * @param storeGenericResponses the new storeGenericResponses
+     * @return a WorkspaceSystemSettingsTooling builder
      */
-    public void setStoreGenericResponses(final Boolean storeGenericResponses) {
-      this.store_generic_responses_serialized_name = storeGenericResponses;
+    public WorkspaceSystemSettingsToolingBuilder newBuilder() {
+      return new WorkspaceSystemSettingsToolingBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('storeGenericResponses', 'store_generic_responses');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('store_generic_responses', 'storeGenericResponses');
+      return mapping;
+    }
+  }
+
+  /**
+   * WorkspaceSystemSettingsTooling Builder.
+   */
+  public class WorkspaceSystemSettingsToolingBuilder {
+    private Boolean storeGenericResponses;
+
+    private WorkspaceSystemSettingsToolingBuilder(WorkspaceSystemSettingsTooling workspaceSystemSettingsTooling) {
+      this.storeGenericResponses = workspaceSystemSettingsTooling.storeGenericResponses;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public WorkspaceSystemSettingsToolingBuilder() {
+    }
+
+    /**
+     * Builds a WorkspaceSystemSettingsTooling.
+     *
+     * @return the workspaceSystemSettingsTooling
+     */
+    public WorkspaceSystemSettingsTooling build() {
+      return new WorkspaceSystemSettingsTooling(this);
+    }
+
+    /**
+     * Set the storeGenericResponses.
+     *
+     * @param storeGenericResponses the storeGenericResponses
+     * @return the WorkspaceSystemSettingsTooling builder
+     */
+    public WorkspaceSystemSettingsToolingBuilder setStoreGenericResponses(Boolean storeGenericResponses) {
+      this.storeGenericResponses = storeGenericResponses;
+      return this;
+    }
   }
 
 }

--- a/force-app/main/default/classes/IBMAssistantV1Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Models.cls
@@ -11,7 +11,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public CaptureGroup() { }
- 
+
     /**
      * Gets the xgroup.
      *
@@ -23,7 +23,7 @@ public class IBMAssistantV1Models {
     public String getXgroup() {
       return xgroup;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -51,15 +51,21 @@ public class IBMAssistantV1Models {
       return new CaptureGroupBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xgroup', 'group');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xgroup', 'group');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('group', 'xgroup');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'group', 'xgroup');
       return mapping;
     }
   }
@@ -121,7 +127,7 @@ public class IBMAssistantV1Models {
      * @param xgroup the xgroup
      * @return the CaptureGroup builder
      */
-    public CaptureGroupBuilder setXgroup(String xgroup) {
+    public CaptureGroupBuilder xgroup(String xgroup) {
       this.xgroup = xgroup;
       return this;
     }
@@ -133,7 +139,7 @@ public class IBMAssistantV1Models {
      * @param location the location
      * @return the CaptureGroup builder
      */
-    public CaptureGroupBuilder setLocation(List<Long> location) {
+    public CaptureGroupBuilder location(List<Long> location) {
       this.location = location;
       return this;
     }
@@ -146,7 +152,7 @@ public class IBMAssistantV1Models {
     private String conversationId;
     private SystemResponse xsystem;
     private MessageContextMetadata metadata;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -219,11 +225,11 @@ public class IBMAssistantV1Models {
 
       // calling custom deserializer for xsystem
       SystemResponse newXsystem = (SystemResponse) new SystemResponse().deserialize(JSON.serialize(ret.getXsystem()), (Map<String, Object>) jsonMap.get('xsystem'), SystemResponse.class);
-      retBuilder.setXsystem(newXsystem);
+      retBuilder.xsystem(newXsystem);
 
       // calling custom deserializer for metadata
       MessageContextMetadata newMetadata = (MessageContextMetadata) new MessageContextMetadata().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), MessageContextMetadata.class);
-      retBuilder.setMetadata(newMetadata);
+      retBuilder.metadata(newMetadata);
 
       Context builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
@@ -237,23 +243,27 @@ public class IBMAssistantV1Models {
       return builderResult;
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('conversationId', 'conversation_id');
-      mapping.put('xsystem', 'system');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'conversationId', 'conversation_id');
+      mapping.put(parentLabel + 'xsystem', 'system');
       if (metadata != null) {
-        mapping.putAll(metadata.getSdkToApiMapping());
+        mapping.putAll(metadata.addToSdkToApiMapping(parentLabel + 'metadata/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('conversation_id', 'conversationId');
-      mapping.put('system', 'xsystem');
-      if (metadata != null) {
-        mapping.putAll(metadata.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'conversation_id', 'conversationId');
+      mapping.put(parentLabel + 'system', 'xsystem');
+      mapping.putAll(((IBMWatsonGenericModel) MessageContextMetadata.class.newInstance()).addToApiToSdkMapping(parentLabel + 'metadata/', mapping));
       return mapping;
     }
   }
@@ -292,7 +302,7 @@ public class IBMAssistantV1Models {
      * @param conversationId the conversationId
      * @return the Context builder
      */
-    public ContextBuilder setConversationId(String conversationId) {
+    public ContextBuilder conversationId(String conversationId) {
       this.conversationId = conversationId;
       return this;
     }
@@ -303,7 +313,7 @@ public class IBMAssistantV1Models {
      * @param xsystem the xsystem
      * @return the Context builder
      */
-    public ContextBuilder setXsystem(SystemResponse xsystem) {
+    public ContextBuilder xsystem(SystemResponse xsystem) {
       this.xsystem = xsystem;
       return this;
     }
@@ -314,7 +324,7 @@ public class IBMAssistantV1Models {
      * @param metadata the metadata
      * @return the Context builder
      */
-    public ContextBuilder setMetadata(MessageContextMetadata metadata) {
+    public ContextBuilder metadata(MessageContextMetadata metadata) {
       this.metadata = metadata;
       return this;
     }
@@ -333,7 +343,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public Counterexample() { }
- 
+
     /**
      * Gets the text.
      *
@@ -347,7 +357,7 @@ public class IBMAssistantV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -359,7 +369,7 @@ public class IBMAssistantV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -467,7 +477,7 @@ public class IBMAssistantV1Models {
   public class CounterexampleCollection extends IBMWatsonResponseModel {
     private List<Counterexample> counterexamples;
     private Pagination pagination;
- 
+
     /**
      * Gets the counterexamples.
      *
@@ -479,7 +489,7 @@ public class IBMAssistantV1Models {
     public List<Counterexample> getCounterexamples() {
       return counterexamples;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -537,11 +547,8 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -963,16 +970,16 @@ public class IBMAssistantV1Models {
       mapping.put('dialogNode', 'dialog_node');
       mapping.put('previousSibling', 'previous_sibling');
       if (output != null) {
-        mapping.putAll(output.getSdkToApiMapping());
+        mapping.putAll(output.addToSdkToApiMapping('', mapping));
       }
       mapping.put('nextStep', 'next_step');
       if (nextStep != null) {
-        mapping.putAll(nextStep.getSdkToApiMapping());
+        mapping.putAll(nextStep.addToSdkToApiMapping('', mapping));
       }
       mapping.put('nodeType', 'type');
       mapping.put('eventName', 'event_name');
       if (actions != null && actions[0] != null) {
-        mapping.putAll(actions[0].getSdkToApiMapping());
+        mapping.putAll(actions[0].addToSdkToApiMapping('', mapping));
       }
       mapping.put('digressIn', 'digress_in');
       mapping.put('digressOut', 'digress_out');
@@ -1332,7 +1339,7 @@ public class IBMAssistantV1Models {
     private Datetime created;
     private Datetime updated;
     private List<CreateValue> values;
- 
+
     /**
      * Gets the entity.
      *
@@ -1346,7 +1353,7 @@ public class IBMAssistantV1Models {
     public String entity() {
       return entity;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -1357,7 +1364,7 @@ public class IBMAssistantV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -1368,7 +1375,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the fuzzyMatch.
      *
@@ -1379,7 +1386,7 @@ public class IBMAssistantV1Models {
     public Boolean fuzzyMatch() {
       return fuzzyMatch;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -1390,7 +1397,7 @@ public class IBMAssistantV1Models {
     public Datetime created() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -1401,7 +1408,7 @@ public class IBMAssistantV1Models {
     public Datetime updated() {
       return updated;
     }
- 
+
     /**
      * Gets the values.
      *
@@ -1433,11 +1440,10 @@ public class IBMAssistantV1Models {
       return new CreateEntityBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('fuzzyMatch', 'fuzzy_match');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'fuzzyMatch', 'fuzzy_match');
       if (values != null && values[0] != null) {
-        mapping.putAll(values[0].getSdkToApiMapping());
+        mapping.putAll(values[0].addToSdkToApiMapping(parentLabel + 'values/', mapping));
       }
       return mapping;
     }
@@ -1689,7 +1695,7 @@ public class IBMAssistantV1Models {
       mapping.put('workspaceId', 'workspace_id');
       mapping.put('fuzzyMatch', 'fuzzy_match');
       if (values != null && values[0] != null) {
-        mapping.putAll(values[0].getSdkToApiMapping());
+        mapping.putAll(values[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -2058,7 +2064,7 @@ public class IBMAssistantV1Models {
     private Datetime created;
     private Datetime updated;
     private List<Example> examples;
- 
+
     /**
      * Gets the intent.
      *
@@ -2071,7 +2077,7 @@ public class IBMAssistantV1Models {
     public String intent() {
       return intent;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -2082,7 +2088,7 @@ public class IBMAssistantV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -2093,7 +2099,7 @@ public class IBMAssistantV1Models {
     public Datetime created() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -2104,7 +2110,7 @@ public class IBMAssistantV1Models {
     public Datetime updated() {
       return updated;
     }
- 
+
     /**
      * Gets the examples.
      *
@@ -2655,7 +2661,7 @@ public class IBMAssistantV1Models {
     private List<String> patterns;
     private Datetime created;
     private Datetime updated;
- 
+
     /**
      * Gets the value.
      *
@@ -2668,7 +2674,7 @@ public class IBMAssistantV1Models {
     public String value() {
       return value;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -2679,7 +2685,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the valueType.
      *
@@ -2690,7 +2696,7 @@ public class IBMAssistantV1Models {
     public String valueType() {
       return valueType;
     }
- 
+
     /**
      * Gets the synonyms.
      *
@@ -2704,7 +2710,7 @@ public class IBMAssistantV1Models {
     public List<String> synonyms() {
       return synonyms;
     }
- 
+
     /**
      * Gets the patterns.
      *
@@ -2718,7 +2724,7 @@ public class IBMAssistantV1Models {
     public List<String> patterns() {
       return patterns;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -2729,7 +2735,7 @@ public class IBMAssistantV1Models {
     public Datetime created() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -2761,9 +2767,8 @@ public class IBMAssistantV1Models {
       return new CreateValueBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('valueType', 'type');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'valueType', 'type');
       return mapping;
     }
   }
@@ -3379,14 +3384,14 @@ public class IBMAssistantV1Models {
       mapping.put('learningOptOut', 'learning_opt_out');
       mapping.put('systemSettings', 'system_settings');
       if (systemSettings != null) {
-        mapping.putAll(systemSettings.getSdkToApiMapping());
+        mapping.putAll(systemSettings.addToSdkToApiMapping('', mapping));
       }
       if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getSdkToApiMapping());
+        mapping.putAll(entities[0].addToSdkToApiMapping('', mapping));
       }
       mapping.put('dialogNodes', 'dialog_nodes');
       if (dialogNodes != null && dialogNodes[0] != null) {
-        mapping.putAll(dialogNodes[0].getSdkToApiMapping());
+        mapping.putAll(dialogNodes[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -4856,7 +4861,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogNode() { }
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -4869,7 +4874,7 @@ public class IBMAssistantV1Models {
     public String getDialogNode() {
       return dialogNode;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -4881,7 +4886,7 @@ public class IBMAssistantV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the conditions.
      *
@@ -4894,7 +4899,7 @@ public class IBMAssistantV1Models {
     public String getConditions() {
       return conditions;
     }
- 
+
     /**
      * Gets the parent.
      *
@@ -4906,7 +4911,7 @@ public class IBMAssistantV1Models {
     public String getParent() {
       return parent;
     }
- 
+
     /**
      * Gets the previousSibling.
      *
@@ -4918,7 +4923,7 @@ public class IBMAssistantV1Models {
     public String getPreviousSibling() {
       return previousSibling;
     }
- 
+
     /**
      * Gets the output.
      *
@@ -4931,7 +4936,7 @@ public class IBMAssistantV1Models {
     public DialogNodeOutput getOutput() {
       return output;
     }
- 
+
     /**
      * Gets the context.
      *
@@ -4943,7 +4948,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel getContext() {
       return context;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -4955,7 +4960,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel getMetadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the nextStep.
      *
@@ -4967,7 +4972,7 @@ public class IBMAssistantV1Models {
     public DialogNodeNextStep getNextStep() {
       return nextStep;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -4980,7 +4985,7 @@ public class IBMAssistantV1Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the nodeType.
      *
@@ -4992,7 +4997,7 @@ public class IBMAssistantV1Models {
     public String getNodeType() {
       return nodeType;
     }
- 
+
     /**
      * Gets the eventName.
      *
@@ -5004,7 +5009,7 @@ public class IBMAssistantV1Models {
     public String getEventName() {
       return eventName;
     }
- 
+
     /**
      * Gets the variable.
      *
@@ -5016,7 +5021,7 @@ public class IBMAssistantV1Models {
     public String getVariable() {
       return variable;
     }
- 
+
     /**
      * Gets the actions.
      *
@@ -5028,7 +5033,7 @@ public class IBMAssistantV1Models {
     public List<DialogNodeAction> getActions() {
       return actions;
     }
- 
+
     /**
      * Gets the digressIn.
      *
@@ -5040,7 +5045,7 @@ public class IBMAssistantV1Models {
     public String getDigressIn() {
       return digressIn;
     }
- 
+
     /**
      * Gets the digressOut.
      *
@@ -5052,7 +5057,7 @@ public class IBMAssistantV1Models {
     public String getDigressOut() {
       return digressOut;
     }
- 
+
     /**
      * Gets the digressOutSlots.
      *
@@ -5064,7 +5069,7 @@ public class IBMAssistantV1Models {
     public String getDigressOutSlots() {
       return digressOutSlots;
     }
- 
+
     /**
      * Gets the userLabel.
      *
@@ -5076,7 +5081,7 @@ public class IBMAssistantV1Models {
     public String getUserLabel() {
       return userLabel;
     }
- 
+
     /**
      * Gets the disabled.
      *
@@ -5088,7 +5093,7 @@ public class IBMAssistantV1Models {
     public Boolean getDisabled() {
       return disabled;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -5100,7 +5105,7 @@ public class IBMAssistantV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -5187,49 +5192,49 @@ public class IBMAssistantV1Models {
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dialogNode', 'dialog_node');
-      mapping.put('previousSibling', 'previous_sibling');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'dialogNode', 'dialog_node');
+      mapping.put(parentLabel + 'previousSibling', 'previous_sibling');
       if (output != null) {
-        mapping.putAll(output.getSdkToApiMapping());
+        mapping.putAll(output.addToSdkToApiMapping(parentLabel + 'output/', mapping));
       }
-      mapping.put('nextStep', 'next_step');
+      mapping.put(parentLabel + 'nextStep', 'next_step');
       if (nextStep != null) {
-        mapping.putAll(nextStep.getSdkToApiMapping());
+        mapping.putAll(nextStep.addToSdkToApiMapping(parentLabel + 'nextStep/', mapping));
       }
-      mapping.put('nodeType', 'type');
-      mapping.put('eventName', 'event_name');
+      mapping.put(parentLabel + 'nodeType', 'type');
+      mapping.put(parentLabel + 'eventName', 'event_name');
       if (actions != null && actions[0] != null) {
-        mapping.putAll(actions[0].getSdkToApiMapping());
+        mapping.putAll(actions[0].addToSdkToApiMapping(parentLabel + 'actions/', mapping));
       }
-      mapping.put('digressIn', 'digress_in');
-      mapping.put('digressOut', 'digress_out');
-      mapping.put('digressOutSlots', 'digress_out_slots');
-      mapping.put('userLabel', 'user_label');
+      mapping.put(parentLabel + 'digressIn', 'digress_in');
+      mapping.put(parentLabel + 'digressOut', 'digress_out');
+      mapping.put(parentLabel + 'digressOutSlots', 'digress_out_slots');
+      mapping.put(parentLabel + 'userLabel', 'user_label');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dialog_node', 'dialogNode');
-      mapping.put('previous_sibling', 'previousSibling');
-      if (output != null) {
-        mapping.putAll(output.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('next_step', 'nextStep');
-      if (nextStep != null) {
-        mapping.putAll(nextStep.getApiToSdkMapping());
-      }
-      mapping.put('type', 'nodeType');
-      mapping.put('event_name', 'eventName');
-      if (actions != null && actions[0] != null) {
-        mapping.putAll(actions[0].getApiToSdkMapping());
-      }
-      mapping.put('digress_in', 'digressIn');
-      mapping.put('digress_out', 'digressOut');
-      mapping.put('digress_out_slots', 'digressOutSlots');
-      mapping.put('user_label', 'userLabel');
+      mapping.put(parentLabel + 'dialog_node', 'dialogNode');
+      mapping.put(parentLabel + 'previous_sibling', 'previousSibling');
+      mapping.putAll(((IBMWatsonDynamicModel) DialogNodeOutput.class.newInstance()).addToApiToSdkMapping(parentLabel + 'output/', mapping));
+      mapping.put(parentLabel + 'next_step', 'nextStep');
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeNextStep.class.newInstance()).addToApiToSdkMapping(parentLabel + 'next_step/', mapping));
+      mapping.put(parentLabel + 'type', 'nodeType');
+      mapping.put(parentLabel + 'event_name', 'eventName');
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeAction.class.newInstance()).addToApiToSdkMapping(parentLabel + 'actions/', mapping));
+      mapping.put(parentLabel + 'digress_in', 'digressIn');
+      mapping.put(parentLabel + 'digress_out', 'digressOut');
+      mapping.put(parentLabel + 'digress_out_slots', 'digressOutSlots');
+      mapping.put(parentLabel + 'user_label', 'userLabel');
       return mapping;
     }
   }
@@ -5571,7 +5576,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogNodeAction() { }
- 
+
     /**
      * Gets the name.
      *
@@ -5583,7 +5588,7 @@ public class IBMAssistantV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the actionType.
      *
@@ -5595,7 +5600,7 @@ public class IBMAssistantV1Models {
     public String getActionType() {
       return actionType;
     }
- 
+
     /**
      * Gets the parameters.
      *
@@ -5607,7 +5612,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel getParameters() {
       return parameters;
     }
- 
+
     /**
      * Gets the resultVariable.
      *
@@ -5619,7 +5624,7 @@ public class IBMAssistantV1Models {
     public String getResultVariable() {
       return resultVariable;
     }
- 
+
     /**
      * Gets the credentials.
      *
@@ -5661,22 +5666,20 @@ public class IBMAssistantV1Models {
 
       // calling custom deserializer for parameters
       IBMWatsonMapModel newParameters = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getParameters()), (Map<String, Object>) jsonMap.get('parameters'), IBMWatsonMapModel.class);
-      retBuilder.setParameters(newParameters);
+      retBuilder.parameters(newParameters);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('actionType', 'type');
-      mapping.put('resultVariable', 'result_variable');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'actionType', 'type');
+      mapping.put(parentLabel + 'resultVariable', 'result_variable');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'actionType');
-      mapping.put('result_variable', 'resultVariable');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'type', 'actionType');
+      mapping.put(parentLabel + 'result_variable', 'resultVariable');
       return mapping;
     }
   }
@@ -5731,7 +5734,7 @@ public class IBMAssistantV1Models {
      * @param name the name
      * @return the DialogNodeAction builder
      */
-    public DialogNodeActionBuilder setName(String name) {
+    public DialogNodeActionBuilder name(String name) {
       this.name = name;
       return this;
     }
@@ -5742,7 +5745,7 @@ public class IBMAssistantV1Models {
      * @param actionType the actionType
      * @return the DialogNodeAction builder
      */
-    public DialogNodeActionBuilder setActionType(String actionType) {
+    public DialogNodeActionBuilder actionType(String actionType) {
       this.actionType = actionType;
       return this;
     }
@@ -5753,7 +5756,7 @@ public class IBMAssistantV1Models {
      * @param parameters the parameters
      * @return the DialogNodeAction builder
      */
-    public DialogNodeActionBuilder setParameters(IBMWatsonMapModel parameters) {
+    public DialogNodeActionBuilder parameters(IBMWatsonMapModel parameters) {
       this.parameters = parameters;
       return this;
     }
@@ -5764,7 +5767,7 @@ public class IBMAssistantV1Models {
      * @param resultVariable the resultVariable
      * @return the DialogNodeAction builder
      */
-    public DialogNodeActionBuilder setResultVariable(String resultVariable) {
+    public DialogNodeActionBuilder resultVariable(String resultVariable) {
       this.resultVariable = resultVariable;
       return this;
     }
@@ -5775,7 +5778,7 @@ public class IBMAssistantV1Models {
      * @param credentials the credentials
      * @return the DialogNodeAction builder
      */
-    public DialogNodeActionBuilder setCredentials(String credentials) {
+    public DialogNodeActionBuilder credentials(String credentials) {
       this.credentials = credentials;
       return this;
     }
@@ -5787,7 +5790,7 @@ public class IBMAssistantV1Models {
   public class DialogNodeCollection extends IBMWatsonResponseModel {
     private List<DialogNode> dialogNodes;
     private Pagination pagination;
- 
+
     /**
      * Gets the dialogNodes.
      *
@@ -5799,7 +5802,7 @@ public class IBMAssistantV1Models {
     public List<DialogNode> getDialogNodes() {
       return dialogNodes;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -5857,15 +5860,14 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dialog_nodes', 'dialogNodes');
-      if (dialogNodes != null && dialogNodes[0] != null) {
-        mapping.putAll(dialogNodes[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'dialog_nodes', 'dialogNodes');
+      mapping.putAll(((IBMWatsonGenericModel) DialogNode.class.newInstance()).addToApiToSdkMapping(parentLabel + 'dialog_nodes/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -5883,7 +5885,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogNodeNextStep() { }
- 
+
     /**
      * Gets the behavior.
      *
@@ -5914,7 +5916,7 @@ public class IBMAssistantV1Models {
     public String getBehavior() {
       return behavior;
     }
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -5926,7 +5928,7 @@ public class IBMAssistantV1Models {
     public String getDialogNode() {
       return dialogNode;
     }
- 
+
     /**
      * Gets the selector.
      *
@@ -5955,15 +5957,13 @@ public class IBMAssistantV1Models {
       return new DialogNodeNextStepBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dialogNode', 'dialog_node');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'dialogNode', 'dialog_node');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dialog_node', 'dialogNode');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'dialog_node', 'dialogNode');
       return mapping;
     }
   }
@@ -6012,7 +6012,7 @@ public class IBMAssistantV1Models {
      * @param behavior the behavior
      * @return the DialogNodeNextStep builder
      */
-    public DialogNodeNextStepBuilder setBehavior(String behavior) {
+    public DialogNodeNextStepBuilder behavior(String behavior) {
       this.behavior = behavior;
       return this;
     }
@@ -6023,7 +6023,7 @@ public class IBMAssistantV1Models {
      * @param dialogNode the dialogNode
      * @return the DialogNodeNextStep builder
      */
-    public DialogNodeNextStepBuilder setDialogNode(String dialogNode) {
+    public DialogNodeNextStepBuilder dialogNode(String dialogNode) {
       this.dialogNode = dialogNode;
       return this;
     }
@@ -6034,7 +6034,7 @@ public class IBMAssistantV1Models {
      * @param selector the selector
      * @return the DialogNodeNextStep builder
      */
-    public DialogNodeNextStepBuilder setSelector(String selector) {
+    public DialogNodeNextStepBuilder selector(String selector) {
       this.selector = selector;
       return this;
     }
@@ -6046,7 +6046,7 @@ public class IBMAssistantV1Models {
   public class DialogNodeOutput extends IBMWatsonDynamicModel {
     private List<DialogNodeOutputGeneric> generic;
     private DialogNodeOutputModifiers modifiers;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -6116,12 +6116,12 @@ public class IBMAssistantV1Models {
           DialogNodeOutputGeneric newItem = (DialogNodeOutputGeneric) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeOutputGeneric.class);
           newGeneric.add(newItem);
         }
-        retBuilder.setGeneric(newGeneric);
+        retBuilder.generic(newGeneric);
       }
 
       // calling custom deserializer for modifiers
       DialogNodeOutputModifiers newModifiers = (DialogNodeOutputModifiers) new DialogNodeOutputModifiers().deserialize(JSON.serialize(ret.getModifiers()), (Map<String, Object>) jsonMap.get('modifiers'), DialogNodeOutputModifiers.class);
-      retBuilder.setModifiers(newModifiers);
+      retBuilder.modifiers(newModifiers);
 
       DialogNodeOutput builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
@@ -6135,19 +6135,15 @@ public class IBMAssistantV1Models {
       return builderResult;
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (generic != null && generic[0] != null) {
-        mapping.putAll(generic[0].getSdkToApiMapping());
+        mapping.putAll(generic[0].addToSdkToApiMapping(parentLabel + 'generic/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (generic != null && generic[0] != null) {
-        mapping.putAll(generic[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeOutputGeneric.class.newInstance()).addToApiToSdkMapping(parentLabel + 'generic/', mapping));
       return mapping;
     }
   }
@@ -6200,7 +6196,7 @@ public class IBMAssistantV1Models {
      * @param generic the generic
      * @return the DialogNodeOutput builder
      */
-    public DialogNodeOutputBuilder setGeneric(List<DialogNodeOutputGeneric> generic) {
+    public DialogNodeOutputBuilder generic(List<DialogNodeOutputGeneric> generic) {
       this.generic = generic;
       return this;
     }
@@ -6211,7 +6207,7 @@ public class IBMAssistantV1Models {
      * @param modifiers the modifiers
      * @return the DialogNodeOutput builder
      */
-    public DialogNodeOutputBuilder setModifiers(DialogNodeOutputModifiers modifiers) {
+    public DialogNodeOutputBuilder modifiers(DialogNodeOutputModifiers modifiers) {
       this.modifiers = modifiers;
       return this;
     }
@@ -6233,18 +6229,25 @@ public class IBMAssistantV1Models {
     private String preference;
     private List<DialogNodeOutputOptionsElement> options;
     private String messageToHumanAgent;
+    private String query;
+    private String queryType;
+    private String filter;
+    private String discoveryVersion;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
      * and should not be called by the client.
      */
     public DialogNodeOutputGeneric() { }
- 
+
     /**
      * Gets the responseType.
      *
      * The type of response returned by the dialog node. The specified response type must be supported by the client
      * application or channel.
+     *
+     * **Note:** The **search_skill** response type is available only for Plus and Premium users, and is used only by
+     * the v2 runtime API.
      *
      * @return the responseType
      */
@@ -6252,7 +6255,7 @@ public class IBMAssistantV1Models {
     public String getResponseType() {
       return responseType;
     }
- 
+
     /**
      * Gets the values.
      *
@@ -6264,7 +6267,7 @@ public class IBMAssistantV1Models {
     public List<DialogNodeOutputTextValuesElement> getValues() {
       return values;
     }
- 
+
     /**
      * Gets the selectionPolicy.
      *
@@ -6277,7 +6280,7 @@ public class IBMAssistantV1Models {
     public String getSelectionPolicy() {
       return selectionPolicy;
     }
- 
+
     /**
      * Gets the delimiter.
      *
@@ -6289,7 +6292,7 @@ public class IBMAssistantV1Models {
     public String getDelimiter() {
       return delimiter;
     }
- 
+
     /**
      * Gets the xtime.
      *
@@ -6302,7 +6305,7 @@ public class IBMAssistantV1Models {
     public Long getXtime() {
       return xtime;
     }
- 
+
     /**
      * Gets the typing.
      *
@@ -6315,7 +6318,7 @@ public class IBMAssistantV1Models {
     public Boolean getTyping() {
       return typing;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -6327,7 +6330,7 @@ public class IBMAssistantV1Models {
     public String getSource() {
       return source;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -6339,7 +6342,7 @@ public class IBMAssistantV1Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -6351,7 +6354,7 @@ public class IBMAssistantV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the preference.
      *
@@ -6364,7 +6367,7 @@ public class IBMAssistantV1Models {
     public String getPreference() {
       return preference;
     }
- 
+
     /**
      * Gets the options.
      *
@@ -6377,7 +6380,7 @@ public class IBMAssistantV1Models {
     public List<DialogNodeOutputOptionsElement> getOptions() {
       return options;
     }
- 
+
     /**
      * Gets the messageToHumanAgent.
      *
@@ -6389,6 +6392,60 @@ public class IBMAssistantV1Models {
     @AuraEnabled
     public String getMessageToHumanAgent() {
       return messageToHumanAgent;
+    }
+
+    /**
+     * Gets the query.
+     *
+     * The text of the search query. This can be either a natural-language query or a query that uses the Discovery
+     * query language syntax, depending on the value of the **query_type** property. For more information, see the
+     * [Discovery service
+     * documentation](https://cloud.ibm.com/docs/services/discovery/query-operators.html#query-operators). Required when
+     * **response_type**=`search_skill`.
+     *
+     * @return the query
+     */
+    @AuraEnabled
+    public String getQuery() {
+      return query;
+    }
+
+    /**
+     * Gets the queryType.
+     *
+     * The type of the search query. Required when **response_type**=`search_skill`.
+     *
+     * @return the queryType
+     */
+    @AuraEnabled
+    public String getQueryType() {
+      return queryType;
+    }
+
+    /**
+     * Gets the filter.
+     *
+     * An optional filter that narrows the set of documents to be searched. For more information, see the [Discovery
+     * service documentation]([Discovery service
+     * documentation](https://cloud.ibm.com/docs/services/discovery/query-parameters.html#filter).
+     *
+     * @return the filter
+     */
+    @AuraEnabled
+    public String getFilter() {
+      return filter;
+    }
+
+    /**
+     * Gets the discoveryVersion.
+     *
+     * The version of the Discovery service API to use for the query.
+     *
+     * @return the discoveryVersion
+     */
+    @AuraEnabled
+    public String getDiscoveryVersion() {
+      return discoveryVersion;
     }
   
     private DialogNodeOutputGeneric(DialogNodeOutputGenericBuilder builder) {
@@ -6405,6 +6462,10 @@ public class IBMAssistantV1Models {
       this.preference = builder.preference;
       this.options = builder.options;
       this.messageToHumanAgent = builder.messageToHumanAgent;
+      this.query = builder.query;
+      this.queryType = builder.queryType;
+      this.filter = builder.filter;
+      this.discoveryVersion = builder.discoveryVersion;
     }
 
     /**
@@ -6434,7 +6495,7 @@ public class IBMAssistantV1Models {
           DialogNodeOutputTextValuesElement newItem = (DialogNodeOutputTextValuesElement) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeOutputTextValuesElement.class);
           newValues.add(newItem);
         }
-        retBuilder.setValues(newValues);
+        retBuilder.values(newValues);
       }
 
       // calling custom deserializer for options
@@ -6447,33 +6508,41 @@ public class IBMAssistantV1Models {
           DialogNodeOutputOptionsElement newItem = (DialogNodeOutputOptionsElement) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeOutputOptionsElement.class);
           newOptions.add(newItem);
         }
-        retBuilder.setOptions(newOptions);
+        retBuilder.options(newOptions);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('responseType', 'response_type');
-      mapping.put('selectionPolicy', 'selection_policy');
-      mapping.put('xtime', 'time');
-      if (options != null && options[0] != null) {
-        mapping.putAll(options[0].getSdkToApiMapping());
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('messageToHumanAgent', 'message_to_human_agent');
+      mapping.put(parentLabel + 'responseType', 'response_type');
+      mapping.put(parentLabel + 'selectionPolicy', 'selection_policy');
+      mapping.put(parentLabel + 'xtime', 'time');
+      if (options != null && options[0] != null) {
+        mapping.putAll(options[0].addToSdkToApiMapping(parentLabel + 'options/', mapping));
+      }
+      mapping.put(parentLabel + 'messageToHumanAgent', 'message_to_human_agent');
+      mapping.put(parentLabel + 'queryType', 'query_type');
+      mapping.put(parentLabel + 'discoveryVersion', 'discovery_version');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('response_type', 'responseType');
-      mapping.put('selection_policy', 'selectionPolicy');
-      mapping.put('time', 'xtime');
-      if (options != null && options[0] != null) {
-        mapping.putAll(options[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('message_to_human_agent', 'messageToHumanAgent');
+      mapping.put(parentLabel + 'response_type', 'responseType');
+      mapping.put(parentLabel + 'selection_policy', 'selectionPolicy');
+      mapping.put(parentLabel + 'time', 'xtime');
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeOutputOptionsElement.class.newInstance()).addToApiToSdkMapping(parentLabel + 'options/', mapping));
+      mapping.put(parentLabel + 'message_to_human_agent', 'messageToHumanAgent');
+      mapping.put(parentLabel + 'query_type', 'queryType');
+      mapping.put(parentLabel + 'discovery_version', 'discoveryVersion');
       return mapping;
     }
   }
@@ -6494,6 +6563,10 @@ public class IBMAssistantV1Models {
     private String preference;
     private List<DialogNodeOutputOptionsElement> options;
     private String messageToHumanAgent;
+    private String query;
+    private String queryType;
+    private String filter;
+    private String discoveryVersion;
 
     private DialogNodeOutputGenericBuilder(DialogNodeOutputGeneric dialogNodeOutputGeneric) {
       this.responseType = dialogNodeOutputGeneric.responseType;
@@ -6508,6 +6581,10 @@ public class IBMAssistantV1Models {
       this.preference = dialogNodeOutputGeneric.preference;
       this.options = dialogNodeOutputGeneric.options;
       this.messageToHumanAgent = dialogNodeOutputGeneric.messageToHumanAgent;
+      this.query = dialogNodeOutputGeneric.query;
+      this.queryType = dialogNodeOutputGeneric.queryType;
+      this.filter = dialogNodeOutputGeneric.filter;
+      this.discoveryVersion = dialogNodeOutputGeneric.discoveryVersion;
     }
 
     /**
@@ -6570,7 +6647,7 @@ public class IBMAssistantV1Models {
      * @param responseType the responseType
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setResponseType(String responseType) {
+    public DialogNodeOutputGenericBuilder responseType(String responseType) {
       this.responseType = responseType;
       return this;
     }
@@ -6582,7 +6659,7 @@ public class IBMAssistantV1Models {
      * @param values the values
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setValues(List<DialogNodeOutputTextValuesElement> values) {
+    public DialogNodeOutputGenericBuilder values(List<DialogNodeOutputTextValuesElement> values) {
       this.values = values;
       return this;
     }
@@ -6593,7 +6670,7 @@ public class IBMAssistantV1Models {
      * @param selectionPolicy the selectionPolicy
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setSelectionPolicy(String selectionPolicy) {
+    public DialogNodeOutputGenericBuilder selectionPolicy(String selectionPolicy) {
       this.selectionPolicy = selectionPolicy;
       return this;
     }
@@ -6604,7 +6681,7 @@ public class IBMAssistantV1Models {
      * @param delimiter the delimiter
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setDelimiter(String delimiter) {
+    public DialogNodeOutputGenericBuilder delimiter(String delimiter) {
       this.delimiter = delimiter;
       return this;
     }
@@ -6615,7 +6692,7 @@ public class IBMAssistantV1Models {
      * @param xtime the xtime
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setXtime(Long xtime) {
+    public DialogNodeOutputGenericBuilder xtime(Long xtime) {
       this.xtime = xtime;
       return this;
     }
@@ -6626,7 +6703,7 @@ public class IBMAssistantV1Models {
      * @param typing the typing
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setTyping(Boolean typing) {
+    public DialogNodeOutputGenericBuilder typing(Boolean typing) {
       this.typing = typing;
       return this;
     }
@@ -6637,7 +6714,7 @@ public class IBMAssistantV1Models {
      * @param source the source
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setSource(String source) {
+    public DialogNodeOutputGenericBuilder source(String source) {
       this.source = source;
       return this;
     }
@@ -6648,7 +6725,7 @@ public class IBMAssistantV1Models {
      * @param title the title
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setTitle(String title) {
+    public DialogNodeOutputGenericBuilder title(String title) {
       this.title = title;
       return this;
     }
@@ -6659,7 +6736,7 @@ public class IBMAssistantV1Models {
      * @param description the description
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setDescription(String description) {
+    public DialogNodeOutputGenericBuilder description(String description) {
       this.description = description;
       return this;
     }
@@ -6670,7 +6747,7 @@ public class IBMAssistantV1Models {
      * @param preference the preference
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setPreference(String preference) {
+    public DialogNodeOutputGenericBuilder preference(String preference) {
       this.preference = preference;
       return this;
     }
@@ -6682,7 +6759,7 @@ public class IBMAssistantV1Models {
      * @param options the options
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setOptions(List<DialogNodeOutputOptionsElement> options) {
+    public DialogNodeOutputGenericBuilder options(List<DialogNodeOutputOptionsElement> options) {
       this.options = options;
       return this;
     }
@@ -6693,8 +6770,52 @@ public class IBMAssistantV1Models {
      * @param messageToHumanAgent the messageToHumanAgent
      * @return the DialogNodeOutputGeneric builder
      */
-    public DialogNodeOutputGenericBuilder setMessageToHumanAgent(String messageToHumanAgent) {
+    public DialogNodeOutputGenericBuilder messageToHumanAgent(String messageToHumanAgent) {
       this.messageToHumanAgent = messageToHumanAgent;
+      return this;
+    }
+
+    /**
+     * Set the query.
+     *
+     * @param query the query
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder query(String query) {
+      this.query = query;
+      return this;
+    }
+
+    /**
+     * Set the queryType.
+     *
+     * @param queryType the queryType
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder queryType(String queryType) {
+      this.queryType = queryType;
+      return this;
+    }
+
+    /**
+     * Set the filter.
+     *
+     * @param filter the filter
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder filter(String filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    /**
+     * Set the discoveryVersion.
+     *
+     * @param discoveryVersion the discoveryVersion
+     * @return the DialogNodeOutputGeneric builder
+     */
+    public DialogNodeOutputGenericBuilder discoveryVersion(String discoveryVersion) {
+      this.discoveryVersion = discoveryVersion;
       return this;
     }
   }
@@ -6710,7 +6831,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogNodeOutputModifiers() { }
- 
+
     /**
      * Gets the overwrite.
      *
@@ -6769,7 +6890,7 @@ public class IBMAssistantV1Models {
      * @param overwrite the overwrite
      * @return the DialogNodeOutputModifiers builder
      */
-    public DialogNodeOutputModifiersBuilder setOverwrite(Boolean overwrite) {
+    public DialogNodeOutputModifiersBuilder overwrite(Boolean overwrite) {
       this.overwrite = overwrite;
       return this;
     }
@@ -6787,7 +6908,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogNodeOutputOptionsElement() { }
- 
+
     /**
      * Gets the label.
      *
@@ -6799,7 +6920,7 @@ public class IBMAssistantV1Models {
     public String getLabel() {
       return label;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -6839,24 +6960,20 @@ public class IBMAssistantV1Models {
 
       // calling custom deserializer for value
       DialogNodeOutputOptionsElementValue newValue = (DialogNodeOutputOptionsElementValue) new DialogNodeOutputOptionsElementValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value'), DialogNodeOutputOptionsElementValue.class);
-      retBuilder.setValue(newValue);
+      retBuilder.value(newValue);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (value != null) {
-        mapping.putAll(value.getSdkToApiMapping());
+        mapping.putAll(value.addToSdkToApiMapping(parentLabel + 'value/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (value != null) {
-        mapping.putAll(value.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeOutputOptionsElementValue.class.newInstance()).addToApiToSdkMapping(parentLabel + 'value/', mapping));
       return mapping;
     }
   }
@@ -6905,7 +7022,7 @@ public class IBMAssistantV1Models {
      * @param label the label
      * @return the DialogNodeOutputOptionsElement builder
      */
-    public DialogNodeOutputOptionsElementBuilder setLabel(String label) {
+    public DialogNodeOutputOptionsElementBuilder label(String label) {
       this.label = label;
       return this;
     }
@@ -6916,7 +7033,7 @@ public class IBMAssistantV1Models {
      * @param value the value
      * @return the DialogNodeOutputOptionsElement builder
      */
-    public DialogNodeOutputOptionsElementBuilder setValue(DialogNodeOutputOptionsElementValue value) {
+    public DialogNodeOutputOptionsElementBuilder value(DialogNodeOutputOptionsElementValue value) {
       this.value = value;
       return this;
     }
@@ -6936,7 +7053,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogNodeOutputOptionsElementValue() { }
- 
+
     /**
      * Gets the input.
      *
@@ -6948,7 +7065,7 @@ public class IBMAssistantV1Models {
     public MessageInput getInput() {
       return input;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -6963,7 +7080,7 @@ public class IBMAssistantV1Models {
     public List<RuntimeIntent> getIntents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -7004,7 +7121,7 @@ public class IBMAssistantV1Models {
 
       // calling custom deserializer for input
       MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input'), MessageInput.class);
-      retBuilder.setInput(newInput);
+      retBuilder.input(newInput);
 
       // calling custom deserializer for intents
       List<RuntimeIntent> newIntents = new List<RuntimeIntent>();
@@ -7016,7 +7133,7 @@ public class IBMAssistantV1Models {
           RuntimeIntent newItem = (RuntimeIntent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeIntent.class);
           newIntents.add(newItem);
         }
-        retBuilder.setIntents(newIntents);
+        retBuilder.intents(newIntents);
       }
 
       // calling custom deserializer for entities
@@ -7029,25 +7146,21 @@ public class IBMAssistantV1Models {
           RuntimeEntity newItem = (RuntimeEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeEntity.class);
           newEntities.add(newItem);
         }
-        retBuilder.setEntities(newEntities);
+        retBuilder.entities(newEntities);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getSdkToApiMapping());
+        mapping.putAll(entities[0].addToSdkToApiMapping(parentLabel + 'entities/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) RuntimeEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
       return mapping;
     }
   }
@@ -7117,7 +7230,7 @@ public class IBMAssistantV1Models {
      * @param input the input
      * @return the DialogNodeOutputOptionsElementValue builder
      */
-    public DialogNodeOutputOptionsElementValueBuilder setInput(MessageInput input) {
+    public DialogNodeOutputOptionsElementValueBuilder input(MessageInput input) {
       this.input = input;
       return this;
     }
@@ -7129,7 +7242,7 @@ public class IBMAssistantV1Models {
      * @param intents the intents
      * @return the DialogNodeOutputOptionsElementValue builder
      */
-    public DialogNodeOutputOptionsElementValueBuilder setIntents(List<RuntimeIntent> intents) {
+    public DialogNodeOutputOptionsElementValueBuilder intents(List<RuntimeIntent> intents) {
       this.intents = intents;
       return this;
     }
@@ -7141,7 +7254,7 @@ public class IBMAssistantV1Models {
      * @param entities the entities
      * @return the DialogNodeOutputOptionsElementValue builder
      */
-    public DialogNodeOutputOptionsElementValueBuilder setEntities(List<RuntimeEntity> entities) {
+    public DialogNodeOutputOptionsElementValueBuilder entities(List<RuntimeEntity> entities) {
       this.entities = entities;
       return this;
     }
@@ -7158,7 +7271,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogNodeOutputTextValuesElement() { }
- 
+
     /**
      * Gets the text.
      *
@@ -7217,7 +7330,7 @@ public class IBMAssistantV1Models {
      * @param text the text
      * @return the DialogNodeOutputTextValuesElement builder
      */
-    public DialogNodeOutputTextValuesElementBuilder setText(String text) {
+    public DialogNodeOutputTextValuesElementBuilder text(String text) {
       this.text = text;
       return this;
     }
@@ -7236,7 +7349,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogNodeVisitedDetails() { }
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -7248,7 +7361,7 @@ public class IBMAssistantV1Models {
     public String getDialogNode() {
       return dialogNode;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -7260,7 +7373,7 @@ public class IBMAssistantV1Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the conditions.
      *
@@ -7288,15 +7401,21 @@ public class IBMAssistantV1Models {
       return new DialogNodeVisitedDetailsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dialogNode', 'dialog_node');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'dialogNode', 'dialog_node');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dialog_node', 'dialogNode');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'dialog_node', 'dialogNode');
       return mapping;
     }
   }
@@ -7336,7 +7455,7 @@ public class IBMAssistantV1Models {
      * @param dialogNode the dialogNode
      * @return the DialogNodeVisitedDetails builder
      */
-    public DialogNodeVisitedDetailsBuilder setDialogNode(String dialogNode) {
+    public DialogNodeVisitedDetailsBuilder dialogNode(String dialogNode) {
       this.dialogNode = dialogNode;
       return this;
     }
@@ -7347,7 +7466,7 @@ public class IBMAssistantV1Models {
      * @param title the title
      * @return the DialogNodeVisitedDetails builder
      */
-    public DialogNodeVisitedDetailsBuilder setTitle(String title) {
+    public DialogNodeVisitedDetailsBuilder title(String title) {
       this.title = title;
       return this;
     }
@@ -7358,7 +7477,7 @@ public class IBMAssistantV1Models {
      * @param conditions the conditions
      * @return the DialogNodeVisitedDetails builder
      */
-    public DialogNodeVisitedDetailsBuilder setConditions(String conditions) {
+    public DialogNodeVisitedDetailsBuilder conditions(String conditions) {
       this.conditions = conditions;
       return this;
     }
@@ -7387,7 +7506,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogRuntimeResponseGeneric() { }
- 
+
     /**
      * Gets the responseType.
      *
@@ -7395,7 +7514,7 @@ public class IBMAssistantV1Models {
      * application or channel.
      *
      * **Note:** The **suggestion** response type is part of the disambiguation feature, which is only available for
-     * Premium users.
+     * Plus and Premium users.
      *
      * @return the responseType
      */
@@ -7403,7 +7522,7 @@ public class IBMAssistantV1Models {
     public String getResponseType() {
       return responseType;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -7415,7 +7534,7 @@ public class IBMAssistantV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the xtime.
      *
@@ -7427,7 +7546,7 @@ public class IBMAssistantV1Models {
     public Long getXtime() {
       return xtime;
     }
- 
+
     /**
      * Gets the typing.
      *
@@ -7439,7 +7558,7 @@ public class IBMAssistantV1Models {
     public Boolean getTyping() {
       return typing;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -7451,7 +7570,7 @@ public class IBMAssistantV1Models {
     public String getSource() {
       return source;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -7463,7 +7582,7 @@ public class IBMAssistantV1Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -7475,7 +7594,7 @@ public class IBMAssistantV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the preference.
      *
@@ -7487,7 +7606,7 @@ public class IBMAssistantV1Models {
     public String getPreference() {
       return preference;
     }
- 
+
     /**
      * Gets the options.
      *
@@ -7499,7 +7618,7 @@ public class IBMAssistantV1Models {
     public List<DialogNodeOutputOptionsElement> getOptions() {
       return options;
     }
- 
+
     /**
      * Gets the messageToHumanAgent.
      *
@@ -7511,7 +7630,7 @@ public class IBMAssistantV1Models {
     public String getMessageToHumanAgent() {
       return messageToHumanAgent;
     }
- 
+
     /**
      * Gets the topic.
      *
@@ -7523,7 +7642,7 @@ public class IBMAssistantV1Models {
     public String getTopic() {
       return topic;
     }
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -7536,7 +7655,7 @@ public class IBMAssistantV1Models {
     public String getDialogNode() {
       return dialogNode;
     }
- 
+
     /**
      * Gets the suggestions.
      *
@@ -7596,7 +7715,7 @@ public class IBMAssistantV1Models {
           DialogNodeOutputOptionsElement newItem = (DialogNodeOutputOptionsElement) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeOutputOptionsElement.class);
           newOptions.add(newItem);
         }
-        retBuilder.setOptions(newOptions);
+        retBuilder.options(newOptions);
       }
 
       // calling custom deserializer for suggestions
@@ -7609,39 +7728,41 @@ public class IBMAssistantV1Models {
           DialogSuggestion newItem = (DialogSuggestion) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogSuggestion.class);
           newSuggestions.add(newItem);
         }
-        retBuilder.setSuggestions(newSuggestions);
+        retBuilder.suggestions(newSuggestions);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('responseType', 'response_type');
-      mapping.put('xtime', 'time');
-      if (options != null && options[0] != null) {
-        mapping.putAll(options[0].getSdkToApiMapping());
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('messageToHumanAgent', 'message_to_human_agent');
-      mapping.put('dialogNode', 'dialog_node');
+      mapping.put(parentLabel + 'responseType', 'response_type');
+      mapping.put(parentLabel + 'xtime', 'time');
+      if (options != null && options[0] != null) {
+        mapping.putAll(options[0].addToSdkToApiMapping(parentLabel + 'options/', mapping));
+      }
+      mapping.put(parentLabel + 'messageToHumanAgent', 'message_to_human_agent');
+      mapping.put(parentLabel + 'dialogNode', 'dialog_node');
       if (suggestions != null && suggestions[0] != null) {
-        mapping.putAll(suggestions[0].getSdkToApiMapping());
+        mapping.putAll(suggestions[0].addToSdkToApiMapping(parentLabel + 'suggestions/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('response_type', 'responseType');
-      mapping.put('time', 'xtime');
-      if (options != null && options[0] != null) {
-        mapping.putAll(options[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('message_to_human_agent', 'messageToHumanAgent');
-      mapping.put('dialog_node', 'dialogNode');
-      if (suggestions != null && suggestions[0] != null) {
-        mapping.putAll(suggestions[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'response_type', 'responseType');
+      mapping.put(parentLabel + 'time', 'xtime');
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeOutputOptionsElement.class.newInstance()).addToApiToSdkMapping(parentLabel + 'options/', mapping));
+      mapping.put(parentLabel + 'message_to_human_agent', 'messageToHumanAgent');
+      mapping.put(parentLabel + 'dialog_node', 'dialogNode');
+      mapping.putAll(((IBMWatsonGenericModel) DialogSuggestion.class.newInstance()).addToApiToSdkMapping(parentLabel + 'suggestions/', mapping));
       return mapping;
     }
   }
@@ -7740,7 +7861,7 @@ public class IBMAssistantV1Models {
      * @param responseType the responseType
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setResponseType(String responseType) {
+    public DialogRuntimeResponseGenericBuilder responseType(String responseType) {
       this.responseType = responseType;
       return this;
     }
@@ -7751,7 +7872,7 @@ public class IBMAssistantV1Models {
      * @param text the text
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setText(String text) {
+    public DialogRuntimeResponseGenericBuilder text(String text) {
       this.text = text;
       return this;
     }
@@ -7762,7 +7883,7 @@ public class IBMAssistantV1Models {
      * @param xtime the xtime
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setXtime(Long xtime) {
+    public DialogRuntimeResponseGenericBuilder xtime(Long xtime) {
       this.xtime = xtime;
       return this;
     }
@@ -7773,7 +7894,7 @@ public class IBMAssistantV1Models {
      * @param typing the typing
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setTyping(Boolean typing) {
+    public DialogRuntimeResponseGenericBuilder typing(Boolean typing) {
       this.typing = typing;
       return this;
     }
@@ -7784,7 +7905,7 @@ public class IBMAssistantV1Models {
      * @param source the source
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setSource(String source) {
+    public DialogRuntimeResponseGenericBuilder source(String source) {
       this.source = source;
       return this;
     }
@@ -7795,7 +7916,7 @@ public class IBMAssistantV1Models {
      * @param title the title
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setTitle(String title) {
+    public DialogRuntimeResponseGenericBuilder title(String title) {
       this.title = title;
       return this;
     }
@@ -7806,7 +7927,7 @@ public class IBMAssistantV1Models {
      * @param description the description
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setDescription(String description) {
+    public DialogRuntimeResponseGenericBuilder description(String description) {
       this.description = description;
       return this;
     }
@@ -7817,7 +7938,7 @@ public class IBMAssistantV1Models {
      * @param preference the preference
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setPreference(String preference) {
+    public DialogRuntimeResponseGenericBuilder preference(String preference) {
       this.preference = preference;
       return this;
     }
@@ -7829,7 +7950,7 @@ public class IBMAssistantV1Models {
      * @param options the options
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setOptions(List<DialogNodeOutputOptionsElement> options) {
+    public DialogRuntimeResponseGenericBuilder options(List<DialogNodeOutputOptionsElement> options) {
       this.options = options;
       return this;
     }
@@ -7840,7 +7961,7 @@ public class IBMAssistantV1Models {
      * @param messageToHumanAgent the messageToHumanAgent
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setMessageToHumanAgent(String messageToHumanAgent) {
+    public DialogRuntimeResponseGenericBuilder messageToHumanAgent(String messageToHumanAgent) {
       this.messageToHumanAgent = messageToHumanAgent;
       return this;
     }
@@ -7851,7 +7972,7 @@ public class IBMAssistantV1Models {
      * @param topic the topic
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setTopic(String topic) {
+    public DialogRuntimeResponseGenericBuilder topic(String topic) {
       this.topic = topic;
       return this;
     }
@@ -7862,7 +7983,7 @@ public class IBMAssistantV1Models {
      * @param dialogNode the dialogNode
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setDialogNode(String dialogNode) {
+    public DialogRuntimeResponseGenericBuilder dialogNode(String dialogNode) {
       this.dialogNode = dialogNode;
       return this;
     }
@@ -7874,7 +7995,7 @@ public class IBMAssistantV1Models {
      * @param suggestions the suggestions
      * @return the DialogRuntimeResponseGeneric builder
      */
-    public DialogRuntimeResponseGenericBuilder setSuggestions(List<DialogSuggestion> suggestions) {
+    public DialogRuntimeResponseGenericBuilder suggestions(List<DialogSuggestion> suggestions) {
       this.suggestions = suggestions;
       return this;
     }
@@ -7894,7 +8015,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogSuggestion() { }
- 
+
     /**
      * Gets the label.
      *
@@ -7907,7 +8028,7 @@ public class IBMAssistantV1Models {
     public String getLabel() {
       return label;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -7920,7 +8041,7 @@ public class IBMAssistantV1Models {
     public DialogSuggestionValue getValue() {
       return value;
     }
- 
+
     /**
      * Gets the output.
      *
@@ -7933,7 +8054,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel getOutput() {
       return output;
     }
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -7975,30 +8096,26 @@ public class IBMAssistantV1Models {
 
       // calling custom deserializer for value
       DialogSuggestionValue newValue = (DialogSuggestionValue) new DialogSuggestionValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value'), DialogSuggestionValue.class);
-      retBuilder.setValue(newValue);
+      retBuilder.value(newValue);
 
       // calling custom deserializer for output
       IBMWatsonMapModel newOutput = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output'), IBMWatsonMapModel.class);
-      retBuilder.setOutput(newOutput);
+      retBuilder.output(newOutput);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (value != null) {
-        mapping.putAll(value.getSdkToApiMapping());
+        mapping.putAll(value.addToSdkToApiMapping(parentLabel + 'value/', mapping));
       }
-      mapping.put('dialogNode', 'dialog_node');
+      mapping.put(parentLabel + 'dialogNode', 'dialog_node');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (value != null) {
-        mapping.putAll(value.getApiToSdkMapping());
-      }
-      mapping.put('dialog_node', 'dialogNode');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) DialogSuggestionValue.class.newInstance()).addToApiToSdkMapping(parentLabel + 'value/', mapping));
+      mapping.put(parentLabel + 'dialog_node', 'dialogNode');
       return mapping;
     }
   }
@@ -8051,7 +8168,7 @@ public class IBMAssistantV1Models {
      * @param label the label
      * @return the DialogSuggestion builder
      */
-    public DialogSuggestionBuilder setLabel(String label) {
+    public DialogSuggestionBuilder label(String label) {
       this.label = label;
       return this;
     }
@@ -8062,7 +8179,7 @@ public class IBMAssistantV1Models {
      * @param value the value
      * @return the DialogSuggestion builder
      */
-    public DialogSuggestionBuilder setValue(DialogSuggestionValue value) {
+    public DialogSuggestionBuilder value(DialogSuggestionValue value) {
       this.value = value;
       return this;
     }
@@ -8073,7 +8190,7 @@ public class IBMAssistantV1Models {
      * @param output the output
      * @return the DialogSuggestion builder
      */
-    public DialogSuggestionBuilder setOutput(IBMWatsonMapModel output) {
+    public DialogSuggestionBuilder output(IBMWatsonMapModel output) {
       this.output = output;
       return this;
     }
@@ -8084,7 +8201,7 @@ public class IBMAssistantV1Models {
      * @param dialogNode the dialogNode
      * @return the DialogSuggestion builder
      */
-    public DialogSuggestionBuilder setDialogNode(String dialogNode) {
+    public DialogSuggestionBuilder dialogNode(String dialogNode) {
       this.dialogNode = dialogNode;
       return this;
     }
@@ -8104,7 +8221,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public DialogSuggestionValue() { }
- 
+
     /**
      * Gets the input.
      *
@@ -8116,7 +8233,7 @@ public class IBMAssistantV1Models {
     public MessageInput getInput() {
       return input;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -8128,7 +8245,7 @@ public class IBMAssistantV1Models {
     public List<RuntimeIntent> getIntents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -8166,7 +8283,7 @@ public class IBMAssistantV1Models {
 
       // calling custom deserializer for input
       MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input'), MessageInput.class);
-      retBuilder.setInput(newInput);
+      retBuilder.input(newInput);
 
       // calling custom deserializer for intents
       List<RuntimeIntent> newIntents = new List<RuntimeIntent>();
@@ -8178,7 +8295,7 @@ public class IBMAssistantV1Models {
           RuntimeIntent newItem = (RuntimeIntent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeIntent.class);
           newIntents.add(newItem);
         }
-        retBuilder.setIntents(newIntents);
+        retBuilder.intents(newIntents);
       }
 
       // calling custom deserializer for entities
@@ -8191,25 +8308,21 @@ public class IBMAssistantV1Models {
           RuntimeEntity newItem = (RuntimeEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeEntity.class);
           newEntities.add(newItem);
         }
-        retBuilder.setEntities(newEntities);
+        retBuilder.entities(newEntities);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getSdkToApiMapping());
+        mapping.putAll(entities[0].addToSdkToApiMapping(parentLabel + 'entities/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) RuntimeEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
       return mapping;
     }
   }
@@ -8279,7 +8392,7 @@ public class IBMAssistantV1Models {
      * @param input the input
      * @return the DialogSuggestionValue builder
      */
-    public DialogSuggestionValueBuilder setInput(MessageInput input) {
+    public DialogSuggestionValueBuilder input(MessageInput input) {
       this.input = input;
       return this;
     }
@@ -8291,7 +8404,7 @@ public class IBMAssistantV1Models {
      * @param intents the intents
      * @return the DialogSuggestionValue builder
      */
-    public DialogSuggestionValueBuilder setIntents(List<RuntimeIntent> intents) {
+    public DialogSuggestionValueBuilder intents(List<RuntimeIntent> intents) {
       this.intents = intents;
       return this;
     }
@@ -8303,7 +8416,7 @@ public class IBMAssistantV1Models {
      * @param entities the entities
      * @return the DialogSuggestionValue builder
      */
-    public DialogSuggestionValueBuilder setEntities(List<RuntimeEntity> entities) {
+    public DialogSuggestionValueBuilder entities(List<RuntimeEntity> entities) {
       this.entities = entities;
       return this;
     }
@@ -8320,7 +8433,7 @@ public class IBMAssistantV1Models {
     private Datetime created;
     private Datetime updated;
     private List<Value> values;
- 
+
     /**
      * Gets the entity.
      *
@@ -8335,7 +8448,7 @@ public class IBMAssistantV1Models {
     public String getEntity() {
       return entity;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -8347,7 +8460,7 @@ public class IBMAssistantV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -8359,7 +8472,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel getMetadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the fuzzyMatch.
      *
@@ -8371,7 +8484,7 @@ public class IBMAssistantV1Models {
     public Boolean getFuzzyMatch() {
       return fuzzyMatch;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -8383,7 +8496,7 @@ public class IBMAssistantV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -8395,7 +8508,7 @@ public class IBMAssistantV1Models {
     public Datetime getUpdated() {
       return updated;
     }
- 
+
     /**
      * Gets the values.
      *
@@ -8480,12 +8593,9 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('fuzzy_match', 'fuzzyMatch');
-      if (values != null && values[0] != null) {
-        mapping.putAll(values[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'fuzzy_match', 'fuzzyMatch');
+      mapping.putAll(((IBMWatsonGenericModel) Value.class.newInstance()).addToApiToSdkMapping(parentLabel + 'values/', mapping));
       return mapping;
     }
   }
@@ -8496,7 +8606,7 @@ public class IBMAssistantV1Models {
   public class EntityCollection extends IBMWatsonResponseModel {
     private List<Entity> entities;
     private Pagination pagination;
- 
+
     /**
      * Gets the entities.
      *
@@ -8508,7 +8618,7 @@ public class IBMAssistantV1Models {
     public List<Entity> getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -8566,14 +8676,9 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Entity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -8585,7 +8690,7 @@ public class IBMAssistantV1Models {
     private String text;
     private String intent;
     private List<Long> location;
- 
+
     /**
      * Gets the text.
      *
@@ -8597,7 +8702,7 @@ public class IBMAssistantV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the intent.
      *
@@ -8609,7 +8714,7 @@ public class IBMAssistantV1Models {
     public String getIntent() {
       return intent;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -8656,7 +8761,7 @@ public class IBMAssistantV1Models {
   public class EntityMentionCollection extends IBMWatsonResponseModel {
     private List<EntityMention> examples;
     private Pagination pagination;
- 
+
     /**
      * Gets the examples.
      *
@@ -8668,7 +8773,7 @@ public class IBMAssistantV1Models {
     public List<EntityMention> getExamples() {
       return examples;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -8726,11 +8831,8 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -8749,7 +8851,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public Example() { }
- 
+
     /**
      * Gets the text.
      *
@@ -8763,7 +8865,7 @@ public class IBMAssistantV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the mentions.
      *
@@ -8775,7 +8877,7 @@ public class IBMAssistantV1Models {
     public List<Mention> getMentions() {
       return mentions;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -8787,7 +8889,7 @@ public class IBMAssistantV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -8949,7 +9051,7 @@ public class IBMAssistantV1Models {
   public class ExampleCollection extends IBMWatsonResponseModel {
     private List<Example> examples;
     private Pagination pagination;
- 
+
     /**
      * Gets the examples.
      *
@@ -8961,7 +9063,7 @@ public class IBMAssistantV1Models {
     public List<Example> getExamples() {
       return examples;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -9019,11 +9121,8 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -10497,7 +10596,7 @@ public class IBMAssistantV1Models {
     private Datetime created;
     private Datetime updated;
     private List<Example> examples;
- 
+
     /**
      * Gets the intent.
      *
@@ -10511,7 +10610,7 @@ public class IBMAssistantV1Models {
     public String getIntent() {
       return intent;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -10523,7 +10622,7 @@ public class IBMAssistantV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -10535,7 +10634,7 @@ public class IBMAssistantV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -10547,7 +10646,7 @@ public class IBMAssistantV1Models {
     public Datetime getUpdated() {
       return updated;
     }
- 
+
     /**
      * Gets the examples.
      *
@@ -10617,7 +10716,7 @@ public class IBMAssistantV1Models {
   public class IntentCollection extends IBMWatsonResponseModel {
     private List<Intent> intents;
     private Pagination pagination;
- 
+
     /**
      * Gets the intents.
      *
@@ -10629,7 +10728,7 @@ public class IBMAssistantV1Models {
     public List<Intent> getIntents() {
       return intents;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -10687,11 +10786,8 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -13304,7 +13400,7 @@ public class IBMAssistantV1Models {
     private String responseTimestamp;
     private String workspaceId;
     private String language;
- 
+
     /**
      * Gets the request.
      *
@@ -13316,7 +13412,7 @@ public class IBMAssistantV1Models {
     public MessageRequest getRequest() {
       return request;
     }
- 
+
     /**
      * Gets the response.
      *
@@ -13328,7 +13424,7 @@ public class IBMAssistantV1Models {
     public MessageResponse getResponse() {
       return response;
     }
- 
+
     /**
      * Gets the logId.
      *
@@ -13340,7 +13436,7 @@ public class IBMAssistantV1Models {
     public String getLogId() {
       return logId;
     }
- 
+
     /**
      * Gets the requestTimestamp.
      *
@@ -13352,7 +13448,7 @@ public class IBMAssistantV1Models {
     public String getRequestTimestamp() {
       return requestTimestamp;
     }
- 
+
     /**
      * Gets the responseTimestamp.
      *
@@ -13364,7 +13460,7 @@ public class IBMAssistantV1Models {
     public String getResponseTimestamp() {
       return responseTimestamp;
     }
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -13376,7 +13472,7 @@ public class IBMAssistantV1Models {
     public String getWorkspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -13470,18 +13566,13 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (request != null) {
-        mapping.putAll(request.getApiToSdkMapping());
-      }
-      if (response != null) {
-        mapping.putAll(response.getApiToSdkMapping());
-      }
-      mapping.put('log_id', 'logId');
-      mapping.put('request_timestamp', 'requestTimestamp');
-      mapping.put('response_timestamp', 'responseTimestamp');
-      mapping.put('workspace_id', 'workspaceId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) MessageRequest.class.newInstance()).addToApiToSdkMapping(parentLabel + 'request/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) MessageResponse.class.newInstance()).addToApiToSdkMapping(parentLabel + 'response/', mapping));
+      mapping.put(parentLabel + 'log_id', 'logId');
+      mapping.put(parentLabel + 'request_timestamp', 'requestTimestamp');
+      mapping.put(parentLabel + 'response_timestamp', 'responseTimestamp');
+      mapping.put(parentLabel + 'workspace_id', 'workspaceId');
       return mapping;
     }
   }
@@ -13492,7 +13583,7 @@ public class IBMAssistantV1Models {
   public class LogCollection extends IBMWatsonResponseModel {
     private List<Log> logs;
     private LogPagination pagination;
- 
+
     /**
      * Gets the logs.
      *
@@ -13504,7 +13595,7 @@ public class IBMAssistantV1Models {
     public List<Log> getLogs() {
       return logs;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -13562,14 +13653,9 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (logs != null && logs[0] != null) {
-        mapping.putAll(logs[0].getApiToSdkMapping());
-      }
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Log.class.newInstance()).addToApiToSdkMapping(parentLabel + 'logs/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) LogPagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -13580,7 +13666,7 @@ public class IBMAssistantV1Models {
   public class LogMessage extends IBMWatsonDynamicModel {
     private String level;
     private String msg;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -13698,7 +13784,7 @@ public class IBMAssistantV1Models {
      * @param level the level
      * @return the LogMessage builder
      */
-    public LogMessageBuilder setLevel(String level) {
+    public LogMessageBuilder level(String level) {
       this.level = level;
       return this;
     }
@@ -13709,7 +13795,7 @@ public class IBMAssistantV1Models {
      * @param msg the msg
      * @return the LogMessage builder
      */
-    public LogMessageBuilder setMsg(String msg) {
+    public LogMessageBuilder msg(String msg) {
       this.msg = msg;
       return this;
     }
@@ -13722,7 +13808,7 @@ public class IBMAssistantV1Models {
     private String nextUrl;
     private Long matched;
     private String nextCursor;
- 
+
     /**
      * Gets the nextUrl.
      *
@@ -13734,7 +13820,7 @@ public class IBMAssistantV1Models {
     public String getNextUrl() {
       return nextUrl;
     }
- 
+
     /**
      * Gets the matched.
      *
@@ -13746,7 +13832,7 @@ public class IBMAssistantV1Models {
     public Long getMatched() {
       return matched;
     }
- 
+
     /**
      * Gets the nextCursor.
      *
@@ -13786,10 +13872,13 @@ public class IBMAssistantV1Models {
       this.nextCursor = nextCursor;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('next_url', 'nextUrl');
-      mapping.put('next_cursor', 'nextCursor');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'next_url', 'nextUrl');
+      mapping.put(parentLabel + 'next_cursor', 'nextCursor');
       return mapping;
     }
   }
@@ -13806,7 +13895,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public Mention() { }
- 
+
     /**
      * Gets the entity.
      *
@@ -13818,7 +13907,7 @@ public class IBMAssistantV1Models {
     public String getEntity() {
       return entity;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -13907,7 +13996,7 @@ public class IBMAssistantV1Models {
      * @param entity the entity
      * @return the Mention builder
      */
-    public MentionBuilder setEntity(String entity) {
+    public MentionBuilder entity(String entity) {
       this.entity = entity;
       return this;
     }
@@ -13919,7 +14008,7 @@ public class IBMAssistantV1Models {
      * @param location the location
      * @return the Mention builder
      */
-    public MentionBuilder setLocation(List<Long> location) {
+    public MentionBuilder location(List<Long> location) {
       this.location = location;
       return this;
     }
@@ -13937,7 +14026,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public MessageContextMetadata() { }
- 
+
     /**
      * Gets the deployment.
      *
@@ -13950,7 +14039,7 @@ public class IBMAssistantV1Models {
     public String getDeployment() {
       return deployment;
     }
- 
+
     /**
      * Gets the userId.
      *
@@ -13980,15 +14069,13 @@ public class IBMAssistantV1Models {
       return new MessageContextMetadataBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('userId', 'user_id');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'userId', 'user_id');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('user_id', 'userId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'user_id', 'userId');
       return mapping;
     }
   }
@@ -14026,7 +14113,7 @@ public class IBMAssistantV1Models {
      * @param deployment the deployment
      * @return the MessageContextMetadata builder
      */
-    public MessageContextMetadataBuilder setDeployment(String deployment) {
+    public MessageContextMetadataBuilder deployment(String deployment) {
       this.deployment = deployment;
       return this;
     }
@@ -14037,7 +14124,7 @@ public class IBMAssistantV1Models {
      * @param userId the userId
      * @return the MessageContextMetadata builder
      */
-    public MessageContextMetadataBuilder setUserId(String userId) {
+    public MessageContextMetadataBuilder userId(String userId) {
       this.userId = userId;
       return this;
     }
@@ -14048,7 +14135,7 @@ public class IBMAssistantV1Models {
    */
   public class MessageInput extends IBMWatsonDynamicModel {
     private String text;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -14277,14 +14364,14 @@ public class IBMAssistantV1Models {
       Map<String, String> mapping = new Map<String, String>();
       mapping.put('workspaceId', 'workspace_id');
       if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getSdkToApiMapping());
+        mapping.putAll(entities[0].addToSdkToApiMapping('', mapping));
       }
       mapping.put('alternateIntents', 'alternate_intents');
       if (context != null) {
-        mapping.putAll(context.getSdkToApiMapping());
+        mapping.putAll(context.addToSdkToApiMapping('', mapping));
       }
       if (output != null) {
-        mapping.putAll(output.getSdkToApiMapping());
+        mapping.putAll(output.addToSdkToApiMapping('', mapping));
       }
       mapping.put('nodesVisitedDetails', 'nodes_visited_details');
       return mapping;
@@ -14506,7 +14593,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public MessageRequest() { }
- 
+
     /**
      * Gets the input.
      *
@@ -14518,7 +14605,7 @@ public class IBMAssistantV1Models {
     public MessageInput getInput() {
       return input;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -14531,7 +14618,7 @@ public class IBMAssistantV1Models {
     public List<RuntimeIntent> getIntents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -14544,7 +14631,7 @@ public class IBMAssistantV1Models {
     public List<RuntimeEntity> getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the alternateIntents.
      *
@@ -14556,7 +14643,7 @@ public class IBMAssistantV1Models {
     public Boolean getAlternateIntents() {
       return alternateIntents;
     }
- 
+
     /**
      * Gets the context.
      *
@@ -14568,7 +14655,7 @@ public class IBMAssistantV1Models {
     public Context getContext() {
       return context;
     }
- 
+
     /**
      * Gets the output.
      *
@@ -14581,7 +14668,7 @@ public class IBMAssistantV1Models {
     public OutputData getOutput() {
       return output;
     }
- 
+
     /**
      * Gets the actions.
      *
@@ -14623,7 +14710,7 @@ public class IBMAssistantV1Models {
 
       // calling custom deserializer for input
       MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input'), MessageInput.class);
-      retBuilder.setInput(newInput);
+      retBuilder.input(newInput);
 
       // calling custom deserializer for intents
       List<RuntimeIntent> newIntents = new List<RuntimeIntent>();
@@ -14635,7 +14722,7 @@ public class IBMAssistantV1Models {
           RuntimeIntent newItem = (RuntimeIntent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeIntent.class);
           newIntents.add(newItem);
         }
-        retBuilder.setIntents(newIntents);
+        retBuilder.intents(newIntents);
       }
 
       // calling custom deserializer for entities
@@ -14648,16 +14735,16 @@ public class IBMAssistantV1Models {
           RuntimeEntity newItem = (RuntimeEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeEntity.class);
           newEntities.add(newItem);
         }
-        retBuilder.setEntities(newEntities);
+        retBuilder.entities(newEntities);
       }
 
       // calling custom deserializer for context
       Context newContext = (Context) new Context().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context'), Context.class);
-      retBuilder.setContext(newContext);
+      retBuilder.context(newContext);
 
       // calling custom deserializer for output
       OutputData newOutput = (OutputData) new OutputData().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output'), OutputData.class);
-      retBuilder.setOutput(newOutput);
+      retBuilder.output(newOutput);
 
       // calling custom deserializer for actions
       List<DialogNodeAction> newActions = new List<DialogNodeAction>();
@@ -14669,45 +14756,35 @@ public class IBMAssistantV1Models {
           DialogNodeAction newItem = (DialogNodeAction) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeAction.class);
           newActions.add(newItem);
         }
-        retBuilder.setActions(newActions);
+        retBuilder.actions(newActions);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getSdkToApiMapping());
+        mapping.putAll(entities[0].addToSdkToApiMapping(parentLabel + 'entities/', mapping));
       }
-      mapping.put('alternateIntents', 'alternate_intents');
+      mapping.put(parentLabel + 'alternateIntents', 'alternate_intents');
       if (context != null) {
-        mapping.putAll(context.getSdkToApiMapping());
+        mapping.putAll(context.addToSdkToApiMapping(parentLabel + 'context/', mapping));
       }
       if (output != null) {
-        mapping.putAll(output.getSdkToApiMapping());
+        mapping.putAll(output.addToSdkToApiMapping(parentLabel + 'output/', mapping));
       }
       if (actions != null && actions[0] != null) {
-        mapping.putAll(actions[0].getSdkToApiMapping());
+        mapping.putAll(actions[0].addToSdkToApiMapping(parentLabel + 'actions/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
-      mapping.put('alternate_intents', 'alternateIntents');
-      if (context != null) {
-        mapping.putAll(context.getApiToSdkMapping());
-      }
-      if (output != null) {
-        mapping.putAll(output.getApiToSdkMapping());
-      }
-      if (actions != null && actions[0] != null) {
-        mapping.putAll(actions[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) RuntimeEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
+      mapping.put(parentLabel + 'alternate_intents', 'alternateIntents');
+      mapping.putAll(((IBMWatsonDynamicModel) Context.class.newInstance()).addToApiToSdkMapping(parentLabel + 'context/', mapping));
+      mapping.putAll(((IBMWatsonDynamicModel) OutputData.class.newInstance()).addToApiToSdkMapping(parentLabel + 'output/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeAction.class.newInstance()).addToApiToSdkMapping(parentLabel + 'actions/', mapping));
       return mapping;
     }
   }
@@ -14800,7 +14877,7 @@ public class IBMAssistantV1Models {
      * @param input the input
      * @return the MessageRequest builder
      */
-    public MessageRequestBuilder setInput(MessageInput input) {
+    public MessageRequestBuilder input(MessageInput input) {
       this.input = input;
       return this;
     }
@@ -14812,7 +14889,7 @@ public class IBMAssistantV1Models {
      * @param intents the intents
      * @return the MessageRequest builder
      */
-    public MessageRequestBuilder setIntents(List<RuntimeIntent> intents) {
+    public MessageRequestBuilder intents(List<RuntimeIntent> intents) {
       this.intents = intents;
       return this;
     }
@@ -14824,7 +14901,7 @@ public class IBMAssistantV1Models {
      * @param entities the entities
      * @return the MessageRequest builder
      */
-    public MessageRequestBuilder setEntities(List<RuntimeEntity> entities) {
+    public MessageRequestBuilder entities(List<RuntimeEntity> entities) {
       this.entities = entities;
       return this;
     }
@@ -14835,7 +14912,7 @@ public class IBMAssistantV1Models {
      * @param alternateIntents the alternateIntents
      * @return the MessageRequest builder
      */
-    public MessageRequestBuilder setAlternateIntents(Boolean alternateIntents) {
+    public MessageRequestBuilder alternateIntents(Boolean alternateIntents) {
       this.alternateIntents = alternateIntents;
       return this;
     }
@@ -14846,7 +14923,7 @@ public class IBMAssistantV1Models {
      * @param context the context
      * @return the MessageRequest builder
      */
-    public MessageRequestBuilder setContext(Context context) {
+    public MessageRequestBuilder context(Context context) {
       this.context = context;
       return this;
     }
@@ -14857,7 +14934,7 @@ public class IBMAssistantV1Models {
      * @param output the output
      * @return the MessageRequest builder
      */
-    public MessageRequestBuilder setOutput(OutputData output) {
+    public MessageRequestBuilder output(OutputData output) {
       this.output = output;
       return this;
     }
@@ -14869,7 +14946,7 @@ public class IBMAssistantV1Models {
      * @param actions the actions
      * @return the MessageRequest builder
      */
-    public MessageRequestBuilder setActions(List<DialogNodeAction> actions) {
+    public MessageRequestBuilder actions(List<DialogNodeAction> actions) {
       this.actions = actions;
       return this;
     }
@@ -14886,7 +14963,7 @@ public class IBMAssistantV1Models {
     private Context context;
     private OutputData output;
     private List<DialogNodeAction> actions;
- 
+
     /**
      * Gets the input.
      *
@@ -14898,7 +14975,7 @@ public class IBMAssistantV1Models {
     public MessageInput getInput() {
       return input;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -14910,7 +14987,7 @@ public class IBMAssistantV1Models {
     public List<RuntimeIntent> getIntents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -14922,7 +14999,7 @@ public class IBMAssistantV1Models {
     public List<RuntimeEntity> getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the alternateIntents.
      *
@@ -14934,7 +15011,7 @@ public class IBMAssistantV1Models {
     public Boolean getAlternateIntents() {
       return alternateIntents;
     }
- 
+
     /**
      * Gets the context.
      *
@@ -14946,7 +15023,7 @@ public class IBMAssistantV1Models {
     public Context getContext() {
       return context;
     }
- 
+
     /**
      * Gets the output.
      *
@@ -14959,7 +15036,7 @@ public class IBMAssistantV1Models {
     public OutputData getOutput() {
       return output;
     }
- 
+
     /**
      * Gets the actions.
      *
@@ -15087,21 +15164,12 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
-      mapping.put('alternate_intents', 'alternateIntents');
-      if (context != null) {
-        mapping.putAll(context.getApiToSdkMapping());
-      }
-      if (output != null) {
-        mapping.putAll(output.getApiToSdkMapping());
-      }
-      if (actions != null && actions[0] != null) {
-        mapping.putAll(actions[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) RuntimeEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
+      mapping.put(parentLabel + 'alternate_intents', 'alternateIntents');
+      mapping.putAll(((IBMWatsonDynamicModel) Context.class.newInstance()).addToApiToSdkMapping(parentLabel + 'context/', mapping));
+      mapping.putAll(((IBMWatsonDynamicModel) OutputData.class.newInstance()).addToApiToSdkMapping(parentLabel + 'output/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeAction.class.newInstance()).addToApiToSdkMapping(parentLabel + 'actions/', mapping));
       return mapping;
     }
   }
@@ -15115,7 +15183,7 @@ public class IBMAssistantV1Models {
     private List<DialogRuntimeResponseGeneric> generic;
     private List<String> nodesVisited;
     private List<DialogNodeVisitedDetails> nodesVisitedDetails;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -15220,7 +15288,7 @@ public class IBMAssistantV1Models {
           LogMessage newItem = (LogMessage) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), LogMessage.class);
           newLogMessages.add(newItem);
         }
-        retBuilder.setLogMessages(newLogMessages);
+        retBuilder.logMessages(newLogMessages);
       }
 
       // calling custom deserializer for generic
@@ -15233,7 +15301,7 @@ public class IBMAssistantV1Models {
           DialogRuntimeResponseGeneric newItem = (DialogRuntimeResponseGeneric) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogRuntimeResponseGeneric.class);
           newGeneric.add(newItem);
         }
-        retBuilder.setGeneric(newGeneric);
+        retBuilder.generic(newGeneric);
       }
 
       // calling custom deserializer for nodesVisitedDetails
@@ -15246,7 +15314,7 @@ public class IBMAssistantV1Models {
           DialogNodeVisitedDetails newItem = (DialogNodeVisitedDetails) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeVisitedDetails.class);
           newNodesVisitedDetails.add(newItem);
         }
-        retBuilder.setNodesVisitedDetails(newNodesVisitedDetails);
+        retBuilder.nodesVisitedDetails(newNodesVisitedDetails);
       }
 
       OutputData builderResult = retBuilder.build();
@@ -15261,31 +15329,33 @@ public class IBMAssistantV1Models {
       return builderResult;
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('logMessages', 'log_messages');
-      if (generic != null && generic[0] != null) {
-        mapping.putAll(generic[0].getSdkToApiMapping());
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('nodesVisited', 'nodes_visited');
-      mapping.put('nodesVisitedDetails', 'nodes_visited_details');
+      mapping.put(parentLabel + 'logMessages', 'log_messages');
+      if (generic != null && generic[0] != null) {
+        mapping.putAll(generic[0].addToSdkToApiMapping(parentLabel + 'generic/', mapping));
+      }
+      mapping.put(parentLabel + 'nodesVisited', 'nodes_visited');
+      mapping.put(parentLabel + 'nodesVisitedDetails', 'nodes_visited_details');
       if (nodesVisitedDetails != null && nodesVisitedDetails[0] != null) {
-        mapping.putAll(nodesVisitedDetails[0].getSdkToApiMapping());
+        mapping.putAll(nodesVisitedDetails[0].addToSdkToApiMapping(parentLabel + 'nodesVisitedDetails/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('log_messages', 'logMessages');
-      if (generic != null && generic[0] != null) {
-        mapping.putAll(generic[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('nodes_visited', 'nodesVisited');
-      mapping.put('nodes_visited_details', 'nodesVisitedDetails');
-      if (nodesVisitedDetails != null && nodesVisitedDetails[0] != null) {
-        mapping.putAll(nodesVisitedDetails[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'log_messages', 'logMessages');
+      mapping.putAll(((IBMWatsonGenericModel) DialogRuntimeResponseGeneric.class.newInstance()).addToApiToSdkMapping(parentLabel + 'generic/', mapping));
+      mapping.put(parentLabel + 'nodes_visited', 'nodesVisited');
+      mapping.put(parentLabel + 'nodes_visited_details', 'nodesVisitedDetails');
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeVisitedDetails.class.newInstance()).addToApiToSdkMapping(parentLabel + 'nodes_visited_details/', mapping));
       return mapping;
     }
   }
@@ -15415,7 +15485,7 @@ public class IBMAssistantV1Models {
      * @param logMessages the logMessages
      * @return the OutputData builder
      */
-    public OutputDataBuilder setLogMessages(List<LogMessage> logMessages) {
+    public OutputDataBuilder logMessages(List<LogMessage> logMessages) {
       this.logMessages = logMessages;
       return this;
     }
@@ -15427,7 +15497,7 @@ public class IBMAssistantV1Models {
      * @param text the text
      * @return the OutputData builder
      */
-    public OutputDataBuilder setText(List<String> text) {
+    public OutputDataBuilder text(List<String> text) {
       this.text = text;
       return this;
     }
@@ -15439,7 +15509,7 @@ public class IBMAssistantV1Models {
      * @param generic the generic
      * @return the OutputData builder
      */
-    public OutputDataBuilder setGeneric(List<DialogRuntimeResponseGeneric> generic) {
+    public OutputDataBuilder generic(List<DialogRuntimeResponseGeneric> generic) {
       this.generic = generic;
       return this;
     }
@@ -15451,7 +15521,7 @@ public class IBMAssistantV1Models {
      * @param nodesVisited the nodesVisited
      * @return the OutputData builder
      */
-    public OutputDataBuilder setNodesVisited(List<String> nodesVisited) {
+    public OutputDataBuilder nodesVisited(List<String> nodesVisited) {
       this.nodesVisited = nodesVisited;
       return this;
     }
@@ -15463,7 +15533,7 @@ public class IBMAssistantV1Models {
      * @param nodesVisitedDetails the nodesVisitedDetails
      * @return the OutputData builder
      */
-    public OutputDataBuilder setNodesVisitedDetails(List<DialogNodeVisitedDetails> nodesVisitedDetails) {
+    public OutputDataBuilder nodesVisitedDetails(List<DialogNodeVisitedDetails> nodesVisitedDetails) {
       this.nodesVisitedDetails = nodesVisitedDetails;
       return this;
     }
@@ -15479,7 +15549,7 @@ public class IBMAssistantV1Models {
     private Long matched;
     private String refreshCursor;
     private String nextCursor;
- 
+
     /**
      * Gets the refreshUrl.
      *
@@ -15491,7 +15561,7 @@ public class IBMAssistantV1Models {
     public String getRefreshUrl() {
       return refreshUrl;
     }
- 
+
     /**
      * Gets the nextUrl.
      *
@@ -15503,7 +15573,7 @@ public class IBMAssistantV1Models {
     public String getNextUrl() {
       return nextUrl;
     }
- 
+
     /**
      * Gets the total.
      *
@@ -15515,7 +15585,7 @@ public class IBMAssistantV1Models {
     public Long getTotal() {
       return total;
     }
- 
+
     /**
      * Gets the matched.
      *
@@ -15527,7 +15597,7 @@ public class IBMAssistantV1Models {
     public Long getMatched() {
       return matched;
     }
- 
+
     /**
      * Gets the refreshCursor.
      *
@@ -15539,7 +15609,7 @@ public class IBMAssistantV1Models {
     public String getRefreshCursor() {
       return refreshCursor;
     }
- 
+
     /**
      * Gets the nextCursor.
      *
@@ -15606,12 +15676,15 @@ public class IBMAssistantV1Models {
       this.nextCursor = nextCursor;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('refresh_url', 'refreshUrl');
-      mapping.put('next_url', 'nextUrl');
-      mapping.put('refresh_cursor', 'refreshCursor');
-      mapping.put('next_cursor', 'nextCursor');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'refresh_url', 'refreshUrl');
+      mapping.put(parentLabel + 'next_url', 'nextUrl');
+      mapping.put(parentLabel + 'refresh_cursor', 'refreshCursor');
+      mapping.put(parentLabel + 'next_cursor', 'nextCursor');
       return mapping;
     }
   }
@@ -15626,7 +15699,7 @@ public class IBMAssistantV1Models {
     private Double confidence;
     private IBMWatsonMapModel metadata;
     private List<CaptureGroup> groups;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -15735,7 +15808,7 @@ public class IBMAssistantV1Models {
 
       // calling custom deserializer for metadata
       IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
-      retBuilder.setMetadata(newMetadata);
+      retBuilder.metadata(newMetadata);
 
       // calling custom deserializer for groups
       List<CaptureGroup> newGroups = new List<CaptureGroup>();
@@ -15747,7 +15820,7 @@ public class IBMAssistantV1Models {
           CaptureGroup newItem = (CaptureGroup) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CaptureGroup.class);
           newGroups.add(newItem);
         }
-        retBuilder.setGroups(newGroups);
+        retBuilder.groups(newGroups);
       }
 
       RuntimeEntity builderResult = retBuilder.build();
@@ -15762,19 +15835,15 @@ public class IBMAssistantV1Models {
       return builderResult;
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (groups != null && groups[0] != null) {
-        mapping.putAll(groups[0].getSdkToApiMapping());
+        mapping.putAll(groups[0].addToSdkToApiMapping(parentLabel + 'groups/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (groups != null && groups[0] != null) {
-        mapping.putAll(groups[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) CaptureGroup.class.newInstance()).addToApiToSdkMapping(parentLabel + 'groups/', mapping));
       return mapping;
     }
   }
@@ -15862,7 +15931,7 @@ public class IBMAssistantV1Models {
      * @param entity the entity
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setEntity(String entity) {
+    public RuntimeEntityBuilder entity(String entity) {
       this.entity = entity;
       return this;
     }
@@ -15874,7 +15943,7 @@ public class IBMAssistantV1Models {
      * @param location the location
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setLocation(List<Long> location) {
+    public RuntimeEntityBuilder location(List<Long> location) {
       this.location = location;
       return this;
     }
@@ -15885,7 +15954,7 @@ public class IBMAssistantV1Models {
      * @param value the value
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setValue(String value) {
+    public RuntimeEntityBuilder value(String value) {
       this.value = value;
       return this;
     }
@@ -15896,7 +15965,7 @@ public class IBMAssistantV1Models {
      * @param confidence the confidence
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setConfidence(Double confidence) {
+    public RuntimeEntityBuilder confidence(Double confidence) {
       this.confidence = confidence;
       return this;
     }
@@ -15907,7 +15976,7 @@ public class IBMAssistantV1Models {
      * @param metadata the metadata
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setMetadata(IBMWatsonMapModel metadata) {
+    public RuntimeEntityBuilder metadata(IBMWatsonMapModel metadata) {
       this.metadata = metadata;
       return this;
     }
@@ -15919,7 +15988,7 @@ public class IBMAssistantV1Models {
      * @param groups the groups
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setGroups(List<CaptureGroup> groups) {
+    public RuntimeEntityBuilder groups(List<CaptureGroup> groups) {
       this.groups = groups;
       return this;
     }
@@ -15931,7 +16000,7 @@ public class IBMAssistantV1Models {
   public class RuntimeIntent extends IBMWatsonDynamicModel {
     private String intent;
     private Double confidence;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -16049,7 +16118,7 @@ public class IBMAssistantV1Models {
      * @param intent the intent
      * @return the RuntimeIntent builder
      */
-    public RuntimeIntentBuilder setIntent(String intent) {
+    public RuntimeIntentBuilder intent(String intent) {
       this.intent = intent;
       return this;
     }
@@ -16060,7 +16129,7 @@ public class IBMAssistantV1Models {
      * @param confidence the confidence
      * @return the RuntimeIntent builder
      */
-    public RuntimeIntentBuilder setConfidence(Double confidence) {
+    public RuntimeIntentBuilder confidence(Double confidence) {
       this.confidence = confidence;
       return this;
     }
@@ -16079,7 +16148,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public Synonym() { }
- 
+
     /**
      * Gets the synonym.
      *
@@ -16093,7 +16162,7 @@ public class IBMAssistantV1Models {
     public String getSynonym() {
       return synonym;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -16105,7 +16174,7 @@ public class IBMAssistantV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -16213,7 +16282,7 @@ public class IBMAssistantV1Models {
   public class SynonymCollection extends IBMWatsonResponseModel {
     private List<Synonym> synonyms;
     private Pagination pagination;
- 
+
     /**
      * Gets the synonyms.
      *
@@ -16225,7 +16294,7 @@ public class IBMAssistantV1Models {
     public List<Synonym> getSynonyms() {
       return synonyms;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -16283,11 +16352,8 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -16296,7 +16362,7 @@ public class IBMAssistantV1Models {
    * For internal use only.
    */
   public class SystemResponse extends IBMWatsonDynamicModel {
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -16821,13 +16887,13 @@ public class IBMAssistantV1Models {
       mapping.put('newPreviousSibling', 'new_previous_sibling');
       mapping.put('newOutput', 'new_output');
       if (newOutput != null) {
-        mapping.putAll(newOutput.getSdkToApiMapping());
+        mapping.putAll(newOutput.addToSdkToApiMapping('', mapping));
       }
       mapping.put('newContext', 'new_context');
       mapping.put('newMetadata', 'new_metadata');
       mapping.put('newNextStep', 'new_next_step');
       if (newNextStep != null) {
-        mapping.putAll(newNextStep.getSdkToApiMapping());
+        mapping.putAll(newNextStep.addToSdkToApiMapping('', mapping));
       }
       mapping.put('newTitle', 'new_title');
       mapping.put('nodeType', 'new_type');
@@ -16835,7 +16901,7 @@ public class IBMAssistantV1Models {
       mapping.put('newVariable', 'new_variable');
       mapping.put('newActions', 'new_actions');
       if (newActions != null && newActions[0] != null) {
-        mapping.putAll(newActions[0].getSdkToApiMapping());
+        mapping.putAll(newActions[0].addToSdkToApiMapping('', mapping));
       }
       mapping.put('newDigressIn', 'new_digress_in');
       mapping.put('newDigressOut', 'new_digress_out');
@@ -17291,7 +17357,7 @@ public class IBMAssistantV1Models {
       mapping.put('newFuzzyMatch', 'new_fuzzy_match');
       mapping.put('newValues', 'new_values');
       if (newValues != null && newValues[0] != null) {
-        mapping.putAll(newValues[0].getSdkToApiMapping());
+        mapping.putAll(newValues[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -18639,14 +18705,14 @@ public class IBMAssistantV1Models {
       mapping.put('learningOptOut', 'learning_opt_out');
       mapping.put('systemSettings', 'system_settings');
       if (systemSettings != null) {
-        mapping.putAll(systemSettings.getSdkToApiMapping());
+        mapping.putAll(systemSettings.addToSdkToApiMapping('', mapping));
       }
       if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getSdkToApiMapping());
+        mapping.putAll(entities[0].addToSdkToApiMapping('', mapping));
       }
       mapping.put('dialogNodes', 'dialog_nodes');
       if (dialogNodes != null && dialogNodes[0] != null) {
-        mapping.putAll(dialogNodes[0].getSdkToApiMapping());
+        mapping.putAll(dialogNodes[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -18935,7 +19001,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public Value() { }
- 
+
     /**
      * Gets the value.
      *
@@ -18949,7 +19015,7 @@ public class IBMAssistantV1Models {
     public String getValue() {
       return value;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -18961,7 +19027,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel getMetadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the valueType.
      *
@@ -18973,7 +19039,7 @@ public class IBMAssistantV1Models {
     public String getValueType() {
       return valueType;
     }
- 
+
     /**
      * Gets the synonyms.
      *
@@ -18988,7 +19054,7 @@ public class IBMAssistantV1Models {
     public List<String> getSynonyms() {
       return synonyms;
     }
- 
+
     /**
      * Gets the patterns.
      *
@@ -19003,7 +19069,7 @@ public class IBMAssistantV1Models {
     public List<String> getPatterns() {
       return patterns;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -19015,7 +19081,7 @@ public class IBMAssistantV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -19064,9 +19130,8 @@ public class IBMAssistantV1Models {
       return retBuilder.build();
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'valueType');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'type', 'valueType');
       return mapping;
     }
   }
@@ -19235,7 +19300,7 @@ public class IBMAssistantV1Models {
   public class ValueCollection extends IBMWatsonResponseModel {
     private List<Value> values;
     private Pagination pagination;
- 
+
     /**
      * Gets the values.
      *
@@ -19247,7 +19312,7 @@ public class IBMAssistantV1Models {
     public List<Value> getValues() {
       return values;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -19305,14 +19370,9 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (values != null && values[0] != null) {
-        mapping.putAll(values[0].getApiToSdkMapping());
-      }
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Value.class.newInstance()).addToApiToSdkMapping(parentLabel + 'values/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -19335,7 +19395,7 @@ public class IBMAssistantV1Models {
     private List<Entity> entities;
     private List<DialogNode> dialogNodes;
     private List<Counterexample> counterexamples;
- 
+
     /**
      * Gets the name.
      *
@@ -19347,7 +19407,7 @@ public class IBMAssistantV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -19359,7 +19419,7 @@ public class IBMAssistantV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -19371,7 +19431,7 @@ public class IBMAssistantV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -19383,7 +19443,7 @@ public class IBMAssistantV1Models {
     public IBMWatsonMapModel getMetadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the learningOptOut.
      *
@@ -19396,7 +19456,7 @@ public class IBMAssistantV1Models {
     public Boolean getLearningOptOut() {
       return learningOptOut;
     }
- 
+
     /**
      * Gets the systemSettings.
      *
@@ -19408,7 +19468,7 @@ public class IBMAssistantV1Models {
     public WorkspaceSystemSettings getSystemSettings() {
       return systemSettings;
     }
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -19420,7 +19480,7 @@ public class IBMAssistantV1Models {
     public String getWorkspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -19432,7 +19492,7 @@ public class IBMAssistantV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -19444,7 +19504,7 @@ public class IBMAssistantV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -19456,7 +19516,7 @@ public class IBMAssistantV1Models {
     public Datetime getUpdated() {
       return updated;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -19468,7 +19528,7 @@ public class IBMAssistantV1Models {
     public List<Intent> getIntents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -19480,7 +19540,7 @@ public class IBMAssistantV1Models {
     public List<Entity> getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the dialogNodes.
      *
@@ -19492,7 +19552,7 @@ public class IBMAssistantV1Models {
     public List<DialogNode> getDialogNodes() {
       return dialogNodes;
     }
- 
+
     /**
      * Gets the counterexamples.
      *
@@ -19665,21 +19725,14 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('learning_opt_out', 'learningOptOut');
-      mapping.put('system_settings', 'systemSettings');
-      if (systemSettings != null) {
-        mapping.putAll(systemSettings.getApiToSdkMapping());
-      }
-      mapping.put('workspace_id', 'workspaceId');
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
-      mapping.put('dialog_nodes', 'dialogNodes');
-      if (dialogNodes != null && dialogNodes[0] != null) {
-        mapping.putAll(dialogNodes[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'learning_opt_out', 'learningOptOut');
+      mapping.put(parentLabel + 'system_settings', 'systemSettings');
+      mapping.putAll(((IBMWatsonGenericModel) WorkspaceSystemSettings.class.newInstance()).addToApiToSdkMapping(parentLabel + 'system_settings/', mapping));
+      mapping.put(parentLabel + 'workspace_id', 'workspaceId');
+      mapping.putAll(((IBMWatsonGenericModel) Entity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
+      mapping.put(parentLabel + 'dialog_nodes', 'dialogNodes');
+      mapping.putAll(((IBMWatsonGenericModel) DialogNode.class.newInstance()).addToApiToSdkMapping(parentLabel + 'dialog_nodes/', mapping));
       return mapping;
     }
   }
@@ -19690,7 +19743,7 @@ public class IBMAssistantV1Models {
   public class WorkspaceCollection extends IBMWatsonResponseModel {
     private List<Workspace> workspaces;
     private Pagination pagination;
- 
+
     /**
      * Gets the workspaces.
      *
@@ -19702,7 +19755,7 @@ public class IBMAssistantV1Models {
     public List<Workspace> getWorkspaces() {
       return workspaces;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -19760,14 +19813,9 @@ public class IBMAssistantV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (workspaces != null && workspaces[0] != null) {
-        mapping.putAll(workspaces[0].getApiToSdkMapping());
-      }
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Workspace.class.newInstance()).addToApiToSdkMapping(parentLabel + 'workspaces/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -19785,7 +19833,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public WorkspaceSystemSettings() { }
- 
+
     /**
      * Gets the tooling.
      *
@@ -19797,7 +19845,7 @@ public class IBMAssistantV1Models {
     public WorkspaceSystemSettingsTooling getTooling() {
       return tooling;
     }
- 
+
     /**
      * Gets the disambiguation.
      *
@@ -19811,7 +19859,7 @@ public class IBMAssistantV1Models {
     public WorkspaceSystemSettingsDisambiguation getDisambiguation() {
       return disambiguation;
     }
- 
+
     /**
      * Gets the humanAgentAssist.
      *
@@ -19849,40 +19897,34 @@ public class IBMAssistantV1Models {
 
       // calling custom deserializer for tooling
       WorkspaceSystemSettingsTooling newTooling = (WorkspaceSystemSettingsTooling) new WorkspaceSystemSettingsTooling().deserialize(JSON.serialize(ret.getTooling()), (Map<String, Object>) jsonMap.get('tooling'), WorkspaceSystemSettingsTooling.class);
-      retBuilder.setTooling(newTooling);
+      retBuilder.tooling(newTooling);
 
       // calling custom deserializer for disambiguation
       WorkspaceSystemSettingsDisambiguation newDisambiguation = (WorkspaceSystemSettingsDisambiguation) new WorkspaceSystemSettingsDisambiguation().deserialize(JSON.serialize(ret.getDisambiguation()), (Map<String, Object>) jsonMap.get('disambiguation'), WorkspaceSystemSettingsDisambiguation.class);
-      retBuilder.setDisambiguation(newDisambiguation);
+      retBuilder.disambiguation(newDisambiguation);
 
       // calling custom deserializer for humanAgentAssist
       IBMWatsonMapModel newHumanAgentAssist = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getHumanAgentAssist()), (Map<String, Object>) jsonMap.get('humanAgentAssist'), IBMWatsonMapModel.class);
-      retBuilder.setHumanAgentAssist(newHumanAgentAssist);
+      retBuilder.humanAgentAssist(newHumanAgentAssist);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (tooling != null) {
-        mapping.putAll(tooling.getSdkToApiMapping());
+        mapping.putAll(tooling.addToSdkToApiMapping(parentLabel + 'tooling/', mapping));
       }
       if (disambiguation != null) {
-        mapping.putAll(disambiguation.getSdkToApiMapping());
+        mapping.putAll(disambiguation.addToSdkToApiMapping(parentLabel + 'disambiguation/', mapping));
       }
-      mapping.put('humanAgentAssist', 'human_agent_assist');
+      mapping.put(parentLabel + 'humanAgentAssist', 'human_agent_assist');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (tooling != null) {
-        mapping.putAll(tooling.getApiToSdkMapping());
-      }
-      if (disambiguation != null) {
-        mapping.putAll(disambiguation.getApiToSdkMapping());
-      }
-      mapping.put('human_agent_assist', 'humanAgentAssist');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) WorkspaceSystemSettingsTooling.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tooling/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) WorkspaceSystemSettingsDisambiguation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'disambiguation/', mapping));
+      mapping.put(parentLabel + 'human_agent_assist', 'humanAgentAssist');
       return mapping;
     }
   }
@@ -19922,7 +19964,7 @@ public class IBMAssistantV1Models {
      * @param tooling the tooling
      * @return the WorkspaceSystemSettings builder
      */
-    public WorkspaceSystemSettingsBuilder setTooling(WorkspaceSystemSettingsTooling tooling) {
+    public WorkspaceSystemSettingsBuilder tooling(WorkspaceSystemSettingsTooling tooling) {
       this.tooling = tooling;
       return this;
     }
@@ -19933,7 +19975,7 @@ public class IBMAssistantV1Models {
      * @param disambiguation the disambiguation
      * @return the WorkspaceSystemSettings builder
      */
-    public WorkspaceSystemSettingsBuilder setDisambiguation(WorkspaceSystemSettingsDisambiguation disambiguation) {
+    public WorkspaceSystemSettingsBuilder disambiguation(WorkspaceSystemSettingsDisambiguation disambiguation) {
       this.disambiguation = disambiguation;
       return this;
     }
@@ -19944,7 +19986,7 @@ public class IBMAssistantV1Models {
      * @param humanAgentAssist the humanAgentAssist
      * @return the WorkspaceSystemSettings builder
      */
-    public WorkspaceSystemSettingsBuilder setHumanAgentAssist(IBMWatsonMapModel humanAgentAssist) {
+    public WorkspaceSystemSettingsBuilder humanAgentAssist(IBMWatsonMapModel humanAgentAssist) {
       this.humanAgentAssist = humanAgentAssist;
       return this;
     }
@@ -19966,7 +20008,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public WorkspaceSystemSettingsDisambiguation() { }
- 
+
     /**
      * Gets the prompt.
      *
@@ -19978,7 +20020,7 @@ public class IBMAssistantV1Models {
     public String getPrompt() {
       return prompt;
     }
- 
+
     /**
      * Gets the noneOfTheAbovePrompt.
      *
@@ -19991,7 +20033,7 @@ public class IBMAssistantV1Models {
     public String getNoneOfTheAbovePrompt() {
       return noneOfTheAbovePrompt;
     }
- 
+
     /**
      * Gets the enabled.
      *
@@ -20003,7 +20045,7 @@ public class IBMAssistantV1Models {
     public Boolean getEnabled() {
       return enabled;
     }
- 
+
     /**
      * Gets the sensitivity.
      *
@@ -20033,15 +20075,13 @@ public class IBMAssistantV1Models {
       return new WorkspaceSystemSettingsDisambiguationBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('noneOfTheAbovePrompt', 'none_of_the_above_prompt');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'noneOfTheAbovePrompt', 'none_of_the_above_prompt');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('none_of_the_above_prompt', 'noneOfTheAbovePrompt');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'none_of_the_above_prompt', 'noneOfTheAbovePrompt');
       return mapping;
     }
   }
@@ -20083,7 +20123,7 @@ public class IBMAssistantV1Models {
      * @param prompt the prompt
      * @return the WorkspaceSystemSettingsDisambiguation builder
      */
-    public WorkspaceSystemSettingsDisambiguationBuilder setPrompt(String prompt) {
+    public WorkspaceSystemSettingsDisambiguationBuilder prompt(String prompt) {
       this.prompt = prompt;
       return this;
     }
@@ -20094,7 +20134,7 @@ public class IBMAssistantV1Models {
      * @param noneOfTheAbovePrompt the noneOfTheAbovePrompt
      * @return the WorkspaceSystemSettingsDisambiguation builder
      */
-    public WorkspaceSystemSettingsDisambiguationBuilder setNoneOfTheAbovePrompt(String noneOfTheAbovePrompt) {
+    public WorkspaceSystemSettingsDisambiguationBuilder noneOfTheAbovePrompt(String noneOfTheAbovePrompt) {
       this.noneOfTheAbovePrompt = noneOfTheAbovePrompt;
       return this;
     }
@@ -20105,7 +20145,7 @@ public class IBMAssistantV1Models {
      * @param enabled the enabled
      * @return the WorkspaceSystemSettingsDisambiguation builder
      */
-    public WorkspaceSystemSettingsDisambiguationBuilder setEnabled(Boolean enabled) {
+    public WorkspaceSystemSettingsDisambiguationBuilder enabled(Boolean enabled) {
       this.enabled = enabled;
       return this;
     }
@@ -20116,7 +20156,7 @@ public class IBMAssistantV1Models {
      * @param sensitivity the sensitivity
      * @return the WorkspaceSystemSettingsDisambiguation builder
      */
-    public WorkspaceSystemSettingsDisambiguationBuilder setSensitivity(String sensitivity) {
+    public WorkspaceSystemSettingsDisambiguationBuilder sensitivity(String sensitivity) {
       this.sensitivity = sensitivity;
       return this;
     }
@@ -20133,7 +20173,7 @@ public class IBMAssistantV1Models {
      * and should not be called by the client.
      */
     public WorkspaceSystemSettingsTooling() { }
- 
+
     /**
      * Gets the storeGenericResponses.
      *
@@ -20159,15 +20199,21 @@ public class IBMAssistantV1Models {
       return new WorkspaceSystemSettingsToolingBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('storeGenericResponses', 'store_generic_responses');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'storeGenericResponses', 'store_generic_responses');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('store_generic_responses', 'storeGenericResponses');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'store_generic_responses', 'storeGenericResponses');
       return mapping;
     }
   }
@@ -20203,7 +20249,7 @@ public class IBMAssistantV1Models {
      * @param storeGenericResponses the storeGenericResponses
      * @return the WorkspaceSystemSettingsTooling builder
      */
-    public WorkspaceSystemSettingsToolingBuilder setStoreGenericResponses(Boolean storeGenericResponses) {
+    public WorkspaceSystemSettingsToolingBuilder storeGenericResponses(Boolean storeGenericResponses) {
       this.storeGenericResponses = storeGenericResponses;
       return this;
     }

--- a/force-app/main/default/classes/IBMAssistantV1Test.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Test.cls
@@ -186,16 +186,18 @@ private class IBMAssistantV1Test {
       .updated((Datetime) JSON.deserialize(timeUpdated, Datetime.class))
       .build();
     createIntent = createIntent.newBuilder().build();
-    IBMAssistantV1Models.DialogNodeAction  dialogNodeAction = new IBMAssistantV1Models.DialogNodeAction();
-    dialogNodeAction.setName('test');
-    dialogNodeAction.setActionType('test');
-    dialogNodeAction.setParameters(metadata);
-    dialogNodeAction.setResultVariable('test');
-    dialogNodeAction.setCredentials('test');
-    IBMAssistantV1Models.DialogNodeNextStep dialogNodeNextStep=new IBMAssistantV1Models.DialogNodeNextStep();
-    dialogNodeNextStep.setBehavior('test');
-    dialogNodeNextStep.setDialogNode('test');
-    dialogNodeNextStep.setSelector('test');
+    IBMAssistantV1Models.DialogNodeAction dialogNodeAction = new IBMAssistantV1Models.DialogNodeActionBuilder()
+      .name('test')
+      .actionType('test')
+      .parameters(metadata)
+      .resultVariable('test')
+      .credentials('test')
+      .build();
+    IBMAssistantV1Models.DialogNodeNextStep dialogNodeNextStep=new IBMAssistantV1Models.DialogNodeNextStepBuilder()
+      .behavior('test')
+      .dialogNode('test')
+      .selector('test')
+      .build();
     String userLabel = 'user_label';
     IBMAssistantV1Models.DialogNode createDialogNode = new IBMAssistantV1Models.DialogNodeBuilder()
       .addActions(dialogNodeAction)
@@ -236,19 +238,22 @@ private class IBMAssistantV1Test {
       .updated((Datetime) JSON.deserialize(timeUpdated, Datetime.class))
       .build();
     createEntity = createEntity.newBuilder().build();
-    IBMAssistantV1Models.WorkspaceSystemSettingsDisambiguation disambiguation = new IBMAssistantV1Models.WorkspaceSystemSettingsDisambiguation();
-    disambiguation.setEnabled(true);
-    disambiguation.setNoneOfTheAbovePrompt('none of the above');
-    disambiguation.setPrompt('prompt');
-    disambiguation.setSensitivity('high');
-    IBMAssistantV1Models.WorkspaceSystemSettingsTooling tooling = new IBMAssistantV1Models.WorkspaceSystemSettingsTooling();
-    tooling.setStoreGenericResponses(true);
+    IBMAssistantV1Models.WorkspaceSystemSettingsDisambiguation disambiguation = new IBMAssistantV1Models.WorkspaceSystemSettingsDisambiguationBuilder()
+      .enabled(true)
+      .noneOfTheAbovePrompt('none of the above')
+      .prompt('prompt')
+      .sensitivity('high')
+      .build();
+    IBMAssistantV1Models.WorkspaceSystemSettingsTooling tooling = new IBMAssistantV1Models.WorkspaceSystemSettingsToolingBuilder()
+      .storeGenericResponses(true)
+      .build();
     IBMWatsonMapModel humanAgentAssist = new IBMWatsonMapModel();
     humanAgentAssist.put('help', 'ok');
-    IBMAssistantV1Models.WorkspaceSystemSettings systemSettings = new IBMAssistantV1Models.WorkspaceSystemSettings();
-    systemSettings.setDisambiguation(disambiguation);
-    systemSettings.setTooling(tooling);
-    systemSettings.setHumanAgentAssist(humanAgentAssist);
+    IBMAssistantV1Models.WorkspaceSystemSettings systemSettings = new IBMAssistantV1Models.WorkspaceSystemSettingsBuilder()
+      .disambiguation(disambiguation)
+      .tooling(tooling)
+      .humanAgentAssist(humanAgentAssist)
+      .build();
 
     IBMAssistantV1Models.CreateWorkspaceOptions createWorkspaceOptions = new IBMAssistantV1Models.CreateWorkspaceOptionsBuilder()
       .name(workspaceName)
@@ -373,19 +378,22 @@ private class IBMAssistantV1Test {
     IBMAssistantV1 assistant = new IBMAssistantV1('2018-02-16');
     assistant.setUsernameAndPassword('username', 'password');
 
-    IBMAssistantV1Models.WorkspaceSystemSettingsDisambiguation disambiguation = new IBMAssistantV1Models.WorkspaceSystemSettingsDisambiguation();
-    disambiguation.setEnabled(true);
-    disambiguation.setNoneOfTheAbovePrompt('none of the above');
-    disambiguation.setPrompt('prompt');
-    disambiguation.setSensitivity('high');
-    IBMAssistantV1Models.WorkspaceSystemSettingsTooling tooling = new IBMAssistantV1Models.WorkspaceSystemSettingsTooling();
-    tooling.setStoreGenericResponses(true);
+    IBMAssistantV1Models.WorkspaceSystemSettingsDisambiguation disambiguation = new IBMAssistantV1Models.WorkspaceSystemSettingsDisambiguationBuilder()
+      .enabled(true)
+      .noneOfTheAbovePrompt('none of the above')
+      .prompt('prompt')
+      .sensitivity('high')
+      .build();
+    IBMAssistantV1Models.WorkspaceSystemSettingsTooling tooling = new IBMAssistantV1Models.WorkspaceSystemSettingsToolingBuilder()
+      .storeGenericResponses(true)
+      .build();
     IBMWatsonMapModel humanAgentAssist = new IBMWatsonMapModel();
     humanAgentAssist.put('help', 'ok');
-    IBMAssistantV1Models.WorkspaceSystemSettings systemSettings = new IBMAssistantV1Models.WorkspaceSystemSettings();
-    systemSettings.setDisambiguation(disambiguation);
-    systemSettings.setTooling(tooling);
-    systemSettings.setHumanAgentAssist(humanAgentAssist);
+    IBMAssistantV1Models.WorkspaceSystemSettings systemSettings = new IBMAssistantV1Models.WorkspaceSystemSettingsBuilder()
+      .disambiguation(disambiguation)
+      .tooling(tooling)
+      .humanAgentAssist(humanAgentAssist)
+      .build();
 
     IBMAssistantV1Models.UpdateWorkspaceOptions updateOptions = new IBMAssistantV1Models.UpdateWorkspaceOptionsBuilder()
       .workspaceId(workspaceId)
@@ -460,11 +468,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1 assistant = new IBMAssistantV1('2018-02-16');
     assistant.setUsernameAndPassword('username', 'password');
 
-    IBMAssistantV1Models.CreateValue createValue = new IBMAssistantV1Models.CreateValueBuilder()
-      .value('value')
-      .build();
     IBMAssistantV1Models.CreateValueOptions createOptions = new IBMAssistantV1Models.CreateValueOptionsBuilder()
-      .createValue(createValue)
       .workspaceId(workspaceId)
       .entity(entityName)
       .value(valueName)
@@ -621,12 +625,13 @@ private class IBMAssistantV1Test {
   static testMethod void testContext() {
     String conversationId = 'conversation_id';
 
-    IBMAssistantV1Models.Context context = new IBMAssistantV1Models.Context();
     IBMAssistantV1Models.SystemResponse systemResponse = new IBMAssistantV1Models.SystemResponse();
     IBMAssistantV1Models.MessageContextMetadata metadata = new IBMAssistantV1Models.MessageContextMetadata();
-    context.setConversationId(conversationId);
-    context.setXsystem(systemResponse);
-    context.setMetadata(metadata);
+    IBMAssistantV1Models.Context context = new IBMAssistantV1Models.ContextBuilder()
+      .conversationId(conversationId)
+      .xsystem(systemResponse)
+      .metadata(metadata)
+      .build();
 
     System.assertEquals(conversationId, context.getConversationId());
     System.assertEquals(systemResponse, context.getXsystem());
@@ -637,9 +642,10 @@ private class IBMAssistantV1Test {
     String deployment = 'deployment';
     String userId = 'user_id';
 
-    IBMAssistantV1Models.MessageContextMetadata metadata = new IBMAssistantV1Models.MessageContextMetadata();
-    metadata.setDeployment(deployment);
-    metadata.setUserId(userId);
+    IBMAssistantV1Models.MessageContextMetadata metadata = new IBMAssistantV1Models.MessageContextMetadataBuilder()
+      .deployment(deployment)
+      .userId(userId)
+      .build();
 
     System.assertEquals(deployment, metadata.getDeployment());
     System.assertEquals(userId, metadata.getUserId());
@@ -888,14 +894,16 @@ private class IBMAssistantV1Test {
     IBMAssistantV1 assistant = new IBMAssistantV1('2018-02-16');
     assistant.setUsernameAndPassword('username', 'password');
 
-    IBMAssistantV1Models.Mention mentions1 = new IBMAssistantV1Models.Mention();
-    mentions1.setEntity('entity');
-    mentions1.setLocation(new List<Long> { 0L, 10L });
+    IBMAssistantV1Models.Mention mentions1 = new IBMAssistantV1Models.MentionBuilder()
+      .entity('entity')
+      .location(new List<Long> { 0L, 10L })
+      .build();
     List<IBMAssistantV1Models.Mention> mentionsList = new List<IBMAssistantV1Models.Mention>();
     mentionsList.add(mentions1);
-    IBMAssistantV1Models.Mention mentions2 = new IBMAssistantV1Models.Mention();
-    mentions2.setEntity('second_entity');
-    mentions2.setLocation(new List<Long> { 0L, 10L });
+    IBMAssistantV1Models.Mention mentions2 = new IBMAssistantV1Models.MentionBuilder()
+      .entity('second_entity')
+      .location(new List<Long> { 0L, 10L })
+      .build();
 
     IBMAssistantV1Models.CreateExampleOptions createOptions = new IBMAssistantV1Models.CreateExampleOptionsBuilder()
       .workspaceId(workspaceId)
@@ -1017,14 +1025,16 @@ private class IBMAssistantV1Test {
     IBMAssistantV1 assistant = new IBMAssistantV1('2018-02-16');
     assistant.setUsernameAndPassword('username', 'password');
 
-    IBMAssistantV1Models.Mention mentions1 = new IBMAssistantV1Models.Mention();
-    mentions1.setEntity('entity');
-    mentions1.setLocation(new List<Long> { 0L, 10L });
+    IBMAssistantV1Models.Mention mentions1 = new IBMAssistantV1Models.MentionBuilder()
+      .entity('entity')
+      .location(new List<Long> { 0L, 10L })
+      .build();
     List<IBMAssistantV1Models.Mention> mentionsList = new List<IBMAssistantV1Models.Mention>();
     mentionsList.add(mentions1);
-    IBMAssistantV1Models.Mention mentions2 = new IBMAssistantV1Models.Mention();
-    mentions2.setEntity('second_entity');
-    mentions2.setLocation(new List<Long> { 0L, 10L });
+    IBMAssistantV1Models.Mention mentions2 = new IBMAssistantV1Models.MentionBuilder()
+      .entity('second_entity')
+      .location(new List<Long> { 0L, 10L })
+      .build();
 
     IBMAssistantV1Models.UpdateExampleOptions updateOptions = new IBMAssistantV1Models.UpdateExampleOptionsBuilder()
       .workspaceId(workspaceId)
@@ -1382,11 +1392,7 @@ private class IBMAssistantV1Test {
     assistant.setUsernameAndPassword('username', 'password');
 
     String userLabel = 'user_label';
-    IBMAssistantV1Models.DialogNode dialogNode = new IBMAssistantV1Models.DialogNodeBuilder()
-      .dialogNode('dialog_node')
-      .build();
     IBMAssistantV1Models.CreateDialogNodeOptions createOptions = new IBMAssistantV1Models.CreateDialogNodeOptionsBuilder()
-      .dialogNode(dialogNode)
       .workspaceId(workspaceId)
       .dialogNode(dialogNodeName)
       .digressIn(dialogNodeDigressIn)
@@ -1398,7 +1404,7 @@ private class IBMAssistantV1Test {
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
     IBMAssistantV1Models.DialogNode response = assistant.createDialogNode(createOptions);
-
+    System.debug('RESPONSE: ' + response.toString());
     System.assertEquals(response.getDialogNode(), dialogNodeName);
     System.assertEquals(response.getDescription(), dialogNodeDescription);
     System.assertEquals(response.getTitle(), dialogNodeTitle);

--- a/force-app/main/default/classes/IBMAssistantV2.cls
+++ b/force-app/main/default/classes/IBMAssistantV2.cls
@@ -131,7 +131,7 @@ public class IBMAssistantV2 extends IBMWatsonService {
     if (messageOptions.context() != null) {
       contentJson.put('context', messageOptions.context());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, messageOptions.getSdkToApiMapping()));
 
     return (IBMAssistantV2Models.MessageResponse) createServiceCall(builder.build(), IBMAssistantV2Models.MessageResponse.class);
   }

--- a/force-app/main/default/classes/IBMAssistantV2Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV2Models.cls
@@ -11,7 +11,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public CaptureGroup() { }
- 
+
     /**
      * Gets the xgroup.
      *
@@ -23,7 +23,7 @@ public class IBMAssistantV2Models {
     public String getXgroup() {
       return xgroup;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -51,15 +51,21 @@ public class IBMAssistantV2Models {
       return new CaptureGroupBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xgroup', 'group');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xgroup', 'group');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('group', 'xgroup');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'group', 'xgroup');
       return mapping;
     }
   }
@@ -121,7 +127,7 @@ public class IBMAssistantV2Models {
      * @param xgroup the xgroup
      * @return the CaptureGroup builder
      */
-    public CaptureGroupBuilder setXgroup(String xgroup) {
+    public CaptureGroupBuilder xgroup(String xgroup) {
       this.xgroup = xgroup;
       return this;
     }
@@ -133,7 +139,7 @@ public class IBMAssistantV2Models {
      * @param location the location
      * @return the CaptureGroup builder
      */
-    public CaptureGroupBuilder setLocation(List<Long> location) {
+    public CaptureGroupBuilder location(List<Long> location) {
       this.location = location;
       return this;
     }
@@ -379,7 +385,7 @@ public class IBMAssistantV2Models {
   public class DialogLogMessage extends IBMWatsonGenericModel {
     private String level;
     private String message;
- 
+
     /**
      * Gets the level.
      *
@@ -391,7 +397,7 @@ public class IBMAssistantV2Models {
     public String getLevel() {
       return level;
     }
- 
+
     /**
      * Gets the message.
      *
@@ -432,7 +438,7 @@ public class IBMAssistantV2Models {
     private IBMWatsonMapModel parameters;
     private String resultVariable;
     private String credentials;
- 
+
     /**
      * Gets the name.
      *
@@ -444,7 +450,7 @@ public class IBMAssistantV2Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the actionType.
      *
@@ -456,7 +462,7 @@ public class IBMAssistantV2Models {
     public String getActionType() {
       return actionType;
     }
- 
+
     /**
      * Gets the parameters.
      *
@@ -468,7 +474,7 @@ public class IBMAssistantV2Models {
     public IBMWatsonMapModel getParameters() {
       return parameters;
     }
- 
+
     /**
      * Gets the resultVariable.
      *
@@ -480,7 +486,7 @@ public class IBMAssistantV2Models {
     public String getResultVariable() {
       return resultVariable;
     }
- 
+
     /**
      * Gets the credentials.
      *
@@ -552,10 +558,9 @@ public class IBMAssistantV2Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'actionType');
-      mapping.put('result_variable', 'resultVariable');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'type', 'actionType');
+      mapping.put(parentLabel + 'result_variable', 'resultVariable');
       return mapping;
     }
   }
@@ -566,7 +571,7 @@ public class IBMAssistantV2Models {
   public class DialogNodeOutputOptionsElement extends IBMWatsonGenericModel {
     private String label;
     private DialogNodeOutputOptionsElementValue value;
- 
+
     /**
      * Gets the label.
      *
@@ -578,7 +583,7 @@ public class IBMAssistantV2Models {
     public String getLabel() {
       return label;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -623,11 +628,8 @@ public class IBMAssistantV2Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (value != null) {
-        mapping.putAll(value.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeOutputOptionsElementValue.class.newInstance()).addToApiToSdkMapping(parentLabel + 'value/', mapping));
       return mapping;
     }
   }
@@ -637,7 +639,7 @@ public class IBMAssistantV2Models {
    */
   public class DialogNodeOutputOptionsElementValue extends IBMWatsonGenericModel {
     private MessageInput input;
- 
+
     /**
      * Gets the input.
      *
@@ -673,11 +675,8 @@ public class IBMAssistantV2Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (input != null) {
-        mapping.putAll(input.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) MessageInput.class.newInstance()).addToApiToSdkMapping(parentLabel + 'input/', mapping));
       return mapping;
     }
   }
@@ -689,7 +688,7 @@ public class IBMAssistantV2Models {
     private String dialogNode;
     private String title;
     private String conditions;
- 
+
     /**
      * Gets the dialogNode.
      *
@@ -701,7 +700,7 @@ public class IBMAssistantV2Models {
     public String getDialogNode() {
       return dialogNode;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -713,7 +712,7 @@ public class IBMAssistantV2Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the conditions.
      *
@@ -753,9 +752,12 @@ public class IBMAssistantV2Models {
       this.conditions = conditions;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dialog_node', 'dialogNode');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'dialog_node', 'dialogNode');
       return mapping;
     }
   }
@@ -784,7 +786,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public DialogRuntimeResponseGeneric() { }
- 
+
     /**
      * Gets the responseType.
      *
@@ -800,7 +802,7 @@ public class IBMAssistantV2Models {
     public String getResponseType() {
       return responseType;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -812,7 +814,7 @@ public class IBMAssistantV2Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the xtime.
      *
@@ -824,7 +826,7 @@ public class IBMAssistantV2Models {
     public Long getXtime() {
       return xtime;
     }
- 
+
     /**
      * Gets the typing.
      *
@@ -836,7 +838,7 @@ public class IBMAssistantV2Models {
     public Boolean getTyping() {
       return typing;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -848,7 +850,7 @@ public class IBMAssistantV2Models {
     public String getSource() {
       return source;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -860,7 +862,7 @@ public class IBMAssistantV2Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -872,7 +874,7 @@ public class IBMAssistantV2Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the preference.
      *
@@ -884,7 +886,7 @@ public class IBMAssistantV2Models {
     public String getPreference() {
       return preference;
     }
- 
+
     /**
      * Gets the options.
      *
@@ -896,7 +898,7 @@ public class IBMAssistantV2Models {
     public List<DialogNodeOutputOptionsElement> getOptions() {
       return options;
     }
- 
+
     /**
      * Gets the messageToHumanAgent.
      *
@@ -908,7 +910,7 @@ public class IBMAssistantV2Models {
     public String getMessageToHumanAgent() {
       return messageToHumanAgent;
     }
- 
+
     /**
      * Gets the topic.
      *
@@ -920,7 +922,7 @@ public class IBMAssistantV2Models {
     public String getTopic() {
       return topic;
     }
- 
+
     /**
      * Gets the suggestions.
      *
@@ -935,7 +937,7 @@ public class IBMAssistantV2Models {
     public List<DialogSuggestion> getSuggestions() {
       return suggestions;
     }
- 
+
     /**
      * Gets the header.
      *
@@ -948,7 +950,7 @@ public class IBMAssistantV2Models {
     public String getHeader() {
       return header;
     }
- 
+
     /**
      * Gets the results.
      *
@@ -1038,20 +1040,17 @@ public class IBMAssistantV2Models {
       return retBuilder.build();
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('response_type', 'responseType');
-      mapping.put('time', 'xtime');
-      if (options != null && options[0] != null) {
-        mapping.putAll(options[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('message_to_human_agent', 'messageToHumanAgent');
-      if (suggestions != null && suggestions[0] != null) {
-        mapping.putAll(suggestions[0].getApiToSdkMapping());
-      }
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'response_type', 'responseType');
+      mapping.put(parentLabel + 'time', 'xtime');
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeOutputOptionsElement.class.newInstance()).addToApiToSdkMapping(parentLabel + 'options/', mapping));
+      mapping.put(parentLabel + 'message_to_human_agent', 'messageToHumanAgent');
+      mapping.putAll(((IBMWatsonGenericModel) DialogSuggestion.class.newInstance()).addToApiToSdkMapping(parentLabel + 'suggestions/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) SearchResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
       return mapping;
     }
   }
@@ -1326,7 +1325,7 @@ public class IBMAssistantV2Models {
     private String label;
     private DialogSuggestionValue value;
     private IBMWatsonMapModel output;
- 
+
     /**
      * Gets the label.
      *
@@ -1339,7 +1338,7 @@ public class IBMAssistantV2Models {
     public String getLabel() {
       return label;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -1352,7 +1351,7 @@ public class IBMAssistantV2Models {
     public DialogSuggestionValue getValue() {
       return value;
     }
- 
+
     /**
      * Gets the output.
      *
@@ -1411,11 +1410,8 @@ public class IBMAssistantV2Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (value != null) {
-        mapping.putAll(value.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) DialogSuggestionValue.class.newInstance()).addToApiToSdkMapping(parentLabel + 'value/', mapping));
       return mapping;
     }
   }
@@ -1426,7 +1422,7 @@ public class IBMAssistantV2Models {
    */
   public class DialogSuggestionValue extends IBMWatsonGenericModel {
     private MessageInput input;
- 
+
     /**
      * Gets the input.
      *
@@ -1462,11 +1458,8 @@ public class IBMAssistantV2Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (input != null) {
-        mapping.putAll(input.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) MessageInput.class.newInstance()).addToApiToSdkMapping(parentLabel + 'input/', mapping));
       return mapping;
     }
   }
@@ -1483,7 +1476,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public MessageContext() { }
- 
+
     /**
      * Gets the xglobal.
      *
@@ -1495,7 +1488,7 @@ public class IBMAssistantV2Models {
     public MessageContextGlobal getXglobal() {
       return xglobal;
     }
- 
+
     /**
      * Gets the skills.
      *
@@ -1535,30 +1528,34 @@ public class IBMAssistantV2Models {
 
       // calling custom deserializer for xglobal
       MessageContextGlobal newXglobal = (MessageContextGlobal) new MessageContextGlobal().deserialize(JSON.serialize(ret.getXglobal()), (Map<String, Object>) jsonMap.get('xglobal'), MessageContextGlobal.class);
-      retBuilder.setXglobal(newXglobal);
+      retBuilder.xglobal(newXglobal);
 
       // calling custom deserializer for skills
       MessageContextSkills newSkills = (MessageContextSkills) new MessageContextSkills().deserialize(JSON.serialize(ret.getSkills()), (Map<String, Object>) jsonMap.get('skills'), MessageContextSkills.class);
-      retBuilder.setSkills(newSkills);
+      retBuilder.skills(newSkills);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xglobal', 'global');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xglobal', 'global');
       if (xglobal != null) {
-        mapping.putAll(xglobal.getSdkToApiMapping());
+        mapping.putAll(xglobal.addToSdkToApiMapping(parentLabel + 'xglobal/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('global', 'xglobal');
-      if (xglobal != null) {
-        mapping.putAll(xglobal.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'global', 'xglobal');
+      mapping.putAll(((IBMWatsonGenericModel) MessageContextGlobal.class.newInstance()).addToApiToSdkMapping(parentLabel + 'global/', mapping));
       return mapping;
     }
   }
@@ -1596,7 +1593,7 @@ public class IBMAssistantV2Models {
      * @param xglobal the xglobal
      * @return the MessageContext builder
      */
-    public MessageContextBuilder setXglobal(MessageContextGlobal xglobal) {
+    public MessageContextBuilder xglobal(MessageContextGlobal xglobal) {
       this.xglobal = xglobal;
       return this;
     }
@@ -1607,7 +1604,7 @@ public class IBMAssistantV2Models {
      * @param skills the skills
      * @return the MessageContext builder
      */
-    public MessageContextBuilder setSkills(MessageContextSkills skills) {
+    public MessageContextBuilder skills(MessageContextSkills skills) {
       this.skills = skills;
       return this;
     }
@@ -1624,7 +1621,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public MessageContextGlobal() { }
- 
+
     /**
      * Gets the xsystem.
      *
@@ -1660,26 +1657,30 @@ public class IBMAssistantV2Models {
 
       // calling custom deserializer for xsystem
       MessageContextGlobalSystem newXsystem = (MessageContextGlobalSystem) new MessageContextGlobalSystem().deserialize(JSON.serialize(ret.getXsystem()), (Map<String, Object>) jsonMap.get('xsystem'), MessageContextGlobalSystem.class);
-      retBuilder.setXsystem(newXsystem);
+      retBuilder.xsystem(newXsystem);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xsystem', 'system');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xsystem', 'system');
       if (xsystem != null) {
-        mapping.putAll(xsystem.getSdkToApiMapping());
+        mapping.putAll(xsystem.addToSdkToApiMapping(parentLabel + 'xsystem/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('system', 'xsystem');
-      if (xsystem != null) {
-        mapping.putAll(xsystem.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'system', 'xsystem');
+      mapping.putAll(((IBMWatsonGenericModel) MessageContextGlobalSystem.class.newInstance()).addToApiToSdkMapping(parentLabel + 'system/', mapping));
       return mapping;
     }
   }
@@ -1715,7 +1716,7 @@ public class IBMAssistantV2Models {
      * @param xsystem the xsystem
      * @return the MessageContextGlobal builder
      */
-    public MessageContextGlobalBuilder setXsystem(MessageContextGlobalSystem xsystem) {
+    public MessageContextGlobalBuilder xsystem(MessageContextGlobalSystem xsystem) {
       this.xsystem = xsystem;
       return this;
     }
@@ -1734,7 +1735,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public MessageContextGlobalSystem() { }
- 
+
     /**
      * Gets the timezone.
      *
@@ -1746,7 +1747,7 @@ public class IBMAssistantV2Models {
     public String getTimezone() {
       return timezone;
     }
- 
+
     /**
      * Gets the userId.
      *
@@ -1761,7 +1762,7 @@ public class IBMAssistantV2Models {
     public String getUserId() {
       return userId;
     }
- 
+
     /**
      * Gets the turnCount.
      *
@@ -1791,17 +1792,15 @@ public class IBMAssistantV2Models {
       return new MessageContextGlobalSystemBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('userId', 'user_id');
-      mapping.put('turnCount', 'turn_count');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'userId', 'user_id');
+      mapping.put(parentLabel + 'turnCount', 'turn_count');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('user_id', 'userId');
-      mapping.put('turn_count', 'turnCount');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'user_id', 'userId');
+      mapping.put(parentLabel + 'turn_count', 'turnCount');
       return mapping;
     }
   }
@@ -1841,7 +1840,7 @@ public class IBMAssistantV2Models {
      * @param timezone the timezone
      * @return the MessageContextGlobalSystem builder
      */
-    public MessageContextGlobalSystemBuilder setTimezone(String timezone) {
+    public MessageContextGlobalSystemBuilder timezone(String timezone) {
       this.timezone = timezone;
       return this;
     }
@@ -1852,7 +1851,7 @@ public class IBMAssistantV2Models {
      * @param userId the userId
      * @return the MessageContextGlobalSystem builder
      */
-    public MessageContextGlobalSystemBuilder setUserId(String userId) {
+    public MessageContextGlobalSystemBuilder userId(String userId) {
       this.userId = userId;
       return this;
     }
@@ -1863,7 +1862,7 @@ public class IBMAssistantV2Models {
      * @param turnCount the turnCount
      * @return the MessageContextGlobalSystem builder
      */
-    public MessageContextGlobalSystemBuilder setTurnCount(Long turnCount) {
+    public MessageContextGlobalSystemBuilder turnCount(Long turnCount) {
       this.turnCount = turnCount;
       return this;
     }
@@ -1880,7 +1879,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public MessageContextSkill() { }
- 
+
     /**
      * Gets the userDefined.
      *
@@ -1916,20 +1915,26 @@ public class IBMAssistantV2Models {
 
       // calling custom deserializer for userDefined
       IBMWatsonMapModel newUserDefined = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getUserDefined()), (Map<String, Object>) jsonMap.get('userDefined'), IBMWatsonMapModel.class);
-      retBuilder.setUserDefined(newUserDefined);
+      retBuilder.userDefined(newUserDefined);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('userDefined', 'user_defined');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'userDefined', 'user_defined');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('user_defined', 'userDefined');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'user_defined', 'userDefined');
       return mapping;
     }
   }
@@ -1965,7 +1970,7 @@ public class IBMAssistantV2Models {
      * @param userDefined the userDefined
      * @return the MessageContextSkill builder
      */
-    public MessageContextSkillBuilder setUserDefined(IBMWatsonMapModel userDefined) {
+    public MessageContextSkillBuilder userDefined(IBMWatsonMapModel userDefined) {
       this.userDefined = userDefined;
       return this;
     }
@@ -1977,7 +1982,7 @@ public class IBMAssistantV2Models {
 **Note:** Currently, only a single property named `main skill` is supported. This object contains variables that apply to the dialog skill used by the assistant.
    */
   public class MessageContextSkills extends IBMWatsonDynamicModel {
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -2067,7 +2072,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public MessageInput() { }
- 
+
     /**
      * Gets the messageType.
      *
@@ -2079,7 +2084,7 @@ public class IBMAssistantV2Models {
     public String getMessageType() {
       return messageType;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -2091,7 +2096,7 @@ public class IBMAssistantV2Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the options.
      *
@@ -2103,7 +2108,7 @@ public class IBMAssistantV2Models {
     public MessageInputOptions getOptions() {
       return options;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -2116,7 +2121,7 @@ public class IBMAssistantV2Models {
     public List<RuntimeIntent> getIntents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -2129,7 +2134,7 @@ public class IBMAssistantV2Models {
     public List<RuntimeEntity> getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the suggestionId.
      *
@@ -2201,29 +2206,31 @@ public class IBMAssistantV2Models {
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('messageType', 'message_type');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'messageType', 'message_type');
       if (options != null) {
-        mapping.putAll(options.getSdkToApiMapping());
+        mapping.putAll(options.addToSdkToApiMapping(parentLabel + 'options/', mapping));
       }
       if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getSdkToApiMapping());
+        mapping.putAll(entities[0].addToSdkToApiMapping(parentLabel + 'entities/', mapping));
       }
-      mapping.put('suggestionId', 'suggestion_id');
+      mapping.put(parentLabel + 'suggestionId', 'suggestion_id');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('message_type', 'messageType');
-      if (options != null) {
-        mapping.putAll(options.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
-      mapping.put('suggestion_id', 'suggestionId');
+      mapping.put(parentLabel + 'message_type', 'messageType');
+      mapping.putAll(((IBMWatsonGenericModel) MessageInputOptions.class.newInstance()).addToApiToSdkMapping(parentLabel + 'options/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) RuntimeEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
+      mapping.put(parentLabel + 'suggestion_id', 'suggestionId');
       return mapping;
     }
   }
@@ -2376,7 +2383,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public MessageInputOptions() { }
- 
+
     /**
      * Gets the debug.
      *
@@ -2389,7 +2396,7 @@ public class IBMAssistantV2Models {
     public Boolean getDebug() {
       return debug;
     }
- 
+
     /**
      * Gets the restart.
      *
@@ -2402,7 +2409,7 @@ public class IBMAssistantV2Models {
     public Boolean getRestart() {
       return restart;
     }
- 
+
     /**
      * Gets the alternateIntents.
      *
@@ -2414,7 +2421,7 @@ public class IBMAssistantV2Models {
     public Boolean getAlternateIntents() {
       return alternateIntents;
     }
- 
+
     /**
      * Gets the returnContext.
      *
@@ -2444,17 +2451,15 @@ public class IBMAssistantV2Models {
       return new MessageInputOptionsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('alternateIntents', 'alternate_intents');
-      mapping.put('returnContext', 'return_context');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'alternateIntents', 'alternate_intents');
+      mapping.put(parentLabel + 'returnContext', 'return_context');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('alternate_intents', 'alternateIntents');
-      mapping.put('return_context', 'returnContext');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'alternate_intents', 'alternateIntents');
+      mapping.put(parentLabel + 'return_context', 'returnContext');
       return mapping;
     }
   }
@@ -2496,7 +2501,7 @@ public class IBMAssistantV2Models {
      * @param debug the debug
      * @return the MessageInputOptions builder
      */
-    public MessageInputOptionsBuilder setDebug(Boolean debug) {
+    public MessageInputOptionsBuilder debug(Boolean debug) {
       this.debug = debug;
       return this;
     }
@@ -2507,7 +2512,7 @@ public class IBMAssistantV2Models {
      * @param restart the restart
      * @return the MessageInputOptions builder
      */
-    public MessageInputOptionsBuilder setRestart(Boolean restart) {
+    public MessageInputOptionsBuilder restart(Boolean restart) {
       this.restart = restart;
       return this;
     }
@@ -2518,7 +2523,7 @@ public class IBMAssistantV2Models {
      * @param alternateIntents the alternateIntents
      * @return the MessageInputOptions builder
      */
-    public MessageInputOptionsBuilder setAlternateIntents(Boolean alternateIntents) {
+    public MessageInputOptionsBuilder alternateIntents(Boolean alternateIntents) {
       this.alternateIntents = alternateIntents;
       return this;
     }
@@ -2529,7 +2534,7 @@ public class IBMAssistantV2Models {
      * @param returnContext the returnContext
      * @return the MessageInputOptions builder
      */
-    public MessageInputOptionsBuilder setReturnContext(Boolean returnContext) {
+    public MessageInputOptionsBuilder returnContext(Boolean returnContext) {
       this.returnContext = returnContext;
       return this;
     }
@@ -2617,10 +2622,10 @@ public class IBMAssistantV2Models {
       mapping.put('assistantId', 'assistant_id');
       mapping.put('sessionId', 'session_id');
       if (input != null) {
-        mapping.putAll(input.getSdkToApiMapping());
+        mapping.putAll(input.addToSdkToApiMapping('', mapping));
       }
       if (context != null) {
-        mapping.putAll(context.getSdkToApiMapping());
+        mapping.putAll(context.addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -2736,7 +2741,7 @@ public class IBMAssistantV2Models {
     private List<DialogNodeAction> actions;
     private MessageOutputDebug debug;
     private IBMWatsonMapModel userDefined;
- 
+
     /**
      * Gets the generic.
      *
@@ -2749,7 +2754,7 @@ public class IBMAssistantV2Models {
     public List<DialogRuntimeResponseGeneric> getGeneric() {
       return generic;
     }
- 
+
     /**
      * Gets the intents.
      *
@@ -2761,7 +2766,7 @@ public class IBMAssistantV2Models {
     public List<RuntimeIntent> getIntents() {
       return intents;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -2773,7 +2778,7 @@ public class IBMAssistantV2Models {
     public List<RuntimeEntity> getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the actions.
      *
@@ -2785,7 +2790,7 @@ public class IBMAssistantV2Models {
     public List<DialogNodeAction> getActions() {
       return actions;
     }
- 
+
     /**
      * Gets the debug.
      *
@@ -2797,7 +2802,7 @@ public class IBMAssistantV2Models {
     public MessageOutputDebug getDebug() {
       return debug;
     }
- 
+
     /**
      * Gets the userDefined.
      *
@@ -2935,21 +2940,12 @@ public class IBMAssistantV2Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (generic != null && generic[0] != null) {
-        mapping.putAll(generic[0].getApiToSdkMapping());
-      }
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
-      if (actions != null && actions[0] != null) {
-        mapping.putAll(actions[0].getApiToSdkMapping());
-      }
-      if (debug != null) {
-        mapping.putAll(debug.getApiToSdkMapping());
-      }
-      mapping.put('user_defined', 'userDefined');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) DialogRuntimeResponseGeneric.class.newInstance()).addToApiToSdkMapping(parentLabel + 'generic/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) RuntimeEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodeAction.class.newInstance()).addToApiToSdkMapping(parentLabel + 'actions/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) MessageOutputDebug.class.newInstance()).addToApiToSdkMapping(parentLabel + 'debug/', mapping));
+      mapping.put(parentLabel + 'user_defined', 'userDefined');
       return mapping;
     }
   }
@@ -2962,7 +2958,7 @@ public class IBMAssistantV2Models {
     private List<DialogLogMessage> logMessages;
     private Boolean branchExited;
     private String branchExitedReason;
- 
+
     /**
      * Gets the nodesVisited.
      *
@@ -2975,7 +2971,7 @@ public class IBMAssistantV2Models {
     public List<DialogNodesVisited> getNodesVisited() {
       return nodesVisited;
     }
- 
+
     /**
      * Gets the logMessages.
      *
@@ -2987,7 +2983,7 @@ public class IBMAssistantV2Models {
     public List<DialogLogMessage> getLogMessages() {
       return logMessages;
     }
- 
+
     /**
      * Gets the branchExited.
      *
@@ -2999,7 +2995,7 @@ public class IBMAssistantV2Models {
     public Boolean getBranchExited() {
       return branchExited;
     }
- 
+
     /**
      * Gets the branchExitedReason.
      *
@@ -3085,15 +3081,16 @@ public class IBMAssistantV2Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('nodes_visited', 'nodesVisited');
-      if (nodesVisited != null && nodesVisited[0] != null) {
-        mapping.putAll(nodesVisited[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('log_messages', 'logMessages');
-      mapping.put('branch_exited', 'branchExited');
-      mapping.put('branch_exited_reason', 'branchExitedReason');
+      mapping.put(parentLabel + 'nodes_visited', 'nodesVisited');
+      mapping.putAll(((IBMWatsonGenericModel) DialogNodesVisited.class.newInstance()).addToApiToSdkMapping(parentLabel + 'nodes_visited/', mapping));
+      mapping.put(parentLabel + 'log_messages', 'logMessages');
+      mapping.put(parentLabel + 'branch_exited', 'branchExited');
+      mapping.put(parentLabel + 'branch_exited_reason', 'branchExitedReason');
       return mapping;
     }
   }
@@ -3104,7 +3101,7 @@ public class IBMAssistantV2Models {
   public class MessageResponse extends IBMWatsonResponseModel {
     private MessageOutput output;
     private MessageContext context;
- 
+
     /**
      * Gets the output.
      *
@@ -3116,7 +3113,7 @@ public class IBMAssistantV2Models {
     public MessageOutput getOutput() {
       return output;
     }
- 
+
     /**
      * Gets the context.
      *
@@ -3168,14 +3165,9 @@ public class IBMAssistantV2Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (output != null) {
-        mapping.putAll(output.getApiToSdkMapping());
-      }
-      if (context != null) {
-        mapping.putAll(context.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) MessageOutput.class.newInstance()).addToApiToSdkMapping(parentLabel + 'output/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) MessageContext.class.newInstance()).addToApiToSdkMapping(parentLabel + 'context/', mapping));
       return mapping;
     }
   }
@@ -3196,7 +3188,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public RuntimeEntity() { }
- 
+
     /**
      * Gets the entity.
      *
@@ -3208,7 +3200,7 @@ public class IBMAssistantV2Models {
     public String getEntity() {
       return entity;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -3221,7 +3213,7 @@ public class IBMAssistantV2Models {
     public List<Long> getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -3233,7 +3225,7 @@ public class IBMAssistantV2Models {
     public String getValue() {
       return value;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -3245,7 +3237,7 @@ public class IBMAssistantV2Models {
     public Double getConfidence() {
       return confidence;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -3257,7 +3249,7 @@ public class IBMAssistantV2Models {
     public IBMWatsonMapModel getMetadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the groups.
      *
@@ -3301,7 +3293,7 @@ public class IBMAssistantV2Models {
 
       // calling custom deserializer for metadata
       IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
-      retBuilder.setMetadata(newMetadata);
+      retBuilder.metadata(newMetadata);
 
       // calling custom deserializer for groups
       List<CaptureGroup> newGroups = new List<CaptureGroup>();
@@ -3313,25 +3305,21 @@ public class IBMAssistantV2Models {
           CaptureGroup newItem = (CaptureGroup) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CaptureGroup.class);
           newGroups.add(newItem);
         }
-        retBuilder.setGroups(newGroups);
+        retBuilder.groups(newGroups);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (groups != null && groups[0] != null) {
-        mapping.putAll(groups[0].getSdkToApiMapping());
+        mapping.putAll(groups[0].addToSdkToApiMapping(parentLabel + 'groups/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (groups != null && groups[0] != null) {
-        mapping.putAll(groups[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) CaptureGroup.class.newInstance()).addToApiToSdkMapping(parentLabel + 'groups/', mapping));
       return mapping;
     }
   }
@@ -3420,7 +3408,7 @@ public class IBMAssistantV2Models {
      * @param entity the entity
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setEntity(String entity) {
+    public RuntimeEntityBuilder entity(String entity) {
       this.entity = entity;
       return this;
     }
@@ -3432,7 +3420,7 @@ public class IBMAssistantV2Models {
      * @param location the location
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setLocation(List<Long> location) {
+    public RuntimeEntityBuilder location(List<Long> location) {
       this.location = location;
       return this;
     }
@@ -3443,7 +3431,7 @@ public class IBMAssistantV2Models {
      * @param value the value
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setValue(String value) {
+    public RuntimeEntityBuilder value(String value) {
       this.value = value;
       return this;
     }
@@ -3454,7 +3442,7 @@ public class IBMAssistantV2Models {
      * @param confidence the confidence
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setConfidence(Double confidence) {
+    public RuntimeEntityBuilder confidence(Double confidence) {
       this.confidence = confidence;
       return this;
     }
@@ -3465,7 +3453,7 @@ public class IBMAssistantV2Models {
      * @param metadata the metadata
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setMetadata(IBMWatsonMapModel metadata) {
+    public RuntimeEntityBuilder metadata(IBMWatsonMapModel metadata) {
       this.metadata = metadata;
       return this;
     }
@@ -3477,7 +3465,7 @@ public class IBMAssistantV2Models {
      * @param groups the groups
      * @return the RuntimeEntity builder
      */
-    public RuntimeEntityBuilder setGroups(List<CaptureGroup> groups) {
+    public RuntimeEntityBuilder groups(List<CaptureGroup> groups) {
       this.groups = groups;
       return this;
     }
@@ -3495,7 +3483,7 @@ public class IBMAssistantV2Models {
      * and should not be called by the client.
      */
     public RuntimeIntent() { }
- 
+
     /**
      * Gets the intent.
      *
@@ -3507,7 +3495,7 @@ public class IBMAssistantV2Models {
     public String getIntent() {
       return intent;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -3581,7 +3569,7 @@ public class IBMAssistantV2Models {
      * @param intent the intent
      * @return the RuntimeIntent builder
      */
-    public RuntimeIntentBuilder setIntent(String intent) {
+    public RuntimeIntentBuilder intent(String intent) {
       this.intent = intent;
       return this;
     }
@@ -3592,7 +3580,7 @@ public class IBMAssistantV2Models {
      * @param confidence the confidence
      * @return the RuntimeIntent builder
      */
-    public RuntimeIntentBuilder setConfidence(Double confidence) {
+    public RuntimeIntentBuilder confidence(Double confidence) {
       this.confidence = confidence;
       return this;
     }
@@ -3608,7 +3596,7 @@ public class IBMAssistantV2Models {
     private String title;
     private String url;
     private SearchResultHighlight highlight;
- 
+
     /**
      * Gets the id.
      *
@@ -3623,7 +3611,7 @@ public class IBMAssistantV2Models {
     public String getId() {
       return id;
     }
- 
+
     /**
      * Gets the resultMetadata.
      *
@@ -3635,7 +3623,7 @@ public class IBMAssistantV2Models {
     public SearchResultMetadata getResultMetadata() {
       return resultMetadata;
     }
- 
+
     /**
      * Gets the body.
      *
@@ -3648,7 +3636,7 @@ public class IBMAssistantV2Models {
     public String getBody() {
       return body;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -3661,7 +3649,7 @@ public class IBMAssistantV2Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -3673,7 +3661,7 @@ public class IBMAssistantV2Models {
     public String getUrl() {
       return url;
     }
- 
+
     /**
      * Gets the highlight.
      *
@@ -3759,9 +3747,8 @@ public class IBMAssistantV2Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('result_metadata', 'resultMetadata');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'result_metadata', 'resultMetadata');
       return mapping;
     }
   }
@@ -3773,7 +3760,7 @@ public class IBMAssistantV2Models {
     private List<String> body;
     private List<String> title;
     private List<String> url;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * Gets the body.
@@ -3867,7 +3854,7 @@ public class IBMAssistantV2Models {
   public class SearchResultMetadata extends IBMWatsonGenericModel {
     private Double confidence;
     private Double score;
- 
+
     /**
      * Gets the confidence.
      *
@@ -3880,7 +3867,7 @@ public class IBMAssistantV2Models {
     public Double getConfidence() {
       return confidence;
     }
- 
+
     /**
      * Gets the score.
      *
@@ -3918,7 +3905,7 @@ public class IBMAssistantV2Models {
    */
   public class SessionResponse extends IBMWatsonResponseModel {
     private String sessionId;
- 
+
     /**
      * Gets the sessionId.
      *
@@ -3940,9 +3927,12 @@ public class IBMAssistantV2Models {
       this.sessionId = sessionId;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('session_id', 'sessionId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'session_id', 'sessionId');
       return mapping;
     }
   }

--- a/force-app/main/default/classes/IBMAssistantV2Models.cls
+++ b/force-app/main/default/classes/IBMAssistantV2Models.cls
@@ -3,8 +3,14 @@ public class IBMAssistantV2Models {
    * CaptureGroup.
    */
   public class CaptureGroup extends IBMWatsonGenericModel {
-    private String group_serialized_name;
-    private List<Long> location_serialized_name;
+    private String xgroup;
+    private List<Long> location;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public CaptureGroup() { }
  
     /**
      * Gets the xgroup.
@@ -15,7 +21,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getXgroup() {
-      return group_serialized_name;
+      return xgroup;
     }
  
     /**
@@ -27,27 +33,110 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
+    }
+  
+    private CaptureGroup(CaptureGroupBuilder builder) {
+      IBMWatsonValidator.notNull(builder.xgroup, 'xgroup cannot be null');
+      this.xgroup = builder.xgroup;
+      this.location = builder.location;
     }
 
     /**
-     * Sets the xgroup.
+     * New builder.
      *
-     * @param xgroup the new xgroup
+     * @return a CaptureGroup builder
      */
-    public void setXgroup(final String xgroup) {
-      this.group_serialized_name = xgroup;
+    public CaptureGroupBuilder newBuilder() {
+      return new CaptureGroupBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xgroup', 'group');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('group', 'xgroup');
+      return mapping;
+    }
+  }
+
+  /**
+   * CaptureGroup Builder.
+   */
+  public class CaptureGroupBuilder {
+    private String xgroup;
+    private List<Long> location;
+
+    private CaptureGroupBuilder(CaptureGroup captureGroup) {
+      this.xgroup = captureGroup.xgroup;
+      this.location = captureGroup.location;
     }
 
     /**
-     * Sets the location.
+     * Instantiates a new builder.
+     */
+    public CaptureGroupBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param xgroup the xgroup
+     */
+    public CaptureGroupBuilder(String xgroup) {
+      this.xgroup = xgroup;
+    }
+
+    /**
+     * Builds a CaptureGroup.
+     *
+     * @return the captureGroup
+     */
+    public CaptureGroup build() {
+      return new CaptureGroup(this);
+    }
+
+    /**
+     * Adds an location to location.
      *
      * @param location the new location
+     * @return the CaptureGroup builder
      */
-    public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
+    public CaptureGroupBuilder addLocation(Long location) {
+      IBMWatsonValidator.notNull(location, 'location cannot be null');
+      if (this.location == null) {
+        this.location = new List<Long>();
+      }
+      this.location.add(location);
+      return this;
     }
 
+    /**
+     * Set the xgroup.
+     *
+     * @param xgroup the xgroup
+     * @return the CaptureGroup builder
+     */
+    public CaptureGroupBuilder setXgroup(String xgroup) {
+      this.xgroup = xgroup;
+      return this;
+    }
+
+    /**
+     * Set the location.
+     * Existing location will be replaced.
+     *
+     * @param location the location
+     * @return the CaptureGroup builder
+     */
+    public CaptureGroupBuilder setLocation(List<Long> location) {
+      this.location = location;
+      return this;
+    }
   }
 
   /**
@@ -55,7 +144,7 @@ public class IBMAssistantV2Models {
    */
   public class CreateSessionOptions extends IBMWatsonOptionsModel {
     private String assistantId;
- 
+
     /**
      * Gets the assistantId.
      *
@@ -86,6 +175,11 @@ public class IBMAssistantV2Models {
       return new CreateSessionOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('assistantId', 'assistant_id');
+      return mapping;
+    }
   }
 
   /**
@@ -153,7 +247,7 @@ public class IBMAssistantV2Models {
   public class DeleteSessionOptions extends IBMWatsonOptionsModel {
     private String assistantId;
     private String sessionId;
- 
+
     /**
      * Gets the assistantId.
      *
@@ -168,7 +262,7 @@ public class IBMAssistantV2Models {
     public String assistantId() {
       return assistantId;
     }
- 
+
     /**
      * Gets the sessionId.
      *
@@ -197,6 +291,12 @@ public class IBMAssistantV2Models {
       return new DeleteSessionOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('assistantId', 'assistant_id');
+      mapping.put('sessionId', 'session_id');
+      return mapping;
+    }
   }
 
   /**
@@ -277,8 +377,8 @@ public class IBMAssistantV2Models {
    * Dialog log message details.
    */
   public class DialogLogMessage extends IBMWatsonGenericModel {
-    private String level_serialized_name;
-    private String message_serialized_name;
+    private String level;
+    private String message;
  
     /**
      * Gets the level.
@@ -289,7 +389,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getLevel() {
-      return level_serialized_name;
+      return level;
     }
  
     /**
@@ -301,7 +401,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getMessage() {
-      return message_serialized_name;
+      return message;
     }
 
     /**
@@ -310,7 +410,7 @@ public class IBMAssistantV2Models {
      * @param level the new level
      */
     public void setLevel(final String level) {
-      this.level_serialized_name = level;
+      this.level = level;
     }
 
     /**
@@ -319,20 +419,19 @@ public class IBMAssistantV2Models {
      * @param message the new message
      */
     public void setMessage(final String message) {
-      this.message_serialized_name = message;
+      this.message = message;
     }
-
   }
 
   /**
    * DialogNodeAction.
    */
   public class DialogNodeAction extends IBMWatsonGenericModel {
-    private String name_serialized_name;
-    private String type_serialized_name;
-    private IBMWatsonMapModel parameters_serialized_name;
-    private String result_variable_serialized_name;
-    private String credentials_serialized_name;
+    private String name;
+    private String actionType;
+    private IBMWatsonMapModel parameters;
+    private String resultVariable;
+    private String credentials;
  
     /**
      * Gets the name.
@@ -343,7 +442,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -355,7 +454,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getActionType() {
-      return type_serialized_name;
+      return actionType;
     }
  
     /**
@@ -367,7 +466,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getParameters() {
-      return parameters_serialized_name;
+      return parameters;
     }
  
     /**
@@ -379,7 +478,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getResultVariable() {
-      return result_variable_serialized_name;
+      return resultVariable;
     }
  
     /**
@@ -391,7 +490,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getCredentials() {
-      return credentials_serialized_name;
+      return credentials;
     }
 
     /**
@@ -400,7 +499,7 @@ public class IBMAssistantV2Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -409,7 +508,7 @@ public class IBMAssistantV2Models {
      * @param actionType the new actionType
      */
     public void setActionType(final String actionType) {
-      this.type_serialized_name = actionType;
+      this.actionType = actionType;
     }
 
     /**
@@ -418,7 +517,7 @@ public class IBMAssistantV2Models {
      * @param parameters the new parameters
      */
     public void setParameters(final IBMWatsonMapModel parameters) {
-      this.parameters_serialized_name = parameters;
+      this.parameters = parameters;
     }
 
     /**
@@ -427,7 +526,7 @@ public class IBMAssistantV2Models {
      * @param resultVariable the new resultVariable
      */
     public void setResultVariable(final String resultVariable) {
-      this.result_variable_serialized_name = resultVariable;
+      this.resultVariable = resultVariable;
     }
 
     /**
@@ -436,7 +535,7 @@ public class IBMAssistantV2Models {
      * @param credentials the new credentials
      */
     public void setCredentials(final String credentials) {
-      this.credentials_serialized_name = credentials;
+      this.credentials = credentials;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -447,10 +546,17 @@ public class IBMAssistantV2Models {
       DialogNodeAction ret = (DialogNodeAction) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for parameters
-      IBMWatsonMapModel newParameters = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getParameters()), (Map<String, Object>) jsonMap.get('parameters_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newParameters = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getParameters()), (Map<String, Object>) jsonMap.get('parameters'), IBMWatsonMapModel.class);
       ret.setParameters(newParameters);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'actionType');
+      mapping.put('result_variable', 'resultVariable');
+      return mapping;
     }
   }
 
@@ -458,8 +564,8 @@ public class IBMAssistantV2Models {
    * DialogNodeOutputOptionsElement.
    */
   public class DialogNodeOutputOptionsElement extends IBMWatsonGenericModel {
-    private String label_serialized_name;
-    private DialogNodeOutputOptionsElementValue value_serialized_name;
+    private String label;
+    private DialogNodeOutputOptionsElementValue value;
  
     /**
      * Gets the label.
@@ -470,7 +576,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getLabel() {
-      return label_serialized_name;
+      return label;
     }
  
     /**
@@ -482,7 +588,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public DialogNodeOutputOptionsElementValue getValue() {
-      return value_serialized_name;
+      return value;
     }
 
     /**
@@ -491,7 +597,7 @@ public class IBMAssistantV2Models {
      * @param label the new label
      */
     public void setLabel(final String label) {
-      this.label_serialized_name = label;
+      this.label = label;
     }
 
     /**
@@ -500,7 +606,7 @@ public class IBMAssistantV2Models {
      * @param value the new value
      */
     public void setValue(final DialogNodeOutputOptionsElementValue value) {
-      this.value_serialized_name = value;
+      this.value = value;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -511,10 +617,18 @@ public class IBMAssistantV2Models {
       DialogNodeOutputOptionsElement ret = (DialogNodeOutputOptionsElement) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for value
-      DialogNodeOutputOptionsElementValue newValue = (DialogNodeOutputOptionsElementValue) new DialogNodeOutputOptionsElementValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value_serialized_name'), DialogNodeOutputOptionsElementValue.class);
+      DialogNodeOutputOptionsElementValue newValue = (DialogNodeOutputOptionsElementValue) new DialogNodeOutputOptionsElementValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value'), DialogNodeOutputOptionsElementValue.class);
       ret.setValue(newValue);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (value != null) {
+        mapping.putAll(value.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -522,7 +636,7 @@ public class IBMAssistantV2Models {
    * An object defining the message input to be sent to the assistant if the user selects the corresponding option.
    */
   public class DialogNodeOutputOptionsElementValue extends IBMWatsonGenericModel {
-    private MessageInput input_serialized_name;
+    private MessageInput input;
  
     /**
      * Gets the input.
@@ -533,7 +647,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public MessageInput getInput() {
-      return input_serialized_name;
+      return input;
     }
 
     /**
@@ -542,7 +656,7 @@ public class IBMAssistantV2Models {
      * @param input the new input
      */
     public void setInput(final MessageInput input) {
-      this.input_serialized_name = input;
+      this.input = input;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -553,10 +667,18 @@ public class IBMAssistantV2Models {
       DialogNodeOutputOptionsElementValue ret = (DialogNodeOutputOptionsElementValue) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for input
-      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input_serialized_name'), MessageInput.class);
+      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input'), MessageInput.class);
       ret.setInput(newInput);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (input != null) {
+        mapping.putAll(input.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -564,9 +686,9 @@ public class IBMAssistantV2Models {
    * DialogNodesVisited.
    */
   public class DialogNodesVisited extends IBMWatsonGenericModel {
-    private String dialog_node_serialized_name;
-    private String title_serialized_name;
-    private String conditions_serialized_name;
+    private String dialogNode;
+    private String title;
+    private String conditions;
  
     /**
      * Gets the dialogNode.
@@ -577,7 +699,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getDialogNode() {
-      return dialog_node_serialized_name;
+      return dialogNode;
     }
  
     /**
@@ -589,7 +711,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -601,7 +723,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getConditions() {
-      return conditions_serialized_name;
+      return conditions;
     }
 
     /**
@@ -610,7 +732,7 @@ public class IBMAssistantV2Models {
      * @param dialogNode the new dialogNode
      */
     public void setDialogNode(final String dialogNode) {
-      this.dialog_node_serialized_name = dialogNode;
+      this.dialogNode = dialogNode;
     }
 
     /**
@@ -619,7 +741,7 @@ public class IBMAssistantV2Models {
      * @param title the new title
      */
     public void setTitle(final String title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     /**
@@ -628,29 +750,34 @@ public class IBMAssistantV2Models {
      * @param conditions the new conditions
      */
     public void setConditions(final String conditions) {
-      this.conditions_serialized_name = conditions;
+      this.conditions = conditions;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dialog_node', 'dialogNode');
+      return mapping;
+    }
   }
 
   /**
    * DialogRuntimeResponseGeneric.
    */
   public class DialogRuntimeResponseGeneric extends IBMWatsonGenericModel {
-    private String response_type_serialized_name;
-    private String text_serialized_name;
-    private Long time_serialized_name;
-    private Boolean typing_serialized_name;
-    private String source_serialized_name;
-    private String title_serialized_name;
-    private String description_serialized_name;
-    private String preference_serialized_name;
-    private List<DialogNodeOutputOptionsElement> options_serialized_name;
-    private String message_to_human_agent_serialized_name;
-    private String topic_serialized_name;
-    private List<DialogSuggestion> suggestions_serialized_name;
-    private String header_serialized_name;
-    private List<SearchResult> results_serialized_name;
+    private String responseType;
+    private String text;
+    private Long xtime;
+    private Boolean typing;
+    private String source;
+    private String title;
+    private String description;
+    private String preference;
+    private List<DialogNodeOutputOptionsElement> options;
+    private String messageToHumanAgent;
+    private String topic;
+    private List<DialogSuggestion> suggestions;
+    private String header;
+    private List<SearchResult> results;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -671,7 +798,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getResponseType() {
-      return response_type_serialized_name;
+      return responseType;
     }
  
     /**
@@ -683,7 +810,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -695,7 +822,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Long getXtime() {
-      return time_serialized_name;
+      return xtime;
     }
  
     /**
@@ -707,7 +834,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Boolean getTyping() {
-      return typing_serialized_name;
+      return typing;
     }
  
     /**
@@ -719,7 +846,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getSource() {
-      return source_serialized_name;
+      return source;
     }
  
     /**
@@ -731,7 +858,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -743,7 +870,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -755,7 +882,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getPreference() {
-      return preference_serialized_name;
+      return preference;
     }
  
     /**
@@ -767,7 +894,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<DialogNodeOutputOptionsElement> getOptions() {
-      return options_serialized_name;
+      return options;
     }
  
     /**
@@ -779,7 +906,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getMessageToHumanAgent() {
-      return message_to_human_agent_serialized_name;
+      return messageToHumanAgent;
     }
  
     /**
@@ -791,7 +918,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getTopic() {
-      return topic_serialized_name;
+      return topic;
     }
  
     /**
@@ -806,7 +933,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<DialogSuggestion> getSuggestions() {
-      return suggestions_serialized_name;
+      return suggestions;
     }
  
     /**
@@ -819,7 +946,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getHeader() {
-      return header_serialized_name;
+      return header;
     }
  
     /**
@@ -831,25 +958,25 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<SearchResult> getResults() {
-      return results_serialized_name;
+      return results;
     }
   
     private DialogRuntimeResponseGeneric(DialogRuntimeResponseGenericBuilder builder) {
       IBMWatsonValidator.notNull(builder.responseType, 'responseType cannot be null');
-      this.response_type_serialized_name = builder.responseType;
-      this.text_serialized_name = builder.text;
-      this.time_serialized_name = builder.xtime;
-      this.typing_serialized_name = builder.typing;
-      this.source_serialized_name = builder.source;
-      this.title_serialized_name = builder.title;
-      this.description_serialized_name = builder.description;
-      this.preference_serialized_name = builder.preference;
-      this.options_serialized_name = builder.options;
-      this.message_to_human_agent_serialized_name = builder.messageToHumanAgent;
-      this.topic_serialized_name = builder.topic;
-      this.suggestions_serialized_name = builder.suggestions;
-      this.header_serialized_name = builder.header;
-      this.results_serialized_name = builder.results;
+      this.responseType = builder.responseType;
+      this.text = builder.text;
+      this.xtime = builder.xtime;
+      this.typing = builder.typing;
+      this.source = builder.source;
+      this.title = builder.title;
+      this.description = builder.description;
+      this.preference = builder.preference;
+      this.options = builder.options;
+      this.messageToHumanAgent = builder.messageToHumanAgent;
+      this.topic = builder.topic;
+      this.suggestions = builder.suggestions;
+      this.header = builder.header;
+      this.results = builder.results;
     }
 
     /**
@@ -875,7 +1002,7 @@ public class IBMAssistantV2Models {
       if (deserializedOptions != null) {
         for (Integer i = 0; i < deserializedOptions.size(); i++) {
           DialogNodeOutputOptionsElement currentItem = ret.getOptions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('options_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('options');
           DialogNodeOutputOptionsElement newItem = (DialogNodeOutputOptionsElement) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeOutputOptionsElement.class);
           newOptions.add(newItem);
         }
@@ -888,7 +1015,7 @@ public class IBMAssistantV2Models {
       if (deserializedSuggestions != null) {
         for (Integer i = 0; i < deserializedSuggestions.size(); i++) {
           DialogSuggestion currentItem = ret.getSuggestions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('suggestions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('suggestions');
           DialogSuggestion newItem = (DialogSuggestion) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogSuggestion.class);
           newSuggestions.add(newItem);
         }
@@ -901,7 +1028,7 @@ public class IBMAssistantV2Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           SearchResult currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           SearchResult newItem = (SearchResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SearchResult.class);
           newResults.add(newItem);
         }
@@ -909,6 +1036,23 @@ public class IBMAssistantV2Models {
       }
 
       return retBuilder.build();
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('response_type', 'responseType');
+      mapping.put('time', 'xtime');
+      if (options != null && options[0] != null) {
+        mapping.putAll(options[0].getApiToSdkMapping());
+      }
+      mapping.put('message_to_human_agent', 'messageToHumanAgent');
+      if (suggestions != null && suggestions[0] != null) {
+        mapping.putAll(suggestions[0].getApiToSdkMapping());
+      }
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -932,20 +1076,20 @@ public class IBMAssistantV2Models {
     private List<SearchResult> results;
 
     private DialogRuntimeResponseGenericBuilder(DialogRuntimeResponseGeneric dialogRuntimeResponseGeneric) {
-      this.responseType = dialogRuntimeResponseGeneric.response_type_serialized_name;
-      this.text = dialogRuntimeResponseGeneric.text_serialized_name;
-      this.xtime = dialogRuntimeResponseGeneric.time_serialized_name;
-      this.typing = dialogRuntimeResponseGeneric.typing_serialized_name;
-      this.source = dialogRuntimeResponseGeneric.source_serialized_name;
-      this.title = dialogRuntimeResponseGeneric.title_serialized_name;
-      this.description = dialogRuntimeResponseGeneric.description_serialized_name;
-      this.preference = dialogRuntimeResponseGeneric.preference_serialized_name;
-      this.options = dialogRuntimeResponseGeneric.options_serialized_name;
-      this.messageToHumanAgent = dialogRuntimeResponseGeneric.message_to_human_agent_serialized_name;
-      this.topic = dialogRuntimeResponseGeneric.topic_serialized_name;
-      this.suggestions = dialogRuntimeResponseGeneric.suggestions_serialized_name;
-      this.header = dialogRuntimeResponseGeneric.header_serialized_name;
-      this.results = dialogRuntimeResponseGeneric.results_serialized_name;
+      this.responseType = dialogRuntimeResponseGeneric.responseType;
+      this.text = dialogRuntimeResponseGeneric.text;
+      this.xtime = dialogRuntimeResponseGeneric.xtime;
+      this.typing = dialogRuntimeResponseGeneric.typing;
+      this.source = dialogRuntimeResponseGeneric.source;
+      this.title = dialogRuntimeResponseGeneric.title;
+      this.description = dialogRuntimeResponseGeneric.description;
+      this.preference = dialogRuntimeResponseGeneric.preference;
+      this.options = dialogRuntimeResponseGeneric.options;
+      this.messageToHumanAgent = dialogRuntimeResponseGeneric.messageToHumanAgent;
+      this.topic = dialogRuntimeResponseGeneric.topic;
+      this.suggestions = dialogRuntimeResponseGeneric.suggestions;
+      this.header = dialogRuntimeResponseGeneric.header;
+      this.results = dialogRuntimeResponseGeneric.results;
     }
 
     /**
@@ -1179,9 +1323,9 @@ public class IBMAssistantV2Models {
    * DialogSuggestion.
    */
   public class DialogSuggestion extends IBMWatsonGenericModel {
-    private String label_serialized_name;
-    private DialogSuggestionValue value_serialized_name;
-    private IBMWatsonMapModel output_serialized_name;
+    private String label;
+    private DialogSuggestionValue value;
+    private IBMWatsonMapModel output;
  
     /**
      * Gets the label.
@@ -1193,7 +1337,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getLabel() {
-      return label_serialized_name;
+      return label;
     }
  
     /**
@@ -1206,7 +1350,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public DialogSuggestionValue getValue() {
-      return value_serialized_name;
+      return value;
     }
  
     /**
@@ -1219,7 +1363,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getOutput() {
-      return output_serialized_name;
+      return output;
     }
 
     /**
@@ -1228,7 +1372,7 @@ public class IBMAssistantV2Models {
      * @param label the new label
      */
     public void setLabel(final String label) {
-      this.label_serialized_name = label;
+      this.label = label;
     }
 
     /**
@@ -1237,7 +1381,7 @@ public class IBMAssistantV2Models {
      * @param value the new value
      */
     public void setValue(final DialogSuggestionValue value) {
-      this.value_serialized_name = value;
+      this.value = value;
     }
 
     /**
@@ -1246,7 +1390,7 @@ public class IBMAssistantV2Models {
      * @param output the new output
      */
     public void setOutput(final IBMWatsonMapModel output) {
-      this.output_serialized_name = output;
+      this.output = output;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1257,14 +1401,22 @@ public class IBMAssistantV2Models {
       DialogSuggestion ret = (DialogSuggestion) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for value
-      DialogSuggestionValue newValue = (DialogSuggestionValue) new DialogSuggestionValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value_serialized_name'), DialogSuggestionValue.class);
+      DialogSuggestionValue newValue = (DialogSuggestionValue) new DialogSuggestionValue().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value'), DialogSuggestionValue.class);
       ret.setValue(newValue);
 
       // calling custom deserializer for output
-      IBMWatsonMapModel newOutput = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newOutput = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output'), IBMWatsonMapModel.class);
       ret.setOutput(newOutput);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (value != null) {
+        mapping.putAll(value.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1273,7 +1425,7 @@ public class IBMAssistantV2Models {
    * disambiguation option.
    */
   public class DialogSuggestionValue extends IBMWatsonGenericModel {
-    private MessageInput input_serialized_name;
+    private MessageInput input;
  
     /**
      * Gets the input.
@@ -1284,7 +1436,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public MessageInput getInput() {
-      return input_serialized_name;
+      return input;
     }
 
     /**
@@ -1293,7 +1445,7 @@ public class IBMAssistantV2Models {
      * @param input the new input
      */
     public void setInput(final MessageInput input) {
-      this.input_serialized_name = input;
+      this.input = input;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1304,10 +1456,18 @@ public class IBMAssistantV2Models {
       DialogSuggestionValue ret = (DialogSuggestionValue) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for input
-      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input_serialized_name'), MessageInput.class);
+      MessageInput newInput = (MessageInput) new MessageInput().deserialize(JSON.serialize(ret.getInput()), (Map<String, Object>) jsonMap.get('input'), MessageInput.class);
       ret.setInput(newInput);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (input != null) {
+        mapping.putAll(input.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1315,8 +1475,14 @@ public class IBMAssistantV2Models {
    * MessageContext.
    */
   public class MessageContext extends IBMWatsonGenericModel {
-    private MessageContextGlobal global_serialized_name;
-    private MessageContextSkills skills_serialized_name;
+    private MessageContextGlobal xglobal;
+    private MessageContextSkills skills;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public MessageContext() { }
  
     /**
      * Gets the xglobal.
@@ -1327,7 +1493,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public MessageContextGlobal getXglobal() {
-      return global_serialized_name;
+      return xglobal;
     }
  
     /**
@@ -1342,25 +1508,21 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public MessageContextSkills getSkills() {
-      return skills_serialized_name;
+      return skills;
+    }
+  
+    private MessageContext(MessageContextBuilder builder) {
+      this.xglobal = builder.xglobal;
+      this.skills = builder.skills;
     }
 
     /**
-     * Sets the xglobal.
+     * New builder.
      *
-     * @param xglobal the new xglobal
+     * @return a MessageContext builder
      */
-    public void setXglobal(final MessageContextGlobal xglobal) {
-      this.global_serialized_name = xglobal;
-    }
-
-    /**
-     * Sets the skills.
-     *
-     * @param skills the new skills
-     */
-    public void setSkills(final MessageContextSkills skills) {
-      this.skills_serialized_name = skills;
+    public MessageContextBuilder newBuilder() {
+      return new MessageContextBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1369,16 +1531,85 @@ public class IBMAssistantV2Models {
       }
 
       MessageContext ret = (MessageContext) super.deserialize(jsonString, jsonMap, classType);
+      MessageContextBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for xglobal
-      MessageContextGlobal newXglobal = (MessageContextGlobal) new MessageContextGlobal().deserialize(JSON.serialize(ret.getXglobal()), (Map<String, Object>) jsonMap.get('global_serialized_name'), MessageContextGlobal.class);
-      ret.setXglobal(newXglobal);
+      MessageContextGlobal newXglobal = (MessageContextGlobal) new MessageContextGlobal().deserialize(JSON.serialize(ret.getXglobal()), (Map<String, Object>) jsonMap.get('xglobal'), MessageContextGlobal.class);
+      retBuilder.setXglobal(newXglobal);
 
       // calling custom deserializer for skills
-      MessageContextSkills newSkills = (MessageContextSkills) new MessageContextSkills().deserialize(JSON.serialize(ret.getSkills()), (Map<String, Object>) jsonMap.get('skills_serialized_name'), MessageContextSkills.class);
-      ret.setSkills(newSkills);
+      MessageContextSkills newSkills = (MessageContextSkills) new MessageContextSkills().deserialize(JSON.serialize(ret.getSkills()), (Map<String, Object>) jsonMap.get('skills'), MessageContextSkills.class);
+      retBuilder.setSkills(newSkills);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xglobal', 'global');
+      if (xglobal != null) {
+        mapping.putAll(xglobal.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('global', 'xglobal');
+      if (xglobal != null) {
+        mapping.putAll(xglobal.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * MessageContext Builder.
+   */
+  public class MessageContextBuilder {
+    private MessageContextGlobal xglobal;
+    private MessageContextSkills skills;
+
+    private MessageContextBuilder(MessageContext messageContext) {
+      this.xglobal = messageContext.xglobal;
+      this.skills = messageContext.skills;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public MessageContextBuilder() {
+    }
+
+    /**
+     * Builds a MessageContext.
+     *
+     * @return the messageContext
+     */
+    public MessageContext build() {
+      return new MessageContext(this);
+    }
+
+    /**
+     * Set the xglobal.
+     *
+     * @param xglobal the xglobal
+     * @return the MessageContext builder
+     */
+    public MessageContextBuilder setXglobal(MessageContextGlobal xglobal) {
+      this.xglobal = xglobal;
+      return this;
+    }
+
+    /**
+     * Set the skills.
+     *
+     * @param skills the skills
+     * @return the MessageContext builder
+     */
+    public MessageContextBuilder setSkills(MessageContextSkills skills) {
+      this.skills = skills;
+      return this;
     }
   }
 
@@ -1386,7 +1617,13 @@ public class IBMAssistantV2Models {
    * Information that is shared by all skills used by the Assistant.
    */
   public class MessageContextGlobal extends IBMWatsonGenericModel {
-    private MessageContextGlobalSystem system_serialized_name;
+    private MessageContextGlobalSystem xsystem;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public MessageContextGlobal() { }
  
     /**
      * Gets the xsystem.
@@ -1397,16 +1634,20 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public MessageContextGlobalSystem getXsystem() {
-      return system_serialized_name;
+      return xsystem;
+    }
+  
+    private MessageContextGlobal(MessageContextGlobalBuilder builder) {
+      this.xsystem = builder.xsystem;
     }
 
     /**
-     * Sets the xsystem.
+     * New builder.
      *
-     * @param xsystem the new xsystem
+     * @return a MessageContextGlobal builder
      */
-    public void setXsystem(final MessageContextGlobalSystem xsystem) {
-      this.system_serialized_name = xsystem;
+    public MessageContextGlobalBuilder newBuilder() {
+      return new MessageContextGlobalBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1415,12 +1656,68 @@ public class IBMAssistantV2Models {
       }
 
       MessageContextGlobal ret = (MessageContextGlobal) super.deserialize(jsonString, jsonMap, classType);
+      MessageContextGlobalBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for xsystem
-      MessageContextGlobalSystem newXsystem = (MessageContextGlobalSystem) new MessageContextGlobalSystem().deserialize(JSON.serialize(ret.getXsystem()), (Map<String, Object>) jsonMap.get('system_serialized_name'), MessageContextGlobalSystem.class);
-      ret.setXsystem(newXsystem);
+      MessageContextGlobalSystem newXsystem = (MessageContextGlobalSystem) new MessageContextGlobalSystem().deserialize(JSON.serialize(ret.getXsystem()), (Map<String, Object>) jsonMap.get('xsystem'), MessageContextGlobalSystem.class);
+      retBuilder.setXsystem(newXsystem);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xsystem', 'system');
+      if (xsystem != null) {
+        mapping.putAll(xsystem.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('system', 'xsystem');
+      if (xsystem != null) {
+        mapping.putAll(xsystem.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * MessageContextGlobal Builder.
+   */
+  public class MessageContextGlobalBuilder {
+    private MessageContextGlobalSystem xsystem;
+
+    private MessageContextGlobalBuilder(MessageContextGlobal messageContextGlobal) {
+      this.xsystem = messageContextGlobal.xsystem;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public MessageContextGlobalBuilder() {
+    }
+
+    /**
+     * Builds a MessageContextGlobal.
+     *
+     * @return the messageContextGlobal
+     */
+    public MessageContextGlobal build() {
+      return new MessageContextGlobal(this);
+    }
+
+    /**
+     * Set the xsystem.
+     *
+     * @param xsystem the xsystem
+     * @return the MessageContextGlobal builder
+     */
+    public MessageContextGlobalBuilder setXsystem(MessageContextGlobalSystem xsystem) {
+      this.xsystem = xsystem;
+      return this;
     }
   }
 
@@ -1428,9 +1725,15 @@ public class IBMAssistantV2Models {
    * Built-in system properties that apply to all skills used by the assistant.
    */
   public class MessageContextGlobalSystem extends IBMWatsonGenericModel {
-    private String timezone_serialized_name;
-    private String user_id_serialized_name;
-    private Long turn_count_serialized_name;
+    private String timezone;
+    private String userId;
+    private Long turnCount;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public MessageContextGlobalSystem() { }
  
     /**
      * Gets the timezone.
@@ -1441,7 +1744,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getTimezone() {
-      return timezone_serialized_name;
+      return timezone;
     }
  
     /**
@@ -1456,7 +1759,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getUserId() {
-      return user_id_serialized_name;
+      return userId;
     }
  
     /**
@@ -1470,43 +1773,113 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Long getTurnCount() {
-      return turn_count_serialized_name;
+      return turnCount;
+    }
+  
+    private MessageContextGlobalSystem(MessageContextGlobalSystemBuilder builder) {
+      this.timezone = builder.timezone;
+      this.userId = builder.userId;
+      this.turnCount = builder.turnCount;
     }
 
     /**
-     * Sets the timezone.
+     * New builder.
      *
-     * @param timezone the new timezone
+     * @return a MessageContextGlobalSystem builder
      */
-    public void setTimezone(final String timezone) {
-      this.timezone_serialized_name = timezone;
+    public MessageContextGlobalSystemBuilder newBuilder() {
+      return new MessageContextGlobalSystemBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('userId', 'user_id');
+      mapping.put('turnCount', 'turn_count');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('user_id', 'userId');
+      mapping.put('turn_count', 'turnCount');
+      return mapping;
+    }
+  }
+
+  /**
+   * MessageContextGlobalSystem Builder.
+   */
+  public class MessageContextGlobalSystemBuilder {
+    private String timezone;
+    private String userId;
+    private Long turnCount;
+
+    private MessageContextGlobalSystemBuilder(MessageContextGlobalSystem messageContextGlobalSystem) {
+      this.timezone = messageContextGlobalSystem.timezone;
+      this.userId = messageContextGlobalSystem.userId;
+      this.turnCount = messageContextGlobalSystem.turnCount;
     }
 
     /**
-     * Sets the userId.
-     *
-     * @param userId the new userId
+     * Instantiates a new builder.
      */
-    public void setUserId(final String userId) {
-      this.user_id_serialized_name = userId;
+    public MessageContextGlobalSystemBuilder() {
     }
 
     /**
-     * Sets the turnCount.
+     * Builds a MessageContextGlobalSystem.
      *
-     * @param turnCount the new turnCount
+     * @return the messageContextGlobalSystem
      */
-    public void setTurnCount(final long turnCount) {
-      this.turn_count_serialized_name = turnCount;
+    public MessageContextGlobalSystem build() {
+      return new MessageContextGlobalSystem(this);
     }
 
+    /**
+     * Set the timezone.
+     *
+     * @param timezone the timezone
+     * @return the MessageContextGlobalSystem builder
+     */
+    public MessageContextGlobalSystemBuilder setTimezone(String timezone) {
+      this.timezone = timezone;
+      return this;
+    }
+
+    /**
+     * Set the userId.
+     *
+     * @param userId the userId
+     * @return the MessageContextGlobalSystem builder
+     */
+    public MessageContextGlobalSystemBuilder setUserId(String userId) {
+      this.userId = userId;
+      return this;
+    }
+
+    /**
+     * Set the turnCount.
+     *
+     * @param turnCount the turnCount
+     * @return the MessageContextGlobalSystem builder
+     */
+    public MessageContextGlobalSystemBuilder setTurnCount(Long turnCount) {
+      this.turnCount = turnCount;
+      return this;
+    }
   }
 
   /**
    * Contains information specific to a particular skill used by the Assistant.
    */
   public class MessageContextSkill extends IBMWatsonGenericModel {
-    private IBMWatsonMapModel user_defined_serialized_name;
+    private IBMWatsonMapModel userDefined;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public MessageContextSkill() { }
  
     /**
      * Gets the userDefined.
@@ -1517,16 +1890,20 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getUserDefined() {
-      return user_defined_serialized_name;
+      return userDefined;
+    }
+  
+    private MessageContextSkill(MessageContextSkillBuilder builder) {
+      this.userDefined = builder.userDefined;
     }
 
     /**
-     * Sets the userDefined.
+     * New builder.
      *
-     * @param userDefined the new userDefined
+     * @return a MessageContextSkill builder
      */
-    public void setUserDefined(final IBMWatsonMapModel userDefined) {
-      this.user_defined_serialized_name = userDefined;
+    public MessageContextSkillBuilder newBuilder() {
+      return new MessageContextSkillBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1535,12 +1912,62 @@ public class IBMAssistantV2Models {
       }
 
       MessageContextSkill ret = (MessageContextSkill) super.deserialize(jsonString, jsonMap, classType);
+      MessageContextSkillBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for userDefined
-      IBMWatsonMapModel newUserDefined = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getUserDefined()), (Map<String, Object>) jsonMap.get('user_defined_serialized_name'), IBMWatsonMapModel.class);
-      ret.setUserDefined(newUserDefined);
+      IBMWatsonMapModel newUserDefined = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getUserDefined()), (Map<String, Object>) jsonMap.get('userDefined'), IBMWatsonMapModel.class);
+      retBuilder.setUserDefined(newUserDefined);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('userDefined', 'user_defined');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('user_defined', 'userDefined');
+      return mapping;
+    }
+  }
+
+  /**
+   * MessageContextSkill Builder.
+   */
+  public class MessageContextSkillBuilder {
+    private IBMWatsonMapModel userDefined;
+
+    private MessageContextSkillBuilder(MessageContextSkill messageContextSkill) {
+      this.userDefined = messageContextSkill.userDefined;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public MessageContextSkillBuilder() {
+    }
+
+    /**
+     * Builds a MessageContextSkill.
+     *
+     * @return the messageContextSkill
+     */
+    public MessageContextSkill build() {
+      return new MessageContextSkill(this);
+    }
+
+    /**
+     * Set the userDefined.
+     *
+     * @param userDefined the userDefined
+     * @return the MessageContextSkill builder
+     */
+    public MessageContextSkillBuilder setUserDefined(IBMWatsonMapModel userDefined) {
+      this.userDefined = userDefined;
+      return this;
     }
   }
 
@@ -1553,6 +1980,12 @@ public class IBMAssistantV2Models {
     private Map<String, Object> additional_properties_serialized_name;
 
     /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public MessageContextSkills() { }
+
+    /**
      * Gets the dynamic properties attached to MessageContextSkills.
      *
      * @return the dynamic properties
@@ -1562,22 +1995,59 @@ public class IBMAssistantV2Models {
       return this.getDynamicProperties();
     }
 
+    private MessageContextSkills(MessageContextSkillsBuilder builder) {
+    }
+
+    /**
+     * New builder.
+     *
+     * @return a MessageContextSkills builder
+     */
+    public MessageContextSkillsBuilder newBuilder() {
+      return new MessageContextSkillsBuilder(this);
+    }
+
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
       if (jsonMap == null) {
         return null;
       }
 
       MessageContextSkills ret = (MessageContextSkills) super.deserialize(jsonString, jsonMap, classType);
+      MessageContextSkillsBuilder retBuilder = ret.newBuilder();
 
+      MessageContextSkills builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
 
       for (String key : jsonMap.keySet()) {
         if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
+          builderResult.put(key, jsonMap.get(key));
         }
       }
 
-      return ret;
+      return builderResult;
+    }
+  }
+
+  /**
+   * MessageContextSkills Builder.
+   */
+  public class MessageContextSkillsBuilder {
+
+    private MessageContextSkillsBuilder(MessageContextSkills messageContextSkills) {
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public MessageContextSkillsBuilder() { }
+
+    /**
+     * Builds a MessageContextSkills.
+     *
+     * @return the messageContextSkills
+     */
+    public MessageContextSkills build() {
+      return new MessageContextSkills(this);
     }
   }
 
@@ -1585,12 +2055,12 @@ public class IBMAssistantV2Models {
    * An input object that includes the input text.
    */
   public class MessageInput extends IBMWatsonGenericModel {
-    private String message_type_serialized_name;
-    private String text_serialized_name;
-    private MessageInputOptions options_serialized_name;
-    private List<RuntimeIntent> intents_serialized_name;
-    private List<RuntimeEntity> entities_serialized_name;
-    private String suggestion_id_serialized_name;
+    private String messageType;
+    private String text;
+    private MessageInputOptions options;
+    private List<RuntimeIntent> intents;
+    private List<RuntimeEntity> entities;
+    private String suggestionId;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -1607,7 +2077,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getMessageType() {
-      return message_type_serialized_name;
+      return messageType;
     }
  
     /**
@@ -1619,7 +2089,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -1631,7 +2101,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public MessageInputOptions getOptions() {
-      return options_serialized_name;
+      return options;
     }
  
     /**
@@ -1644,7 +2114,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<RuntimeIntent> getIntents() {
-      return intents_serialized_name;
+      return intents;
     }
  
     /**
@@ -1657,7 +2127,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<RuntimeEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -1669,16 +2139,16 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getSuggestionId() {
-      return suggestion_id_serialized_name;
+      return suggestionId;
     }
   
     private MessageInput(MessageInputBuilder builder) {
-      this.message_type_serialized_name = builder.messageType;
-      this.text_serialized_name = builder.text;
-      this.options_serialized_name = builder.options;
-      this.intents_serialized_name = builder.intents;
-      this.entities_serialized_name = builder.entities;
-      this.suggestion_id_serialized_name = builder.suggestionId;
+      this.messageType = builder.messageType;
+      this.text = builder.text;
+      this.options = builder.options;
+      this.intents = builder.intents;
+      this.entities = builder.entities;
+      this.suggestionId = builder.suggestionId;
     }
 
     /**
@@ -1699,7 +2169,7 @@ public class IBMAssistantV2Models {
       MessageInputBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for options
-      MessageInputOptions newOptions = (MessageInputOptions) new MessageInputOptions().deserialize(JSON.serialize(ret.getOptions()), (Map<String, Object>) jsonMap.get('options_serialized_name'), MessageInputOptions.class);
+      MessageInputOptions newOptions = (MessageInputOptions) new MessageInputOptions().deserialize(JSON.serialize(ret.getOptions()), (Map<String, Object>) jsonMap.get('options'), MessageInputOptions.class);
       retBuilder.options(newOptions);
 
       // calling custom deserializer for intents
@@ -1708,7 +2178,7 @@ public class IBMAssistantV2Models {
       if (deserializedIntents != null) {
         for (Integer i = 0; i < deserializedIntents.size(); i++) {
           RuntimeIntent currentItem = ret.getIntents().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('intents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('intents');
           RuntimeIntent newItem = (RuntimeIntent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeIntent.class);
           newIntents.add(newItem);
         }
@@ -1721,7 +2191,7 @@ public class IBMAssistantV2Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           RuntimeEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           RuntimeEntity newItem = (RuntimeEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeEntity.class);
           newEntities.add(newItem);
         }
@@ -1729,6 +2199,32 @@ public class IBMAssistantV2Models {
       }
 
       return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('messageType', 'message_type');
+      if (options != null) {
+        mapping.putAll(options.getSdkToApiMapping());
+      }
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getSdkToApiMapping());
+      }
+      mapping.put('suggestionId', 'suggestion_id');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('message_type', 'messageType');
+      if (options != null) {
+        mapping.putAll(options.getApiToSdkMapping());
+      }
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      mapping.put('suggestion_id', 'suggestionId');
+      return mapping;
     }
   }
 
@@ -1744,12 +2240,12 @@ public class IBMAssistantV2Models {
     private String suggestionId;
 
     private MessageInputBuilder(MessageInput messageInput) {
-      this.messageType = messageInput.message_type_serialized_name;
-      this.text = messageInput.text_serialized_name;
-      this.options = messageInput.options_serialized_name;
-      this.intents = messageInput.intents_serialized_name;
-      this.entities = messageInput.entities_serialized_name;
-      this.suggestionId = messageInput.suggestion_id_serialized_name;
+      this.messageType = messageInput.messageType;
+      this.text = messageInput.text;
+      this.options = messageInput.options;
+      this.intents = messageInput.intents;
+      this.entities = messageInput.entities;
+      this.suggestionId = messageInput.suggestionId;
     }
 
     /**
@@ -1870,10 +2366,16 @@ public class IBMAssistantV2Models {
    * Optional properties that control how the assistant responds.
    */
   public class MessageInputOptions extends IBMWatsonGenericModel {
-    private Boolean debug_serialized_name;
-    private Boolean restart_serialized_name;
-    private Boolean alternate_intents_serialized_name;
-    private Boolean return_context_serialized_name;
+    private Boolean debug;
+    private Boolean restart;
+    private Boolean alternateIntents;
+    private Boolean returnContext;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public MessageInputOptions() { }
  
     /**
      * Gets the debug.
@@ -1885,7 +2387,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Boolean getDebug() {
-      return debug_serialized_name;
+      return debug;
     }
  
     /**
@@ -1898,7 +2400,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Boolean getRestart() {
-      return restart_serialized_name;
+      return restart;
     }
  
     /**
@@ -1910,7 +2412,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Boolean getAlternateIntents() {
-      return alternate_intents_serialized_name;
+      return alternateIntents;
     }
  
     /**
@@ -1923,45 +2425,114 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Boolean getReturnContext() {
-      return return_context_serialized_name;
+      return returnContext;
+    }
+  
+    private MessageInputOptions(MessageInputOptionsBuilder builder) {
+      this.debug = builder.debug;
+      this.restart = builder.restart;
+      this.alternateIntents = builder.alternateIntents;
+      this.returnContext = builder.returnContext;
     }
 
     /**
-     * Sets the debug.
+     * New builder.
      *
-     * @param debug the new debug
+     * @return a MessageInputOptions builder
      */
-    public void setDebug(final Boolean debug) {
-      this.debug_serialized_name = debug;
+    public MessageInputOptionsBuilder newBuilder() {
+      return new MessageInputOptionsBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('alternateIntents', 'alternate_intents');
+      mapping.put('returnContext', 'return_context');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('alternate_intents', 'alternateIntents');
+      mapping.put('return_context', 'returnContext');
+      return mapping;
+    }
+  }
+
+  /**
+   * MessageInputOptions Builder.
+   */
+  public class MessageInputOptionsBuilder {
+    private Boolean debug;
+    private Boolean restart;
+    private Boolean alternateIntents;
+    private Boolean returnContext;
+
+    private MessageInputOptionsBuilder(MessageInputOptions messageInputOptions) {
+      this.debug = messageInputOptions.debug;
+      this.restart = messageInputOptions.restart;
+      this.alternateIntents = messageInputOptions.alternateIntents;
+      this.returnContext = messageInputOptions.returnContext;
     }
 
     /**
-     * Sets the restart.
-     *
-     * @param restart the new restart
+     * Instantiates a new builder.
      */
-    public void setRestart(final Boolean restart) {
-      this.restart_serialized_name = restart;
+    public MessageInputOptionsBuilder() {
     }
 
     /**
-     * Sets the alternateIntents.
+     * Builds a MessageInputOptions.
      *
-     * @param alternateIntents the new alternateIntents
+     * @return the messageInputOptions
      */
-    public void setAlternateIntents(final Boolean alternateIntents) {
-      this.alternate_intents_serialized_name = alternateIntents;
+    public MessageInputOptions build() {
+      return new MessageInputOptions(this);
     }
 
     /**
-     * Sets the returnContext.
+     * Set the debug.
      *
-     * @param returnContext the new returnContext
+     * @param debug the debug
+     * @return the MessageInputOptions builder
      */
-    public void setReturnContext(final Boolean returnContext) {
-      this.return_context_serialized_name = returnContext;
+    public MessageInputOptionsBuilder setDebug(Boolean debug) {
+      this.debug = debug;
+      return this;
     }
 
+    /**
+     * Set the restart.
+     *
+     * @param restart the restart
+     * @return the MessageInputOptions builder
+     */
+    public MessageInputOptionsBuilder setRestart(Boolean restart) {
+      this.restart = restart;
+      return this;
+    }
+
+    /**
+     * Set the alternateIntents.
+     *
+     * @param alternateIntents the alternateIntents
+     * @return the MessageInputOptions builder
+     */
+    public MessageInputOptionsBuilder setAlternateIntents(Boolean alternateIntents) {
+      this.alternateIntents = alternateIntents;
+      return this;
+    }
+
+    /**
+     * Set the returnContext.
+     *
+     * @param returnContext the returnContext
+     * @return the MessageInputOptions builder
+     */
+    public MessageInputOptionsBuilder setReturnContext(Boolean returnContext) {
+      this.returnContext = returnContext;
+      return this;
+    }
   }
 
   /**
@@ -1972,7 +2543,7 @@ public class IBMAssistantV2Models {
     private String sessionId;
     private MessageInput input;
     private MessageContext context;
- 
+
     /**
      * Gets the assistantId.
      *
@@ -1987,7 +2558,7 @@ public class IBMAssistantV2Models {
     public String assistantId() {
       return assistantId;
     }
- 
+
     /**
      * Gets the sessionId.
      *
@@ -1998,7 +2569,7 @@ public class IBMAssistantV2Models {
     public String sessionId() {
       return sessionId;
     }
- 
+
     /**
      * Gets the input.
      *
@@ -2009,7 +2580,7 @@ public class IBMAssistantV2Models {
     public MessageInput input() {
       return input;
     }
- 
+
     /**
      * Gets the context.
      *
@@ -2041,6 +2612,18 @@ public class IBMAssistantV2Models {
       return new MessageOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('assistantId', 'assistant_id');
+      mapping.put('sessionId', 'session_id');
+      if (input != null) {
+        mapping.putAll(input.getSdkToApiMapping());
+      }
+      if (context != null) {
+        mapping.putAll(context.getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -2147,12 +2730,12 @@ public class IBMAssistantV2Models {
    * Assistant output to be rendered or processed by the client.
    */
   public class MessageOutput extends IBMWatsonGenericModel {
-    private List<DialogRuntimeResponseGeneric> generic_serialized_name;
-    private List<RuntimeIntent> intents_serialized_name;
-    private List<RuntimeEntity> entities_serialized_name;
-    private List<DialogNodeAction> actions_serialized_name;
-    private MessageOutputDebug debug_serialized_name;
-    private IBMWatsonMapModel user_defined_serialized_name;
+    private List<DialogRuntimeResponseGeneric> generic;
+    private List<RuntimeIntent> intents;
+    private List<RuntimeEntity> entities;
+    private List<DialogNodeAction> actions;
+    private MessageOutputDebug debug;
+    private IBMWatsonMapModel userDefined;
  
     /**
      * Gets the generic.
@@ -2164,7 +2747,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<DialogRuntimeResponseGeneric> getGeneric() {
-      return generic_serialized_name;
+      return generic;
     }
  
     /**
@@ -2176,7 +2759,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<RuntimeIntent> getIntents() {
-      return intents_serialized_name;
+      return intents;
     }
  
     /**
@@ -2188,7 +2771,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<RuntimeEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -2200,7 +2783,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<DialogNodeAction> getActions() {
-      return actions_serialized_name;
+      return actions;
     }
  
     /**
@@ -2212,7 +2795,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public MessageOutputDebug getDebug() {
-      return debug_serialized_name;
+      return debug;
     }
  
     /**
@@ -2225,7 +2808,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getUserDefined() {
-      return user_defined_serialized_name;
+      return userDefined;
     }
 
     /**
@@ -2234,7 +2817,7 @@ public class IBMAssistantV2Models {
      * @param generic the new generic
      */
     public void setGeneric(final List<DialogRuntimeResponseGeneric> generic) {
-      this.generic_serialized_name = generic;
+      this.generic = generic;
     }
 
     /**
@@ -2243,7 +2826,7 @@ public class IBMAssistantV2Models {
      * @param intents the new intents
      */
     public void setIntents(final List<RuntimeIntent> intents) {
-      this.intents_serialized_name = intents;
+      this.intents = intents;
     }
 
     /**
@@ -2252,7 +2835,7 @@ public class IBMAssistantV2Models {
      * @param entities the new entities
      */
     public void setEntities(final List<RuntimeEntity> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     /**
@@ -2261,7 +2844,7 @@ public class IBMAssistantV2Models {
      * @param actions the new actions
      */
     public void setActions(final List<DialogNodeAction> actions) {
-      this.actions_serialized_name = actions;
+      this.actions = actions;
     }
 
     /**
@@ -2270,7 +2853,7 @@ public class IBMAssistantV2Models {
      * @param debug the new debug
      */
     public void setDebug(final MessageOutputDebug debug) {
-      this.debug_serialized_name = debug;
+      this.debug = debug;
     }
 
     /**
@@ -2279,7 +2862,7 @@ public class IBMAssistantV2Models {
      * @param userDefined the new userDefined
      */
     public void setUserDefined(final IBMWatsonMapModel userDefined) {
-      this.user_defined_serialized_name = userDefined;
+      this.userDefined = userDefined;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2295,11 +2878,11 @@ public class IBMAssistantV2Models {
       if (deserializedGeneric != null) {
         for (Integer i = 0; i < deserializedGeneric.size(); i++) {
           DialogRuntimeResponseGeneric currentItem = ret.getGeneric().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('generic_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('generic');
           DialogRuntimeResponseGeneric newItem = (DialogRuntimeResponseGeneric) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogRuntimeResponseGeneric.class);
           newGeneric.add(newItem);
         }
-        ret.generic_serialized_name = newGeneric;
+        ret.generic = newGeneric;
       }
 
       // calling custom deserializer for intents
@@ -2308,11 +2891,11 @@ public class IBMAssistantV2Models {
       if (deserializedIntents != null) {
         for (Integer i = 0; i < deserializedIntents.size(); i++) {
           RuntimeIntent currentItem = ret.getIntents().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('intents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('intents');
           RuntimeIntent newItem = (RuntimeIntent) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeIntent.class);
           newIntents.add(newItem);
         }
-        ret.intents_serialized_name = newIntents;
+        ret.intents = newIntents;
       }
 
       // calling custom deserializer for entities
@@ -2321,11 +2904,11 @@ public class IBMAssistantV2Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           RuntimeEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           RuntimeEntity newItem = (RuntimeEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RuntimeEntity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       // calling custom deserializer for actions
@@ -2334,22 +2917,40 @@ public class IBMAssistantV2Models {
       if (deserializedActions != null) {
         for (Integer i = 0; i < deserializedActions.size(); i++) {
           DialogNodeAction currentItem = ret.getActions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('actions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('actions');
           DialogNodeAction newItem = (DialogNodeAction) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodeAction.class);
           newActions.add(newItem);
         }
-        ret.actions_serialized_name = newActions;
+        ret.actions = newActions;
       }
 
       // calling custom deserializer for debug
-      MessageOutputDebug newDebug = (MessageOutputDebug) new MessageOutputDebug().deserialize(JSON.serialize(ret.getDebug()), (Map<String, Object>) jsonMap.get('debug_serialized_name'), MessageOutputDebug.class);
+      MessageOutputDebug newDebug = (MessageOutputDebug) new MessageOutputDebug().deserialize(JSON.serialize(ret.getDebug()), (Map<String, Object>) jsonMap.get('debug'), MessageOutputDebug.class);
       ret.setDebug(newDebug);
 
       // calling custom deserializer for userDefined
-      IBMWatsonMapModel newUserDefined = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getUserDefined()), (Map<String, Object>) jsonMap.get('user_defined_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newUserDefined = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getUserDefined()), (Map<String, Object>) jsonMap.get('userDefined'), IBMWatsonMapModel.class);
       ret.setUserDefined(newUserDefined);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (generic != null && generic[0] != null) {
+        mapping.putAll(generic[0].getApiToSdkMapping());
+      }
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      if (actions != null && actions[0] != null) {
+        mapping.putAll(actions[0].getApiToSdkMapping());
+      }
+      if (debug != null) {
+        mapping.putAll(debug.getApiToSdkMapping());
+      }
+      mapping.put('user_defined', 'userDefined');
+      return mapping;
     }
   }
 
@@ -2357,10 +2958,10 @@ public class IBMAssistantV2Models {
    * Additional detailed information about a message response and how it was generated.
    */
   public class MessageOutputDebug extends IBMWatsonGenericModel {
-    private List<DialogNodesVisited> nodes_visited_serialized_name;
-    private List<DialogLogMessage> log_messages_serialized_name;
-    private Boolean branch_exited_serialized_name;
-    private String branch_exited_reason_serialized_name;
+    private List<DialogNodesVisited> nodesVisited;
+    private List<DialogLogMessage> logMessages;
+    private Boolean branchExited;
+    private String branchExitedReason;
  
     /**
      * Gets the nodesVisited.
@@ -2372,7 +2973,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<DialogNodesVisited> getNodesVisited() {
-      return nodes_visited_serialized_name;
+      return nodesVisited;
     }
  
     /**
@@ -2384,7 +2985,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<DialogLogMessage> getLogMessages() {
-      return log_messages_serialized_name;
+      return logMessages;
     }
  
     /**
@@ -2396,7 +2997,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Boolean getBranchExited() {
-      return branch_exited_serialized_name;
+      return branchExited;
     }
  
     /**
@@ -2409,7 +3010,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getBranchExitedReason() {
-      return branch_exited_reason_serialized_name;
+      return branchExitedReason;
     }
 
     /**
@@ -2418,7 +3019,7 @@ public class IBMAssistantV2Models {
      * @param nodesVisited the new nodesVisited
      */
     public void setNodesVisited(final List<DialogNodesVisited> nodesVisited) {
-      this.nodes_visited_serialized_name = nodesVisited;
+      this.nodesVisited = nodesVisited;
     }
 
     /**
@@ -2427,7 +3028,7 @@ public class IBMAssistantV2Models {
      * @param logMessages the new logMessages
      */
     public void setLogMessages(final List<DialogLogMessage> logMessages) {
-      this.log_messages_serialized_name = logMessages;
+      this.logMessages = logMessages;
     }
 
     /**
@@ -2436,7 +3037,7 @@ public class IBMAssistantV2Models {
      * @param branchExited the new branchExited
      */
     public void setBranchExited(final Boolean branchExited) {
-      this.branch_exited_serialized_name = branchExited;
+      this.branchExited = branchExited;
     }
 
     /**
@@ -2445,7 +3046,7 @@ public class IBMAssistantV2Models {
      * @param branchExitedReason the new branchExitedReason
      */
     public void setBranchExitedReason(final String branchExitedReason) {
-      this.branch_exited_reason_serialized_name = branchExitedReason;
+      this.branchExitedReason = branchExitedReason;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2461,11 +3062,11 @@ public class IBMAssistantV2Models {
       if (deserializedNodesVisited != null) {
         for (Integer i = 0; i < deserializedNodesVisited.size(); i++) {
           DialogNodesVisited currentItem = ret.getNodesVisited().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('nodes_visited_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('nodesVisited');
           DialogNodesVisited newItem = (DialogNodesVisited) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogNodesVisited.class);
           newNodesVisited.add(newItem);
         }
-        ret.nodes_visited_serialized_name = newNodesVisited;
+        ret.nodesVisited = newNodesVisited;
       }
 
       // calling custom deserializer for logMessages
@@ -2474,14 +3075,26 @@ public class IBMAssistantV2Models {
       if (deserializedLogMessages != null) {
         for (Integer i = 0; i < deserializedLogMessages.size(); i++) {
           DialogLogMessage currentItem = ret.getLogMessages().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('log_messages_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('logMessages');
           DialogLogMessage newItem = (DialogLogMessage) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DialogLogMessage.class);
           newLogMessages.add(newItem);
         }
-        ret.log_messages_serialized_name = newLogMessages;
+        ret.logMessages = newLogMessages;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('nodes_visited', 'nodesVisited');
+      if (nodesVisited != null && nodesVisited[0] != null) {
+        mapping.putAll(nodesVisited[0].getApiToSdkMapping());
+      }
+      mapping.put('log_messages', 'logMessages');
+      mapping.put('branch_exited', 'branchExited');
+      mapping.put('branch_exited_reason', 'branchExitedReason');
+      return mapping;
     }
   }
 
@@ -2489,8 +3102,8 @@ public class IBMAssistantV2Models {
    * A response from the Watson Assistant service.
    */
   public class MessageResponse extends IBMWatsonResponseModel {
-    private MessageOutput output_serialized_name;
-    private MessageContext context_serialized_name;
+    private MessageOutput output;
+    private MessageContext context;
  
     /**
      * Gets the output.
@@ -2501,7 +3114,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public MessageOutput getOutput() {
-      return output_serialized_name;
+      return output;
     }
  
     /**
@@ -2516,7 +3129,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public MessageContext getContext() {
-      return context_serialized_name;
+      return context;
     }
 
     /**
@@ -2525,7 +3138,7 @@ public class IBMAssistantV2Models {
      * @param output the new output
      */
     public void setOutput(final MessageOutput output) {
-      this.output_serialized_name = output;
+      this.output = output;
     }
 
     /**
@@ -2534,7 +3147,7 @@ public class IBMAssistantV2Models {
      * @param context the new context
      */
     public void setContext(final MessageContext context) {
-      this.context_serialized_name = context;
+      this.context = context;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2545,14 +3158,25 @@ public class IBMAssistantV2Models {
       MessageResponse ret = (MessageResponse) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for output
-      MessageOutput newOutput = (MessageOutput) new MessageOutput().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output_serialized_name'), MessageOutput.class);
+      MessageOutput newOutput = (MessageOutput) new MessageOutput().deserialize(JSON.serialize(ret.getOutput()), (Map<String, Object>) jsonMap.get('output'), MessageOutput.class);
       ret.setOutput(newOutput);
 
       // calling custom deserializer for context
-      MessageContext newContext = (MessageContext) new MessageContext().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context_serialized_name'), MessageContext.class);
+      MessageContext newContext = (MessageContext) new MessageContext().deserialize(JSON.serialize(ret.getContext()), (Map<String, Object>) jsonMap.get('context'), MessageContext.class);
       ret.setContext(newContext);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (output != null) {
+        mapping.putAll(output.getApiToSdkMapping());
+      }
+      if (context != null) {
+        mapping.putAll(context.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2560,12 +3184,18 @@ public class IBMAssistantV2Models {
    * The entity value that was recognized in the user input.
    */
   public class RuntimeEntity extends IBMWatsonGenericModel {
-    private String entity_serialized_name;
-    private List<Long> location_serialized_name;
-    private String value_serialized_name;
-    private Double confidence_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private List<CaptureGroup> groups_serialized_name;
+    private String entity;
+    private List<Long> location;
+    private String value;
+    private Double confidence;
+    private IBMWatsonMapModel metadata;
+    private List<CaptureGroup> groups;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public RuntimeEntity() { }
  
     /**
      * Gets the entity.
@@ -2576,7 +3206,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getEntity() {
-      return entity_serialized_name;
+      return entity;
     }
  
     /**
@@ -2589,7 +3219,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -2601,7 +3231,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getValue() {
-      return value_serialized_name;
+      return value;
     }
  
     /**
@@ -2613,7 +3243,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
  
     /**
@@ -2625,7 +3255,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
  
     /**
@@ -2637,61 +3267,28 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<CaptureGroup> getGroups() {
-      return groups_serialized_name;
+      return groups;
+    }
+  
+    private RuntimeEntity(RuntimeEntityBuilder builder) {
+      IBMWatsonValidator.notNull(builder.entity, 'entity cannot be null');
+      IBMWatsonValidator.notNull(builder.location, 'location cannot be null');
+      IBMWatsonValidator.notNull(builder.value, 'value cannot be null');
+      this.entity = builder.entity;
+      this.location = builder.location;
+      this.value = builder.value;
+      this.confidence = builder.confidence;
+      this.metadata = builder.metadata;
+      this.groups = builder.groups;
     }
 
     /**
-     * Sets the entity.
+     * New builder.
      *
-     * @param entity the new entity
+     * @return a RuntimeEntity builder
      */
-    public void setEntity(final String entity) {
-      this.entity_serialized_name = entity;
-    }
-
-    /**
-     * Sets the location.
-     *
-     * @param location the new location
-     */
-    public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
-    }
-
-    /**
-     * Sets the value.
-     *
-     * @param value the new value
-     */
-    public void setValue(final String value) {
-      this.value_serialized_name = value;
-    }
-
-    /**
-     * Sets the confidence.
-     *
-     * @param confidence the new confidence
-     */
-    public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
-    }
-
-    /**
-     * Sets the metadata.
-     *
-     * @param metadata the new metadata
-     */
-    public void setMetadata(final IBMWatsonMapModel metadata) {
-      this.metadata_serialized_name = metadata;
-    }
-
-    /**
-     * Sets the groups.
-     *
-     * @param groups the new groups
-     */
-    public void setGroups(final List<CaptureGroup> groups) {
-      this.groups_serialized_name = groups;
+    public RuntimeEntityBuilder newBuilder() {
+      return new RuntimeEntityBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2700,10 +3297,11 @@ public class IBMAssistantV2Models {
       }
 
       RuntimeEntity ret = (RuntimeEntity) super.deserialize(jsonString, jsonMap, classType);
+      RuntimeEntityBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for metadata
-      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), IBMWatsonMapModel.class);
-      ret.setMetadata(newMetadata);
+      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
+      retBuilder.setMetadata(newMetadata);
 
       // calling custom deserializer for groups
       List<CaptureGroup> newGroups = new List<CaptureGroup>();
@@ -2711,14 +3309,177 @@ public class IBMAssistantV2Models {
       if (deserializedGroups != null) {
         for (Integer i = 0; i < deserializedGroups.size(); i++) {
           CaptureGroup currentItem = ret.getGroups().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('groups_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('groups');
           CaptureGroup newItem = (CaptureGroup) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CaptureGroup.class);
           newGroups.add(newItem);
         }
-        ret.groups_serialized_name = newGroups;
+        retBuilder.setGroups(newGroups);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (groups != null && groups[0] != null) {
+        mapping.putAll(groups[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (groups != null && groups[0] != null) {
+        mapping.putAll(groups[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * RuntimeEntity Builder.
+   */
+  public class RuntimeEntityBuilder {
+    private String entity;
+    private List<Long> location;
+    private String value;
+    private Double confidence;
+    private IBMWatsonMapModel metadata;
+    private List<CaptureGroup> groups;
+
+    private RuntimeEntityBuilder(RuntimeEntity runtimeEntity) {
+      this.entity = runtimeEntity.entity;
+      this.location = runtimeEntity.location;
+      this.value = runtimeEntity.value;
+      this.confidence = runtimeEntity.confidence;
+      this.metadata = runtimeEntity.metadata;
+      this.groups = runtimeEntity.groups;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public RuntimeEntityBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param entity the entity
+     * @param location the location
+     * @param value the value
+     */
+    public RuntimeEntityBuilder(String entity, List<Long> location, String value) {
+      this.entity = entity;
+      this.location = location;
+      this.value = value;
+    }
+
+    /**
+     * Builds a RuntimeEntity.
+     *
+     * @return the runtimeEntity
+     */
+    public RuntimeEntity build() {
+      return new RuntimeEntity(this);
+    }
+
+    /**
+     * Adds an location to location.
+     *
+     * @param location the new location
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder addLocation(Long location) {
+      IBMWatsonValidator.notNull(location, 'location cannot be null');
+      if (this.location == null) {
+        this.location = new List<Long>();
+      }
+      this.location.add(location);
+      return this;
+    }
+
+    /**
+     * Adds an groups to groups.
+     *
+     * @param groups the new groups
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder addGroups(CaptureGroup groups) {
+      IBMWatsonValidator.notNull(groups, 'groups cannot be null');
+      if (this.groups == null) {
+        this.groups = new List<CaptureGroup>();
+      }
+      this.groups.add(groups);
+      return this;
+    }
+
+    /**
+     * Set the entity.
+     *
+     * @param entity the entity
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setEntity(String entity) {
+      this.entity = entity;
+      return this;
+    }
+
+    /**
+     * Set the location.
+     * Existing location will be replaced.
+     *
+     * @param location the location
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setLocation(List<Long> location) {
+      this.location = location;
+      return this;
+    }
+
+    /**
+     * Set the value.
+     *
+     * @param value the value
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setValue(String value) {
+      this.value = value;
+      return this;
+    }
+
+    /**
+     * Set the confidence.
+     *
+     * @param confidence the confidence
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setConfidence(Double confidence) {
+      this.confidence = confidence;
+      return this;
+    }
+
+    /**
+     * Set the metadata.
+     *
+     * @param metadata the metadata
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setMetadata(IBMWatsonMapModel metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+
+    /**
+     * Set the groups.
+     * Existing groups will be replaced.
+     *
+     * @param groups the groups
+     * @return the RuntimeEntity builder
+     */
+    public RuntimeEntityBuilder setGroups(List<CaptureGroup> groups) {
+      this.groups = groups;
+      return this;
     }
   }
 
@@ -2726,8 +3487,14 @@ public class IBMAssistantV2Models {
    * An intent identified in the user input.
    */
   public class RuntimeIntent extends IBMWatsonGenericModel {
-    private String intent_serialized_name;
-    private Double confidence_serialized_name;
+    private String intent;
+    private Double confidence;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public RuntimeIntent() { }
  
     /**
      * Gets the intent.
@@ -2738,7 +3505,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getIntent() {
-      return intent_serialized_name;
+      return intent;
     }
  
     /**
@@ -2750,39 +3517,97 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
+    }
+  
+    private RuntimeIntent(RuntimeIntentBuilder builder) {
+      IBMWatsonValidator.notNull(builder.intent, 'intent cannot be null');
+      IBMWatsonValidator.notNull(builder.confidence, 'confidence cannot be null');
+      this.intent = builder.intent;
+      this.confidence = builder.confidence;
     }
 
     /**
-     * Sets the intent.
+     * New builder.
      *
-     * @param intent the new intent
+     * @return a RuntimeIntent builder
      */
-    public void setIntent(final String intent) {
-      this.intent_serialized_name = intent;
+    public RuntimeIntentBuilder newBuilder() {
+      return new RuntimeIntentBuilder(this);
+    }
+  }
+
+  /**
+   * RuntimeIntent Builder.
+   */
+  public class RuntimeIntentBuilder {
+    private String intent;
+    private Double confidence;
+
+    private RuntimeIntentBuilder(RuntimeIntent runtimeIntent) {
+      this.intent = runtimeIntent.intent;
+      this.confidence = runtimeIntent.confidence;
     }
 
     /**
-     * Sets the confidence.
-     *
-     * @param confidence the new confidence
+     * Instantiates a new builder.
      */
-    public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+    public RuntimeIntentBuilder() {
     }
 
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param intent the intent
+     * @param confidence the confidence
+     */
+    public RuntimeIntentBuilder(String intent, Double confidence) {
+      this.intent = intent;
+      this.confidence = confidence;
+    }
+
+    /**
+     * Builds a RuntimeIntent.
+     *
+     * @return the runtimeIntent
+     */
+    public RuntimeIntent build() {
+      return new RuntimeIntent(this);
+    }
+
+    /**
+     * Set the intent.
+     *
+     * @param intent the intent
+     * @return the RuntimeIntent builder
+     */
+    public RuntimeIntentBuilder setIntent(String intent) {
+      this.intent = intent;
+      return this;
+    }
+
+    /**
+     * Set the confidence.
+     *
+     * @param confidence the confidence
+     * @return the RuntimeIntent builder
+     */
+    public RuntimeIntentBuilder setConfidence(Double confidence) {
+      this.confidence = confidence;
+      return this;
+    }
   }
 
   /**
    * SearchResult.
    */
   public class SearchResult extends IBMWatsonGenericModel {
-    private String id_serialized_name;
-    private SearchResultMetadata result_metadata_serialized_name;
-    private String body_serialized_name;
-    private String title_serialized_name;
-    private String url_serialized_name;
-    private SearchResultHighlight highlight_serialized_name;
+    private String id;
+    private SearchResultMetadata resultMetadata;
+    private String body;
+    private String title;
+    private String url;
+    private SearchResultHighlight highlight;
  
     /**
      * Gets the id.
@@ -2796,7 +3621,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getId() {
-      return id_serialized_name;
+      return id;
     }
  
     /**
@@ -2808,7 +3633,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public SearchResultMetadata getResultMetadata() {
-      return result_metadata_serialized_name;
+      return resultMetadata;
     }
  
     /**
@@ -2821,7 +3646,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getBody() {
-      return body_serialized_name;
+      return body;
     }
  
     /**
@@ -2834,7 +3659,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -2846,7 +3671,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
  
     /**
@@ -2859,7 +3684,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public SearchResultHighlight getHighlight() {
-      return highlight_serialized_name;
+      return highlight;
     }
 
     /**
@@ -2868,7 +3693,7 @@ public class IBMAssistantV2Models {
      * @param id the new id
      */
     public void setId(final String id) {
-      this.id_serialized_name = id;
+      this.id = id;
     }
 
     /**
@@ -2877,7 +3702,7 @@ public class IBMAssistantV2Models {
      * @param resultMetadata the new resultMetadata
      */
     public void setResultMetadata(final SearchResultMetadata resultMetadata) {
-      this.result_metadata_serialized_name = resultMetadata;
+      this.resultMetadata = resultMetadata;
     }
 
     /**
@@ -2886,7 +3711,7 @@ public class IBMAssistantV2Models {
      * @param body the new body
      */
     public void setBody(final String body) {
-      this.body_serialized_name = body;
+      this.body = body;
     }
 
     /**
@@ -2895,7 +3720,7 @@ public class IBMAssistantV2Models {
      * @param title the new title
      */
     public void setTitle(final String title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     /**
@@ -2904,7 +3729,7 @@ public class IBMAssistantV2Models {
      * @param url the new url
      */
     public void setUrl(final String url) {
-      this.url_serialized_name = url;
+      this.url = url;
     }
 
     /**
@@ -2913,7 +3738,7 @@ public class IBMAssistantV2Models {
      * @param highlight the new highlight
      */
     public void setHighlight(final SearchResultHighlight highlight) {
-      this.highlight_serialized_name = highlight;
+      this.highlight = highlight;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2924,14 +3749,20 @@ public class IBMAssistantV2Models {
       SearchResult ret = (SearchResult) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for resultMetadata
-      SearchResultMetadata newResultMetadata = (SearchResultMetadata) new SearchResultMetadata().deserialize(JSON.serialize(ret.getResultMetadata()), (Map<String, Object>) jsonMap.get('result_metadata_serialized_name'), SearchResultMetadata.class);
+      SearchResultMetadata newResultMetadata = (SearchResultMetadata) new SearchResultMetadata().deserialize(JSON.serialize(ret.getResultMetadata()), (Map<String, Object>) jsonMap.get('resultMetadata'), SearchResultMetadata.class);
       ret.setResultMetadata(newResultMetadata);
 
       // calling custom deserializer for highlight
-      SearchResultHighlight newHighlight = (SearchResultHighlight) new SearchResultHighlight().deserialize(JSON.serialize(ret.getHighlight()), (Map<String, Object>) jsonMap.get('highlight_serialized_name'), SearchResultHighlight.class);
+      SearchResultHighlight newHighlight = (SearchResultHighlight) new SearchResultHighlight().deserialize(JSON.serialize(ret.getHighlight()), (Map<String, Object>) jsonMap.get('highlight'), SearchResultHighlight.class);
       ret.setHighlight(newHighlight);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('result_metadata', 'resultMetadata');
+      return mapping;
     }
   }
 
@@ -2939,9 +3770,9 @@ public class IBMAssistantV2Models {
    * An object containing segments of text from search results with query-matching text highlighted using HTML <em> tags.
    */
   public class SearchResultHighlight extends IBMWatsonDynamicModel {
-    private List<String> body_serialized_name;
-    private List<String> title_serialized_name;
-    private List<String> url_serialized_name;
+    private List<String> body;
+    private List<String> title;
+    private List<String> url;
     private Map<String, Object> additional_properties_serialized_name;
 
     /**
@@ -2951,7 +3782,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<String> getBody() {
-      return body_serialized_name;
+      return body;
     }
 
     /**
@@ -2961,7 +3792,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<String> getTitle() {
-      return title_serialized_name;
+      return title;
     }
 
     /**
@@ -2971,7 +3802,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public List<String> getUrl() {
-      return url_serialized_name;
+      return url;
     }
 
     /**
@@ -2990,7 +3821,7 @@ public class IBMAssistantV2Models {
      * @param body the new body
      */
     public void setBody(final List<String> body) {
-      this.body_serialized_name = body;
+      this.body = body;
     }
 
     /**
@@ -2999,7 +3830,7 @@ public class IBMAssistantV2Models {
      * @param title the new title
      */
     public void setTitle(final List<String> title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     /**
@@ -3008,7 +3839,7 @@ public class IBMAssistantV2Models {
      * @param url the new url
      */
     public void setUrl(final List<String> url) {
-      this.url_serialized_name = url;
+      this.url = url;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3034,8 +3865,8 @@ public class IBMAssistantV2Models {
    * An object containing search result metadata from the Discovery service.
    */
   public class SearchResultMetadata extends IBMWatsonGenericModel {
-    private Double confidence_serialized_name;
-    private Double score_serialized_name;
+    private Double confidence;
+    private Double score;
  
     /**
      * Gets the confidence.
@@ -3047,7 +3878,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
  
     /**
@@ -3060,7 +3891,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
 
     /**
@@ -3069,7 +3900,7 @@ public class IBMAssistantV2Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
 
     /**
@@ -3078,16 +3909,15 @@ public class IBMAssistantV2Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
-
   }
 
   /**
    * SessionResponse.
    */
   public class SessionResponse extends IBMWatsonResponseModel {
-    private String session_id_serialized_name;
+    private String sessionId;
  
     /**
      * Gets the sessionId.
@@ -3098,7 +3928,7 @@ public class IBMAssistantV2Models {
      */
     @AuraEnabled
     public String getSessionId() {
-      return session_id_serialized_name;
+      return sessionId;
     }
 
     /**
@@ -3107,9 +3937,14 @@ public class IBMAssistantV2Models {
      * @param sessionId the new sessionId
      */
     public void setSessionId(final String sessionId) {
-      this.session_id_serialized_name = sessionId;
+      this.sessionId = sessionId;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('session_id', 'sessionId');
+      return mapping;
+    }
   }
 
 }

--- a/force-app/main/default/classes/IBMAssistantV2Test.cls
+++ b/force-app/main/default/classes/IBMAssistantV2Test.cls
@@ -77,9 +77,10 @@ private class IBMAssistantV2Test {
   static testMethod void testCaptureGroup() {
     Test.startTest();
 
-    IBMAssistantV2Models.CaptureGroup captureGroup = new IBMAssistantV2Models.CaptureGroup();
-    captureGroup.setXgroup(GROUP_STR);
-    captureGroup.setLocation(LOCATION);
+    IBMAssistantV2Models.CaptureGroup captureGroup = new IBMAssistantV2Models.CaptureGroupBuilder()
+      .xgroup(GROUP_STR)
+      .location(LOCATION)
+      .build();
 
     System.assertEquals(GROUP_STR, captureGroup.getXgroup());
     System.assertEquals(LOCATION, captureGroup.getLocation());
@@ -115,10 +116,11 @@ private class IBMAssistantV2Test {
   static testMethod void testMessageContextGlobalSystem() {
     Test.startTest();
 
-    IBMAssistantV2Models.MessageContextGlobalSystem messageContextGlobalSystem = new IBMAssistantV2Models.MessageContextGlobalSystem();
-    messageContextGlobalSystem.setTimezone(TIMEZONE);
-    messageContextGlobalSystem.setTurnCount(TURN_COUNT);
-    messageContextGlobalSystem.setUserId(USER_ID);
+    IBMAssistantV2Models.MessageContextGlobalSystem messageContextGlobalSystem = new IBMAssistantV2Models.MessageContextGlobalSystemBuilder()
+      .timezone(TIMEZONE)
+      .turnCount(TURN_COUNT)
+      .userId(USER_ID)
+      .build();
 
     System.assertEquals(TIMEZONE, messageContextGlobalSystem.getTimezone());
     System.assertEquals(TURN_COUNT, messageContextGlobalSystem.getTurnCount());
@@ -131,8 +133,9 @@ private class IBMAssistantV2Test {
 
     IBMAssistantV2Models.MessageContextGlobalSystem messageContextGlobalSystem = new IBMAssistantV2Models.MessageContextGlobalSystem();
 
-    IBMAssistantV2Models.MessageContextGlobal messageContextGlobal = new IBMAssistantV2Models.MessageContextGlobal();
-    messageContextGlobal.setXsystem(messageContextGlobalSystem);
+    IBMAssistantV2Models.MessageContextGlobal messageContextGlobal = new IBMAssistantV2Models.MessageContextGlobalBuilder()
+      .xsystem(messageContextGlobalSystem)
+      .build();
 
     System.assertEquals(messageContextGlobalSystem, messageContextGlobal.getXsystem());
     Test.stopTest();
@@ -144,9 +147,10 @@ private class IBMAssistantV2Test {
     IBMAssistantV2Models.MessageContextGlobal messageContextGlobal = new IBMAssistantV2Models.MessageContextGlobal();
     IBMAssistantV2Models.MessageContextSkills messageContextSkills = new IBMAssistantV2Models.MessageContextSkills();
 
-    IBMAssistantV2Models.MessageContext messageContext = new IBMAssistantV2Models.MessageContext();
-    messageContext.setXglobal(messageContextGlobal);
-    messageContext.setSkills(messageContextSkills);
+    IBMAssistantV2Models.MessageContext messageContext = new IBMAssistantV2Models.MessageContextBuilder()
+      .xglobal(messageContextGlobal)
+      .skills(messageContextSkills)
+      .build();
 
     System.assertEquals(messageContextGlobal, messageContext.getXglobal());
     System.assertEquals(messageContextSkills, messageContext.getSkills());
@@ -156,22 +160,26 @@ private class IBMAssistantV2Test {
   static testMethod void testMessageInput() {
     Test.startTest();
 
-    IBMAssistantV2Models.RuntimeEntity entity1 = new IBMAssistantV2Models.RuntimeEntity();
-    entity1.setEntity(ENTITY);
-    entity1.setLocation(LOCATION);
-    entity1.setValue(VALUE);
-    IBMAssistantV2Models.RuntimeEntity entity2 = new IBMAssistantV2Models.RuntimeEntity();
-    entity2.setEntity(ENTITY);
-    entity2.setLocation(LOCATION);
-    entity2.setValue(VALUE);
+    IBMAssistantV2Models.RuntimeEntity entity1 = new IBMAssistantV2Models.RuntimeEntityBuilder()
+      .entity(ENTITY)
+      .location(LOCATION)
+      .value(VALUE)
+      .build();
+    IBMAssistantV2Models.RuntimeEntity entity2 = new IBMAssistantV2Models.RuntimeEntityBuilder()
+      .entity(ENTITY)
+      .location(LOCATION)
+      .value(VALUE)
+      .build();
     List<IBMAssistantV2Models.RuntimeEntity> entityList = new List<IBMAssistantV2Models.RuntimeEntity>();
     entityList.add(entity1);
-    IBMAssistantV2Models.RuntimeIntent intent1 = new IBMAssistantV2Models.RuntimeIntent();
-    intent1.setConfidence(CONFIDENCE);
-    intent1.setIntent(INTENT);
-    IBMAssistantV2Models.RuntimeIntent intent2 = new IBMAssistantV2Models.RuntimeIntent();
-    intent2.setConfidence(CONFIDENCE);
-    intent2.setIntent(INTENT);
+    IBMAssistantV2Models.RuntimeIntent intent1 = new IBMAssistantV2Models.RuntimeIntentBuilder()
+      .confidence(CONFIDENCE)
+      .intent(INTENT)
+      .build();
+    IBMAssistantV2Models.RuntimeIntent intent2 = new IBMAssistantV2Models.RuntimeIntentBuilder()
+      .confidence(CONFIDENCE)
+      .intent(INTENT)
+      .build();
     List<IBMAssistantV2Models.RuntimeIntent> intentList = new List<IBMAssistantV2Models.RuntimeIntent>();
     intentList.add(intent1);
     IBMAssistantV2Models.MessageInputOptions inputOptions = new IBMAssistantV2Models.MessageInputOptions();
@@ -202,11 +210,12 @@ private class IBMAssistantV2Test {
   static testMethod void testMessageInputOptions() {
     Test.startTest();
 
-    IBMAssistantV2Models.MessageInputOptions inputOptions = new IBMAssistantV2Models.MessageInputOptions();
-    inputOptions.setAlternateIntents(true);
-    inputOptions.setDebug(true);
-    inputOptions.setRestart(true);
-    inputOptions.setReturnContext(true);
+    IBMAssistantV2Models.MessageInputOptions inputOptions = new IBMAssistantV2Models.MessageInputOptionsBuilder()
+      .alternateIntents(true)
+      .debug(true)
+      .restart(true)
+      .returnContext(true)
+      .build();
 
     System.assert(inputOptions.getAlternateIntents());
     System.assert(inputOptions.getDebug());
@@ -239,17 +248,18 @@ private class IBMAssistantV2Test {
   static testMethod void testRuntimeEntity() {
     Test.startTest();
 
-    IBMAssistantV2Models.CaptureGroup captureGroup = new IBMAssistantV2Models.CaptureGroup();
-    captureGroup.setXgroup(GROUP_STR);
+    IBMAssistantV2Models.CaptureGroup captureGroup = new IBMAssistantV2Models.CaptureGroupBuilder()
+      .xgroup(GROUP_STR)
+      .build();
     List<IBMAssistantV2Models.CaptureGroup> captureGroupList = new List<IBMAssistantV2Models.CaptureGroup> { captureGroup };
-
-    IBMAssistantV2Models.RuntimeEntity runtimeEntity = new IBMAssistantV2Models.RuntimeEntity();
-    runtimeEntity.setConfidence(CONFIDENCE);
-    runtimeEntity.setEntity(ENTITY);
-    runtimeEntity.setGroups(captureGroupList);
-    runtimeEntity.setLocation(LOCATION);
-    runtimeEntity.setMetadata(KEY_VAL);
-    runtimeEntity.setValue(VALUE);
+    IBMAssistantV2Models.RuntimeEntity runtimeEntity = new IBMAssistantV2Models.RuntimeEntityBuilder()
+      .confidence(CONFIDENCE)
+      .entity(ENTITY)
+      .groups(captureGroupList)
+      .location(LOCATION)
+      .metadata(KEY_VAL)
+      .value(VALUE)
+      .build();
 
     System.assertEquals(CONFIDENCE, runtimeEntity.getConfidence());
     System.assertEquals(ENTITY, runtimeEntity.getEntity());
@@ -263,9 +273,10 @@ private class IBMAssistantV2Test {
   static testMethod void testRuntimeIntent() {
     Test.startTest();
 
-    IBMAssistantV2Models.RuntimeIntent runtimeIntent = new IBMAssistantV2Models.RuntimeIntent();
-    runtimeIntent.setConfidence(CONFIDENCE);
-    runtimeIntent.setIntent(INTENT);
+    IBMAssistantV2Models.RuntimeIntent runtimeIntent = new IBMAssistantV2Models.RuntimeIntentBuilder()
+      .confidence(CONFIDENCE)
+      .intent(INTENT)
+      .build();
 
     System.assertEquals(CONFIDENCE, runtimeIntent.getConfidence());
     System.assertEquals(INTENT, runtimeIntent.getIntent());

--- a/force-app/main/default/classes/IBMCompareComplyV1.cls
+++ b/force-app/main/default/classes/IBMCompareComplyV1.cls
@@ -222,7 +222,7 @@ public class IBMCompareComplyV1 extends IBMWatsonService {
     if (addFeedbackOptions.comment() != null) {
       contentJson.put('comment', addFeedbackOptions.comment());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, addFeedbackOptions.getSdkToApiMapping()));
 
     return (IBMCompareComplyV1Models.FeedbackReturn) createServiceCall(builder.build(), IBMCompareComplyV1Models.FeedbackReturn.class);
   }

--- a/force-app/main/default/classes/IBMCompareComplyV1Models.cls
+++ b/force-app/main/default/classes/IBMCompareComplyV1Models.cls
@@ -61,7 +61,7 @@ public class IBMCompareComplyV1Models {
       Map<String, String> mapping = new Map<String, String>();
       mapping.put('feedbackData', 'feedback_data');
       if (feedbackData != null) {
-        mapping.putAll(feedbackData.getSdkToApiMapping());
+        mapping.putAll(feedbackData.addToSdkToApiMapping('', mapping));
       }
       mapping.put('userId', 'user_id');
       return mapping;
@@ -159,7 +159,7 @@ public class IBMCompareComplyV1Models {
   public class Address extends IBMWatsonGenericModel {
     private String text;
     private Location location;
- 
+
     /**
      * Gets the text.
      *
@@ -171,7 +171,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -217,11 +217,8 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -234,7 +231,7 @@ public class IBMCompareComplyV1Models {
     private Boolean identicalText;
     private List<String> provenanceIds;
     private Boolean significantElements;
- 
+
     /**
      * Gets the elementPair.
      *
@@ -246,7 +243,7 @@ public class IBMCompareComplyV1Models {
     public List<ElementPair> getElementPair() {
       return elementPair;
     }
- 
+
     /**
      * Gets the identicalText.
      *
@@ -260,11 +257,11 @@ public class IBMCompareComplyV1Models {
     public Boolean getIdenticalText() {
       return identicalText;
     }
- 
+
     /**
      * Gets the provenanceIds.
      *
-     * One or more hashed values that you can send to IBM to provide feedback or receive support.
+     * Hashed values that you can send to IBM to provide feedback or receive support.
      *
      * @return the provenanceIds
      */
@@ -272,7 +269,7 @@ public class IBMCompareComplyV1Models {
     public List<String> getProvenanceIds() {
       return provenanceIds;
     }
- 
+
     /**
      * Gets the significantElements.
      *
@@ -344,15 +341,16 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('element_pair', 'elementPair');
-      if (elementPair != null && elementPair[0] != null) {
-        mapping.putAll(elementPair[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('identical_text', 'identicalText');
-      mapping.put('provenance_ids', 'provenanceIds');
-      mapping.put('significant_elements', 'significantElements');
+      mapping.put(parentLabel + 'element_pair', 'elementPair');
+      mapping.putAll(((IBMWatsonGenericModel) ElementPair.class.newInstance()).addToApiToSdkMapping(parentLabel + 'element_pair/', mapping));
+      mapping.put(parentLabel + 'identical_text', 'identicalText');
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
+      mapping.put(parentLabel + 'significant_elements', 'significantElements');
       return mapping;
     }
   }
@@ -364,7 +362,7 @@ public class IBMCompareComplyV1Models {
     private String xtype;
     private String text;
     private Location location;
- 
+
     /**
      * Gets the xtype.
      *
@@ -376,7 +374,7 @@ public class IBMCompareComplyV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -388,7 +386,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -443,12 +441,13 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'type', 'xtype');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -467,7 +466,7 @@ public class IBMCompareComplyV1Models {
     private String status;
     private Datetime created;
     private Datetime updated;
- 
+
     /**
      * Gets the function.
      *
@@ -480,7 +479,7 @@ public class IBMCompareComplyV1Models {
     public String getFunction() {
       return function;
     }
- 
+
     /**
      * Gets the inputBucketLocation.
      *
@@ -493,7 +492,7 @@ public class IBMCompareComplyV1Models {
     public String getInputBucketLocation() {
       return inputBucketLocation;
     }
- 
+
     /**
      * Gets the inputBucketName.
      *
@@ -505,7 +504,7 @@ public class IBMCompareComplyV1Models {
     public String getInputBucketName() {
       return inputBucketName;
     }
- 
+
     /**
      * Gets the outputBucketLocation.
      *
@@ -518,7 +517,7 @@ public class IBMCompareComplyV1Models {
     public String getOutputBucketLocation() {
       return outputBucketLocation;
     }
- 
+
     /**
      * Gets the outputBucketName.
      *
@@ -530,7 +529,7 @@ public class IBMCompareComplyV1Models {
     public String getOutputBucketName() {
       return outputBucketName;
     }
- 
+
     /**
      * Gets the batchId.
      *
@@ -542,7 +541,7 @@ public class IBMCompareComplyV1Models {
     public String getBatchId() {
       return batchId;
     }
- 
+
     /**
      * Gets the documentCounts.
      *
@@ -554,7 +553,7 @@ public class IBMCompareComplyV1Models {
     public DocCounts getDocumentCounts() {
       return documentCounts;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -566,7 +565,7 @@ public class IBMCompareComplyV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -578,7 +577,7 @@ public class IBMCompareComplyV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -695,14 +694,13 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('input_bucket_location', 'inputBucketLocation');
-      mapping.put('input_bucket_name', 'inputBucketName');
-      mapping.put('output_bucket_location', 'outputBucketLocation');
-      mapping.put('output_bucket_name', 'outputBucketName');
-      mapping.put('batch_id', 'batchId');
-      mapping.put('document_counts', 'documentCounts');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'input_bucket_location', 'inputBucketLocation');
+      mapping.put(parentLabel + 'input_bucket_name', 'inputBucketName');
+      mapping.put(parentLabel + 'output_bucket_location', 'outputBucketLocation');
+      mapping.put(parentLabel + 'output_bucket_name', 'outputBucketName');
+      mapping.put(parentLabel + 'batch_id', 'batchId');
+      mapping.put(parentLabel + 'document_counts', 'documentCounts');
       return mapping;
     }
   }
@@ -712,7 +710,7 @@ public class IBMCompareComplyV1Models {
    */
   public class Batches extends IBMWatsonResponseModel {
     private List<BatchStatus> batches;
- 
+
     /**
      * Gets the batches.
      *
@@ -757,11 +755,8 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (batches != null && batches[0] != null) {
-        mapping.putAll(batches[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) BatchStatus.class.newInstance()).addToApiToSdkMapping(parentLabel + 'batches/', mapping));
       return mapping;
     }
   }
@@ -784,7 +779,7 @@ public class IBMCompareComplyV1Models {
     private List<ColumnHeaderTexts> columnHeaderTexts;
     private List<ColumnHeaderTextsNormalized> columnHeaderTextsNormalized;
     private List<Attribute> attributes;
- 
+
     /**
      * Gets the cellId.
      *
@@ -796,7 +791,7 @@ public class IBMCompareComplyV1Models {
     public String getCellId() {
       return cellId;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -809,7 +804,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -821,7 +816,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the rowIndexBegin.
      *
@@ -833,7 +828,7 @@ public class IBMCompareComplyV1Models {
     public Long getRowIndexBegin() {
       return rowIndexBegin;
     }
- 
+
     /**
      * Gets the rowIndexEnd.
      *
@@ -845,7 +840,7 @@ public class IBMCompareComplyV1Models {
     public Long getRowIndexEnd() {
       return rowIndexEnd;
     }
- 
+
     /**
      * Gets the columnIndexBegin.
      *
@@ -857,7 +852,7 @@ public class IBMCompareComplyV1Models {
     public Long getColumnIndexBegin() {
       return columnIndexBegin;
     }
- 
+
     /**
      * Gets the columnIndexEnd.
      *
@@ -869,7 +864,7 @@ public class IBMCompareComplyV1Models {
     public Long getColumnIndexEnd() {
       return columnIndexEnd;
     }
- 
+
     /**
      * Gets the rowHeaderIds.
      *
@@ -879,7 +874,7 @@ public class IBMCompareComplyV1Models {
     public List<RowHeaderIds> getRowHeaderIds() {
       return rowHeaderIds;
     }
- 
+
     /**
      * Gets the rowHeaderTexts.
      *
@@ -889,7 +884,7 @@ public class IBMCompareComplyV1Models {
     public List<RowHeaderTexts> getRowHeaderTexts() {
       return rowHeaderTexts;
     }
- 
+
     /**
      * Gets the rowHeaderTextsNormalized.
      *
@@ -899,7 +894,7 @@ public class IBMCompareComplyV1Models {
     public List<RowHeaderTextsNormalized> getRowHeaderTextsNormalized() {
       return rowHeaderTextsNormalized;
     }
- 
+
     /**
      * Gets the columnHeaderIds.
      *
@@ -909,7 +904,7 @@ public class IBMCompareComplyV1Models {
     public List<ColumnHeaderIds> getColumnHeaderIds() {
       return columnHeaderIds;
     }
- 
+
     /**
      * Gets the columnHeaderTexts.
      *
@@ -919,7 +914,7 @@ public class IBMCompareComplyV1Models {
     public List<ColumnHeaderTexts> getColumnHeaderTexts() {
       return columnHeaderTexts;
     }
- 
+
     /**
      * Gets the columnHeaderTextsNormalized.
      *
@@ -929,7 +924,7 @@ public class IBMCompareComplyV1Models {
     public List<ColumnHeaderTextsNormalized> getColumnHeaderTextsNormalized() {
       return columnHeaderTextsNormalized;
     }
- 
+
     /**
      * Gets the attributes.
      *
@@ -1171,31 +1166,26 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('cell_id', 'cellId');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('row_index_begin', 'rowIndexBegin');
-      mapping.put('row_index_end', 'rowIndexEnd');
-      mapping.put('column_index_begin', 'columnIndexBegin');
-      mapping.put('column_index_end', 'columnIndexEnd');
-      mapping.put('row_header_ids', 'rowHeaderIds');
-      mapping.put('row_header_texts', 'rowHeaderTexts');
-      mapping.put('row_header_texts_normalized', 'rowHeaderTextsNormalized');
-      if (rowHeaderTextsNormalized != null && rowHeaderTextsNormalized[0] != null) {
-        mapping.putAll(rowHeaderTextsNormalized[0].getApiToSdkMapping());
-      }
-      mapping.put('column_header_ids', 'columnHeaderIds');
-      mapping.put('column_header_texts', 'columnHeaderTexts');
-      mapping.put('column_header_texts_normalized', 'columnHeaderTextsNormalized');
-      if (columnHeaderTextsNormalized != null && columnHeaderTextsNormalized[0] != null) {
-        mapping.putAll(columnHeaderTextsNormalized[0].getApiToSdkMapping());
-      }
-      if (attributes != null && attributes[0] != null) {
-        mapping.putAll(attributes[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'cell_id', 'cellId');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      mapping.put(parentLabel + 'row_index_begin', 'rowIndexBegin');
+      mapping.put(parentLabel + 'row_index_end', 'rowIndexEnd');
+      mapping.put(parentLabel + 'column_index_begin', 'columnIndexBegin');
+      mapping.put(parentLabel + 'column_index_end', 'columnIndexEnd');
+      mapping.put(parentLabel + 'row_header_ids', 'rowHeaderIds');
+      mapping.put(parentLabel + 'row_header_texts', 'rowHeaderTexts');
+      mapping.put(parentLabel + 'row_header_texts_normalized', 'rowHeaderTextsNormalized');
+      mapping.putAll(((IBMWatsonGenericModel) RowHeaderTextsNormalized.class.newInstance()).addToApiToSdkMapping(parentLabel + 'row_header_texts_normalized/', mapping));
+      mapping.put(parentLabel + 'column_header_ids', 'columnHeaderIds');
+      mapping.put(parentLabel + 'column_header_texts', 'columnHeaderTexts');
+      mapping.put(parentLabel + 'column_header_texts_normalized', 'columnHeaderTextsNormalized');
+      mapping.putAll(((IBMWatsonGenericModel) ColumnHeaderTextsNormalized.class.newInstance()).addToApiToSdkMapping(parentLabel + 'column_header_texts_normalized/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Attribute.class.newInstance()).addToApiToSdkMapping(parentLabel + 'attributes/', mapping));
       return mapping;
     }
   }
@@ -1212,7 +1202,7 @@ public class IBMCompareComplyV1Models {
      * and should not be called by the client.
      */
     public Category() { }
- 
+
     /**
      * Gets the label.
      *
@@ -1224,11 +1214,11 @@ public class IBMCompareComplyV1Models {
     public String getLabel() {
       return label;
     }
- 
+
     /**
      * Gets the provenanceIds.
      *
-     * One or more hashed values that you can send to IBM to provide feedback or receive support.
+     * Hashed values that you can send to IBM to provide feedback or receive support.
      *
      * @return the provenanceIds
      */
@@ -1251,15 +1241,13 @@ public class IBMCompareComplyV1Models {
       return new CategoryBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('provenanceIds', 'provenance_ids');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'provenanceIds', 'provenance_ids');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('provenance_ids', 'provenanceIds');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
       return mapping;
     }
   }
@@ -1312,7 +1300,7 @@ public class IBMCompareComplyV1Models {
      * @param label the label
      * @return the Category builder
      */
-    public CategoryBuilder setLabel(String label) {
+    public CategoryBuilder label(String label) {
       this.label = label;
       return this;
     }
@@ -1324,7 +1312,7 @@ public class IBMCompareComplyV1Models {
      * @param provenanceIds the provenanceIds
      * @return the Category builder
      */
-    public CategoryBuilder setProvenanceIds(List<String> provenanceIds) {
+    public CategoryBuilder provenanceIds(List<String> provenanceIds) {
       this.provenanceIds = provenanceIds;
       return this;
     }
@@ -1335,7 +1323,7 @@ public class IBMCompareComplyV1Models {
    */
   public class CategoryComparison extends IBMWatsonGenericModel {
     private String label;
- 
+
     /**
      * Gets the label.
      *
@@ -1524,10 +1512,11 @@ public class IBMCompareComplyV1Models {
     private List<ContractTypes> contractTypes;
     private List<ContractTerms> contractTerms;
     private List<PaymentTerms> paymentTerms;
+    private List<ContractCurrencies> contractCurrencies;
     private List<Tables> tables;
     private DocStructure documentStructure;
     private List<Parties> parties;
- 
+
     /**
      * Gets the document.
      *
@@ -1539,7 +1528,7 @@ public class IBMCompareComplyV1Models {
     public Document getDocument() {
       return document;
     }
- 
+
     /**
      * Gets the modelId.
      *
@@ -1552,7 +1541,7 @@ public class IBMCompareComplyV1Models {
     public String getModelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the modelVersion.
      *
@@ -1564,7 +1553,7 @@ public class IBMCompareComplyV1Models {
     public String getModelVersion() {
       return modelVersion;
     }
- 
+
     /**
      * Gets the elements.
      *
@@ -1576,7 +1565,7 @@ public class IBMCompareComplyV1Models {
     public List<Element> getElements() {
       return elements;
     }
- 
+
     /**
      * Gets the effectiveDates.
      *
@@ -1588,7 +1577,7 @@ public class IBMCompareComplyV1Models {
     public List<EffectiveDates> getEffectiveDates() {
       return effectiveDates;
     }
- 
+
     /**
      * Gets the contractAmounts.
      *
@@ -1601,11 +1590,11 @@ public class IBMCompareComplyV1Models {
     public List<ContractAmts> getContractAmounts() {
       return contractAmounts;
     }
- 
+
     /**
      * Gets the terminationDates.
      *
-     * The date or dates on which the document is to be terminated.
+     * The dates on which the document is to be terminated.
      *
      * @return the terminationDates
      */
@@ -1613,11 +1602,11 @@ public class IBMCompareComplyV1Models {
     public List<TerminationDates> getTerminationDates() {
       return terminationDates;
     }
- 
+
     /**
      * Gets the contractTypes.
      *
-     * The document's contract type or types as declared in the document.
+     * The contract type as declared in the document.
      *
      * @return the contractTypes
      */
@@ -1625,11 +1614,11 @@ public class IBMCompareComplyV1Models {
     public List<ContractTypes> getContractTypes() {
       return contractTypes;
     }
- 
+
     /**
      * Gets the contractTerms.
      *
-     * The duration or durations of the contract.
+     * The durations of the contract.
      *
      * @return the contractTerms
      */
@@ -1637,11 +1626,11 @@ public class IBMCompareComplyV1Models {
     public List<ContractTerms> getContractTerms() {
       return contractTerms;
     }
- 
+
     /**
      * Gets the paymentTerms.
      *
-     * The document's payment duration or durations.
+     * The document's payment durations.
      *
      * @return the paymentTerms
      */
@@ -1649,7 +1638,19 @@ public class IBMCompareComplyV1Models {
     public List<PaymentTerms> getPaymentTerms() {
       return paymentTerms;
     }
- 
+
+    /**
+     * Gets the contractCurrencies.
+     *
+     * The contract currencies as declared in the document.
+     *
+     * @return the contractCurrencies
+     */
+    @AuraEnabled
+    public List<ContractCurrencies> getContractCurrencies() {
+      return contractCurrencies;
+    }
+
     /**
      * Gets the tables.
      *
@@ -1661,7 +1662,7 @@ public class IBMCompareComplyV1Models {
     public List<Tables> getTables() {
       return tables;
     }
- 
+
     /**
      * Gets the documentStructure.
      *
@@ -1673,7 +1674,7 @@ public class IBMCompareComplyV1Models {
     public DocStructure getDocumentStructure() {
       return documentStructure;
     }
- 
+
     /**
      * Gets the parties.
      *
@@ -1774,6 +1775,15 @@ public class IBMCompareComplyV1Models {
      */
     public void setPaymentTerms(final List<PaymentTerms> paymentTerms) {
       this.paymentTerms = paymentTerms;
+    }
+
+    /**
+     * Sets the contractCurrencies.
+     *
+     * @param contractCurrencies the new contractCurrencies
+     */
+    public void setContractCurrencies(final List<ContractCurrencies> contractCurrencies) {
+      this.contractCurrencies = contractCurrencies;
     }
 
     /**
@@ -1905,6 +1915,19 @@ public class IBMCompareComplyV1Models {
         ret.paymentTerms = newPaymentTerms;
       }
 
+      // calling custom deserializer for contractCurrencies
+      List<ContractCurrencies> newContractCurrencies = new List<ContractCurrencies>();
+      List<ContractCurrencies> deserializedContractCurrencies = ret.getContractCurrencies();
+      if (deserializedContractCurrencies != null) {
+        for (Integer i = 0; i < deserializedContractCurrencies.size(); i++) {
+          ContractCurrencies currentItem = ret.getContractCurrencies().get(i);
+          List<Object> itemInMap = (List<Object>) jsonMap.get('contractCurrencies');
+          ContractCurrencies newItem = (ContractCurrencies) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ContractCurrencies.class);
+          newContractCurrencies.add(newItem);
+        }
+        ret.contractCurrencies = newContractCurrencies;
+      }
+
       // calling custom deserializer for tables
       List<Tables> newTables = new List<Tables>();
       List<Tables> deserializedTables = ret.getTables();
@@ -1938,47 +1961,28 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('model_id', 'modelId');
-      mapping.put('model_version', 'modelVersion');
-      if (elements != null && elements[0] != null) {
-        mapping.putAll(elements[0].getApiToSdkMapping());
-      }
-      mapping.put('effective_dates', 'effectiveDates');
-      if (effectiveDates != null && effectiveDates[0] != null) {
-        mapping.putAll(effectiveDates[0].getApiToSdkMapping());
-      }
-      mapping.put('contract_amounts', 'contractAmounts');
-      if (contractAmounts != null && contractAmounts[0] != null) {
-        mapping.putAll(contractAmounts[0].getApiToSdkMapping());
-      }
-      mapping.put('termination_dates', 'terminationDates');
-      if (terminationDates != null && terminationDates[0] != null) {
-        mapping.putAll(terminationDates[0].getApiToSdkMapping());
-      }
-      mapping.put('contract_types', 'contractTypes');
-      if (contractTypes != null && contractTypes[0] != null) {
-        mapping.putAll(contractTypes[0].getApiToSdkMapping());
-      }
-      mapping.put('contract_terms', 'contractTerms');
-      if (contractTerms != null && contractTerms[0] != null) {
-        mapping.putAll(contractTerms[0].getApiToSdkMapping());
-      }
-      mapping.put('payment_terms', 'paymentTerms');
-      if (paymentTerms != null && paymentTerms[0] != null) {
-        mapping.putAll(paymentTerms[0].getApiToSdkMapping());
-      }
-      if (tables != null && tables[0] != null) {
-        mapping.putAll(tables[0].getApiToSdkMapping());
-      }
-      mapping.put('document_structure', 'documentStructure');
-      if (documentStructure != null) {
-        mapping.putAll(documentStructure.getApiToSdkMapping());
-      }
-      if (parties != null && parties[0] != null) {
-        mapping.putAll(parties[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'model_id', 'modelId');
+      mapping.put(parentLabel + 'model_version', 'modelVersion');
+      mapping.putAll(((IBMWatsonGenericModel) Element.class.newInstance()).addToApiToSdkMapping(parentLabel + 'elements/', mapping));
+      mapping.put(parentLabel + 'effective_dates', 'effectiveDates');
+      mapping.putAll(((IBMWatsonGenericModel) EffectiveDates.class.newInstance()).addToApiToSdkMapping(parentLabel + 'effective_dates/', mapping));
+      mapping.put(parentLabel + 'contract_amounts', 'contractAmounts');
+      mapping.putAll(((IBMWatsonGenericModel) ContractAmts.class.newInstance()).addToApiToSdkMapping(parentLabel + 'contract_amounts/', mapping));
+      mapping.put(parentLabel + 'termination_dates', 'terminationDates');
+      mapping.putAll(((IBMWatsonGenericModel) TerminationDates.class.newInstance()).addToApiToSdkMapping(parentLabel + 'termination_dates/', mapping));
+      mapping.put(parentLabel + 'contract_types', 'contractTypes');
+      mapping.putAll(((IBMWatsonGenericModel) ContractTypes.class.newInstance()).addToApiToSdkMapping(parentLabel + 'contract_types/', mapping));
+      mapping.put(parentLabel + 'contract_terms', 'contractTerms');
+      mapping.putAll(((IBMWatsonGenericModel) ContractTerms.class.newInstance()).addToApiToSdkMapping(parentLabel + 'contract_terms/', mapping));
+      mapping.put(parentLabel + 'payment_terms', 'paymentTerms');
+      mapping.putAll(((IBMWatsonGenericModel) PaymentTerms.class.newInstance()).addToApiToSdkMapping(parentLabel + 'payment_terms/', mapping));
+      mapping.put(parentLabel + 'contract_currencies', 'contractCurrencies');
+      mapping.putAll(((IBMWatsonGenericModel) ContractCurrencies.class.newInstance()).addToApiToSdkMapping(parentLabel + 'contract_currencies/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Tables.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tables/', mapping));
+      mapping.put(parentLabel + 'document_structure', 'documentStructure');
+      mapping.putAll(((IBMWatsonGenericModel) DocStructure.class.newInstance()).addToApiToSdkMapping(parentLabel + 'document_structure/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Parties.class.newInstance()).addToApiToSdkMapping(parentLabel + 'parties/', mapping));
       return mapping;
     }
   }
@@ -1988,7 +1992,7 @@ public class IBMCompareComplyV1Models {
    */
   public class ColumnHeaderIds extends IBMWatsonGenericModel {
     private String id;
- 
+
     /**
      * Gets the id.
      *
@@ -2016,7 +2020,7 @@ public class IBMCompareComplyV1Models {
    */
   public class ColumnHeaderTexts extends IBMWatsonGenericModel {
     private String text;
- 
+
     /**
      * Gets the text.
      *
@@ -2045,7 +2049,7 @@ public class IBMCompareComplyV1Models {
    */
   public class ColumnHeaderTextsNormalized extends IBMWatsonGenericModel {
     private String textNormalized;
- 
+
     /**
      * Gets the textNormalized.
      *
@@ -2067,9 +2071,12 @@ public class IBMCompareComplyV1Models {
       this.textNormalized = textNormalized;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('text_normalized', 'textNormalized');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
       return mapping;
     }
   }
@@ -2086,7 +2093,7 @@ public class IBMCompareComplyV1Models {
     private Long rowIndexEnd;
     private Long columnIndexBegin;
     private Long columnIndexEnd;
- 
+
     /**
      * Gets the cellId.
      *
@@ -2098,7 +2105,7 @@ public class IBMCompareComplyV1Models {
     public String getCellId() {
       return cellId;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -2111,7 +2118,7 @@ public class IBMCompareComplyV1Models {
     public IBMWatsonMapModel getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -2123,7 +2130,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the textNormalized.
      *
@@ -2136,7 +2143,7 @@ public class IBMCompareComplyV1Models {
     public String getTextNormalized() {
       return textNormalized;
     }
- 
+
     /**
      * Gets the rowIndexBegin.
      *
@@ -2148,7 +2155,7 @@ public class IBMCompareComplyV1Models {
     public Long getRowIndexBegin() {
       return rowIndexBegin;
     }
- 
+
     /**
      * Gets the rowIndexEnd.
      *
@@ -2160,7 +2167,7 @@ public class IBMCompareComplyV1Models {
     public Long getRowIndexEnd() {
       return rowIndexEnd;
     }
- 
+
     /**
      * Gets the columnIndexBegin.
      *
@@ -2172,7 +2179,7 @@ public class IBMCompareComplyV1Models {
     public Long getColumnIndexBegin() {
       return columnIndexBegin;
     }
- 
+
     /**
      * Gets the columnIndexEnd.
      *
@@ -2271,14 +2278,17 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('cell_id', 'cellId');
-      mapping.put('text_normalized', 'textNormalized');
-      mapping.put('row_index_begin', 'rowIndexBegin');
-      mapping.put('row_index_end', 'rowIndexEnd');
-      mapping.put('column_index_begin', 'columnIndexBegin');
-      mapping.put('column_index_end', 'columnIndexEnd');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'cell_id', 'cellId');
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
+      mapping.put(parentLabel + 'row_index_begin', 'rowIndexBegin');
+      mapping.put(parentLabel + 'row_index_end', 'rowIndexEnd');
+      mapping.put(parentLabel + 'column_index_begin', 'columnIndexBegin');
+      mapping.put(parentLabel + 'column_index_end', 'columnIndexEnd');
       return mapping;
     }
   }
@@ -2556,7 +2566,7 @@ public class IBMCompareComplyV1Models {
     private List<Document> documents;
     private List<AlignedElement> alignedElements;
     private List<UnalignedElement> unalignedElements;
- 
+
     /**
      * Gets the modelId.
      *
@@ -2569,7 +2579,7 @@ public class IBMCompareComplyV1Models {
     public String getModelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the modelVersion.
      *
@@ -2581,7 +2591,7 @@ public class IBMCompareComplyV1Models {
     public String getModelVersion() {
       return modelVersion;
     }
- 
+
     /**
      * Gets the documents.
      *
@@ -2593,7 +2603,7 @@ public class IBMCompareComplyV1Models {
     public List<Document> getDocuments() {
       return documents;
     }
- 
+
     /**
      * Gets the alignedElements.
      *
@@ -2605,7 +2615,7 @@ public class IBMCompareComplyV1Models {
     public List<AlignedElement> getAlignedElements() {
       return alignedElements;
     }
- 
+
     /**
      * Gets the unalignedElements.
      *
@@ -2712,18 +2722,17 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('model_id', 'modelId');
-      mapping.put('model_version', 'modelVersion');
-      mapping.put('aligned_elements', 'alignedElements');
-      if (alignedElements != null && alignedElements[0] != null) {
-        mapping.putAll(alignedElements[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('unaligned_elements', 'unalignedElements');
-      if (unalignedElements != null && unalignedElements[0] != null) {
-        mapping.putAll(unalignedElements[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'model_id', 'modelId');
+      mapping.put(parentLabel + 'model_version', 'modelVersion');
+      mapping.put(parentLabel + 'aligned_elements', 'alignedElements');
+      mapping.putAll(((IBMWatsonGenericModel) AlignedElement.class.newInstance()).addToApiToSdkMapping(parentLabel + 'aligned_elements/', mapping));
+      mapping.put(parentLabel + 'unaligned_elements', 'unalignedElements');
+      mapping.putAll(((IBMWatsonGenericModel) UnalignedElement.class.newInstance()).addToApiToSdkMapping(parentLabel + 'unaligned_elements/', mapping));
       return mapping;
     }
   }
@@ -2734,7 +2743,7 @@ public class IBMCompareComplyV1Models {
   public class Contact extends IBMWatsonGenericModel {
     private String name;
     private String role;
- 
+
     /**
      * Gets the name.
      *
@@ -2746,7 +2755,7 @@ public class IBMCompareComplyV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the role.
      *
@@ -2784,7 +2793,7 @@ public class IBMCompareComplyV1Models {
   public class Contexts extends IBMWatsonGenericModel {
     private String text;
     private Location location;
- 
+
     /**
      * Gets the text.
      *
@@ -2796,7 +2805,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -2842,11 +2851,8 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -2861,7 +2867,7 @@ public class IBMCompareComplyV1Models {
     private Interpretation interpretation;
     private List<String> provenanceIds;
     private Location location;
- 
+
     /**
      * Gets the confidenceLevel.
      *
@@ -2873,7 +2879,7 @@ public class IBMCompareComplyV1Models {
     public String getConfidenceLevel() {
       return confidenceLevel;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -2885,12 +2891,12 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the textNormalized.
      *
-     * The normalized form of the amount, which is listed as a string. This element is optional; that is, the service
-     * output lists it only if normalized text exists.
+     * The normalized form of the amount, which is listed as a string. This element is optional; it is returned only if
+     * normalized text exists.
      *
      * @return the textNormalized
      */
@@ -2898,12 +2904,12 @@ public class IBMCompareComplyV1Models {
     public String getTextNormalized() {
       return textNormalized;
     }
- 
+
     /**
      * Gets the interpretation.
      *
-     * The details of the normalized text, if applicable. This element is optional; that is, the service output lists it
-     * only if normalized text exists.
+     * The details of the normalized text, if applicable. This element is optional; it is returned only if normalized
+     * text exists.
      *
      * @return the interpretation
      */
@@ -2911,11 +2917,11 @@ public class IBMCompareComplyV1Models {
     public Interpretation getInterpretation() {
       return interpretation;
     }
- 
+
     /**
      * Gets the provenanceIds.
      *
-     * One or more hash values that you can send to IBM to provide feedback or receive support.
+     * Hashed values that you can send to IBM to provide feedback or receive support.
      *
      * @return the provenanceIds
      */
@@ -2923,7 +2929,7 @@ public class IBMCompareComplyV1Models {
     public List<String> getProvenanceIds() {
       return provenanceIds;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -3009,17 +3015,161 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('confidence_level', 'confidenceLevel');
-      mapping.put('text_normalized', 'textNormalized');
-      if (interpretation != null) {
-        mapping.putAll(interpretation.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('provenance_ids', 'provenanceIds');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+      mapping.put(parentLabel + 'confidence_level', 'confidenceLevel');
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
+      mapping.putAll(((IBMWatsonGenericModel) Interpretation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'interpretation/', mapping));
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      return mapping;
+    }
+  }
+
+  /**
+   * The contract currencies that are declared in the document.
+   */
+  public class ContractCurrencies extends IBMWatsonGenericModel {
+    private String confidenceLevel;
+    private String text;
+    private String textNormalized;
+    private List<String> provenanceIds;
+    private Location location;
+
+    /**
+     * Gets the confidenceLevel.
+     *
+     * The confidence level in the identification of the contract currency.
+     *
+     * @return the confidenceLevel
+     */
+    @AuraEnabled
+    public String getConfidenceLevel() {
+      return confidenceLevel;
+    }
+
+    /**
+     * Gets the text.
+     *
+     * The contract currency.
+     *
+     * @return the text
+     */
+    @AuraEnabled
+    public String getText() {
+      return text;
+    }
+
+    /**
+     * Gets the textNormalized.
+     *
+     * The normalized form of the contract currency, which is listed as a string in
+     * [ISO-4217](https://www.iso.org/iso-4217-currency-codes.html) format. This element is optional; it is returned
+     * only if normalized text exists.
+     *
+     * @return the textNormalized
+     */
+    @AuraEnabled
+    public String getTextNormalized() {
+      return textNormalized;
+    }
+
+    /**
+     * Gets the provenanceIds.
+     *
+     * Hashed values that you can send to IBM to provide feedback or receive support.
+     *
+     * @return the provenanceIds
+     */
+    @AuraEnabled
+    public List<String> getProvenanceIds() {
+      return provenanceIds;
+    }
+
+    /**
+     * Gets the location.
+     *
+     * The numeric location of the identified element in the document, represented with two integers labeled `begin` and
+     * `end`.
+     *
+     * @return the location
+     */
+    @AuraEnabled
+    public Location getLocation() {
+      return location;
+    }
+
+    /**
+     * Sets the confidenceLevel.
+     *
+     * @param confidenceLevel the new confidenceLevel
+     */
+    public void setConfidenceLevel(final String confidenceLevel) {
+      this.confidenceLevel = confidenceLevel;
+    }
+
+    /**
+     * Sets the text.
+     *
+     * @param text the new text
+     */
+    public void setText(final String text) {
+      this.text = text;
+    }
+
+    /**
+     * Sets the textNormalized.
+     *
+     * @param textNormalized the new textNormalized
+     */
+    public void setTextNormalized(final String textNormalized) {
+      this.textNormalized = textNormalized;
+    }
+
+    /**
+     * Sets the provenanceIds.
+     *
+     * @param provenanceIds the new provenanceIds
+     */
+    public void setProvenanceIds(final List<String> provenanceIds) {
+      this.provenanceIds = provenanceIds;
+    }
+
+    /**
+     * Sets the location.
+     *
+     * @param location the new location
+     */
+    public void setLocation(final Location location) {
+      this.location = location;
+    }
+
+    public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
+      if (jsonMap == null) {
+        return null;
       }
+
+      ContractCurrencies ret = (ContractCurrencies) super.deserialize(jsonString, jsonMap, classType);
+
+      // calling custom deserializer for location
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
+      ret.setLocation(newLocation);
+
+      return ret;
+    }
+
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'confidence_level', 'confidenceLevel');
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -3034,7 +3184,7 @@ public class IBMCompareComplyV1Models {
     private Interpretation interpretation;
     private List<String> provenanceIds;
     private Location location;
- 
+
     /**
      * Gets the confidenceLevel.
      *
@@ -3046,7 +3196,7 @@ public class IBMCompareComplyV1Models {
     public String getConfidenceLevel() {
       return confidenceLevel;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -3058,12 +3208,12 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the textNormalized.
      *
-     * The normalized form of the contract term, which is listed as a string. This element is optional; that is, the
-     * service output lists it only if normalized text exists.
+     * The normalized form of the contract term, which is listed as a string. This element is optional; it is returned
+     * only if normalized text exists.
      *
      * @return the textNormalized
      */
@@ -3071,12 +3221,12 @@ public class IBMCompareComplyV1Models {
     public String getTextNormalized() {
       return textNormalized;
     }
- 
+
     /**
      * Gets the interpretation.
      *
-     * The details of the normalized text, if applicable. This element is optional; that is, the service output lists it
-     * only if normalized text exists.
+     * The details of the normalized text, if applicable. This element is optional; it is returned only if normalized
+     * text exists.
      *
      * @return the interpretation
      */
@@ -3084,11 +3234,11 @@ public class IBMCompareComplyV1Models {
     public Interpretation getInterpretation() {
       return interpretation;
     }
- 
+
     /**
      * Gets the provenanceIds.
      *
-     * One or more hash values that you can send to IBM to provide feedback or receive support.
+     * Hashed values that you can send to IBM to provide feedback or receive support.
      *
      * @return the provenanceIds
      */
@@ -3096,7 +3246,7 @@ public class IBMCompareComplyV1Models {
     public List<String> getProvenanceIds() {
       return provenanceIds;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -3182,17 +3332,16 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('confidence_level', 'confidenceLevel');
-      mapping.put('text_normalized', 'textNormalized');
-      if (interpretation != null) {
-        mapping.putAll(interpretation.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('provenance_ids', 'provenanceIds');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'confidence_level', 'confidenceLevel');
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
+      mapping.putAll(((IBMWatsonGenericModel) Interpretation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'interpretation/', mapping));
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -3205,7 +3354,7 @@ public class IBMCompareComplyV1Models {
     private String text;
     private List<String> provenanceIds;
     private Location location;
- 
+
     /**
      * Gets the confidenceLevel.
      *
@@ -3217,7 +3366,7 @@ public class IBMCompareComplyV1Models {
     public String getConfidenceLevel() {
       return confidenceLevel;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -3229,11 +3378,11 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the provenanceIds.
      *
-     * One or more hash values that you can send to IBM to provide feedback or receive support.
+     * Hashed values that you can send to IBM to provide feedback or receive support.
      *
      * @return the provenanceIds
      */
@@ -3241,7 +3390,7 @@ public class IBMCompareComplyV1Models {
     public List<String> getProvenanceIds() {
       return provenanceIds;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -3305,13 +3454,14 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('confidence_level', 'confidenceLevel');
-      mapping.put('provenance_ids', 'provenanceIds');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'confidence_level', 'confidenceLevel');
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -3940,7 +4090,7 @@ public class IBMCompareComplyV1Models {
     private Long pending;
     private Long successful;
     private Long failed;
- 
+
     /**
      * Gets the total.
      *
@@ -3952,7 +4102,7 @@ public class IBMCompareComplyV1Models {
     public Long getTotal() {
       return total;
     }
- 
+
     /**
      * Gets the pending.
      *
@@ -3964,7 +4114,7 @@ public class IBMCompareComplyV1Models {
     public Long getPending() {
       return pending;
     }
- 
+
     /**
      * Gets the successful.
      *
@@ -3976,7 +4126,7 @@ public class IBMCompareComplyV1Models {
     public Long getSuccessful() {
       return successful;
     }
- 
+
     /**
      * Gets the failed.
      *
@@ -4033,7 +4183,7 @@ public class IBMCompareComplyV1Models {
     private String html;
     private String title;
     private String hash;
- 
+
     /**
      * Gets the html.
      *
@@ -4045,7 +4195,7 @@ public class IBMCompareComplyV1Models {
     public String getHtml() {
       return html;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -4057,7 +4207,7 @@ public class IBMCompareComplyV1Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the hash.
      *
@@ -4105,7 +4255,7 @@ public class IBMCompareComplyV1Models {
     private List<SectionTitles> sectionTitles;
     private List<LeadingSentence> leadingSentences;
     private List<Paragraphs> paragraphs;
- 
+
     /**
      * Gets the sectionTitles.
      *
@@ -4117,7 +4267,7 @@ public class IBMCompareComplyV1Models {
     public List<SectionTitles> getSectionTitles() {
       return sectionTitles;
     }
- 
+
     /**
      * Gets the leadingSentences.
      *
@@ -4130,7 +4280,7 @@ public class IBMCompareComplyV1Models {
     public List<LeadingSentence> getLeadingSentences() {
       return leadingSentences;
     }
- 
+
     /**
      * Gets the paragraphs.
      *
@@ -4220,19 +4370,16 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('section_titles', 'sectionTitles');
-      if (sectionTitles != null && sectionTitles[0] != null) {
-        mapping.putAll(sectionTitles[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('leading_sentences', 'leadingSentences');
-      if (leadingSentences != null && leadingSentences[0] != null) {
-        mapping.putAll(leadingSentences[0].getApiToSdkMapping());
-      }
-      if (paragraphs != null && paragraphs[0] != null) {
-        mapping.putAll(paragraphs[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'section_titles', 'sectionTitles');
+      mapping.putAll(((IBMWatsonGenericModel) SectionTitles.class.newInstance()).addToApiToSdkMapping(parentLabel + 'section_titles/', mapping));
+      mapping.put(parentLabel + 'leading_sentences', 'leadingSentences');
+      mapping.putAll(((IBMWatsonGenericModel) LeadingSentence.class.newInstance()).addToApiToSdkMapping(parentLabel + 'leading_sentences/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Paragraphs.class.newInstance()).addToApiToSdkMapping(parentLabel + 'paragraphs/', mapping));
       return mapping;
     }
   }
@@ -4245,7 +4392,7 @@ public class IBMCompareComplyV1Models {
     private String html;
     private String hash;
     private String label;
- 
+
     /**
      * Gets the title.
      *
@@ -4257,7 +4404,7 @@ public class IBMCompareComplyV1Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the html.
      *
@@ -4269,7 +4416,7 @@ public class IBMCompareComplyV1Models {
     public String getHtml() {
       return html;
     }
- 
+
     /**
      * Gets the hash.
      *
@@ -4281,7 +4428,7 @@ public class IBMCompareComplyV1Models {
     public String getHash() {
       return hash;
     }
- 
+
     /**
      * Gets the label.
      *
@@ -4341,7 +4488,7 @@ public class IBMCompareComplyV1Models {
     private String textNormalized;
     private List<String> provenanceIds;
     private Location location;
- 
+
     /**
      * Gets the confidenceLevel.
      *
@@ -4353,7 +4500,7 @@ public class IBMCompareComplyV1Models {
     public String getConfidenceLevel() {
       return confidenceLevel;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -4365,12 +4512,12 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the textNormalized.
      *
-     * The normalized form of the effective date, which is listed as a string. This element is optional; that is, the
-     * service output lists it only if normalized text exists.
+     * The normalized form of the effective date, which is listed as a string. This element is optional; it is returned
+     * only if normalized text exists.
      *
      * @return the textNormalized
      */
@@ -4378,11 +4525,11 @@ public class IBMCompareComplyV1Models {
     public String getTextNormalized() {
       return textNormalized;
     }
- 
+
     /**
      * Gets the provenanceIds.
      *
-     * One or more hash values that you can send to IBM to provide feedback or receive support.
+     * Hashed values that you can send to IBM to provide feedback or receive support.
      *
      * @return the provenanceIds
      */
@@ -4390,7 +4537,7 @@ public class IBMCompareComplyV1Models {
     public List<String> getProvenanceIds() {
       return provenanceIds;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -4463,14 +4610,15 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('confidence_level', 'confidenceLevel');
-      mapping.put('text_normalized', 'textNormalized');
-      mapping.put('provenance_ids', 'provenanceIds');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'confidence_level', 'confidenceLevel');
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -4484,7 +4632,7 @@ public class IBMCompareComplyV1Models {
     private List<TypeLabel> types;
     private List<Category> categories;
     private List<Attribute> attributes;
- 
+
     /**
      * Gets the location.
      *
@@ -4497,7 +4645,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -4509,7 +4657,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the types.
      *
@@ -4521,7 +4669,7 @@ public class IBMCompareComplyV1Models {
     public List<TypeLabel> getTypes() {
       return types;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -4533,7 +4681,7 @@ public class IBMCompareComplyV1Models {
     public List<Category> getCategories() {
       return categories;
     }
- 
+
     /**
      * Gets the attributes.
      *
@@ -4644,20 +4792,11 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
-      if (types != null && types[0] != null) {
-        mapping.putAll(types[0].getApiToSdkMapping());
-      }
-      if (categories != null && categories[0] != null) {
-        mapping.putAll(categories[0].getApiToSdkMapping());
-      }
-      if (attributes != null && attributes[0] != null) {
-        mapping.putAll(attributes[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) TypeLabel.class.newInstance()).addToApiToSdkMapping(parentLabel + 'types/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Category.class.newInstance()).addToApiToSdkMapping(parentLabel + 'categories/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Attribute.class.newInstance()).addToApiToSdkMapping(parentLabel + 'attributes/', mapping));
       return mapping;
     }
   }
@@ -4668,7 +4807,7 @@ public class IBMCompareComplyV1Models {
   public class ElementLocations extends IBMWatsonGenericModel {
     private Long xbegin;
     private Long xend;
- 
+
     /**
      * Gets the xbegin.
      *
@@ -4680,7 +4819,7 @@ public class IBMCompareComplyV1Models {
     public Long getXbegin() {
       return xbegin;
     }
- 
+
     /**
      * Gets the xend.
      *
@@ -4711,10 +4850,13 @@ public class IBMCompareComplyV1Models {
       this.xend = xend;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('begin', 'xbegin');
-      mapping.put('end', 'xend');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'begin', 'xbegin');
+      mapping.put(parentLabel + 'end', 'xend');
       return mapping;
     }
   }
@@ -4729,7 +4871,7 @@ public class IBMCompareComplyV1Models {
     private List<TypeLabelComparison> types;
     private List<CategoryComparison> categories;
     private List<Attribute> attributes;
- 
+
     /**
      * Gets the documentLabel.
      *
@@ -4742,7 +4884,7 @@ public class IBMCompareComplyV1Models {
     public String getDocumentLabel() {
       return documentLabel;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -4754,7 +4896,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -4767,7 +4909,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the types.
      *
@@ -4779,7 +4921,7 @@ public class IBMCompareComplyV1Models {
     public List<TypeLabelComparison> getTypes() {
       return types;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -4791,7 +4933,7 @@ public class IBMCompareComplyV1Models {
     public List<CategoryComparison> getCategories() {
       return categories;
     }
- 
+
     /**
      * Gets the attributes.
      *
@@ -4911,15 +5053,14 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_label', 'documentLabel');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (attributes != null && attributes[0] != null) {
-        mapping.putAll(attributes[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'document_label', 'documentLabel');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Attribute.class.newInstance()).addToApiToSdkMapping(parentLabel + 'attributes/', mapping));
       return mapping;
     }
   }
@@ -5088,7 +5229,7 @@ public class IBMCompareComplyV1Models {
     private String text;
     private OriginalLabelsIn originalLabels;
     private UpdatedLabelsIn updatedLabels;
- 
+
     /**
      * Gets the feedbackType.
      *
@@ -5099,7 +5240,7 @@ public class IBMCompareComplyV1Models {
     public String getFeedbackType() {
       return feedbackType;
     }
- 
+
     /**
      * Gets the document.
      *
@@ -5110,7 +5251,7 @@ public class IBMCompareComplyV1Models {
     public ShortDoc getDocument() {
       return document;
     }
- 
+
     /**
      * Gets the modelId.
      *
@@ -5121,7 +5262,7 @@ public class IBMCompareComplyV1Models {
     public String getModelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the modelVersion.
      *
@@ -5132,7 +5273,7 @@ public class IBMCompareComplyV1Models {
     public String getModelVersion() {
       return modelVersion;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -5144,7 +5285,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -5155,7 +5296,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the originalLabels.
      *
@@ -5166,7 +5307,7 @@ public class IBMCompareComplyV1Models {
     public OriginalLabelsIn getOriginalLabels() {
       return originalLabels;
     }
- 
+
     /**
      * Gets the updatedLabels.
      *
@@ -5203,21 +5344,24 @@ public class IBMCompareComplyV1Models {
       return new FeedbackDataInputBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('feedbackType', 'feedback_type');
-      mapping.put('modelId', 'model_id');
-      mapping.put('modelVersion', 'model_version');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'feedbackType', 'feedback_type');
+      mapping.put(parentLabel + 'modelId', 'model_id');
+      mapping.put(parentLabel + 'modelVersion', 'model_version');
       if (location != null) {
-        mapping.putAll(location.getSdkToApiMapping());
+        mapping.putAll(location.addToSdkToApiMapping(parentLabel + 'location/', mapping));
       }
-      mapping.put('originalLabels', 'original_labels');
+      mapping.put(parentLabel + 'originalLabels', 'original_labels');
       if (originalLabels != null) {
-        mapping.putAll(originalLabels.getSdkToApiMapping());
+        mapping.putAll(originalLabels.addToSdkToApiMapping(parentLabel + 'originalLabels/', mapping));
       }
-      mapping.put('updatedLabels', 'updated_labels');
+      mapping.put(parentLabel + 'updatedLabels', 'updated_labels');
       if (updatedLabels != null) {
-        mapping.putAll(updatedLabels.getSdkToApiMapping());
+        mapping.putAll(updatedLabels.addToSdkToApiMapping(parentLabel + 'updatedLabels/', mapping));
       }
       return mapping;
     }
@@ -5285,7 +5429,7 @@ public class IBMCompareComplyV1Models {
      * @param feedbackType the feedbackType
      * @return the FeedbackDataInput builder
      */
-    public FeedbackDataInputBuilder setFeedbackType(String feedbackType) {
+    public FeedbackDataInputBuilder feedbackType(String feedbackType) {
       this.feedbackType = feedbackType;
       return this;
     }
@@ -5296,7 +5440,7 @@ public class IBMCompareComplyV1Models {
      * @param document the document
      * @return the FeedbackDataInput builder
      */
-    public FeedbackDataInputBuilder setDocument(ShortDoc document) {
+    public FeedbackDataInputBuilder document(ShortDoc document) {
       this.document = document;
       return this;
     }
@@ -5307,7 +5451,7 @@ public class IBMCompareComplyV1Models {
      * @param modelId the modelId
      * @return the FeedbackDataInput builder
      */
-    public FeedbackDataInputBuilder setModelId(String modelId) {
+    public FeedbackDataInputBuilder modelId(String modelId) {
       this.modelId = modelId;
       return this;
     }
@@ -5318,7 +5462,7 @@ public class IBMCompareComplyV1Models {
      * @param modelVersion the modelVersion
      * @return the FeedbackDataInput builder
      */
-    public FeedbackDataInputBuilder setModelVersion(String modelVersion) {
+    public FeedbackDataInputBuilder modelVersion(String modelVersion) {
       this.modelVersion = modelVersion;
       return this;
     }
@@ -5329,7 +5473,7 @@ public class IBMCompareComplyV1Models {
      * @param location the location
      * @return the FeedbackDataInput builder
      */
-    public FeedbackDataInputBuilder setLocation(Location location) {
+    public FeedbackDataInputBuilder location(Location location) {
       this.location = location;
       return this;
     }
@@ -5340,7 +5484,7 @@ public class IBMCompareComplyV1Models {
      * @param text the text
      * @return the FeedbackDataInput builder
      */
-    public FeedbackDataInputBuilder setText(String text) {
+    public FeedbackDataInputBuilder text(String text) {
       this.text = text;
       return this;
     }
@@ -5351,7 +5495,7 @@ public class IBMCompareComplyV1Models {
      * @param originalLabels the originalLabels
      * @return the FeedbackDataInput builder
      */
-    public FeedbackDataInputBuilder setOriginalLabels(OriginalLabelsIn originalLabels) {
+    public FeedbackDataInputBuilder originalLabels(OriginalLabelsIn originalLabels) {
       this.originalLabels = originalLabels;
       return this;
     }
@@ -5362,7 +5506,7 @@ public class IBMCompareComplyV1Models {
      * @param updatedLabels the updatedLabels
      * @return the FeedbackDataInput builder
      */
-    public FeedbackDataInputBuilder setUpdatedLabels(UpdatedLabelsIn updatedLabels) {
+    public FeedbackDataInputBuilder updatedLabels(UpdatedLabelsIn updatedLabels) {
       this.updatedLabels = updatedLabels;
       return this;
     }
@@ -5381,7 +5525,7 @@ public class IBMCompareComplyV1Models {
     private OriginalLabelsOut originalLabels;
     private UpdatedLabelsOut updatedLabels;
     private Pagination pagination;
- 
+
     /**
      * Gets the feedbackType.
      *
@@ -5393,7 +5537,7 @@ public class IBMCompareComplyV1Models {
     public String getFeedbackType() {
       return feedbackType;
     }
- 
+
     /**
      * Gets the document.
      *
@@ -5405,7 +5549,7 @@ public class IBMCompareComplyV1Models {
     public ShortDoc getDocument() {
       return document;
     }
- 
+
     /**
      * Gets the modelId.
      *
@@ -5417,7 +5561,7 @@ public class IBMCompareComplyV1Models {
     public String getModelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the modelVersion.
      *
@@ -5429,7 +5573,7 @@ public class IBMCompareComplyV1Models {
     public String getModelVersion() {
       return modelVersion;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -5442,7 +5586,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -5454,7 +5598,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the originalLabels.
      *
@@ -5466,7 +5610,7 @@ public class IBMCompareComplyV1Models {
     public OriginalLabelsOut getOriginalLabels() {
       return originalLabels;
     }
- 
+
     /**
      * Gets the updatedLabels.
      *
@@ -5478,7 +5622,7 @@ public class IBMCompareComplyV1Models {
     public UpdatedLabelsOut getUpdatedLabels() {
       return updatedLabels;
     }
- 
+
     /**
      * Gets the pagination.
      *
@@ -5602,25 +5746,20 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('feedback_type', 'feedbackType');
-      mapping.put('model_id', 'modelId');
-      mapping.put('model_version', 'modelVersion');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('original_labels', 'originalLabels');
-      if (originalLabels != null) {
-        mapping.putAll(originalLabels.getApiToSdkMapping());
-      }
-      mapping.put('updated_labels', 'updatedLabels');
-      if (updatedLabels != null) {
-        mapping.putAll(updatedLabels.getApiToSdkMapping());
-      }
-      if (pagination != null) {
-        mapping.putAll(pagination.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'feedback_type', 'feedbackType');
+      mapping.put(parentLabel + 'model_id', 'modelId');
+      mapping.put(parentLabel + 'model_version', 'modelVersion');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      mapping.put(parentLabel + 'original_labels', 'originalLabels');
+      mapping.putAll(((IBMWatsonGenericModel) OriginalLabelsOut.class.newInstance()).addToApiToSdkMapping(parentLabel + 'original_labels/', mapping));
+      mapping.put(parentLabel + 'updated_labels', 'updatedLabels');
+      mapping.putAll(((IBMWatsonGenericModel) UpdatedLabelsOut.class.newInstance()).addToApiToSdkMapping(parentLabel + 'updated_labels/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Pagination.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pagination/', mapping));
       return mapping;
     }
   }
@@ -5630,7 +5769,7 @@ public class IBMCompareComplyV1Models {
    */
   public class FeedbackList extends IBMWatsonResponseModel {
     private List<GetFeedback> feedback;
- 
+
     /**
      * Gets the feedback.
      *
@@ -5675,11 +5814,8 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (feedback != null && feedback[0] != null) {
-        mapping.putAll(feedback[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) GetFeedback.class.newInstance()).addToApiToSdkMapping(parentLabel + 'feedback/', mapping));
       return mapping;
     }
   }
@@ -5693,7 +5829,7 @@ public class IBMCompareComplyV1Models {
     private String comment;
     private Datetime created;
     private FeedbackDataOutput feedbackData;
- 
+
     /**
      * Gets the feedbackId.
      *
@@ -5705,7 +5841,7 @@ public class IBMCompareComplyV1Models {
     public String getFeedbackId() {
       return feedbackId;
     }
- 
+
     /**
      * Gets the userId.
      *
@@ -5717,7 +5853,7 @@ public class IBMCompareComplyV1Models {
     public String getUserId() {
       return userId;
     }
- 
+
     /**
      * Gets the comment.
      *
@@ -5729,7 +5865,7 @@ public class IBMCompareComplyV1Models {
     public String getComment() {
       return comment;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -5741,7 +5877,7 @@ public class IBMCompareComplyV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the feedbackData.
      *
@@ -5813,14 +5949,15 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('feedback_id', 'feedbackId');
-      mapping.put('user_id', 'userId');
-      mapping.put('feedback_data', 'feedbackData');
-      if (feedbackData != null) {
-        mapping.putAll(feedbackData.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'feedback_id', 'feedbackId');
+      mapping.put(parentLabel + 'user_id', 'userId');
+      mapping.put(parentLabel + 'feedback_data', 'feedbackData');
+      mapping.putAll(((IBMWatsonGenericModel) FeedbackDataOutput.class.newInstance()).addToApiToSdkMapping(parentLabel + 'feedback_data/', mapping));
       return mapping;
     }
   }
@@ -5931,7 +6068,7 @@ public class IBMCompareComplyV1Models {
     private Datetime created;
     private String comment;
     private FeedbackDataOutput feedbackData;
- 
+
     /**
      * Gets the feedbackId.
      *
@@ -5943,7 +6080,7 @@ public class IBMCompareComplyV1Models {
     public String getFeedbackId() {
       return feedbackId;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -5955,7 +6092,7 @@ public class IBMCompareComplyV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the comment.
      *
@@ -5967,7 +6104,7 @@ public class IBMCompareComplyV1Models {
     public String getComment() {
       return comment;
     }
- 
+
     /**
      * Gets the feedbackData.
      *
@@ -6030,13 +6167,14 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('feedback_id', 'feedbackId');
-      mapping.put('feedback_data', 'feedbackData');
-      if (feedbackData != null) {
-        mapping.putAll(feedbackData.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'feedback_id', 'feedbackId');
+      mapping.put(parentLabel + 'feedback_data', 'feedbackData');
+      mapping.putAll(((IBMWatsonGenericModel) FeedbackDataOutput.class.newInstance()).addToApiToSdkMapping(parentLabel + 'feedback_data/', mapping));
       return mapping;
     }
   }
@@ -6176,7 +6314,7 @@ public class IBMCompareComplyV1Models {
     private String publicationDate;
     private String title;
     private String html;
- 
+
     /**
      * Gets the numPages.
      *
@@ -6188,7 +6326,7 @@ public class IBMCompareComplyV1Models {
     public String getNumPages() {
       return numPages;
     }
- 
+
     /**
      * Gets the author.
      *
@@ -6200,7 +6338,7 @@ public class IBMCompareComplyV1Models {
     public String getAuthor() {
       return author;
     }
- 
+
     /**
      * Gets the publicationDate.
      *
@@ -6212,7 +6350,7 @@ public class IBMCompareComplyV1Models {
     public String getPublicationDate() {
       return publicationDate;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -6224,7 +6362,7 @@ public class IBMCompareComplyV1Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the html.
      *
@@ -6282,23 +6420,26 @@ public class IBMCompareComplyV1Models {
       this.html = html;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('num_pages', 'numPages');
-      mapping.put('publication_date', 'publicationDate');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'num_pages', 'numPages');
+      mapping.put(parentLabel + 'publication_date', 'publicationDate');
       return mapping;
     }
   }
 
   /**
-   * The details of the normalized text, if applicable. This element is optional; that is, the service output lists it
-   * only if normalized text exists.
+   * The details of the normalized text, if applicable. This element is optional; it is returned only if normalized text
+   * exists.
    */
   public class Interpretation extends IBMWatsonGenericModel {
     private String value;
     private Double numericValue;
     private String unit;
- 
+
     /**
      * Gets the value.
      *
@@ -6310,7 +6451,7 @@ public class IBMCompareComplyV1Models {
     public String getValue() {
       return value;
     }
- 
+
     /**
      * Gets the numericValue.
      *
@@ -6322,7 +6463,7 @@ public class IBMCompareComplyV1Models {
     public Double getNumericValue() {
       return numericValue;
     }
- 
+
     /**
      * Gets the unit.
      *
@@ -6366,9 +6507,8 @@ public class IBMCompareComplyV1Models {
       this.unit = unit;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('numeric_value', 'numericValue');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'numeric_value', 'numericValue');
       return mapping;
     }
   }
@@ -6380,7 +6520,7 @@ public class IBMCompareComplyV1Models {
     private String cellId;
     private Location location;
     private String text;
- 
+
     /**
      * Gets the cellId.
      *
@@ -6392,7 +6532,7 @@ public class IBMCompareComplyV1Models {
     public String getCellId() {
       return cellId;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -6405,7 +6545,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -6459,12 +6599,13 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('cell_id', 'cellId');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'cell_id', 'cellId');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -6474,8 +6615,8 @@ public class IBMCompareComplyV1Models {
    */
   public class KeyValuePair extends IBMWatsonGenericModel {
     private Key key;
-    private Value value;
- 
+    private List<Value> value;
+
     /**
      * Gets the key.
      *
@@ -6487,16 +6628,16 @@ public class IBMCompareComplyV1Models {
     public Key getKey() {
       return key;
     }
- 
+
     /**
      * Gets the value.
      *
-     * A value in a key-value pair.
+     * A list of values in a key-value pair.
      *
      * @return the value
      */
     @AuraEnabled
-    public Value getValue() {
+    public List<Value> getValue() {
       return value;
     }
 
@@ -6514,7 +6655,7 @@ public class IBMCompareComplyV1Models {
      *
      * @param value the new value
      */
-    public void setValue(final Value value) {
+    public void setValue(final List<Value> value) {
       this.value = value;
     }
 
@@ -6530,20 +6671,24 @@ public class IBMCompareComplyV1Models {
       ret.setKey(newKey);
 
       // calling custom deserializer for value
-      Value newValue = (Value) new Value().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value'), Value.class);
-      ret.setValue(newValue);
+      List<Value> newValue = new List<Value>();
+      List<Value> deserializedValue = ret.getValue();
+      if (deserializedValue != null) {
+        for (Integer i = 0; i < deserializedValue.size(); i++) {
+          Value currentItem = ret.getValue().get(i);
+          List<Object> itemInMap = (List<Object>) jsonMap.get('value');
+          Value newItem = (Value) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Value.class);
+          newValue.add(newItem);
+        }
+        ret.value = newValue;
+      }
 
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (key != null) {
-        mapping.putAll(key.getApiToSdkMapping());
-      }
-      if (value != null) {
-        mapping.putAll(value.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Key.class.newInstance()).addToApiToSdkMapping(parentLabel + 'key/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Value.class.newInstance()).addToApiToSdkMapping(parentLabel + 'value/', mapping));
       return mapping;
     }
   }
@@ -6561,7 +6706,7 @@ public class IBMCompareComplyV1Models {
      * and should not be called by the client.
      */
     public Label() { }
- 
+
     /**
      * Gets the nature.
      *
@@ -6573,7 +6718,7 @@ public class IBMCompareComplyV1Models {
     public String getNature() {
       return nature;
     }
- 
+
     /**
      * Gets the party.
      *
@@ -6647,7 +6792,7 @@ public class IBMCompareComplyV1Models {
      * @param nature the nature
      * @return the Label builder
      */
-    public LabelBuilder setNature(String nature) {
+    public LabelBuilder nature(String nature) {
       this.nature = nature;
       return this;
     }
@@ -6658,7 +6803,7 @@ public class IBMCompareComplyV1Models {
      * @param party the party
      * @return the Label builder
      */
-    public LabelBuilder setParty(String party) {
+    public LabelBuilder party(String party) {
       this.party = party;
       return this;
     }
@@ -6671,7 +6816,7 @@ public class IBMCompareComplyV1Models {
     private String text;
     private Location location;
     private List<ElementLocations> elementLocations;
- 
+
     /**
      * Gets the text.
      *
@@ -6683,7 +6828,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -6696,7 +6841,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the elementLocations.
      *
@@ -6763,15 +6908,10 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
-      mapping.put('element_locations', 'elementLocations');
-      if (elementLocations != null && elementLocations[0] != null) {
-        mapping.putAll(elementLocations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      mapping.put(parentLabel + 'element_locations', 'elementLocations');
+      mapping.putAll(((IBMWatsonGenericModel) ElementLocations.class.newInstance()).addToApiToSdkMapping(parentLabel + 'element_locations/', mapping));
       return mapping;
     }
   }
@@ -6927,7 +7067,7 @@ public class IBMCompareComplyV1Models {
     /**
      * Gets the categoryRemoved.
      *
-     * An optional string in the form of a comma-separated list of categories. If this is specified, the service filters
+     * An optional string in the form of a comma-separated list of categories. If it is specified, the service filters
      * the output to include only feedback that has at least one category from the list removed.
      *
      * @return the categoryRemoved
@@ -7350,7 +7490,7 @@ public class IBMCompareComplyV1Models {
      * and should not be called by the client.
      */
     public Location() { }
- 
+
     /**
      * Gets the xbegin.
      *
@@ -7362,7 +7502,7 @@ public class IBMCompareComplyV1Models {
     public Long getXbegin() {
       return xbegin;
     }
- 
+
     /**
      * Gets the xend.
      *
@@ -7391,17 +7531,23 @@ public class IBMCompareComplyV1Models {
       return new LocationBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xbegin', 'begin');
-      mapping.put('xend', 'end');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xbegin', 'begin');
+      mapping.put(parentLabel + 'xend', 'end');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('begin', 'xbegin');
-      mapping.put('end', 'xend');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'begin', 'xbegin');
+      mapping.put(parentLabel + 'end', 'xend');
       return mapping;
     }
   }
@@ -7450,7 +7596,7 @@ public class IBMCompareComplyV1Models {
      * @param xbegin the xbegin
      * @return the Location builder
      */
-    public LocationBuilder setXbegin(Long xbegin) {
+    public LocationBuilder xbegin(Long xbegin) {
       this.xbegin = xbegin;
       return this;
     }
@@ -7461,7 +7607,7 @@ public class IBMCompareComplyV1Models {
      * @param xend the xend
      * @return the Location builder
      */
-    public LocationBuilder setXend(Long xend) {
+    public LocationBuilder xend(Long xend) {
       this.xend = xend;
       return this;
     }
@@ -7473,7 +7619,7 @@ public class IBMCompareComplyV1Models {
   public class Mention extends IBMWatsonGenericModel {
     private String text;
     private Location location;
- 
+
     /**
      * Gets the text.
      *
@@ -7485,7 +7631,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -7531,11 +7677,8 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -7546,7 +7689,7 @@ public class IBMCompareComplyV1Models {
   public class OriginalLabelsIn extends IBMWatsonGenericModel {
     private List<TypeLabel> types;
     private List<Category> categories;
- 
+
     /**
      * Gets the types.
      *
@@ -7557,7 +7700,7 @@ public class IBMCompareComplyV1Models {
     public List<TypeLabel> getTypes() {
       return types;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -7585,13 +7728,12 @@ public class IBMCompareComplyV1Models {
       return new OriginalLabelsInBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (types != null && types[0] != null) {
-        mapping.putAll(types[0].getSdkToApiMapping());
+        mapping.putAll(types[0].addToSdkToApiMapping(parentLabel + 'types/', mapping));
       }
       if (categories != null && categories[0] != null) {
-        mapping.putAll(categories[0].getSdkToApiMapping());
+        mapping.putAll(categories[0].addToSdkToApiMapping(parentLabel + 'categories/', mapping));
       }
       return mapping;
     }
@@ -7672,7 +7814,7 @@ public class IBMCompareComplyV1Models {
      * @param types the types
      * @return the OriginalLabelsIn builder
      */
-    public OriginalLabelsInBuilder setTypes(List<TypeLabel> types) {
+    public OriginalLabelsInBuilder types(List<TypeLabel> types) {
       this.types = types;
       return this;
     }
@@ -7684,7 +7826,7 @@ public class IBMCompareComplyV1Models {
      * @param categories the categories
      * @return the OriginalLabelsIn builder
      */
-    public OriginalLabelsInBuilder setCategories(List<Category> categories) {
+    public OriginalLabelsInBuilder categories(List<Category> categories) {
       this.categories = categories;
       return this;
     }
@@ -7697,7 +7839,7 @@ public class IBMCompareComplyV1Models {
     private List<TypeLabel> types;
     private List<Category> categories;
     private String modification;
- 
+
     /**
      * Gets the types.
      *
@@ -7709,7 +7851,7 @@ public class IBMCompareComplyV1Models {
     public List<TypeLabel> getTypes() {
       return types;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -7721,7 +7863,7 @@ public class IBMCompareComplyV1Models {
     public List<Category> getCategories() {
       return categories;
     }
- 
+
     /**
      * Gets the modification.
      *
@@ -7798,14 +7940,9 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (types != null && types[0] != null) {
-        mapping.putAll(types[0].getApiToSdkMapping());
-      }
-      if (categories != null && categories[0] != null) {
-        mapping.putAll(categories[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) TypeLabel.class.newInstance()).addToApiToSdkMapping(parentLabel + 'types/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Category.class.newInstance()).addToApiToSdkMapping(parentLabel + 'categories/', mapping));
       return mapping;
     }
   }
@@ -7819,7 +7956,7 @@ public class IBMCompareComplyV1Models {
     private String refreshUrl;
     private String nextUrl;
     private Long total;
- 
+
     /**
      * Gets the refreshCursor.
      *
@@ -7831,7 +7968,7 @@ public class IBMCompareComplyV1Models {
     public String getRefreshCursor() {
       return refreshCursor;
     }
- 
+
     /**
      * Gets the nextCursor.
      *
@@ -7843,7 +7980,7 @@ public class IBMCompareComplyV1Models {
     public String getNextCursor() {
       return nextCursor;
     }
- 
+
     /**
      * Gets the refreshUrl.
      *
@@ -7855,7 +7992,7 @@ public class IBMCompareComplyV1Models {
     public String getRefreshUrl() {
       return refreshUrl;
     }
- 
+
     /**
      * Gets the nextUrl.
      *
@@ -7867,7 +8004,7 @@ public class IBMCompareComplyV1Models {
     public String getNextUrl() {
       return nextUrl;
     }
- 
+
     /**
      * Gets the total.
      *
@@ -7925,12 +8062,15 @@ public class IBMCompareComplyV1Models {
       this.total = total;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('refresh_cursor', 'refreshCursor');
-      mapping.put('next_cursor', 'nextCursor');
-      mapping.put('refresh_url', 'refreshUrl');
-      mapping.put('next_url', 'nextUrl');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'refresh_cursor', 'refreshCursor');
+      mapping.put(parentLabel + 'next_cursor', 'nextCursor');
+      mapping.put(parentLabel + 'refresh_url', 'refreshUrl');
+      mapping.put(parentLabel + 'next_url', 'nextUrl');
       return mapping;
     }
   }
@@ -7940,7 +8080,7 @@ public class IBMCompareComplyV1Models {
    */
   public class Paragraphs extends IBMWatsonGenericModel {
     private Location location;
- 
+
     /**
      * Gets the location.
      *
@@ -7977,11 +8117,8 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -7996,7 +8133,7 @@ public class IBMCompareComplyV1Models {
     private List<Address> addresses;
     private List<Contact> contacts;
     private List<Mention> mentions;
- 
+
     /**
      * Gets the party.
      *
@@ -8008,7 +8145,7 @@ public class IBMCompareComplyV1Models {
     public String getParty() {
       return party;
     }
- 
+
     /**
      * Gets the role.
      *
@@ -8020,7 +8157,7 @@ public class IBMCompareComplyV1Models {
     public String getRole() {
       return role;
     }
- 
+
     /**
      * Gets the importance.
      *
@@ -8032,7 +8169,7 @@ public class IBMCompareComplyV1Models {
     public String getImportance() {
       return importance;
     }
- 
+
     /**
      * Gets the addresses.
      *
@@ -8044,7 +8181,7 @@ public class IBMCompareComplyV1Models {
     public List<Address> getAddresses() {
       return addresses;
     }
- 
+
     /**
      * Gets the contacts.
      *
@@ -8056,7 +8193,7 @@ public class IBMCompareComplyV1Models {
     public List<Contact> getContacts() {
       return contacts;
     }
- 
+
     /**
      * Gets the mentions.
      *
@@ -8172,14 +8309,9 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (addresses != null && addresses[0] != null) {
-        mapping.putAll(addresses[0].getApiToSdkMapping());
-      }
-      if (mentions != null && mentions[0] != null) {
-        mapping.putAll(mentions[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Address.class.newInstance()).addToApiToSdkMapping(parentLabel + 'addresses/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Mention.class.newInstance()).addToApiToSdkMapping(parentLabel + 'mentions/', mapping));
       return mapping;
     }
   }
@@ -8194,7 +8326,7 @@ public class IBMCompareComplyV1Models {
     private Interpretation interpretation;
     private List<String> provenanceIds;
     private Location location;
- 
+
     /**
      * Gets the confidenceLevel.
      *
@@ -8206,7 +8338,7 @@ public class IBMCompareComplyV1Models {
     public String getConfidenceLevel() {
       return confidenceLevel;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -8218,12 +8350,12 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the textNormalized.
      *
-     * The normalized form of the payment term, which is listed as a string. This element is optional; that is, the
-     * service output lists it only if normalized text exists.
+     * The normalized form of the payment term, which is listed as a string. This element is optional; it is returned
+     * only if normalized text exists.
      *
      * @return the textNormalized
      */
@@ -8231,12 +8363,12 @@ public class IBMCompareComplyV1Models {
     public String getTextNormalized() {
       return textNormalized;
     }
- 
+
     /**
      * Gets the interpretation.
      *
-     * The details of the normalized text, if applicable. This element is optional; that is, the service output lists it
-     * only if normalized text exists.
+     * The details of the normalized text, if applicable. This element is optional; it is returned only if normalized
+     * text exists.
      *
      * @return the interpretation
      */
@@ -8244,11 +8376,11 @@ public class IBMCompareComplyV1Models {
     public Interpretation getInterpretation() {
       return interpretation;
     }
- 
+
     /**
      * Gets the provenanceIds.
      *
-     * One or more hash values that you can send to IBM to provide feedback or receive support.
+     * Hashed values that you can send to IBM to provide feedback or receive support.
      *
      * @return the provenanceIds
      */
@@ -8256,7 +8388,7 @@ public class IBMCompareComplyV1Models {
     public List<String> getProvenanceIds() {
       return provenanceIds;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -8342,17 +8474,16 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('confidence_level', 'confidenceLevel');
-      mapping.put('text_normalized', 'textNormalized');
-      if (interpretation != null) {
-        mapping.putAll(interpretation.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('provenance_ids', 'provenanceIds');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'confidence_level', 'confidenceLevel');
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
+      mapping.putAll(((IBMWatsonGenericModel) Interpretation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'interpretation/', mapping));
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -8362,7 +8493,7 @@ public class IBMCompareComplyV1Models {
    */
   public class RowHeaderIds extends IBMWatsonGenericModel {
     private String id;
- 
+
     /**
      * Gets the id.
      *
@@ -8390,7 +8521,7 @@ public class IBMCompareComplyV1Models {
    */
   public class RowHeaderTexts extends IBMWatsonGenericModel {
     private String text;
- 
+
     /**
      * Gets the text.
      *
@@ -8419,7 +8550,7 @@ public class IBMCompareComplyV1Models {
    */
   public class RowHeaderTextsNormalized extends IBMWatsonGenericModel {
     private String textNormalized;
- 
+
     /**
      * Gets the textNormalized.
      *
@@ -8441,9 +8572,12 @@ public class IBMCompareComplyV1Models {
       this.textNormalized = textNormalized;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('text_normalized', 'textNormalized');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
       return mapping;
     }
   }
@@ -8460,7 +8594,7 @@ public class IBMCompareComplyV1Models {
     private Long rowIndexEnd;
     private Long columnIndexBegin;
     private Long columnIndexEnd;
- 
+
     /**
      * Gets the cellId.
      *
@@ -8472,7 +8606,7 @@ public class IBMCompareComplyV1Models {
     public String getCellId() {
       return cellId;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -8485,7 +8619,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -8497,7 +8631,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the textNormalized.
      *
@@ -8510,7 +8644,7 @@ public class IBMCompareComplyV1Models {
     public String getTextNormalized() {
       return textNormalized;
     }
- 
+
     /**
      * Gets the rowIndexBegin.
      *
@@ -8522,7 +8656,7 @@ public class IBMCompareComplyV1Models {
     public Long getRowIndexBegin() {
       return rowIndexBegin;
     }
- 
+
     /**
      * Gets the rowIndexEnd.
      *
@@ -8534,7 +8668,7 @@ public class IBMCompareComplyV1Models {
     public Long getRowIndexEnd() {
       return rowIndexEnd;
     }
- 
+
     /**
      * Gets the columnIndexBegin.
      *
@@ -8546,7 +8680,7 @@ public class IBMCompareComplyV1Models {
     public Long getColumnIndexBegin() {
       return columnIndexBegin;
     }
- 
+
     /**
      * Gets the columnIndexEnd.
      *
@@ -8645,17 +8779,18 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('cell_id', 'cellId');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('text_normalized', 'textNormalized');
-      mapping.put('row_index_begin', 'rowIndexBegin');
-      mapping.put('row_index_end', 'rowIndexEnd');
-      mapping.put('column_index_begin', 'columnIndexBegin');
-      mapping.put('column_index_end', 'columnIndexEnd');
+      mapping.put(parentLabel + 'cell_id', 'cellId');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
+      mapping.put(parentLabel + 'row_index_begin', 'rowIndexBegin');
+      mapping.put(parentLabel + 'row_index_end', 'rowIndexEnd');
+      mapping.put(parentLabel + 'column_index_begin', 'columnIndexBegin');
+      mapping.put(parentLabel + 'column_index_end', 'columnIndexEnd');
       return mapping;
     }
   }
@@ -8666,7 +8801,7 @@ public class IBMCompareComplyV1Models {
   public class SectionTitle extends IBMWatsonGenericModel {
     private String text;
     private Location location;
- 
+
     /**
      * Gets the text.
      *
@@ -8678,7 +8813,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -8724,11 +8859,8 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -8743,7 +8875,7 @@ public class IBMCompareComplyV1Models {
     private Location location;
     private Long level;
     private List<ElementLocations> elementLocations;
- 
+
     /**
      * Gets the text.
      *
@@ -8755,7 +8887,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -8768,7 +8900,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the level.
      *
@@ -8781,7 +8913,7 @@ public class IBMCompareComplyV1Models {
     public Long getLevel() {
       return level;
     }
- 
+
     /**
      * Gets the elementLocations.
      *
@@ -8857,15 +8989,10 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
-      mapping.put('element_locations', 'elementLocations');
-      if (elementLocations != null && elementLocations[0] != null) {
-        mapping.putAll(elementLocations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      mapping.put(parentLabel + 'element_locations', 'elementLocations');
+      mapping.putAll(((IBMWatsonGenericModel) ElementLocations.class.newInstance()).addToApiToSdkMapping(parentLabel + 'element_locations/', mapping));
       return mapping;
     }
   }
@@ -8882,7 +9009,7 @@ public class IBMCompareComplyV1Models {
      * and should not be called by the client.
      */
     public ShortDoc() { }
- 
+
     /**
      * Gets the title.
      *
@@ -8894,7 +9021,7 @@ public class IBMCompareComplyV1Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the hash.
      *
@@ -8955,7 +9082,7 @@ public class IBMCompareComplyV1Models {
      * @param title the title
      * @return the ShortDoc builder
      */
-    public ShortDocBuilder setTitle(String title) {
+    public ShortDocBuilder title(String title) {
       this.title = title;
       return this;
     }
@@ -8966,7 +9093,7 @@ public class IBMCompareComplyV1Models {
      * @param hash the hash
      * @return the ShortDoc builder
      */
-    public ShortDocBuilder setHash(String hash) {
+    public ShortDocBuilder hash(String hash) {
       this.hash = hash;
       return this;
     }
@@ -8983,7 +9110,7 @@ public class IBMCompareComplyV1Models {
     private Long rowIndexEnd;
     private Long columnIndexBegin;
     private Long columnIndexEnd;
- 
+
     /**
      * Gets the cellId.
      *
@@ -8995,7 +9122,7 @@ public class IBMCompareComplyV1Models {
     public String getCellId() {
       return cellId;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -9008,7 +9135,7 @@ public class IBMCompareComplyV1Models {
     public IBMWatsonMapModel getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -9020,7 +9147,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the rowIndexBegin.
      *
@@ -9032,7 +9159,7 @@ public class IBMCompareComplyV1Models {
     public Long getRowIndexBegin() {
       return rowIndexBegin;
     }
- 
+
     /**
      * Gets the rowIndexEnd.
      *
@@ -9044,7 +9171,7 @@ public class IBMCompareComplyV1Models {
     public Long getRowIndexEnd() {
       return rowIndexEnd;
     }
- 
+
     /**
      * Gets the columnIndexBegin.
      *
@@ -9056,7 +9183,7 @@ public class IBMCompareComplyV1Models {
     public Long getColumnIndexBegin() {
       return columnIndexBegin;
     }
- 
+
     /**
      * Gets the columnIndexEnd.
      *
@@ -9146,13 +9273,16 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('cell_id', 'cellId');
-      mapping.put('row_index_begin', 'rowIndexBegin');
-      mapping.put('row_index_end', 'rowIndexEnd');
-      mapping.put('column_index_begin', 'columnIndexBegin');
-      mapping.put('column_index_end', 'columnIndexEnd');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'cell_id', 'cellId');
+      mapping.put(parentLabel + 'row_index_begin', 'rowIndexBegin');
+      mapping.put(parentLabel + 'row_index_end', 'rowIndexEnd');
+      mapping.put(parentLabel + 'column_index_begin', 'columnIndexBegin');
+      mapping.put(parentLabel + 'column_index_end', 'columnIndexEnd');
       return mapping;
     }
   }
@@ -9165,7 +9295,7 @@ public class IBMCompareComplyV1Models {
     private String modelId;
     private String modelVersion;
     private List<Tables> tables;
- 
+
     /**
      * Gets the document.
      *
@@ -9177,7 +9307,7 @@ public class IBMCompareComplyV1Models {
     public DocInfo getDocument() {
       return document;
     }
- 
+
     /**
      * Gets the modelId.
      *
@@ -9189,7 +9319,7 @@ public class IBMCompareComplyV1Models {
     public String getModelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the modelVersion.
      *
@@ -9201,7 +9331,7 @@ public class IBMCompareComplyV1Models {
     public String getModelVersion() {
       return modelVersion;
     }
- 
+
     /**
      * Gets the tables.
      *
@@ -9277,13 +9407,10 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('model_id', 'modelId');
-      mapping.put('model_version', 'modelVersion');
-      if (tables != null && tables[0] != null) {
-        mapping.putAll(tables[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'model_id', 'modelId');
+      mapping.put(parentLabel + 'model_version', 'modelVersion');
+      mapping.putAll(((IBMWatsonGenericModel) Tables.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tables/', mapping));
       return mapping;
     }
   }
@@ -9295,7 +9422,7 @@ public class IBMCompareComplyV1Models {
   public class TableTitle extends IBMWatsonGenericModel {
     private Location location;
     private String text;
- 
+
     /**
      * Gets the location.
      *
@@ -9308,7 +9435,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -9353,11 +9480,8 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -9376,7 +9500,7 @@ public class IBMCompareComplyV1Models {
     private List<BodyCells> bodyCells;
     private List<Contexts> contexts;
     private List<KeyValuePair> keyValuePairs;
- 
+
     /**
      * Gets the location.
      *
@@ -9389,7 +9513,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -9401,7 +9525,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the sectionTitle.
      *
@@ -9413,7 +9537,7 @@ public class IBMCompareComplyV1Models {
     public SectionTitle getSectionTitle() {
       return sectionTitle;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -9426,7 +9550,7 @@ public class IBMCompareComplyV1Models {
     public TableTitle getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the tableHeaders.
      *
@@ -9438,7 +9562,7 @@ public class IBMCompareComplyV1Models {
     public List<TableHeaders> getTableHeaders() {
       return tableHeaders;
     }
- 
+
     /**
      * Gets the rowHeaders.
      *
@@ -9451,7 +9575,7 @@ public class IBMCompareComplyV1Models {
     public List<RowHeaders> getRowHeaders() {
       return rowHeaders;
     }
- 
+
     /**
      * Gets the columnHeaders.
      *
@@ -9464,7 +9588,7 @@ public class IBMCompareComplyV1Models {
     public List<ColumnHeaders> getColumnHeaders() {
       return columnHeaders;
     }
- 
+
     /**
      * Gets the bodyCells.
      *
@@ -9477,7 +9601,7 @@ public class IBMCompareComplyV1Models {
     public List<BodyCells> getBodyCells() {
       return bodyCells;
     }
- 
+
     /**
      * Gets the contexts.
      *
@@ -9490,7 +9614,7 @@ public class IBMCompareComplyV1Models {
     public List<Contexts> getContexts() {
       return contexts;
     }
- 
+
     /**
      * Gets the keyValuePairs.
      *
@@ -9693,41 +9817,22 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
-      }
-      mapping.put('section_title', 'sectionTitle');
-      if (sectionTitle != null) {
-        mapping.putAll(sectionTitle.getApiToSdkMapping());
-      }
-      if (title != null) {
-        mapping.putAll(title.getApiToSdkMapping());
-      }
-      mapping.put('table_headers', 'tableHeaders');
-      if (tableHeaders != null && tableHeaders[0] != null) {
-        mapping.putAll(tableHeaders[0].getApiToSdkMapping());
-      }
-      mapping.put('row_headers', 'rowHeaders');
-      if (rowHeaders != null && rowHeaders[0] != null) {
-        mapping.putAll(rowHeaders[0].getApiToSdkMapping());
-      }
-      mapping.put('column_headers', 'columnHeaders');
-      if (columnHeaders != null && columnHeaders[0] != null) {
-        mapping.putAll(columnHeaders[0].getApiToSdkMapping());
-      }
-      mapping.put('body_cells', 'bodyCells');
-      if (bodyCells != null && bodyCells[0] != null) {
-        mapping.putAll(bodyCells[0].getApiToSdkMapping());
-      }
-      if (contexts != null && contexts[0] != null) {
-        mapping.putAll(contexts[0].getApiToSdkMapping());
-      }
-      mapping.put('key_value_pairs', 'keyValuePairs');
-      if (keyValuePairs != null && keyValuePairs[0] != null) {
-        mapping.putAll(keyValuePairs[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      mapping.put(parentLabel + 'section_title', 'sectionTitle');
+      mapping.putAll(((IBMWatsonGenericModel) SectionTitle.class.newInstance()).addToApiToSdkMapping(parentLabel + 'section_title/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) TableTitle.class.newInstance()).addToApiToSdkMapping(parentLabel + 'title/', mapping));
+      mapping.put(parentLabel + 'table_headers', 'tableHeaders');
+      mapping.putAll(((IBMWatsonGenericModel) TableHeaders.class.newInstance()).addToApiToSdkMapping(parentLabel + 'table_headers/', mapping));
+      mapping.put(parentLabel + 'row_headers', 'rowHeaders');
+      mapping.putAll(((IBMWatsonGenericModel) RowHeaders.class.newInstance()).addToApiToSdkMapping(parentLabel + 'row_headers/', mapping));
+      mapping.put(parentLabel + 'column_headers', 'columnHeaders');
+      mapping.putAll(((IBMWatsonGenericModel) ColumnHeaders.class.newInstance()).addToApiToSdkMapping(parentLabel + 'column_headers/', mapping));
+      mapping.put(parentLabel + 'body_cells', 'bodyCells');
+      mapping.putAll(((IBMWatsonGenericModel) BodyCells.class.newInstance()).addToApiToSdkMapping(parentLabel + 'body_cells/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Contexts.class.newInstance()).addToApiToSdkMapping(parentLabel + 'contexts/', mapping));
+      mapping.put(parentLabel + 'key_value_pairs', 'keyValuePairs');
+      mapping.putAll(((IBMWatsonGenericModel) KeyValuePair.class.newInstance()).addToApiToSdkMapping(parentLabel + 'key_value_pairs/', mapping));
       return mapping;
     }
   }
@@ -9741,7 +9846,7 @@ public class IBMCompareComplyV1Models {
     private String textNormalized;
     private List<String> provenanceIds;
     private Location location;
- 
+
     /**
      * Gets the confidenceLevel.
      *
@@ -9753,7 +9858,7 @@ public class IBMCompareComplyV1Models {
     public String getConfidenceLevel() {
       return confidenceLevel;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -9765,12 +9870,12 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the textNormalized.
      *
-     * The normalized form of the termination date, which is listed as a string. This element is optional; that is, the
-     * service output lists it only if normalized text exists.
+     * The normalized form of the termination date, which is listed as a string. This element is optional; it is
+     * returned only if normalized text exists.
      *
      * @return the textNormalized
      */
@@ -9778,11 +9883,11 @@ public class IBMCompareComplyV1Models {
     public String getTextNormalized() {
       return textNormalized;
     }
- 
+
     /**
      * Gets the provenanceIds.
      *
-     * One or more hash values that you can send to IBM to provide feedback or receive support.
+     * Hashed values that you can send to IBM to provide feedback or receive support.
      *
      * @return the provenanceIds
      */
@@ -9790,7 +9895,7 @@ public class IBMCompareComplyV1Models {
     public List<String> getProvenanceIds() {
       return provenanceIds;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -9863,14 +9968,15 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('confidence_level', 'confidenceLevel');
-      mapping.put('text_normalized', 'textNormalized');
-      mapping.put('provenance_ids', 'provenanceIds');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'confidence_level', 'confidenceLevel');
+      mapping.put(parentLabel + 'text_normalized', 'textNormalized');
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }
@@ -9887,7 +9993,7 @@ public class IBMCompareComplyV1Models {
      * and should not be called by the client.
      */
     public TypeLabel() { }
- 
+
     /**
      * Gets the label.
      *
@@ -9900,11 +10006,11 @@ public class IBMCompareComplyV1Models {
     public Label getLabel() {
       return label;
     }
- 
+
     /**
      * Gets the provenanceIds.
      *
-     * One or more hash values that you can send to IBM to provide feedback or receive support.
+     * Hashed values that you can send to IBM to provide feedback or receive support.
      *
      * @return the provenanceIds
      */
@@ -9937,20 +10043,18 @@ public class IBMCompareComplyV1Models {
 
       // calling custom deserializer for label
       Label newLabel = (Label) new Label().deserialize(JSON.serialize(ret.getLabel()), (Map<String, Object>) jsonMap.get('label'), Label.class);
-      retBuilder.setLabel(newLabel);
+      retBuilder.label(newLabel);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('provenanceIds', 'provenance_ids');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'provenanceIds', 'provenance_ids');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('provenance_ids', 'provenanceIds');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'provenance_ids', 'provenanceIds');
       return mapping;
     }
   }
@@ -10003,7 +10107,7 @@ public class IBMCompareComplyV1Models {
      * @param label the label
      * @return the TypeLabel builder
      */
-    public TypeLabelBuilder setLabel(Label label) {
+    public TypeLabelBuilder label(Label label) {
       this.label = label;
       return this;
     }
@@ -10015,7 +10119,7 @@ public class IBMCompareComplyV1Models {
      * @param provenanceIds the provenanceIds
      * @return the TypeLabel builder
      */
-    public TypeLabelBuilder setProvenanceIds(List<String> provenanceIds) {
+    public TypeLabelBuilder provenanceIds(List<String> provenanceIds) {
       this.provenanceIds = provenanceIds;
       return this;
     }
@@ -10026,7 +10130,7 @@ public class IBMCompareComplyV1Models {
    */
   public class TypeLabelComparison extends IBMWatsonGenericModel {
     private Label label;
- 
+
     /**
      * Gets the label.
      *
@@ -10074,7 +10178,7 @@ public class IBMCompareComplyV1Models {
     private List<TypeLabelComparison> types;
     private List<CategoryComparison> categories;
     private List<Attribute> attributes;
- 
+
     /**
      * Gets the documentLabel.
      *
@@ -10087,7 +10191,7 @@ public class IBMCompareComplyV1Models {
     public String getDocumentLabel() {
       return documentLabel;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -10100,7 +10204,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -10112,7 +10216,7 @@ public class IBMCompareComplyV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the types.
      *
@@ -10124,7 +10228,7 @@ public class IBMCompareComplyV1Models {
     public List<TypeLabelComparison> getTypes() {
       return types;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -10136,7 +10240,7 @@ public class IBMCompareComplyV1Models {
     public List<CategoryComparison> getCategories() {
       return categories;
     }
- 
+
     /**
      * Gets the attributes.
      *
@@ -10256,15 +10360,14 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_label', 'documentLabel');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (attributes != null && attributes[0] != null) {
-        mapping.putAll(attributes[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'document_label', 'documentLabel');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Attribute.class.newInstance()).addToApiToSdkMapping(parentLabel + 'attributes/', mapping));
       return mapping;
     }
   }
@@ -10430,7 +10533,7 @@ public class IBMCompareComplyV1Models {
   public class UpdatedLabelsIn extends IBMWatsonGenericModel {
     private List<TypeLabel> types;
     private List<Category> categories;
- 
+
     /**
      * Gets the types.
      *
@@ -10441,7 +10544,7 @@ public class IBMCompareComplyV1Models {
     public List<TypeLabel> getTypes() {
       return types;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -10469,13 +10572,12 @@ public class IBMCompareComplyV1Models {
       return new UpdatedLabelsInBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (types != null && types[0] != null) {
-        mapping.putAll(types[0].getSdkToApiMapping());
+        mapping.putAll(types[0].addToSdkToApiMapping(parentLabel + 'types/', mapping));
       }
       if (categories != null && categories[0] != null) {
-        mapping.putAll(categories[0].getSdkToApiMapping());
+        mapping.putAll(categories[0].addToSdkToApiMapping(parentLabel + 'categories/', mapping));
       }
       return mapping;
     }
@@ -10556,7 +10658,7 @@ public class IBMCompareComplyV1Models {
      * @param types the types
      * @return the UpdatedLabelsIn builder
      */
-    public UpdatedLabelsInBuilder setTypes(List<TypeLabel> types) {
+    public UpdatedLabelsInBuilder types(List<TypeLabel> types) {
       this.types = types;
       return this;
     }
@@ -10568,7 +10670,7 @@ public class IBMCompareComplyV1Models {
      * @param categories the categories
      * @return the UpdatedLabelsIn builder
      */
-    public UpdatedLabelsInBuilder setCategories(List<Category> categories) {
+    public UpdatedLabelsInBuilder categories(List<Category> categories) {
       this.categories = categories;
       return this;
     }
@@ -10581,7 +10683,7 @@ public class IBMCompareComplyV1Models {
     private List<TypeLabel> types;
     private List<Category> categories;
     private String modification;
- 
+
     /**
      * Gets the types.
      *
@@ -10593,7 +10695,7 @@ public class IBMCompareComplyV1Models {
     public List<TypeLabel> getTypes() {
       return types;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -10605,7 +10707,7 @@ public class IBMCompareComplyV1Models {
     public List<Category> getCategories() {
       return categories;
     }
- 
+
     /**
      * Gets the modification.
      *
@@ -10682,14 +10784,9 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (types != null && types[0] != null) {
-        mapping.putAll(types[0].getApiToSdkMapping());
-      }
-      if (categories != null && categories[0] != null) {
-        mapping.putAll(categories[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) TypeLabel.class.newInstance()).addToApiToSdkMapping(parentLabel + 'types/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Category.class.newInstance()).addToApiToSdkMapping(parentLabel + 'categories/', mapping));
       return mapping;
     }
   }
@@ -10701,7 +10798,7 @@ public class IBMCompareComplyV1Models {
     private String cellId;
     private Location location;
     private String text;
- 
+
     /**
      * Gets the cellId.
      *
@@ -10713,7 +10810,7 @@ public class IBMCompareComplyV1Models {
     public String getCellId() {
       return cellId;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -10726,7 +10823,7 @@ public class IBMCompareComplyV1Models {
     public Location getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -10780,12 +10877,13 @@ public class IBMCompareComplyV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('cell_id', 'cellId');
-      if (location != null) {
-        mapping.putAll(location.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'cell_id', 'cellId');
+      mapping.putAll(((IBMWatsonGenericModel) Location.class.newInstance()).addToApiToSdkMapping(parentLabel + 'location/', mapping));
       return mapping;
     }
   }

--- a/force-app/main/default/classes/IBMCompareComplyV1Models.cls
+++ b/force-app/main/default/classes/IBMCompareComplyV1Models.cls
@@ -6,7 +6,7 @@ public class IBMCompareComplyV1Models {
     private FeedbackDataInput feedbackData;
     private String userId;
     private String comment;
- 
+
     /**
      * Gets the feedbackData.
      *
@@ -17,7 +17,7 @@ public class IBMCompareComplyV1Models {
     public FeedbackDataInput feedbackData() {
       return feedbackData;
     }
- 
+
     /**
      * Gets the userId.
      *
@@ -28,7 +28,7 @@ public class IBMCompareComplyV1Models {
     public String userId() {
       return userId;
     }
- 
+
     /**
      * Gets the comment.
      *
@@ -57,6 +57,15 @@ public class IBMCompareComplyV1Models {
       return new AddFeedbackOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('feedbackData', 'feedback_data');
+      if (feedbackData != null) {
+        mapping.putAll(feedbackData.getSdkToApiMapping());
+      }
+      mapping.put('userId', 'user_id');
+      return mapping;
+    }
   }
 
   /**
@@ -148,8 +157,8 @@ public class IBMCompareComplyV1Models {
    * A party's address.
    */
   public class Address extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private Location location_serialized_name;
+    private String text;
+    private Location location;
  
     /**
      * Gets the text.
@@ -160,7 +169,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -173,7 +182,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -182,7 +191,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -191,7 +200,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -202,10 +211,18 @@ public class IBMCompareComplyV1Models {
       Address ret = (Address) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -213,10 +230,10 @@ public class IBMCompareComplyV1Models {
    * AlignedElement.
    */
   public class AlignedElement extends IBMWatsonGenericModel {
-    private List<ElementPair> element_pair_serialized_name;
-    private Boolean identical_text_serialized_name;
-    private List<String> provenance_ids_serialized_name;
-    private Boolean significant_elements_serialized_name;
+    private List<ElementPair> elementPair;
+    private Boolean identicalText;
+    private List<String> provenanceIds;
+    private Boolean significantElements;
  
     /**
      * Gets the elementPair.
@@ -227,7 +244,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ElementPair> getElementPair() {
-      return element_pair_serialized_name;
+      return elementPair;
     }
  
     /**
@@ -241,7 +258,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Boolean getIdenticalText() {
-      return identical_text_serialized_name;
+      return identicalText;
     }
  
     /**
@@ -253,7 +270,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<String> getProvenanceIds() {
-      return provenance_ids_serialized_name;
+      return provenanceIds;
     }
  
     /**
@@ -265,7 +282,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Boolean getSignificantElements() {
-      return significant_elements_serialized_name;
+      return significantElements;
     }
 
     /**
@@ -274,7 +291,7 @@ public class IBMCompareComplyV1Models {
      * @param elementPair the new elementPair
      */
     public void setElementPair(final List<ElementPair> elementPair) {
-      this.element_pair_serialized_name = elementPair;
+      this.elementPair = elementPair;
     }
 
     /**
@@ -283,7 +300,7 @@ public class IBMCompareComplyV1Models {
      * @param identicalText the new identicalText
      */
     public void setIdenticalText(final Boolean identicalText) {
-      this.identical_text_serialized_name = identicalText;
+      this.identicalText = identicalText;
     }
 
     /**
@@ -292,7 +309,7 @@ public class IBMCompareComplyV1Models {
      * @param provenanceIds the new provenanceIds
      */
     public void setProvenanceIds(final List<String> provenanceIds) {
-      this.provenance_ids_serialized_name = provenanceIds;
+      this.provenanceIds = provenanceIds;
     }
 
     /**
@@ -301,7 +318,7 @@ public class IBMCompareComplyV1Models {
      * @param significantElements the new significantElements
      */
     public void setSignificantElements(final Boolean significantElements) {
-      this.significant_elements_serialized_name = significantElements;
+      this.significantElements = significantElements;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -317,14 +334,26 @@ public class IBMCompareComplyV1Models {
       if (deserializedElementPair != null) {
         for (Integer i = 0; i < deserializedElementPair.size(); i++) {
           ElementPair currentItem = ret.getElementPair().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('element_pair_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('elementPair');
           ElementPair newItem = (ElementPair) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ElementPair.class);
           newElementPair.add(newItem);
         }
-        ret.element_pair_serialized_name = newElementPair;
+        ret.elementPair = newElementPair;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('element_pair', 'elementPair');
+      if (elementPair != null && elementPair[0] != null) {
+        mapping.putAll(elementPair[0].getApiToSdkMapping());
+      }
+      mapping.put('identical_text', 'identicalText');
+      mapping.put('provenance_ids', 'provenanceIds');
+      mapping.put('significant_elements', 'significantElements');
+      return mapping;
     }
   }
 
@@ -332,9 +361,9 @@ public class IBMCompareComplyV1Models {
    * List of document attributes.
    */
   public class Attribute extends IBMWatsonGenericModel {
-    private String type_serialized_name;
-    private String text_serialized_name;
-    private Location location_serialized_name;
+    private String xtype;
+    private String text;
+    private Location location;
  
     /**
      * Gets the xtype.
@@ -345,7 +374,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -357,7 +386,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -370,7 +399,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -379,7 +408,7 @@ public class IBMCompareComplyV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -388,7 +417,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -397,7 +426,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -408,10 +437,19 @@ public class IBMCompareComplyV1Models {
       Attribute ret = (Attribute) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -419,16 +457,16 @@ public class IBMCompareComplyV1Models {
    * The batch-request status.
    */
   public class BatchStatus extends IBMWatsonResponseModel {
-    private String function_serialized_name;
-    private String input_bucket_location_serialized_name;
-    private String input_bucket_name_serialized_name;
-    private String output_bucket_location_serialized_name;
-    private String output_bucket_name_serialized_name;
-    private String batch_id_serialized_name;
-    private DocCounts document_counts_serialized_name;
-    private String status_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
+    private String function;
+    private String inputBucketLocation;
+    private String inputBucketName;
+    private String outputBucketLocation;
+    private String outputBucketName;
+    private String batchId;
+    private DocCounts documentCounts;
+    private String status;
+    private Datetime created;
+    private Datetime updated;
  
     /**
      * Gets the function.
@@ -440,7 +478,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getFunction() {
-      return function_serialized_name;
+      return function;
     }
  
     /**
@@ -453,7 +491,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getInputBucketLocation() {
-      return input_bucket_location_serialized_name;
+      return inputBucketLocation;
     }
  
     /**
@@ -465,7 +503,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getInputBucketName() {
-      return input_bucket_name_serialized_name;
+      return inputBucketName;
     }
  
     /**
@@ -478,7 +516,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getOutputBucketLocation() {
-      return output_bucket_location_serialized_name;
+      return outputBucketLocation;
     }
  
     /**
@@ -490,7 +528,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getOutputBucketName() {
-      return output_bucket_name_serialized_name;
+      return outputBucketName;
     }
  
     /**
@@ -502,7 +540,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getBatchId() {
-      return batch_id_serialized_name;
+      return batchId;
     }
  
     /**
@@ -514,7 +552,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public DocCounts getDocumentCounts() {
-      return document_counts_serialized_name;
+      return documentCounts;
     }
  
     /**
@@ -526,7 +564,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -538,7 +576,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -550,7 +588,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
 
     /**
@@ -559,7 +597,7 @@ public class IBMCompareComplyV1Models {
      * @param function the new function
      */
     public void setFunction(final String function) {
-      this.function_serialized_name = function;
+      this.function = function;
     }
 
     /**
@@ -568,7 +606,7 @@ public class IBMCompareComplyV1Models {
      * @param inputBucketLocation the new inputBucketLocation
      */
     public void setInputBucketLocation(final String inputBucketLocation) {
-      this.input_bucket_location_serialized_name = inputBucketLocation;
+      this.inputBucketLocation = inputBucketLocation;
     }
 
     /**
@@ -577,7 +615,7 @@ public class IBMCompareComplyV1Models {
      * @param inputBucketName the new inputBucketName
      */
     public void setInputBucketName(final String inputBucketName) {
-      this.input_bucket_name_serialized_name = inputBucketName;
+      this.inputBucketName = inputBucketName;
     }
 
     /**
@@ -586,7 +624,7 @@ public class IBMCompareComplyV1Models {
      * @param outputBucketLocation the new outputBucketLocation
      */
     public void setOutputBucketLocation(final String outputBucketLocation) {
-      this.output_bucket_location_serialized_name = outputBucketLocation;
+      this.outputBucketLocation = outputBucketLocation;
     }
 
     /**
@@ -595,7 +633,7 @@ public class IBMCompareComplyV1Models {
      * @param outputBucketName the new outputBucketName
      */
     public void setOutputBucketName(final String outputBucketName) {
-      this.output_bucket_name_serialized_name = outputBucketName;
+      this.outputBucketName = outputBucketName;
     }
 
     /**
@@ -604,7 +642,7 @@ public class IBMCompareComplyV1Models {
      * @param batchId the new batchId
      */
     public void setBatchId(final String batchId) {
-      this.batch_id_serialized_name = batchId;
+      this.batchId = batchId;
     }
 
     /**
@@ -613,7 +651,7 @@ public class IBMCompareComplyV1Models {
      * @param documentCounts the new documentCounts
      */
     public void setDocumentCounts(final DocCounts documentCounts) {
-      this.document_counts_serialized_name = documentCounts;
+      this.documentCounts = documentCounts;
     }
 
     /**
@@ -622,7 +660,7 @@ public class IBMCompareComplyV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -631,7 +669,7 @@ public class IBMCompareComplyV1Models {
      * @param created the new created
      */
     public void setCreated(final Datetime created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
     /**
@@ -640,7 +678,7 @@ public class IBMCompareComplyV1Models {
      * @param updated the new updated
      */
     public void setUpdated(final Datetime updated) {
-      this.updated_serialized_name = updated;
+      this.updated = updated;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -651,10 +689,21 @@ public class IBMCompareComplyV1Models {
       BatchStatus ret = (BatchStatus) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for documentCounts
-      DocCounts newDocumentCounts = (DocCounts) new DocCounts().deserialize(JSON.serialize(ret.getDocumentCounts()), (Map<String, Object>) jsonMap.get('document_counts_serialized_name'), DocCounts.class);
+      DocCounts newDocumentCounts = (DocCounts) new DocCounts().deserialize(JSON.serialize(ret.getDocumentCounts()), (Map<String, Object>) jsonMap.get('documentCounts'), DocCounts.class);
       ret.setDocumentCounts(newDocumentCounts);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('input_bucket_location', 'inputBucketLocation');
+      mapping.put('input_bucket_name', 'inputBucketName');
+      mapping.put('output_bucket_location', 'outputBucketLocation');
+      mapping.put('output_bucket_name', 'outputBucketName');
+      mapping.put('batch_id', 'batchId');
+      mapping.put('document_counts', 'documentCounts');
+      return mapping;
     }
   }
 
@@ -662,7 +711,7 @@ public class IBMCompareComplyV1Models {
    * The results of a successful **List Batches** request.
    */
   public class Batches extends IBMWatsonResponseModel {
-    private List<BatchStatus> batches_serialized_name;
+    private List<BatchStatus> batches;
  
     /**
      * Gets the batches.
@@ -673,7 +722,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<BatchStatus> getBatches() {
-      return batches_serialized_name;
+      return batches;
     }
 
     /**
@@ -682,7 +731,7 @@ public class IBMCompareComplyV1Models {
      * @param batches the new batches
      */
     public void setBatches(final List<BatchStatus> batches) {
-      this.batches_serialized_name = batches;
+      this.batches = batches;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -698,14 +747,22 @@ public class IBMCompareComplyV1Models {
       if (deserializedBatches != null) {
         for (Integer i = 0; i < deserializedBatches.size(); i++) {
           BatchStatus currentItem = ret.getBatches().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('batches_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('batches');
           BatchStatus newItem = (BatchStatus) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), BatchStatus.class);
           newBatches.add(newItem);
         }
-        ret.batches_serialized_name = newBatches;
+        ret.batches = newBatches;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (batches != null && batches[0] != null) {
+        mapping.putAll(batches[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -713,20 +770,20 @@ public class IBMCompareComplyV1Models {
    * Cells that are not table header, column header, or row header cells.
    */
   public class BodyCells extends IBMWatsonGenericModel {
-    private String cell_id_serialized_name;
-    private Location location_serialized_name;
-    private String text_serialized_name;
-    private Long row_index_begin_serialized_name;
-    private Long row_index_end_serialized_name;
-    private Long column_index_begin_serialized_name;
-    private Long column_index_end_serialized_name;
-    private List<RowHeaderIds> row_header_ids_serialized_name;
-    private List<RowHeaderTexts> row_header_texts_serialized_name;
-    private List<RowHeaderTextsNormalized> row_header_texts_normalized_serialized_name;
-    private List<ColumnHeaderIds> column_header_ids_serialized_name;
-    private List<ColumnHeaderTexts> column_header_texts_serialized_name;
-    private List<ColumnHeaderTextsNormalized> column_header_texts_normalized_serialized_name;
-    private List<Attribute> attributes_serialized_name;
+    private String cellId;
+    private Location location;
+    private String text;
+    private Long rowIndexBegin;
+    private Long rowIndexEnd;
+    private Long columnIndexBegin;
+    private Long columnIndexEnd;
+    private List<RowHeaderIds> rowHeaderIds;
+    private List<RowHeaderTexts> rowHeaderTexts;
+    private List<RowHeaderTextsNormalized> rowHeaderTextsNormalized;
+    private List<ColumnHeaderIds> columnHeaderIds;
+    private List<ColumnHeaderTexts> columnHeaderTexts;
+    private List<ColumnHeaderTextsNormalized> columnHeaderTextsNormalized;
+    private List<Attribute> attributes;
  
     /**
      * Gets the cellId.
@@ -737,7 +794,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getCellId() {
-      return cell_id_serialized_name;
+      return cellId;
     }
  
     /**
@@ -750,7 +807,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -762,7 +819,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -774,7 +831,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getRowIndexBegin() {
-      return row_index_begin_serialized_name;
+      return rowIndexBegin;
     }
  
     /**
@@ -786,7 +843,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getRowIndexEnd() {
-      return row_index_end_serialized_name;
+      return rowIndexEnd;
     }
  
     /**
@@ -798,7 +855,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getColumnIndexBegin() {
-      return column_index_begin_serialized_name;
+      return columnIndexBegin;
     }
  
     /**
@@ -810,7 +867,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getColumnIndexEnd() {
-      return column_index_end_serialized_name;
+      return columnIndexEnd;
     }
  
     /**
@@ -820,7 +877,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<RowHeaderIds> getRowHeaderIds() {
-      return row_header_ids_serialized_name;
+      return rowHeaderIds;
     }
  
     /**
@@ -830,7 +887,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<RowHeaderTexts> getRowHeaderTexts() {
-      return row_header_texts_serialized_name;
+      return rowHeaderTexts;
     }
  
     /**
@@ -840,7 +897,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<RowHeaderTextsNormalized> getRowHeaderTextsNormalized() {
-      return row_header_texts_normalized_serialized_name;
+      return rowHeaderTextsNormalized;
     }
  
     /**
@@ -850,7 +907,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ColumnHeaderIds> getColumnHeaderIds() {
-      return column_header_ids_serialized_name;
+      return columnHeaderIds;
     }
  
     /**
@@ -860,7 +917,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ColumnHeaderTexts> getColumnHeaderTexts() {
-      return column_header_texts_serialized_name;
+      return columnHeaderTexts;
     }
  
     /**
@@ -870,7 +927,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ColumnHeaderTextsNormalized> getColumnHeaderTextsNormalized() {
-      return column_header_texts_normalized_serialized_name;
+      return columnHeaderTextsNormalized;
     }
  
     /**
@@ -880,7 +937,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Attribute> getAttributes() {
-      return attributes_serialized_name;
+      return attributes;
     }
 
     /**
@@ -889,7 +946,7 @@ public class IBMCompareComplyV1Models {
      * @param cellId the new cellId
      */
     public void setCellId(final String cellId) {
-      this.cell_id_serialized_name = cellId;
+      this.cellId = cellId;
     }
 
     /**
@@ -898,7 +955,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -907,7 +964,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -916,7 +973,7 @@ public class IBMCompareComplyV1Models {
      * @param rowIndexBegin the new rowIndexBegin
      */
     public void setRowIndexBegin(final long rowIndexBegin) {
-      this.row_index_begin_serialized_name = rowIndexBegin;
+      this.rowIndexBegin = rowIndexBegin;
     }
 
     /**
@@ -925,7 +982,7 @@ public class IBMCompareComplyV1Models {
      * @param rowIndexEnd the new rowIndexEnd
      */
     public void setRowIndexEnd(final long rowIndexEnd) {
-      this.row_index_end_serialized_name = rowIndexEnd;
+      this.rowIndexEnd = rowIndexEnd;
     }
 
     /**
@@ -934,7 +991,7 @@ public class IBMCompareComplyV1Models {
      * @param columnIndexBegin the new columnIndexBegin
      */
     public void setColumnIndexBegin(final long columnIndexBegin) {
-      this.column_index_begin_serialized_name = columnIndexBegin;
+      this.columnIndexBegin = columnIndexBegin;
     }
 
     /**
@@ -943,7 +1000,7 @@ public class IBMCompareComplyV1Models {
      * @param columnIndexEnd the new columnIndexEnd
      */
     public void setColumnIndexEnd(final long columnIndexEnd) {
-      this.column_index_end_serialized_name = columnIndexEnd;
+      this.columnIndexEnd = columnIndexEnd;
     }
 
     /**
@@ -952,7 +1009,7 @@ public class IBMCompareComplyV1Models {
      * @param rowHeaderIds the new rowHeaderIds
      */
     public void setRowHeaderIds(final List<RowHeaderIds> rowHeaderIds) {
-      this.row_header_ids_serialized_name = rowHeaderIds;
+      this.rowHeaderIds = rowHeaderIds;
     }
 
     /**
@@ -961,7 +1018,7 @@ public class IBMCompareComplyV1Models {
      * @param rowHeaderTexts the new rowHeaderTexts
      */
     public void setRowHeaderTexts(final List<RowHeaderTexts> rowHeaderTexts) {
-      this.row_header_texts_serialized_name = rowHeaderTexts;
+      this.rowHeaderTexts = rowHeaderTexts;
     }
 
     /**
@@ -970,7 +1027,7 @@ public class IBMCompareComplyV1Models {
      * @param rowHeaderTextsNormalized the new rowHeaderTextsNormalized
      */
     public void setRowHeaderTextsNormalized(final List<RowHeaderTextsNormalized> rowHeaderTextsNormalized) {
-      this.row_header_texts_normalized_serialized_name = rowHeaderTextsNormalized;
+      this.rowHeaderTextsNormalized = rowHeaderTextsNormalized;
     }
 
     /**
@@ -979,7 +1036,7 @@ public class IBMCompareComplyV1Models {
      * @param columnHeaderIds the new columnHeaderIds
      */
     public void setColumnHeaderIds(final List<ColumnHeaderIds> columnHeaderIds) {
-      this.column_header_ids_serialized_name = columnHeaderIds;
+      this.columnHeaderIds = columnHeaderIds;
     }
 
     /**
@@ -988,7 +1045,7 @@ public class IBMCompareComplyV1Models {
      * @param columnHeaderTexts the new columnHeaderTexts
      */
     public void setColumnHeaderTexts(final List<ColumnHeaderTexts> columnHeaderTexts) {
-      this.column_header_texts_serialized_name = columnHeaderTexts;
+      this.columnHeaderTexts = columnHeaderTexts;
     }
 
     /**
@@ -997,7 +1054,7 @@ public class IBMCompareComplyV1Models {
      * @param columnHeaderTextsNormalized the new columnHeaderTextsNormalized
      */
     public void setColumnHeaderTextsNormalized(final List<ColumnHeaderTextsNormalized> columnHeaderTextsNormalized) {
-      this.column_header_texts_normalized_serialized_name = columnHeaderTextsNormalized;
+      this.columnHeaderTextsNormalized = columnHeaderTextsNormalized;
     }
 
     /**
@@ -1006,7 +1063,7 @@ public class IBMCompareComplyV1Models {
      * @param attributes the new attributes
      */
     public void setAttributes(final List<Attribute> attributes) {
-      this.attributes_serialized_name = attributes;
+      this.attributes = attributes;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1017,7 +1074,7 @@ public class IBMCompareComplyV1Models {
       BodyCells ret = (BodyCells) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       // calling custom deserializer for rowHeaderIds
@@ -1026,11 +1083,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedRowHeaderIds != null) {
         for (Integer i = 0; i < deserializedRowHeaderIds.size(); i++) {
           RowHeaderIds currentItem = ret.getRowHeaderIds().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('row_header_ids_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('rowHeaderIds');
           RowHeaderIds newItem = (RowHeaderIds) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RowHeaderIds.class);
           newRowHeaderIds.add(newItem);
         }
-        ret.row_header_ids_serialized_name = newRowHeaderIds;
+        ret.rowHeaderIds = newRowHeaderIds;
       }
 
       // calling custom deserializer for rowHeaderTexts
@@ -1039,11 +1096,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedRowHeaderTexts != null) {
         for (Integer i = 0; i < deserializedRowHeaderTexts.size(); i++) {
           RowHeaderTexts currentItem = ret.getRowHeaderTexts().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('row_header_texts_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('rowHeaderTexts');
           RowHeaderTexts newItem = (RowHeaderTexts) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RowHeaderTexts.class);
           newRowHeaderTexts.add(newItem);
         }
-        ret.row_header_texts_serialized_name = newRowHeaderTexts;
+        ret.rowHeaderTexts = newRowHeaderTexts;
       }
 
       // calling custom deserializer for rowHeaderTextsNormalized
@@ -1052,11 +1109,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedRowHeaderTextsNormalized != null) {
         for (Integer i = 0; i < deserializedRowHeaderTextsNormalized.size(); i++) {
           RowHeaderTextsNormalized currentItem = ret.getRowHeaderTextsNormalized().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('row_header_texts_normalized_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('rowHeaderTextsNormalized');
           RowHeaderTextsNormalized newItem = (RowHeaderTextsNormalized) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RowHeaderTextsNormalized.class);
           newRowHeaderTextsNormalized.add(newItem);
         }
-        ret.row_header_texts_normalized_serialized_name = newRowHeaderTextsNormalized;
+        ret.rowHeaderTextsNormalized = newRowHeaderTextsNormalized;
       }
 
       // calling custom deserializer for columnHeaderIds
@@ -1065,11 +1122,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedColumnHeaderIds != null) {
         for (Integer i = 0; i < deserializedColumnHeaderIds.size(); i++) {
           ColumnHeaderIds currentItem = ret.getColumnHeaderIds().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('column_header_ids_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('columnHeaderIds');
           ColumnHeaderIds newItem = (ColumnHeaderIds) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ColumnHeaderIds.class);
           newColumnHeaderIds.add(newItem);
         }
-        ret.column_header_ids_serialized_name = newColumnHeaderIds;
+        ret.columnHeaderIds = newColumnHeaderIds;
       }
 
       // calling custom deserializer for columnHeaderTexts
@@ -1078,11 +1135,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedColumnHeaderTexts != null) {
         for (Integer i = 0; i < deserializedColumnHeaderTexts.size(); i++) {
           ColumnHeaderTexts currentItem = ret.getColumnHeaderTexts().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('column_header_texts_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('columnHeaderTexts');
           ColumnHeaderTexts newItem = (ColumnHeaderTexts) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ColumnHeaderTexts.class);
           newColumnHeaderTexts.add(newItem);
         }
-        ret.column_header_texts_serialized_name = newColumnHeaderTexts;
+        ret.columnHeaderTexts = newColumnHeaderTexts;
       }
 
       // calling custom deserializer for columnHeaderTextsNormalized
@@ -1091,11 +1148,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedColumnHeaderTextsNormalized != null) {
         for (Integer i = 0; i < deserializedColumnHeaderTextsNormalized.size(); i++) {
           ColumnHeaderTextsNormalized currentItem = ret.getColumnHeaderTextsNormalized().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('column_header_texts_normalized_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('columnHeaderTextsNormalized');
           ColumnHeaderTextsNormalized newItem = (ColumnHeaderTextsNormalized) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ColumnHeaderTextsNormalized.class);
           newColumnHeaderTextsNormalized.add(newItem);
         }
-        ret.column_header_texts_normalized_serialized_name = newColumnHeaderTextsNormalized;
+        ret.columnHeaderTextsNormalized = newColumnHeaderTextsNormalized;
       }
 
       // calling custom deserializer for attributes
@@ -1104,14 +1161,42 @@ public class IBMCompareComplyV1Models {
       if (deserializedAttributes != null) {
         for (Integer i = 0; i < deserializedAttributes.size(); i++) {
           Attribute currentItem = ret.getAttributes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('attributes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('attributes');
           Attribute newItem = (Attribute) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Attribute.class);
           newAttributes.add(newItem);
         }
-        ret.attributes_serialized_name = newAttributes;
+        ret.attributes = newAttributes;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('cell_id', 'cellId');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      mapping.put('row_index_begin', 'rowIndexBegin');
+      mapping.put('row_index_end', 'rowIndexEnd');
+      mapping.put('column_index_begin', 'columnIndexBegin');
+      mapping.put('column_index_end', 'columnIndexEnd');
+      mapping.put('row_header_ids', 'rowHeaderIds');
+      mapping.put('row_header_texts', 'rowHeaderTexts');
+      mapping.put('row_header_texts_normalized', 'rowHeaderTextsNormalized');
+      if (rowHeaderTextsNormalized != null && rowHeaderTextsNormalized[0] != null) {
+        mapping.putAll(rowHeaderTextsNormalized[0].getApiToSdkMapping());
+      }
+      mapping.put('column_header_ids', 'columnHeaderIds');
+      mapping.put('column_header_texts', 'columnHeaderTexts');
+      mapping.put('column_header_texts_normalized', 'columnHeaderTextsNormalized');
+      if (columnHeaderTextsNormalized != null && columnHeaderTextsNormalized[0] != null) {
+        mapping.putAll(columnHeaderTextsNormalized[0].getApiToSdkMapping());
+      }
+      if (attributes != null && attributes[0] != null) {
+        mapping.putAll(attributes[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1119,8 +1204,14 @@ public class IBMCompareComplyV1Models {
    * Information defining an element's subject matter.
    */
   public class Category extends IBMWatsonGenericModel {
-    private String label_serialized_name;
-    private List<String> provenance_ids_serialized_name;
+    private String label;
+    private List<String> provenanceIds;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Category() { }
  
     /**
      * Gets the label.
@@ -1131,7 +1222,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getLabel() {
-      return label_serialized_name;
+      return label;
     }
  
     /**
@@ -1143,34 +1234,107 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<String> getProvenanceIds() {
-      return provenance_ids_serialized_name;
+      return provenanceIds;
+    }
+  
+    private Category(CategoryBuilder builder) {
+      this.label = builder.label;
+      this.provenanceIds = builder.provenanceIds;
     }
 
     /**
-     * Sets the label.
+     * New builder.
      *
-     * @param label the new label
+     * @return a Category builder
      */
-    public void setLabel(final String label) {
-      this.label_serialized_name = label;
+    public CategoryBuilder newBuilder() {
+      return new CategoryBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('provenanceIds', 'provenance_ids');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('provenance_ids', 'provenanceIds');
+      return mapping;
+    }
+  }
+
+  /**
+   * Category Builder.
+   */
+  public class CategoryBuilder {
+    private String label;
+    private List<String> provenanceIds;
+
+    private CategoryBuilder(Category category) {
+      this.label = category.label;
+      this.provenanceIds = category.provenanceIds;
     }
 
     /**
-     * Sets the provenanceIds.
+     * Instantiates a new builder.
+     */
+    public CategoryBuilder() {
+    }
+
+    /**
+     * Builds a Category.
+     *
+     * @return the category
+     */
+    public Category build() {
+      return new Category(this);
+    }
+
+    /**
+     * Adds an provenanceIds to provenanceIds.
      *
      * @param provenanceIds the new provenanceIds
+     * @return the Category builder
      */
-    public void setProvenanceIds(final List<String> provenanceIds) {
-      this.provenance_ids_serialized_name = provenanceIds;
+    public CategoryBuilder addProvenanceIds(String provenanceIds) {
+      IBMWatsonValidator.notNull(provenanceIds, 'provenanceIds cannot be null');
+      if (this.provenanceIds == null) {
+        this.provenanceIds = new List<String>();
+      }
+      this.provenanceIds.add(provenanceIds);
+      return this;
     }
 
+    /**
+     * Set the label.
+     *
+     * @param label the label
+     * @return the Category builder
+     */
+    public CategoryBuilder setLabel(String label) {
+      this.label = label;
+      return this;
+    }
+
+    /**
+     * Set the provenanceIds.
+     * Existing provenanceIds will be replaced.
+     *
+     * @param provenanceIds the provenanceIds
+     * @return the Category builder
+     */
+    public CategoryBuilder setProvenanceIds(List<String> provenanceIds) {
+      this.provenanceIds = provenanceIds;
+      return this;
+    }
   }
 
   /**
    * Information defining an element's subject matter.
    */
   public class CategoryComparison extends IBMWatsonGenericModel {
-    private String label_serialized_name;
+    private String label;
  
     /**
      * Gets the label.
@@ -1181,7 +1345,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getLabel() {
-      return label_serialized_name;
+      return label;
     }
 
     /**
@@ -1190,9 +1354,8 @@ public class IBMCompareComplyV1Models {
      * @param label the new label
      */
     public void setLabel(final String label) {
-      this.label_serialized_name = label;
+      this.label = label;
     }
-
   }
 
   /**
@@ -1202,7 +1365,7 @@ public class IBMCompareComplyV1Models {
     private IBMWatsonFile file;
     private String fileContentType;
     private String model;
- 
+
     /**
      * Gets the file.
      *
@@ -1213,7 +1376,7 @@ public class IBMCompareComplyV1Models {
     public IBMWatsonFile file() {
       return file;
     }
- 
+
     /**
      * Gets the fileContentType.
      *
@@ -1224,7 +1387,7 @@ public class IBMCompareComplyV1Models {
     public String fileContentType() {
       return fileContentType;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -1255,6 +1418,11 @@ public class IBMCompareComplyV1Models {
       return new ClassifyElementsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('fileContentType', 'file_content_type');
+      return mapping;
+    }
   }
 
   /**
@@ -1346,19 +1514,19 @@ public class IBMCompareComplyV1Models {
    * The analysis of objects returned by the **Element classification** method.
    */
   public class ClassifyReturn extends IBMWatsonResponseModel {
-    private Document document_serialized_name;
-    private String model_id_serialized_name;
-    private String model_version_serialized_name;
-    private List<Element> elements_serialized_name;
-    private List<EffectiveDates> effective_dates_serialized_name;
-    private List<ContractAmts> contract_amounts_serialized_name;
-    private List<TerminationDates> termination_dates_serialized_name;
-    private List<ContractTypes> contract_types_serialized_name;
-    private List<ContractTerms> contract_terms_serialized_name;
-    private List<PaymentTerms> payment_terms_serialized_name;
-    private List<Tables> tables_serialized_name;
-    private DocStructure document_structure_serialized_name;
-    private List<Parties> parties_serialized_name;
+    private Document document;
+    private String modelId;
+    private String modelVersion;
+    private List<Element> elements;
+    private List<EffectiveDates> effectiveDates;
+    private List<ContractAmts> contractAmounts;
+    private List<TerminationDates> terminationDates;
+    private List<ContractTypes> contractTypes;
+    private List<ContractTerms> contractTerms;
+    private List<PaymentTerms> paymentTerms;
+    private List<Tables> tables;
+    private DocStructure documentStructure;
+    private List<Parties> parties;
  
     /**
      * Gets the document.
@@ -1369,7 +1537,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Document getDocument() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -1382,7 +1550,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModelId() {
-      return model_id_serialized_name;
+      return modelId;
     }
  
     /**
@@ -1394,7 +1562,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModelVersion() {
-      return model_version_serialized_name;
+      return modelVersion;
     }
  
     /**
@@ -1406,7 +1574,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Element> getElements() {
-      return elements_serialized_name;
+      return elements;
     }
  
     /**
@@ -1418,7 +1586,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<EffectiveDates> getEffectiveDates() {
-      return effective_dates_serialized_name;
+      return effectiveDates;
     }
  
     /**
@@ -1431,7 +1599,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ContractAmts> getContractAmounts() {
-      return contract_amounts_serialized_name;
+      return contractAmounts;
     }
  
     /**
@@ -1443,7 +1611,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<TerminationDates> getTerminationDates() {
-      return termination_dates_serialized_name;
+      return terminationDates;
     }
  
     /**
@@ -1455,7 +1623,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ContractTypes> getContractTypes() {
-      return contract_types_serialized_name;
+      return contractTypes;
     }
  
     /**
@@ -1467,7 +1635,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ContractTerms> getContractTerms() {
-      return contract_terms_serialized_name;
+      return contractTerms;
     }
  
     /**
@@ -1479,7 +1647,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<PaymentTerms> getPaymentTerms() {
-      return payment_terms_serialized_name;
+      return paymentTerms;
     }
  
     /**
@@ -1491,7 +1659,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Tables> getTables() {
-      return tables_serialized_name;
+      return tables;
     }
  
     /**
@@ -1503,7 +1671,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public DocStructure getDocumentStructure() {
-      return document_structure_serialized_name;
+      return documentStructure;
     }
  
     /**
@@ -1515,7 +1683,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Parties> getParties() {
-      return parties_serialized_name;
+      return parties;
     }
 
     /**
@@ -1524,7 +1692,7 @@ public class IBMCompareComplyV1Models {
      * @param document the new document
      */
     public void setDocument(final Document document) {
-      this.document_serialized_name = document;
+      this.document = document;
     }
 
     /**
@@ -1533,7 +1701,7 @@ public class IBMCompareComplyV1Models {
      * @param modelId the new modelId
      */
     public void setModelId(final String modelId) {
-      this.model_id_serialized_name = modelId;
+      this.modelId = modelId;
     }
 
     /**
@@ -1542,7 +1710,7 @@ public class IBMCompareComplyV1Models {
      * @param modelVersion the new modelVersion
      */
     public void setModelVersion(final String modelVersion) {
-      this.model_version_serialized_name = modelVersion;
+      this.modelVersion = modelVersion;
     }
 
     /**
@@ -1551,7 +1719,7 @@ public class IBMCompareComplyV1Models {
      * @param elements the new elements
      */
     public void setElements(final List<Element> elements) {
-      this.elements_serialized_name = elements;
+      this.elements = elements;
     }
 
     /**
@@ -1560,7 +1728,7 @@ public class IBMCompareComplyV1Models {
      * @param effectiveDates the new effectiveDates
      */
     public void setEffectiveDates(final List<EffectiveDates> effectiveDates) {
-      this.effective_dates_serialized_name = effectiveDates;
+      this.effectiveDates = effectiveDates;
     }
 
     /**
@@ -1569,7 +1737,7 @@ public class IBMCompareComplyV1Models {
      * @param contractAmounts the new contractAmounts
      */
     public void setContractAmounts(final List<ContractAmts> contractAmounts) {
-      this.contract_amounts_serialized_name = contractAmounts;
+      this.contractAmounts = contractAmounts;
     }
 
     /**
@@ -1578,7 +1746,7 @@ public class IBMCompareComplyV1Models {
      * @param terminationDates the new terminationDates
      */
     public void setTerminationDates(final List<TerminationDates> terminationDates) {
-      this.termination_dates_serialized_name = terminationDates;
+      this.terminationDates = terminationDates;
     }
 
     /**
@@ -1587,7 +1755,7 @@ public class IBMCompareComplyV1Models {
      * @param contractTypes the new contractTypes
      */
     public void setContractTypes(final List<ContractTypes> contractTypes) {
-      this.contract_types_serialized_name = contractTypes;
+      this.contractTypes = contractTypes;
     }
 
     /**
@@ -1596,7 +1764,7 @@ public class IBMCompareComplyV1Models {
      * @param contractTerms the new contractTerms
      */
     public void setContractTerms(final List<ContractTerms> contractTerms) {
-      this.contract_terms_serialized_name = contractTerms;
+      this.contractTerms = contractTerms;
     }
 
     /**
@@ -1605,7 +1773,7 @@ public class IBMCompareComplyV1Models {
      * @param paymentTerms the new paymentTerms
      */
     public void setPaymentTerms(final List<PaymentTerms> paymentTerms) {
-      this.payment_terms_serialized_name = paymentTerms;
+      this.paymentTerms = paymentTerms;
     }
 
     /**
@@ -1614,7 +1782,7 @@ public class IBMCompareComplyV1Models {
      * @param tables the new tables
      */
     public void setTables(final List<Tables> tables) {
-      this.tables_serialized_name = tables;
+      this.tables = tables;
     }
 
     /**
@@ -1623,7 +1791,7 @@ public class IBMCompareComplyV1Models {
      * @param documentStructure the new documentStructure
      */
     public void setDocumentStructure(final DocStructure documentStructure) {
-      this.document_structure_serialized_name = documentStructure;
+      this.documentStructure = documentStructure;
     }
 
     /**
@@ -1632,7 +1800,7 @@ public class IBMCompareComplyV1Models {
      * @param parties the new parties
      */
     public void setParties(final List<Parties> parties) {
-      this.parties_serialized_name = parties;
+      this.parties = parties;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1643,7 +1811,7 @@ public class IBMCompareComplyV1Models {
       ClassifyReturn ret = (ClassifyReturn) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for document
-      Document newDocument = (Document) new Document().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document_serialized_name'), Document.class);
+      Document newDocument = (Document) new Document().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document'), Document.class);
       ret.setDocument(newDocument);
 
       // calling custom deserializer for elements
@@ -1652,11 +1820,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedElements != null) {
         for (Integer i = 0; i < deserializedElements.size(); i++) {
           Element currentItem = ret.getElements().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('elements_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('elements');
           Element newItem = (Element) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Element.class);
           newElements.add(newItem);
         }
-        ret.elements_serialized_name = newElements;
+        ret.elements = newElements;
       }
 
       // calling custom deserializer for effectiveDates
@@ -1665,11 +1833,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedEffectiveDates != null) {
         for (Integer i = 0; i < deserializedEffectiveDates.size(); i++) {
           EffectiveDates currentItem = ret.getEffectiveDates().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('effective_dates_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('effectiveDates');
           EffectiveDates newItem = (EffectiveDates) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), EffectiveDates.class);
           newEffectiveDates.add(newItem);
         }
-        ret.effective_dates_serialized_name = newEffectiveDates;
+        ret.effectiveDates = newEffectiveDates;
       }
 
       // calling custom deserializer for contractAmounts
@@ -1678,11 +1846,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedContractAmounts != null) {
         for (Integer i = 0; i < deserializedContractAmounts.size(); i++) {
           ContractAmts currentItem = ret.getContractAmounts().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('contract_amounts_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('contractAmounts');
           ContractAmts newItem = (ContractAmts) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ContractAmts.class);
           newContractAmounts.add(newItem);
         }
-        ret.contract_amounts_serialized_name = newContractAmounts;
+        ret.contractAmounts = newContractAmounts;
       }
 
       // calling custom deserializer for terminationDates
@@ -1691,11 +1859,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedTerminationDates != null) {
         for (Integer i = 0; i < deserializedTerminationDates.size(); i++) {
           TerminationDates currentItem = ret.getTerminationDates().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('termination_dates_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('terminationDates');
           TerminationDates newItem = (TerminationDates) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TerminationDates.class);
           newTerminationDates.add(newItem);
         }
-        ret.termination_dates_serialized_name = newTerminationDates;
+        ret.terminationDates = newTerminationDates;
       }
 
       // calling custom deserializer for contractTypes
@@ -1704,11 +1872,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedContractTypes != null) {
         for (Integer i = 0; i < deserializedContractTypes.size(); i++) {
           ContractTypes currentItem = ret.getContractTypes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('contract_types_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('contractTypes');
           ContractTypes newItem = (ContractTypes) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ContractTypes.class);
           newContractTypes.add(newItem);
         }
-        ret.contract_types_serialized_name = newContractTypes;
+        ret.contractTypes = newContractTypes;
       }
 
       // calling custom deserializer for contractTerms
@@ -1717,11 +1885,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedContractTerms != null) {
         for (Integer i = 0; i < deserializedContractTerms.size(); i++) {
           ContractTerms currentItem = ret.getContractTerms().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('contract_terms_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('contractTerms');
           ContractTerms newItem = (ContractTerms) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ContractTerms.class);
           newContractTerms.add(newItem);
         }
-        ret.contract_terms_serialized_name = newContractTerms;
+        ret.contractTerms = newContractTerms;
       }
 
       // calling custom deserializer for paymentTerms
@@ -1730,11 +1898,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedPaymentTerms != null) {
         for (Integer i = 0; i < deserializedPaymentTerms.size(); i++) {
           PaymentTerms currentItem = ret.getPaymentTerms().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('payment_terms_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('paymentTerms');
           PaymentTerms newItem = (PaymentTerms) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), PaymentTerms.class);
           newPaymentTerms.add(newItem);
         }
-        ret.payment_terms_serialized_name = newPaymentTerms;
+        ret.paymentTerms = newPaymentTerms;
       }
 
       // calling custom deserializer for tables
@@ -1743,15 +1911,15 @@ public class IBMCompareComplyV1Models {
       if (deserializedTables != null) {
         for (Integer i = 0; i < deserializedTables.size(); i++) {
           Tables currentItem = ret.getTables().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('tables_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('tables');
           Tables newItem = (Tables) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Tables.class);
           newTables.add(newItem);
         }
-        ret.tables_serialized_name = newTables;
+        ret.tables = newTables;
       }
 
       // calling custom deserializer for documentStructure
-      DocStructure newDocumentStructure = (DocStructure) new DocStructure().deserialize(JSON.serialize(ret.getDocumentStructure()), (Map<String, Object>) jsonMap.get('document_structure_serialized_name'), DocStructure.class);
+      DocStructure newDocumentStructure = (DocStructure) new DocStructure().deserialize(JSON.serialize(ret.getDocumentStructure()), (Map<String, Object>) jsonMap.get('documentStructure'), DocStructure.class);
       ret.setDocumentStructure(newDocumentStructure);
 
       // calling custom deserializer for parties
@@ -1760,14 +1928,58 @@ public class IBMCompareComplyV1Models {
       if (deserializedParties != null) {
         for (Integer i = 0; i < deserializedParties.size(); i++) {
           Parties currentItem = ret.getParties().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('parties_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('parties');
           Parties newItem = (Parties) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Parties.class);
           newParties.add(newItem);
         }
-        ret.parties_serialized_name = newParties;
+        ret.parties = newParties;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('model_id', 'modelId');
+      mapping.put('model_version', 'modelVersion');
+      if (elements != null && elements[0] != null) {
+        mapping.putAll(elements[0].getApiToSdkMapping());
+      }
+      mapping.put('effective_dates', 'effectiveDates');
+      if (effectiveDates != null && effectiveDates[0] != null) {
+        mapping.putAll(effectiveDates[0].getApiToSdkMapping());
+      }
+      mapping.put('contract_amounts', 'contractAmounts');
+      if (contractAmounts != null && contractAmounts[0] != null) {
+        mapping.putAll(contractAmounts[0].getApiToSdkMapping());
+      }
+      mapping.put('termination_dates', 'terminationDates');
+      if (terminationDates != null && terminationDates[0] != null) {
+        mapping.putAll(terminationDates[0].getApiToSdkMapping());
+      }
+      mapping.put('contract_types', 'contractTypes');
+      if (contractTypes != null && contractTypes[0] != null) {
+        mapping.putAll(contractTypes[0].getApiToSdkMapping());
+      }
+      mapping.put('contract_terms', 'contractTerms');
+      if (contractTerms != null && contractTerms[0] != null) {
+        mapping.putAll(contractTerms[0].getApiToSdkMapping());
+      }
+      mapping.put('payment_terms', 'paymentTerms');
+      if (paymentTerms != null && paymentTerms[0] != null) {
+        mapping.putAll(paymentTerms[0].getApiToSdkMapping());
+      }
+      if (tables != null && tables[0] != null) {
+        mapping.putAll(tables[0].getApiToSdkMapping());
+      }
+      mapping.put('document_structure', 'documentStructure');
+      if (documentStructure != null) {
+        mapping.putAll(documentStructure.getApiToSdkMapping());
+      }
+      if (parties != null && parties[0] != null) {
+        mapping.putAll(parties[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1775,7 +1987,7 @@ public class IBMCompareComplyV1Models {
    * An array of values, each being the `id` value of a column header that is applicable to the current cell.
    */
   public class ColumnHeaderIds extends IBMWatsonGenericModel {
-    private String id_serialized_name;
+    private String id;
  
     /**
      * Gets the id.
@@ -1786,7 +1998,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getId() {
-      return id_serialized_name;
+      return id;
     }
 
     /**
@@ -1795,16 +2007,15 @@ public class IBMCompareComplyV1Models {
      * @param id the new id
      */
     public void setId(final String id) {
-      this.id_serialized_name = id;
+      this.id = id;
     }
-
   }
 
   /**
    * An array of values, each being the `text` value of a column header that is applicable to the current cell.
    */
   public class ColumnHeaderTexts extends IBMWatsonGenericModel {
-    private String text_serialized_name;
+    private String text;
  
     /**
      * Gets the text.
@@ -1815,7 +2026,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -1824,9 +2035,8 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
-
   }
 
   /**
@@ -1834,7 +2044,7 @@ public class IBMCompareComplyV1Models {
    * customization; otherwise, the same value as `column_header_texts`.
    */
   public class ColumnHeaderTextsNormalized extends IBMWatsonGenericModel {
-    private String text_normalized_serialized_name;
+    private String textNormalized;
  
     /**
      * Gets the textNormalized.
@@ -1845,7 +2055,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTextNormalized() {
-      return text_normalized_serialized_name;
+      return textNormalized;
     }
 
     /**
@@ -1854,23 +2064,28 @@ public class IBMCompareComplyV1Models {
      * @param textNormalized the new textNormalized
      */
     public void setTextNormalized(final String textNormalized) {
-      this.text_normalized_serialized_name = textNormalized;
+      this.textNormalized = textNormalized;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('text_normalized', 'textNormalized');
+      return mapping;
+    }
   }
 
   /**
    * Column-level cells, each applicable as a header to other cells in the same column as itself, of the current table.
    */
   public class ColumnHeaders extends IBMWatsonGenericModel {
-    private String cell_id_serialized_name;
-    private IBMWatsonMapModel location_serialized_name;
-    private String text_serialized_name;
-    private String text_normalized_serialized_name;
-    private Long row_index_begin_serialized_name;
-    private Long row_index_end_serialized_name;
-    private Long column_index_begin_serialized_name;
-    private Long column_index_end_serialized_name;
+    private String cellId;
+    private IBMWatsonMapModel location;
+    private String text;
+    private String textNormalized;
+    private Long rowIndexBegin;
+    private Long rowIndexEnd;
+    private Long columnIndexBegin;
+    private Long columnIndexEnd;
  
     /**
      * Gets the cellId.
@@ -1881,7 +2096,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getCellId() {
-      return cell_id_serialized_name;
+      return cellId;
     }
  
     /**
@@ -1894,7 +2109,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -1906,7 +2121,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -1919,7 +2134,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTextNormalized() {
-      return text_normalized_serialized_name;
+      return textNormalized;
     }
  
     /**
@@ -1931,7 +2146,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getRowIndexBegin() {
-      return row_index_begin_serialized_name;
+      return rowIndexBegin;
     }
  
     /**
@@ -1943,7 +2158,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getRowIndexEnd() {
-      return row_index_end_serialized_name;
+      return rowIndexEnd;
     }
  
     /**
@@ -1955,7 +2170,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getColumnIndexBegin() {
-      return column_index_begin_serialized_name;
+      return columnIndexBegin;
     }
  
     /**
@@ -1967,7 +2182,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getColumnIndexEnd() {
-      return column_index_end_serialized_name;
+      return columnIndexEnd;
     }
 
     /**
@@ -1976,7 +2191,7 @@ public class IBMCompareComplyV1Models {
      * @param cellId the new cellId
      */
     public void setCellId(final String cellId) {
-      this.cell_id_serialized_name = cellId;
+      this.cellId = cellId;
     }
 
     /**
@@ -1985,7 +2200,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final IBMWatsonMapModel location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -1994,7 +2209,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -2003,7 +2218,7 @@ public class IBMCompareComplyV1Models {
      * @param textNormalized the new textNormalized
      */
     public void setTextNormalized(final String textNormalized) {
-      this.text_normalized_serialized_name = textNormalized;
+      this.textNormalized = textNormalized;
     }
 
     /**
@@ -2012,7 +2227,7 @@ public class IBMCompareComplyV1Models {
      * @param rowIndexBegin the new rowIndexBegin
      */
     public void setRowIndexBegin(final long rowIndexBegin) {
-      this.row_index_begin_serialized_name = rowIndexBegin;
+      this.rowIndexBegin = rowIndexBegin;
     }
 
     /**
@@ -2021,7 +2236,7 @@ public class IBMCompareComplyV1Models {
      * @param rowIndexEnd the new rowIndexEnd
      */
     public void setRowIndexEnd(final long rowIndexEnd) {
-      this.row_index_end_serialized_name = rowIndexEnd;
+      this.rowIndexEnd = rowIndexEnd;
     }
 
     /**
@@ -2030,7 +2245,7 @@ public class IBMCompareComplyV1Models {
      * @param columnIndexBegin the new columnIndexBegin
      */
     public void setColumnIndexBegin(final long columnIndexBegin) {
-      this.column_index_begin_serialized_name = columnIndexBegin;
+      this.columnIndexBegin = columnIndexBegin;
     }
 
     /**
@@ -2039,7 +2254,7 @@ public class IBMCompareComplyV1Models {
      * @param columnIndexEnd the new columnIndexEnd
      */
     public void setColumnIndexEnd(final long columnIndexEnd) {
-      this.column_index_end_serialized_name = columnIndexEnd;
+      this.columnIndexEnd = columnIndexEnd;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2050,10 +2265,21 @@ public class IBMCompareComplyV1Models {
       ColumnHeaders ret = (ColumnHeaders) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      IBMWatsonMapModel newLocation = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newLocation = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), IBMWatsonMapModel.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('cell_id', 'cellId');
+      mapping.put('text_normalized', 'textNormalized');
+      mapping.put('row_index_begin', 'rowIndexBegin');
+      mapping.put('row_index_end', 'rowIndexEnd');
+      mapping.put('column_index_begin', 'columnIndexBegin');
+      mapping.put('column_index_end', 'columnIndexEnd');
+      return mapping;
     }
   }
 
@@ -2068,7 +2294,7 @@ public class IBMCompareComplyV1Models {
     private String file1Label;
     private String file2Label;
     private String model;
- 
+
     /**
      * Gets the file1.
      *
@@ -2079,7 +2305,7 @@ public class IBMCompareComplyV1Models {
     public IBMWatsonFile file1() {
       return file1;
     }
- 
+
     /**
      * Gets the file2.
      *
@@ -2090,7 +2316,7 @@ public class IBMCompareComplyV1Models {
     public IBMWatsonFile file2() {
       return file2;
     }
- 
+
     /**
      * Gets the file1ContentType.
      *
@@ -2101,7 +2327,7 @@ public class IBMCompareComplyV1Models {
     public String file1ContentType() {
       return file1ContentType;
     }
- 
+
     /**
      * Gets the file2ContentType.
      *
@@ -2112,7 +2338,7 @@ public class IBMCompareComplyV1Models {
     public String file2ContentType() {
       return file2ContentType;
     }
- 
+
     /**
      * Gets the file1Label.
      *
@@ -2123,7 +2349,7 @@ public class IBMCompareComplyV1Models {
     public String file1Label() {
       return file1Label;
     }
- 
+
     /**
      * Gets the file2Label.
      *
@@ -2134,7 +2360,7 @@ public class IBMCompareComplyV1Models {
     public String file2Label() {
       return file2Label;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -2170,6 +2396,16 @@ public class IBMCompareComplyV1Models {
       return new CompareDocumentsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('file1', 'file_1');
+      mapping.put('file2', 'file_2');
+      mapping.put('file1ContentType', 'file_1_content_type');
+      mapping.put('file2ContentType', 'file_2_content_type');
+      mapping.put('file1Label', 'file_1_label');
+      mapping.put('file2Label', 'file_2_label');
+      return mapping;
+    }
   }
 
   /**
@@ -2315,11 +2551,11 @@ public class IBMCompareComplyV1Models {
    * The comparison of the two submitted documents.
    */
   public class CompareReturn extends IBMWatsonResponseModel {
-    private String model_id_serialized_name;
-    private String model_version_serialized_name;
-    private List<Document> documents_serialized_name;
-    private List<AlignedElement> aligned_elements_serialized_name;
-    private List<UnalignedElement> unaligned_elements_serialized_name;
+    private String modelId;
+    private String modelVersion;
+    private List<Document> documents;
+    private List<AlignedElement> alignedElements;
+    private List<UnalignedElement> unalignedElements;
  
     /**
      * Gets the modelId.
@@ -2331,7 +2567,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModelId() {
-      return model_id_serialized_name;
+      return modelId;
     }
  
     /**
@@ -2343,7 +2579,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModelVersion() {
-      return model_version_serialized_name;
+      return modelVersion;
     }
  
     /**
@@ -2355,7 +2591,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Document> getDocuments() {
-      return documents_serialized_name;
+      return documents;
     }
  
     /**
@@ -2367,7 +2603,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<AlignedElement> getAlignedElements() {
-      return aligned_elements_serialized_name;
+      return alignedElements;
     }
  
     /**
@@ -2379,7 +2615,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<UnalignedElement> getUnalignedElements() {
-      return unaligned_elements_serialized_name;
+      return unalignedElements;
     }
 
     /**
@@ -2388,7 +2624,7 @@ public class IBMCompareComplyV1Models {
      * @param modelId the new modelId
      */
     public void setModelId(final String modelId) {
-      this.model_id_serialized_name = modelId;
+      this.modelId = modelId;
     }
 
     /**
@@ -2397,7 +2633,7 @@ public class IBMCompareComplyV1Models {
      * @param modelVersion the new modelVersion
      */
     public void setModelVersion(final String modelVersion) {
-      this.model_version_serialized_name = modelVersion;
+      this.modelVersion = modelVersion;
     }
 
     /**
@@ -2406,7 +2642,7 @@ public class IBMCompareComplyV1Models {
      * @param documents the new documents
      */
     public void setDocuments(final List<Document> documents) {
-      this.documents_serialized_name = documents;
+      this.documents = documents;
     }
 
     /**
@@ -2415,7 +2651,7 @@ public class IBMCompareComplyV1Models {
      * @param alignedElements the new alignedElements
      */
     public void setAlignedElements(final List<AlignedElement> alignedElements) {
-      this.aligned_elements_serialized_name = alignedElements;
+      this.alignedElements = alignedElements;
     }
 
     /**
@@ -2424,7 +2660,7 @@ public class IBMCompareComplyV1Models {
      * @param unalignedElements the new unalignedElements
      */
     public void setUnalignedElements(final List<UnalignedElement> unalignedElements) {
-      this.unaligned_elements_serialized_name = unalignedElements;
+      this.unalignedElements = unalignedElements;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2440,11 +2676,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedDocuments != null) {
         for (Integer i = 0; i < deserializedDocuments.size(); i++) {
           Document currentItem = ret.getDocuments().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('documents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('documents');
           Document newItem = (Document) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Document.class);
           newDocuments.add(newItem);
         }
-        ret.documents_serialized_name = newDocuments;
+        ret.documents = newDocuments;
       }
 
       // calling custom deserializer for alignedElements
@@ -2453,11 +2689,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedAlignedElements != null) {
         for (Integer i = 0; i < deserializedAlignedElements.size(); i++) {
           AlignedElement currentItem = ret.getAlignedElements().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('aligned_elements_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('alignedElements');
           AlignedElement newItem = (AlignedElement) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), AlignedElement.class);
           newAlignedElements.add(newItem);
         }
-        ret.aligned_elements_serialized_name = newAlignedElements;
+        ret.alignedElements = newAlignedElements;
       }
 
       // calling custom deserializer for unalignedElements
@@ -2466,14 +2702,29 @@ public class IBMCompareComplyV1Models {
       if (deserializedUnalignedElements != null) {
         for (Integer i = 0; i < deserializedUnalignedElements.size(); i++) {
           UnalignedElement currentItem = ret.getUnalignedElements().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('unaligned_elements_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('unalignedElements');
           UnalignedElement newItem = (UnalignedElement) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), UnalignedElement.class);
           newUnalignedElements.add(newItem);
         }
-        ret.unaligned_elements_serialized_name = newUnalignedElements;
+        ret.unalignedElements = newUnalignedElements;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('model_id', 'modelId');
+      mapping.put('model_version', 'modelVersion');
+      mapping.put('aligned_elements', 'alignedElements');
+      if (alignedElements != null && alignedElements[0] != null) {
+        mapping.putAll(alignedElements[0].getApiToSdkMapping());
+      }
+      mapping.put('unaligned_elements', 'unalignedElements');
+      if (unalignedElements != null && unalignedElements[0] != null) {
+        mapping.putAll(unalignedElements[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2481,8 +2732,8 @@ public class IBMCompareComplyV1Models {
    * A contact.
    */
   public class Contact extends IBMWatsonGenericModel {
-    private String name_serialized_name;
-    private String role_serialized_name;
+    private String name;
+    private String role;
  
     /**
      * Gets the name.
@@ -2493,7 +2744,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -2505,7 +2756,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getRole() {
-      return role_serialized_name;
+      return role;
     }
 
     /**
@@ -2514,7 +2765,7 @@ public class IBMCompareComplyV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -2523,17 +2774,16 @@ public class IBMCompareComplyV1Models {
      * @param role the new role
      */
     public void setRole(final String role) {
-      this.role_serialized_name = role;
+      this.role = role;
     }
-
   }
 
   /**
    * Text that is related to the contents of the table and that precedes or follows the current table.
    */
   public class Contexts extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private Location location_serialized_name;
+    private String text;
+    private Location location;
  
     /**
      * Gets the text.
@@ -2544,7 +2794,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -2557,7 +2807,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -2566,7 +2816,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -2575,7 +2825,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2586,10 +2836,18 @@ public class IBMCompareComplyV1Models {
       Contexts ret = (Contexts) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2597,12 +2855,12 @@ public class IBMCompareComplyV1Models {
    * A monetary amount identified in the input document.
    */
   public class ContractAmts extends IBMWatsonGenericModel {
-    private String confidence_level_serialized_name;
-    private String text_serialized_name;
-    private String text_normalized_serialized_name;
-    private Interpretation interpretation_serialized_name;
-    private List<String> provenance_ids_serialized_name;
-    private Location location_serialized_name;
+    private String confidenceLevel;
+    private String text;
+    private String textNormalized;
+    private Interpretation interpretation;
+    private List<String> provenanceIds;
+    private Location location;
  
     /**
      * Gets the confidenceLevel.
@@ -2613,7 +2871,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getConfidenceLevel() {
-      return confidence_level_serialized_name;
+      return confidenceLevel;
     }
  
     /**
@@ -2625,7 +2883,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -2638,7 +2896,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTextNormalized() {
-      return text_normalized_serialized_name;
+      return textNormalized;
     }
  
     /**
@@ -2651,7 +2909,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Interpretation getInterpretation() {
-      return interpretation_serialized_name;
+      return interpretation;
     }
  
     /**
@@ -2663,7 +2921,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<String> getProvenanceIds() {
-      return provenance_ids_serialized_name;
+      return provenanceIds;
     }
  
     /**
@@ -2676,7 +2934,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -2685,7 +2943,7 @@ public class IBMCompareComplyV1Models {
      * @param confidenceLevel the new confidenceLevel
      */
     public void setConfidenceLevel(final String confidenceLevel) {
-      this.confidence_level_serialized_name = confidenceLevel;
+      this.confidenceLevel = confidenceLevel;
     }
 
     /**
@@ -2694,7 +2952,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -2703,7 +2961,7 @@ public class IBMCompareComplyV1Models {
      * @param textNormalized the new textNormalized
      */
     public void setTextNormalized(final String textNormalized) {
-      this.text_normalized_serialized_name = textNormalized;
+      this.textNormalized = textNormalized;
     }
 
     /**
@@ -2712,7 +2970,7 @@ public class IBMCompareComplyV1Models {
      * @param interpretation the new interpretation
      */
     public void setInterpretation(final Interpretation interpretation) {
-      this.interpretation_serialized_name = interpretation;
+      this.interpretation = interpretation;
     }
 
     /**
@@ -2721,7 +2979,7 @@ public class IBMCompareComplyV1Models {
      * @param provenanceIds the new provenanceIds
      */
     public void setProvenanceIds(final List<String> provenanceIds) {
-      this.provenance_ids_serialized_name = provenanceIds;
+      this.provenanceIds = provenanceIds;
     }
 
     /**
@@ -2730,7 +2988,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2741,14 +2999,28 @@ public class IBMCompareComplyV1Models {
       ContractAmts ret = (ContractAmts) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for interpretation
-      Interpretation newInterpretation = (Interpretation) new Interpretation().deserialize(JSON.serialize(ret.getInterpretation()), (Map<String, Object>) jsonMap.get('interpretation_serialized_name'), Interpretation.class);
+      Interpretation newInterpretation = (Interpretation) new Interpretation().deserialize(JSON.serialize(ret.getInterpretation()), (Map<String, Object>) jsonMap.get('interpretation'), Interpretation.class);
       ret.setInterpretation(newInterpretation);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('confidence_level', 'confidenceLevel');
+      mapping.put('text_normalized', 'textNormalized');
+      if (interpretation != null) {
+        mapping.putAll(interpretation.getApiToSdkMapping());
+      }
+      mapping.put('provenance_ids', 'provenanceIds');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2756,12 +3028,12 @@ public class IBMCompareComplyV1Models {
    * The duration or durations of the contract.
    */
   public class ContractTerms extends IBMWatsonGenericModel {
-    private String confidence_level_serialized_name;
-    private String text_serialized_name;
-    private String text_normalized_serialized_name;
-    private Interpretation interpretation_serialized_name;
-    private List<String> provenance_ids_serialized_name;
-    private Location location_serialized_name;
+    private String confidenceLevel;
+    private String text;
+    private String textNormalized;
+    private Interpretation interpretation;
+    private List<String> provenanceIds;
+    private Location location;
  
     /**
      * Gets the confidenceLevel.
@@ -2772,7 +3044,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getConfidenceLevel() {
-      return confidence_level_serialized_name;
+      return confidenceLevel;
     }
  
     /**
@@ -2784,7 +3056,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -2797,7 +3069,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTextNormalized() {
-      return text_normalized_serialized_name;
+      return textNormalized;
     }
  
     /**
@@ -2810,7 +3082,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Interpretation getInterpretation() {
-      return interpretation_serialized_name;
+      return interpretation;
     }
  
     /**
@@ -2822,7 +3094,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<String> getProvenanceIds() {
-      return provenance_ids_serialized_name;
+      return provenanceIds;
     }
  
     /**
@@ -2835,7 +3107,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -2844,7 +3116,7 @@ public class IBMCompareComplyV1Models {
      * @param confidenceLevel the new confidenceLevel
      */
     public void setConfidenceLevel(final String confidenceLevel) {
-      this.confidence_level_serialized_name = confidenceLevel;
+      this.confidenceLevel = confidenceLevel;
     }
 
     /**
@@ -2853,7 +3125,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -2862,7 +3134,7 @@ public class IBMCompareComplyV1Models {
      * @param textNormalized the new textNormalized
      */
     public void setTextNormalized(final String textNormalized) {
-      this.text_normalized_serialized_name = textNormalized;
+      this.textNormalized = textNormalized;
     }
 
     /**
@@ -2871,7 +3143,7 @@ public class IBMCompareComplyV1Models {
      * @param interpretation the new interpretation
      */
     public void setInterpretation(final Interpretation interpretation) {
-      this.interpretation_serialized_name = interpretation;
+      this.interpretation = interpretation;
     }
 
     /**
@@ -2880,7 +3152,7 @@ public class IBMCompareComplyV1Models {
      * @param provenanceIds the new provenanceIds
      */
     public void setProvenanceIds(final List<String> provenanceIds) {
-      this.provenance_ids_serialized_name = provenanceIds;
+      this.provenanceIds = provenanceIds;
     }
 
     /**
@@ -2889,7 +3161,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2900,14 +3172,28 @@ public class IBMCompareComplyV1Models {
       ContractTerms ret = (ContractTerms) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for interpretation
-      Interpretation newInterpretation = (Interpretation) new Interpretation().deserialize(JSON.serialize(ret.getInterpretation()), (Map<String, Object>) jsonMap.get('interpretation_serialized_name'), Interpretation.class);
+      Interpretation newInterpretation = (Interpretation) new Interpretation().deserialize(JSON.serialize(ret.getInterpretation()), (Map<String, Object>) jsonMap.get('interpretation'), Interpretation.class);
       ret.setInterpretation(newInterpretation);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('confidence_level', 'confidenceLevel');
+      mapping.put('text_normalized', 'textNormalized');
+      if (interpretation != null) {
+        mapping.putAll(interpretation.getApiToSdkMapping());
+      }
+      mapping.put('provenance_ids', 'provenanceIds');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2915,10 +3201,10 @@ public class IBMCompareComplyV1Models {
    * The contract type identified in the input document.
    */
   public class ContractTypes extends IBMWatsonGenericModel {
-    private String confidence_level_serialized_name;
-    private String text_serialized_name;
-    private List<String> provenance_ids_serialized_name;
-    private Location location_serialized_name;
+    private String confidenceLevel;
+    private String text;
+    private List<String> provenanceIds;
+    private Location location;
  
     /**
      * Gets the confidenceLevel.
@@ -2929,7 +3215,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getConfidenceLevel() {
-      return confidence_level_serialized_name;
+      return confidenceLevel;
     }
  
     /**
@@ -2941,7 +3227,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -2953,7 +3239,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<String> getProvenanceIds() {
-      return provenance_ids_serialized_name;
+      return provenanceIds;
     }
  
     /**
@@ -2966,7 +3252,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -2975,7 +3261,7 @@ public class IBMCompareComplyV1Models {
      * @param confidenceLevel the new confidenceLevel
      */
     public void setConfidenceLevel(final String confidenceLevel) {
-      this.confidence_level_serialized_name = confidenceLevel;
+      this.confidenceLevel = confidenceLevel;
     }
 
     /**
@@ -2984,7 +3270,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -2993,7 +3279,7 @@ public class IBMCompareComplyV1Models {
      * @param provenanceIds the new provenanceIds
      */
     public void setProvenanceIds(final List<String> provenanceIds) {
-      this.provenance_ids_serialized_name = provenanceIds;
+      this.provenanceIds = provenanceIds;
     }
 
     /**
@@ -3002,7 +3288,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3013,10 +3299,20 @@ public class IBMCompareComplyV1Models {
       ContractTypes ret = (ContractTypes) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('confidence_level', 'confidenceLevel');
+      mapping.put('provenance_ids', 'provenanceIds');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -3028,7 +3324,7 @@ public class IBMCompareComplyV1Models {
     private String filename;
     private String fileContentType;
     private String model;
- 
+
     /**
      * Gets the file.
      *
@@ -3039,7 +3335,7 @@ public class IBMCompareComplyV1Models {
     public IBMWatsonFile file() {
       return file;
     }
- 
+
     /**
      * Gets the filename.
      *
@@ -3050,7 +3346,7 @@ public class IBMCompareComplyV1Models {
     public String filename() {
       return filename;
     }
- 
+
     /**
      * Gets the fileContentType.
      *
@@ -3061,7 +3357,7 @@ public class IBMCompareComplyV1Models {
     public String fileContentType() {
       return fileContentType;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -3094,6 +3390,11 @@ public class IBMCompareComplyV1Models {
       return new ConvertToHtmlOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('fileContentType', 'file_content_type');
+      return mapping;
+    }
   }
 
   /**
@@ -3208,7 +3509,7 @@ public class IBMCompareComplyV1Models {
     private String outputBucketLocation;
     private String outputBucketName;
     private String model;
- 
+
     /**
      * Gets the function.
      *
@@ -3219,7 +3520,7 @@ public class IBMCompareComplyV1Models {
     public String function() {
       return function;
     }
- 
+
     /**
      * Gets the inputCredentialsFile.
      *
@@ -3231,7 +3532,7 @@ public class IBMCompareComplyV1Models {
     public IBMWatsonFile inputCredentialsFile() {
       return inputCredentialsFile;
     }
- 
+
     /**
      * Gets the inputBucketLocation.
      *
@@ -3243,7 +3544,7 @@ public class IBMCompareComplyV1Models {
     public String inputBucketLocation() {
       return inputBucketLocation;
     }
- 
+
     /**
      * Gets the inputBucketName.
      *
@@ -3254,7 +3555,7 @@ public class IBMCompareComplyV1Models {
     public String inputBucketName() {
       return inputBucketName;
     }
- 
+
     /**
      * Gets the outputCredentialsFile.
      *
@@ -3266,7 +3567,7 @@ public class IBMCompareComplyV1Models {
     public IBMWatsonFile outputCredentialsFile() {
       return outputCredentialsFile;
     }
- 
+
     /**
      * Gets the outputBucketLocation.
      *
@@ -3278,7 +3579,7 @@ public class IBMCompareComplyV1Models {
     public String outputBucketLocation() {
       return outputBucketLocation;
     }
- 
+
     /**
      * Gets the outputBucketName.
      *
@@ -3289,7 +3590,7 @@ public class IBMCompareComplyV1Models {
     public String outputBucketName() {
       return outputBucketName;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -3331,6 +3632,16 @@ public class IBMCompareComplyV1Models {
       return new CreateBatchOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('inputCredentialsFile', 'input_credentials_file');
+      mapping.put('inputBucketLocation', 'input_bucket_location');
+      mapping.put('inputBucketName', 'input_bucket_name');
+      mapping.put('outputCredentialsFile', 'output_credentials_file');
+      mapping.put('outputBucketLocation', 'output_bucket_location');
+      mapping.put('outputBucketName', 'output_bucket_name');
+      return mapping;
+    }
   }
 
   /**
@@ -3501,7 +3812,7 @@ public class IBMCompareComplyV1Models {
   public class DeleteFeedbackOptions extends IBMWatsonOptionsModel {
     private String feedbackId;
     private String model;
- 
+
     /**
      * Gets the feedbackId.
      *
@@ -3512,7 +3823,7 @@ public class IBMCompareComplyV1Models {
     public String feedbackId() {
       return feedbackId;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -3542,6 +3853,11 @@ public class IBMCompareComplyV1Models {
       return new DeleteFeedbackOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('feedbackId', 'feedback_id');
+      return mapping;
+    }
   }
 
   /**
@@ -3620,10 +3936,10 @@ public class IBMCompareComplyV1Models {
    * Document counts.
    */
   public class DocCounts extends IBMWatsonGenericModel {
-    private Long total_serialized_name;
-    private Long pending_serialized_name;
-    private Long successful_serialized_name;
-    private Long failed_serialized_name;
+    private Long total;
+    private Long pending;
+    private Long successful;
+    private Long failed;
  
     /**
      * Gets the total.
@@ -3634,7 +3950,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getTotal() {
-      return total_serialized_name;
+      return total;
     }
  
     /**
@@ -3646,7 +3962,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getPending() {
-      return pending_serialized_name;
+      return pending;
     }
  
     /**
@@ -3658,7 +3974,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getSuccessful() {
-      return successful_serialized_name;
+      return successful;
     }
  
     /**
@@ -3670,7 +3986,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getFailed() {
-      return failed_serialized_name;
+      return failed;
     }
 
     /**
@@ -3679,7 +3995,7 @@ public class IBMCompareComplyV1Models {
      * @param total the new total
      */
     public void setTotal(final long total) {
-      this.total_serialized_name = total;
+      this.total = total;
     }
 
     /**
@@ -3688,7 +4004,7 @@ public class IBMCompareComplyV1Models {
      * @param pending the new pending
      */
     public void setPending(final long pending) {
-      this.pending_serialized_name = pending;
+      this.pending = pending;
     }
 
     /**
@@ -3697,7 +4013,7 @@ public class IBMCompareComplyV1Models {
      * @param successful the new successful
      */
     public void setSuccessful(final long successful) {
-      this.successful_serialized_name = successful;
+      this.successful = successful;
     }
 
     /**
@@ -3706,18 +4022,17 @@ public class IBMCompareComplyV1Models {
      * @param failed the new failed
      */
     public void setFailed(final long failed) {
-      this.failed_serialized_name = failed;
+      this.failed = failed;
     }
-
   }
 
   /**
    * Information about the parsed input document.
    */
   public class DocInfo extends IBMWatsonGenericModel {
-    private String html_serialized_name;
-    private String title_serialized_name;
-    private String hash_serialized_name;
+    private String html;
+    private String title;
+    private String hash;
  
     /**
      * Gets the html.
@@ -3728,7 +4043,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getHtml() {
-      return html_serialized_name;
+      return html;
     }
  
     /**
@@ -3740,7 +4055,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -3752,7 +4067,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getHash() {
-      return hash_serialized_name;
+      return hash;
     }
 
     /**
@@ -3761,7 +4076,7 @@ public class IBMCompareComplyV1Models {
      * @param html the new html
      */
     public void setHtml(final String html) {
-      this.html_serialized_name = html;
+      this.html = html;
     }
 
     /**
@@ -3770,7 +4085,7 @@ public class IBMCompareComplyV1Models {
      * @param title the new title
      */
     public void setTitle(final String title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     /**
@@ -3779,18 +4094,17 @@ public class IBMCompareComplyV1Models {
      * @param hash the new hash
      */
     public void setHash(final String hash) {
-      this.hash_serialized_name = hash;
+      this.hash = hash;
     }
-
   }
 
   /**
    * The structure of the input document.
    */
   public class DocStructure extends IBMWatsonGenericModel {
-    private List<SectionTitles> section_titles_serialized_name;
-    private List<LeadingSentence> leading_sentences_serialized_name;
-    private List<Paragraphs> paragraphs_serialized_name;
+    private List<SectionTitles> sectionTitles;
+    private List<LeadingSentence> leadingSentences;
+    private List<Paragraphs> paragraphs;
  
     /**
      * Gets the sectionTitles.
@@ -3801,7 +4115,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<SectionTitles> getSectionTitles() {
-      return section_titles_serialized_name;
+      return sectionTitles;
     }
  
     /**
@@ -3814,7 +4128,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<LeadingSentence> getLeadingSentences() {
-      return leading_sentences_serialized_name;
+      return leadingSentences;
     }
  
     /**
@@ -3827,7 +4141,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Paragraphs> getParagraphs() {
-      return paragraphs_serialized_name;
+      return paragraphs;
     }
 
     /**
@@ -3836,7 +4150,7 @@ public class IBMCompareComplyV1Models {
      * @param sectionTitles the new sectionTitles
      */
     public void setSectionTitles(final List<SectionTitles> sectionTitles) {
-      this.section_titles_serialized_name = sectionTitles;
+      this.sectionTitles = sectionTitles;
     }
 
     /**
@@ -3845,7 +4159,7 @@ public class IBMCompareComplyV1Models {
      * @param leadingSentences the new leadingSentences
      */
     public void setLeadingSentences(final List<LeadingSentence> leadingSentences) {
-      this.leading_sentences_serialized_name = leadingSentences;
+      this.leadingSentences = leadingSentences;
     }
 
     /**
@@ -3854,7 +4168,7 @@ public class IBMCompareComplyV1Models {
      * @param paragraphs the new paragraphs
      */
     public void setParagraphs(final List<Paragraphs> paragraphs) {
-      this.paragraphs_serialized_name = paragraphs;
+      this.paragraphs = paragraphs;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3870,11 +4184,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedSectionTitles != null) {
         for (Integer i = 0; i < deserializedSectionTitles.size(); i++) {
           SectionTitles currentItem = ret.getSectionTitles().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('section_titles_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('sectionTitles');
           SectionTitles newItem = (SectionTitles) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SectionTitles.class);
           newSectionTitles.add(newItem);
         }
-        ret.section_titles_serialized_name = newSectionTitles;
+        ret.sectionTitles = newSectionTitles;
       }
 
       // calling custom deserializer for leadingSentences
@@ -3883,11 +4197,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedLeadingSentences != null) {
         for (Integer i = 0; i < deserializedLeadingSentences.size(); i++) {
           LeadingSentence currentItem = ret.getLeadingSentences().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('leading_sentences_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('leadingSentences');
           LeadingSentence newItem = (LeadingSentence) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), LeadingSentence.class);
           newLeadingSentences.add(newItem);
         }
-        ret.leading_sentences_serialized_name = newLeadingSentences;
+        ret.leadingSentences = newLeadingSentences;
       }
 
       // calling custom deserializer for paragraphs
@@ -3896,14 +4210,30 @@ public class IBMCompareComplyV1Models {
       if (deserializedParagraphs != null) {
         for (Integer i = 0; i < deserializedParagraphs.size(); i++) {
           Paragraphs currentItem = ret.getParagraphs().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('paragraphs_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('paragraphs');
           Paragraphs newItem = (Paragraphs) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Paragraphs.class);
           newParagraphs.add(newItem);
         }
-        ret.paragraphs_serialized_name = newParagraphs;
+        ret.paragraphs = newParagraphs;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('section_titles', 'sectionTitles');
+      if (sectionTitles != null && sectionTitles[0] != null) {
+        mapping.putAll(sectionTitles[0].getApiToSdkMapping());
+      }
+      mapping.put('leading_sentences', 'leadingSentences');
+      if (leadingSentences != null && leadingSentences[0] != null) {
+        mapping.putAll(leadingSentences[0].getApiToSdkMapping());
+      }
+      if (paragraphs != null && paragraphs[0] != null) {
+        mapping.putAll(paragraphs[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -3911,10 +4241,10 @@ public class IBMCompareComplyV1Models {
    * Basic information about the input document.
    */
   public class Document extends IBMWatsonGenericModel {
-    private String title_serialized_name;
-    private String html_serialized_name;
-    private String hash_serialized_name;
-    private String label_serialized_name;
+    private String title;
+    private String html;
+    private String hash;
+    private String label;
  
     /**
      * Gets the title.
@@ -3925,7 +4255,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -3937,7 +4267,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getHtml() {
-      return html_serialized_name;
+      return html;
     }
  
     /**
@@ -3949,7 +4279,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getHash() {
-      return hash_serialized_name;
+      return hash;
     }
  
     /**
@@ -3962,7 +4292,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getLabel() {
-      return label_serialized_name;
+      return label;
     }
 
     /**
@@ -3971,7 +4301,7 @@ public class IBMCompareComplyV1Models {
      * @param title the new title
      */
     public void setTitle(final String title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     /**
@@ -3980,7 +4310,7 @@ public class IBMCompareComplyV1Models {
      * @param html the new html
      */
     public void setHtml(final String html) {
-      this.html_serialized_name = html;
+      this.html = html;
     }
 
     /**
@@ -3989,7 +4319,7 @@ public class IBMCompareComplyV1Models {
      * @param hash the new hash
      */
     public void setHash(final String hash) {
-      this.hash_serialized_name = hash;
+      this.hash = hash;
     }
 
     /**
@@ -3998,20 +4328,19 @@ public class IBMCompareComplyV1Models {
      * @param label the new label
      */
     public void setLabel(final String label) {
-      this.label_serialized_name = label;
+      this.label = label;
     }
-
   }
 
   /**
    * An effective date.
    */
   public class EffectiveDates extends IBMWatsonGenericModel {
-    private String confidence_level_serialized_name;
-    private String text_serialized_name;
-    private String text_normalized_serialized_name;
-    private List<String> provenance_ids_serialized_name;
-    private Location location_serialized_name;
+    private String confidenceLevel;
+    private String text;
+    private String textNormalized;
+    private List<String> provenanceIds;
+    private Location location;
  
     /**
      * Gets the confidenceLevel.
@@ -4022,7 +4351,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getConfidenceLevel() {
-      return confidence_level_serialized_name;
+      return confidenceLevel;
     }
  
     /**
@@ -4034,7 +4363,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4047,7 +4376,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTextNormalized() {
-      return text_normalized_serialized_name;
+      return textNormalized;
     }
  
     /**
@@ -4059,7 +4388,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<String> getProvenanceIds() {
-      return provenance_ids_serialized_name;
+      return provenanceIds;
     }
  
     /**
@@ -4072,7 +4401,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -4081,7 +4410,7 @@ public class IBMCompareComplyV1Models {
      * @param confidenceLevel the new confidenceLevel
      */
     public void setConfidenceLevel(final String confidenceLevel) {
-      this.confidence_level_serialized_name = confidenceLevel;
+      this.confidenceLevel = confidenceLevel;
     }
 
     /**
@@ -4090,7 +4419,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4099,7 +4428,7 @@ public class IBMCompareComplyV1Models {
      * @param textNormalized the new textNormalized
      */
     public void setTextNormalized(final String textNormalized) {
-      this.text_normalized_serialized_name = textNormalized;
+      this.textNormalized = textNormalized;
     }
 
     /**
@@ -4108,7 +4437,7 @@ public class IBMCompareComplyV1Models {
      * @param provenanceIds the new provenanceIds
      */
     public void setProvenanceIds(final List<String> provenanceIds) {
-      this.provenance_ids_serialized_name = provenanceIds;
+      this.provenanceIds = provenanceIds;
     }
 
     /**
@@ -4117,7 +4446,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4128,10 +4457,21 @@ public class IBMCompareComplyV1Models {
       EffectiveDates ret = (EffectiveDates) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('confidence_level', 'confidenceLevel');
+      mapping.put('text_normalized', 'textNormalized');
+      mapping.put('provenance_ids', 'provenanceIds');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -4139,11 +4479,11 @@ public class IBMCompareComplyV1Models {
    * A component part of the document.
    */
   public class Element extends IBMWatsonGenericModel {
-    private Location location_serialized_name;
-    private String text_serialized_name;
-    private List<TypeLabel> types_serialized_name;
-    private List<Category> categories_serialized_name;
-    private List<Attribute> attributes_serialized_name;
+    private Location location;
+    private String text;
+    private List<TypeLabel> types;
+    private List<Category> categories;
+    private List<Attribute> attributes;
  
     /**
      * Gets the location.
@@ -4155,7 +4495,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -4167,7 +4507,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4179,7 +4519,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<TypeLabel> getTypes() {
-      return types_serialized_name;
+      return types;
     }
  
     /**
@@ -4191,7 +4531,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Category> getCategories() {
-      return categories_serialized_name;
+      return categories;
     }
  
     /**
@@ -4203,7 +4543,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Attribute> getAttributes() {
-      return attributes_serialized_name;
+      return attributes;
     }
 
     /**
@@ -4212,7 +4552,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -4221,7 +4561,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4230,7 +4570,7 @@ public class IBMCompareComplyV1Models {
      * @param types the new types
      */
     public void setTypes(final List<TypeLabel> types) {
-      this.types_serialized_name = types;
+      this.types = types;
     }
 
     /**
@@ -4239,7 +4579,7 @@ public class IBMCompareComplyV1Models {
      * @param categories the new categories
      */
     public void setCategories(final List<Category> categories) {
-      this.categories_serialized_name = categories;
+      this.categories = categories;
     }
 
     /**
@@ -4248,7 +4588,7 @@ public class IBMCompareComplyV1Models {
      * @param attributes the new attributes
      */
     public void setAttributes(final List<Attribute> attributes) {
-      this.attributes_serialized_name = attributes;
+      this.attributes = attributes;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4259,7 +4599,7 @@ public class IBMCompareComplyV1Models {
       Element ret = (Element) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       // calling custom deserializer for types
@@ -4268,11 +4608,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedTypes != null) {
         for (Integer i = 0; i < deserializedTypes.size(); i++) {
           TypeLabel currentItem = ret.getTypes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('types_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('types');
           TypeLabel newItem = (TypeLabel) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TypeLabel.class);
           newTypes.add(newItem);
         }
-        ret.types_serialized_name = newTypes;
+        ret.types = newTypes;
       }
 
       // calling custom deserializer for categories
@@ -4281,11 +4621,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedCategories != null) {
         for (Integer i = 0; i < deserializedCategories.size(); i++) {
           Category currentItem = ret.getCategories().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('categories_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('categories');
           Category newItem = (Category) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Category.class);
           newCategories.add(newItem);
         }
-        ret.categories_serialized_name = newCategories;
+        ret.categories = newCategories;
       }
 
       // calling custom deserializer for attributes
@@ -4294,14 +4634,31 @@ public class IBMCompareComplyV1Models {
       if (deserializedAttributes != null) {
         for (Integer i = 0; i < deserializedAttributes.size(); i++) {
           Attribute currentItem = ret.getAttributes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('attributes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('attributes');
           Attribute newItem = (Attribute) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Attribute.class);
           newAttributes.add(newItem);
         }
-        ret.attributes_serialized_name = newAttributes;
+        ret.attributes = newAttributes;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      if (types != null && types[0] != null) {
+        mapping.putAll(types[0].getApiToSdkMapping());
+      }
+      if (categories != null && categories[0] != null) {
+        mapping.putAll(categories[0].getApiToSdkMapping());
+      }
+      if (attributes != null && attributes[0] != null) {
+        mapping.putAll(attributes[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -4309,8 +4666,8 @@ public class IBMCompareComplyV1Models {
    * A list of `begin` and `end` indexes that indicate the locations of the elements in the input document.
    */
   public class ElementLocations extends IBMWatsonGenericModel {
-    private Long begin_serialized_name;
-    private Long end_serialized_name;
+    private Long xbegin;
+    private Long xend;
  
     /**
      * Gets the xbegin.
@@ -4321,7 +4678,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getXbegin() {
-      return begin_serialized_name;
+      return xbegin;
     }
  
     /**
@@ -4333,7 +4690,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getXend() {
-      return end_serialized_name;
+      return xend;
     }
 
     /**
@@ -4342,7 +4699,7 @@ public class IBMCompareComplyV1Models {
      * @param xbegin the new xbegin
      */
     public void setXbegin(final long xbegin) {
-      this.begin_serialized_name = xbegin;
+      this.xbegin = xbegin;
     }
 
     /**
@@ -4351,21 +4708,27 @@ public class IBMCompareComplyV1Models {
      * @param xend the new xend
      */
     public void setXend(final long xend) {
-      this.end_serialized_name = xend;
+      this.xend = xend;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('begin', 'xbegin');
+      mapping.put('end', 'xend');
+      return mapping;
+    }
   }
 
   /**
    * Details of semantically aligned elements.
    */
   public class ElementPair extends IBMWatsonGenericModel {
-    private String document_label_serialized_name;
-    private String text_serialized_name;
-    private Location location_serialized_name;
-    private List<TypeLabelComparison> types_serialized_name;
-    private List<CategoryComparison> categories_serialized_name;
-    private List<Attribute> attributes_serialized_name;
+    private String documentLabel;
+    private String text;
+    private Location location;
+    private List<TypeLabelComparison> types;
+    private List<CategoryComparison> categories;
+    private List<Attribute> attributes;
  
     /**
      * Gets the documentLabel.
@@ -4377,7 +4740,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getDocumentLabel() {
-      return document_label_serialized_name;
+      return documentLabel;
     }
  
     /**
@@ -4389,7 +4752,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4402,7 +4765,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -4414,7 +4777,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<TypeLabelComparison> getTypes() {
-      return types_serialized_name;
+      return types;
     }
  
     /**
@@ -4426,7 +4789,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<CategoryComparison> getCategories() {
-      return categories_serialized_name;
+      return categories;
     }
  
     /**
@@ -4438,7 +4801,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Attribute> getAttributes() {
-      return attributes_serialized_name;
+      return attributes;
     }
 
     /**
@@ -4447,7 +4810,7 @@ public class IBMCompareComplyV1Models {
      * @param documentLabel the new documentLabel
      */
     public void setDocumentLabel(final String documentLabel) {
-      this.document_label_serialized_name = documentLabel;
+      this.documentLabel = documentLabel;
     }
 
     /**
@@ -4456,7 +4819,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4465,7 +4828,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -4474,7 +4837,7 @@ public class IBMCompareComplyV1Models {
      * @param types the new types
      */
     public void setTypes(final List<TypeLabelComparison> types) {
-      this.types_serialized_name = types;
+      this.types = types;
     }
 
     /**
@@ -4483,7 +4846,7 @@ public class IBMCompareComplyV1Models {
      * @param categories the new categories
      */
     public void setCategories(final List<CategoryComparison> categories) {
-      this.categories_serialized_name = categories;
+      this.categories = categories;
     }
 
     /**
@@ -4492,7 +4855,7 @@ public class IBMCompareComplyV1Models {
      * @param attributes the new attributes
      */
     public void setAttributes(final List<Attribute> attributes) {
-      this.attributes_serialized_name = attributes;
+      this.attributes = attributes;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4503,7 +4866,7 @@ public class IBMCompareComplyV1Models {
       ElementPair ret = (ElementPair) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       // calling custom deserializer for types
@@ -4512,11 +4875,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedTypes != null) {
         for (Integer i = 0; i < deserializedTypes.size(); i++) {
           TypeLabelComparison currentItem = ret.getTypes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('types_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('types');
           TypeLabelComparison newItem = (TypeLabelComparison) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TypeLabelComparison.class);
           newTypes.add(newItem);
         }
-        ret.types_serialized_name = newTypes;
+        ret.types = newTypes;
       }
 
       // calling custom deserializer for categories
@@ -4525,11 +4888,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedCategories != null) {
         for (Integer i = 0; i < deserializedCategories.size(); i++) {
           CategoryComparison currentItem = ret.getCategories().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('categories_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('categories');
           CategoryComparison newItem = (CategoryComparison) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CategoryComparison.class);
           newCategories.add(newItem);
         }
-        ret.categories_serialized_name = newCategories;
+        ret.categories = newCategories;
       }
 
       // calling custom deserializer for attributes
@@ -4538,14 +4901,26 @@ public class IBMCompareComplyV1Models {
       if (deserializedAttributes != null) {
         for (Integer i = 0; i < deserializedAttributes.size(); i++) {
           Attribute currentItem = ret.getAttributes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('attributes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('attributes');
           Attribute newItem = (Attribute) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Attribute.class);
           newAttributes.add(newItem);
         }
-        ret.attributes_serialized_name = newAttributes;
+        ret.attributes = newAttributes;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_label', 'documentLabel');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      if (attributes != null && attributes[0] != null) {
+        mapping.putAll(attributes[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -4556,7 +4931,7 @@ public class IBMCompareComplyV1Models {
     private IBMWatsonFile file;
     private String fileContentType;
     private String model;
- 
+
     /**
      * Gets the file.
      *
@@ -4567,7 +4942,7 @@ public class IBMCompareComplyV1Models {
     public IBMWatsonFile file() {
       return file;
     }
- 
+
     /**
      * Gets the fileContentType.
      *
@@ -4578,7 +4953,7 @@ public class IBMCompareComplyV1Models {
     public String fileContentType() {
       return fileContentType;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -4609,6 +4984,11 @@ public class IBMCompareComplyV1Models {
       return new ExtractTablesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('fileContentType', 'file_content_type');
+      return mapping;
+    }
   }
 
   /**
@@ -4699,15 +5079,15 @@ public class IBMCompareComplyV1Models {
   /**
    * Feedback data for submission.
    */
-  public class FeedbackDataInput {
-    private String feedback_type_serialized_name;
-    private ShortDoc document_serialized_name;
-    private String model_id_serialized_name;
-    private String model_version_serialized_name;
-    private Location location_serialized_name;
-    private String text_serialized_name;
-    private OriginalLabelsIn original_labels_serialized_name;
-    private UpdatedLabelsIn updated_labels_serialized_name;
+  public class FeedbackDataInput extends IBMWatsonGenericModel {
+    private String feedbackType;
+    private ShortDoc document;
+    private String modelId;
+    private String modelVersion;
+    private Location location;
+    private String text;
+    private OriginalLabelsIn originalLabels;
+    private UpdatedLabelsIn updatedLabels;
  
     /**
      * Gets the feedbackType.
@@ -4717,7 +5097,7 @@ public class IBMCompareComplyV1Models {
      * @return the feedbackType
      */
     public String getFeedbackType() {
-      return feedback_type_serialized_name;
+      return feedbackType;
     }
  
     /**
@@ -4728,7 +5108,7 @@ public class IBMCompareComplyV1Models {
      * @return the document
      */
     public ShortDoc getDocument() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -4739,7 +5119,7 @@ public class IBMCompareComplyV1Models {
      * @return the modelId
      */
     public String getModelId() {
-      return model_id_serialized_name;
+      return modelId;
     }
  
     /**
@@ -4750,7 +5130,7 @@ public class IBMCompareComplyV1Models {
      * @return the modelVersion
      */
     public String getModelVersion() {
-      return model_version_serialized_name;
+      return modelVersion;
     }
  
     /**
@@ -4762,7 +5142,7 @@ public class IBMCompareComplyV1Models {
      * @return the location
      */
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -4773,7 +5153,7 @@ public class IBMCompareComplyV1Models {
      * @return the text
      */
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4784,7 +5164,7 @@ public class IBMCompareComplyV1Models {
      * @return the originalLabels
      */
     public OriginalLabelsIn getOriginalLabels() {
-      return original_labels_serialized_name;
+      return originalLabels;
     }
  
     /**
@@ -4795,96 +5175,212 @@ public class IBMCompareComplyV1Models {
      * @return the updatedLabels
      */
     public UpdatedLabelsIn getUpdatedLabels() {
-      return updated_labels_serialized_name;
+      return updatedLabels;
+    }
+  
+    private FeedbackDataInput(FeedbackDataInputBuilder builder) {
+      IBMWatsonValidator.notNull(builder.feedbackType, 'feedbackType cannot be null');
+      IBMWatsonValidator.notNull(builder.location, 'location cannot be null');
+      IBMWatsonValidator.notNull(builder.text, 'text cannot be null');
+      IBMWatsonValidator.notNull(builder.originalLabels, 'originalLabels cannot be null');
+      IBMWatsonValidator.notNull(builder.updatedLabels, 'updatedLabels cannot be null');
+      this.feedbackType = builder.feedbackType;
+      this.document = builder.document;
+      this.modelId = builder.modelId;
+      this.modelVersion = builder.modelVersion;
+      this.location = builder.location;
+      this.text = builder.text;
+      this.originalLabels = builder.originalLabels;
+      this.updatedLabels = builder.updatedLabels;
     }
 
     /**
-     * Sets the feedbackType.
+     * New builder.
      *
-     * @param feedbackType the new feedbackType
+     * @return a FeedbackDataInput builder
      */
-    public void setFeedbackType(final String feedbackType) {
-      this.feedback_type_serialized_name = feedbackType;
+    public FeedbackDataInputBuilder newBuilder() {
+      return new FeedbackDataInputBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('feedbackType', 'feedback_type');
+      mapping.put('modelId', 'model_id');
+      mapping.put('modelVersion', 'model_version');
+      if (location != null) {
+        mapping.putAll(location.getSdkToApiMapping());
+      }
+      mapping.put('originalLabels', 'original_labels');
+      if (originalLabels != null) {
+        mapping.putAll(originalLabels.getSdkToApiMapping());
+      }
+      mapping.put('updatedLabels', 'updated_labels');
+      if (updatedLabels != null) {
+        mapping.putAll(updatedLabels.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * FeedbackDataInput Builder.
+   */
+  public class FeedbackDataInputBuilder {
+    private String feedbackType;
+    private ShortDoc document;
+    private String modelId;
+    private String modelVersion;
+    private Location location;
+    private String text;
+    private OriginalLabelsIn originalLabels;
+    private UpdatedLabelsIn updatedLabels;
+
+    private FeedbackDataInputBuilder(FeedbackDataInput feedbackDataInput) {
+      this.feedbackType = feedbackDataInput.feedbackType;
+      this.document = feedbackDataInput.document;
+      this.modelId = feedbackDataInput.modelId;
+      this.modelVersion = feedbackDataInput.modelVersion;
+      this.location = feedbackDataInput.location;
+      this.text = feedbackDataInput.text;
+      this.originalLabels = feedbackDataInput.originalLabels;
+      this.updatedLabels = feedbackDataInput.updatedLabels;
     }
 
     /**
-     * Sets the document.
-     *
-     * @param document the new document
+     * Instantiates a new builder.
      */
-    public void setDocument(final ShortDoc document) {
-      this.document_serialized_name = document;
+    public FeedbackDataInputBuilder() {
     }
 
     /**
-     * Sets the modelId.
+     * Instantiates a new builder with required properties.
      *
-     * @param modelId the new modelId
+     * @param feedbackType the feedbackType
+     * @param location the location
+     * @param text the text
+     * @param originalLabels the originalLabels
+     * @param updatedLabels the updatedLabels
      */
-    public void setModelId(final String modelId) {
-      this.model_id_serialized_name = modelId;
+    public FeedbackDataInputBuilder(String feedbackType, Location location, String text, OriginalLabelsIn originalLabels, UpdatedLabelsIn updatedLabels) {
+      this.feedbackType = feedbackType;
+      this.location = location;
+      this.text = text;
+      this.originalLabels = originalLabels;
+      this.updatedLabels = updatedLabels;
     }
 
     /**
-     * Sets the modelVersion.
+     * Builds a FeedbackDataInput.
      *
-     * @param modelVersion the new modelVersion
+     * @return the feedbackDataInput
      */
-    public void setModelVersion(final String modelVersion) {
-      this.model_version_serialized_name = modelVersion;
+    public FeedbackDataInput build() {
+      return new FeedbackDataInput(this);
     }
 
     /**
-     * Sets the location.
+     * Set the feedbackType.
      *
-     * @param location the new location
+     * @param feedbackType the feedbackType
+     * @return the FeedbackDataInput builder
      */
-    public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+    public FeedbackDataInputBuilder setFeedbackType(String feedbackType) {
+      this.feedbackType = feedbackType;
+      return this;
     }
 
     /**
-     * Sets the text.
+     * Set the document.
      *
-     * @param text the new text
+     * @param document the document
+     * @return the FeedbackDataInput builder
      */
-    public void setText(final String text) {
-      this.text_serialized_name = text;
+    public FeedbackDataInputBuilder setDocument(ShortDoc document) {
+      this.document = document;
+      return this;
     }
 
     /**
-     * Sets the originalLabels.
+     * Set the modelId.
      *
-     * @param originalLabels the new originalLabels
+     * @param modelId the modelId
+     * @return the FeedbackDataInput builder
      */
-    public void setOriginalLabels(final OriginalLabelsIn originalLabels) {
-      this.original_labels_serialized_name = originalLabels;
+    public FeedbackDataInputBuilder setModelId(String modelId) {
+      this.modelId = modelId;
+      return this;
     }
 
     /**
-     * Sets the updatedLabels.
+     * Set the modelVersion.
      *
-     * @param updatedLabels the new updatedLabels
+     * @param modelVersion the modelVersion
+     * @return the FeedbackDataInput builder
      */
-    public void setUpdatedLabels(final UpdatedLabelsIn updatedLabels) {
-      this.updated_labels_serialized_name = updatedLabels;
+    public FeedbackDataInputBuilder setModelVersion(String modelVersion) {
+      this.modelVersion = modelVersion;
+      return this;
     }
 
+    /**
+     * Set the location.
+     *
+     * @param location the location
+     * @return the FeedbackDataInput builder
+     */
+    public FeedbackDataInputBuilder setLocation(Location location) {
+      this.location = location;
+      return this;
+    }
+
+    /**
+     * Set the text.
+     *
+     * @param text the text
+     * @return the FeedbackDataInput builder
+     */
+    public FeedbackDataInputBuilder setText(String text) {
+      this.text = text;
+      return this;
+    }
+
+    /**
+     * Set the originalLabels.
+     *
+     * @param originalLabels the originalLabels
+     * @return the FeedbackDataInput builder
+     */
+    public FeedbackDataInputBuilder setOriginalLabels(OriginalLabelsIn originalLabels) {
+      this.originalLabels = originalLabels;
+      return this;
+    }
+
+    /**
+     * Set the updatedLabels.
+     *
+     * @param updatedLabels the updatedLabels
+     * @return the FeedbackDataInput builder
+     */
+    public FeedbackDataInputBuilder setUpdatedLabels(UpdatedLabelsIn updatedLabels) {
+      this.updatedLabels = updatedLabels;
+      return this;
+    }
   }
 
   /**
    * Information returned from the **Add Feedback** method.
    */
   public class FeedbackDataOutput extends IBMWatsonGenericModel {
-    private String feedback_type_serialized_name;
-    private ShortDoc document_serialized_name;
-    private String model_id_serialized_name;
-    private String model_version_serialized_name;
-    private Location location_serialized_name;
-    private String text_serialized_name;
-    private OriginalLabelsOut original_labels_serialized_name;
-    private UpdatedLabelsOut updated_labels_serialized_name;
-    private Pagination pagination_serialized_name;
+    private String feedbackType;
+    private ShortDoc document;
+    private String modelId;
+    private String modelVersion;
+    private Location location;
+    private String text;
+    private OriginalLabelsOut originalLabels;
+    private UpdatedLabelsOut updatedLabels;
+    private Pagination pagination;
  
     /**
      * Gets the feedbackType.
@@ -4895,7 +5391,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getFeedbackType() {
-      return feedback_type_serialized_name;
+      return feedbackType;
     }
  
     /**
@@ -4907,7 +5403,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public ShortDoc getDocument() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -4919,7 +5415,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModelId() {
-      return model_id_serialized_name;
+      return modelId;
     }
  
     /**
@@ -4931,7 +5427,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModelVersion() {
-      return model_version_serialized_name;
+      return modelVersion;
     }
  
     /**
@@ -4944,7 +5440,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -4956,7 +5452,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4968,7 +5464,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public OriginalLabelsOut getOriginalLabels() {
-      return original_labels_serialized_name;
+      return originalLabels;
     }
  
     /**
@@ -4980,7 +5476,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public UpdatedLabelsOut getUpdatedLabels() {
-      return updated_labels_serialized_name;
+      return updatedLabels;
     }
  
     /**
@@ -4992,7 +5488,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Pagination getPagination() {
-      return pagination_serialized_name;
+      return pagination;
     }
 
     /**
@@ -5001,7 +5497,7 @@ public class IBMCompareComplyV1Models {
      * @param feedbackType the new feedbackType
      */
     public void setFeedbackType(final String feedbackType) {
-      this.feedback_type_serialized_name = feedbackType;
+      this.feedbackType = feedbackType;
     }
 
     /**
@@ -5010,7 +5506,7 @@ public class IBMCompareComplyV1Models {
      * @param document the new document
      */
     public void setDocument(final ShortDoc document) {
-      this.document_serialized_name = document;
+      this.document = document;
     }
 
     /**
@@ -5019,7 +5515,7 @@ public class IBMCompareComplyV1Models {
      * @param modelId the new modelId
      */
     public void setModelId(final String modelId) {
-      this.model_id_serialized_name = modelId;
+      this.modelId = modelId;
     }
 
     /**
@@ -5028,7 +5524,7 @@ public class IBMCompareComplyV1Models {
      * @param modelVersion the new modelVersion
      */
     public void setModelVersion(final String modelVersion) {
-      this.model_version_serialized_name = modelVersion;
+      this.modelVersion = modelVersion;
     }
 
     /**
@@ -5037,7 +5533,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -5046,7 +5542,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -5055,7 +5551,7 @@ public class IBMCompareComplyV1Models {
      * @param originalLabels the new originalLabels
      */
     public void setOriginalLabels(final OriginalLabelsOut originalLabels) {
-      this.original_labels_serialized_name = originalLabels;
+      this.originalLabels = originalLabels;
     }
 
     /**
@@ -5064,7 +5560,7 @@ public class IBMCompareComplyV1Models {
      * @param updatedLabels the new updatedLabels
      */
     public void setUpdatedLabels(final UpdatedLabelsOut updatedLabels) {
-      this.updated_labels_serialized_name = updatedLabels;
+      this.updatedLabels = updatedLabels;
     }
 
     /**
@@ -5073,7 +5569,7 @@ public class IBMCompareComplyV1Models {
      * @param pagination the new pagination
      */
     public void setPagination(final Pagination pagination) {
-      this.pagination_serialized_name = pagination;
+      this.pagination = pagination;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5084,26 +5580,48 @@ public class IBMCompareComplyV1Models {
       FeedbackDataOutput ret = (FeedbackDataOutput) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for document
-      ShortDoc newDocument = (ShortDoc) new ShortDoc().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document_serialized_name'), ShortDoc.class);
+      ShortDoc newDocument = (ShortDoc) new ShortDoc().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document'), ShortDoc.class);
       ret.setDocument(newDocument);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       // calling custom deserializer for originalLabels
-      OriginalLabelsOut newOriginalLabels = (OriginalLabelsOut) new OriginalLabelsOut().deserialize(JSON.serialize(ret.getOriginalLabels()), (Map<String, Object>) jsonMap.get('original_labels_serialized_name'), OriginalLabelsOut.class);
+      OriginalLabelsOut newOriginalLabels = (OriginalLabelsOut) new OriginalLabelsOut().deserialize(JSON.serialize(ret.getOriginalLabels()), (Map<String, Object>) jsonMap.get('originalLabels'), OriginalLabelsOut.class);
       ret.setOriginalLabels(newOriginalLabels);
 
       // calling custom deserializer for updatedLabels
-      UpdatedLabelsOut newUpdatedLabels = (UpdatedLabelsOut) new UpdatedLabelsOut().deserialize(JSON.serialize(ret.getUpdatedLabels()), (Map<String, Object>) jsonMap.get('updated_labels_serialized_name'), UpdatedLabelsOut.class);
+      UpdatedLabelsOut newUpdatedLabels = (UpdatedLabelsOut) new UpdatedLabelsOut().deserialize(JSON.serialize(ret.getUpdatedLabels()), (Map<String, Object>) jsonMap.get('updatedLabels'), UpdatedLabelsOut.class);
       ret.setUpdatedLabels(newUpdatedLabels);
 
       // calling custom deserializer for pagination
-      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination_serialized_name'), Pagination.class);
+      Pagination newPagination = (Pagination) new Pagination().deserialize(JSON.serialize(ret.getPagination()), (Map<String, Object>) jsonMap.get('pagination'), Pagination.class);
       ret.setPagination(newPagination);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('feedback_type', 'feedbackType');
+      mapping.put('model_id', 'modelId');
+      mapping.put('model_version', 'modelVersion');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      mapping.put('original_labels', 'originalLabels');
+      if (originalLabels != null) {
+        mapping.putAll(originalLabels.getApiToSdkMapping());
+      }
+      mapping.put('updated_labels', 'updatedLabels');
+      if (updatedLabels != null) {
+        mapping.putAll(updatedLabels.getApiToSdkMapping());
+      }
+      if (pagination != null) {
+        mapping.putAll(pagination.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5111,7 +5629,7 @@ public class IBMCompareComplyV1Models {
    * The results of a successful **List Feedback** request for all feedback.
    */
   public class FeedbackList extends IBMWatsonResponseModel {
-    private List<GetFeedback> feedback_serialized_name;
+    private List<GetFeedback> feedback;
  
     /**
      * Gets the feedback.
@@ -5122,7 +5640,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<GetFeedback> getFeedback() {
-      return feedback_serialized_name;
+      return feedback;
     }
 
     /**
@@ -5131,7 +5649,7 @@ public class IBMCompareComplyV1Models {
      * @param feedback the new feedback
      */
     public void setFeedback(final List<GetFeedback> feedback) {
-      this.feedback_serialized_name = feedback;
+      this.feedback = feedback;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5147,14 +5665,22 @@ public class IBMCompareComplyV1Models {
       if (deserializedFeedback != null) {
         for (Integer i = 0; i < deserializedFeedback.size(); i++) {
           GetFeedback currentItem = ret.getFeedback().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('feedback_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('feedback');
           GetFeedback newItem = (GetFeedback) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), GetFeedback.class);
           newFeedback.add(newItem);
         }
-        ret.feedback_serialized_name = newFeedback;
+        ret.feedback = newFeedback;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (feedback != null && feedback[0] != null) {
+        mapping.putAll(feedback[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5162,11 +5688,11 @@ public class IBMCompareComplyV1Models {
    * Information about the document and the submitted feedback.
    */
   public class FeedbackReturn extends IBMWatsonResponseModel {
-    private String feedback_id_serialized_name;
-    private String user_id_serialized_name;
-    private String comment_serialized_name;
-    private Datetime created_serialized_name;
-    private FeedbackDataOutput feedback_data_serialized_name;
+    private String feedbackId;
+    private String userId;
+    private String comment;
+    private Datetime created;
+    private FeedbackDataOutput feedbackData;
  
     /**
      * Gets the feedbackId.
@@ -5177,7 +5703,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getFeedbackId() {
-      return feedback_id_serialized_name;
+      return feedbackId;
     }
  
     /**
@@ -5189,7 +5715,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getUserId() {
-      return user_id_serialized_name;
+      return userId;
     }
  
     /**
@@ -5201,7 +5727,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getComment() {
-      return comment_serialized_name;
+      return comment;
     }
  
     /**
@@ -5213,7 +5739,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -5225,7 +5751,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public FeedbackDataOutput getFeedbackData() {
-      return feedback_data_serialized_name;
+      return feedbackData;
     }
 
     /**
@@ -5234,7 +5760,7 @@ public class IBMCompareComplyV1Models {
      * @param feedbackId the new feedbackId
      */
     public void setFeedbackId(final String feedbackId) {
-      this.feedback_id_serialized_name = feedbackId;
+      this.feedbackId = feedbackId;
     }
 
     /**
@@ -5243,7 +5769,7 @@ public class IBMCompareComplyV1Models {
      * @param userId the new userId
      */
     public void setUserId(final String userId) {
-      this.user_id_serialized_name = userId;
+      this.userId = userId;
     }
 
     /**
@@ -5252,7 +5778,7 @@ public class IBMCompareComplyV1Models {
      * @param comment the new comment
      */
     public void setComment(final String comment) {
-      this.comment_serialized_name = comment;
+      this.comment = comment;
     }
 
     /**
@@ -5261,7 +5787,7 @@ public class IBMCompareComplyV1Models {
      * @param created the new created
      */
     public void setCreated(final Datetime created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
     /**
@@ -5270,7 +5796,7 @@ public class IBMCompareComplyV1Models {
      * @param feedbackData the new feedbackData
      */
     public void setFeedbackData(final FeedbackDataOutput feedbackData) {
-      this.feedback_data_serialized_name = feedbackData;
+      this.feedbackData = feedbackData;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5281,10 +5807,21 @@ public class IBMCompareComplyV1Models {
       FeedbackReturn ret = (FeedbackReturn) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for feedbackData
-      FeedbackDataOutput newFeedbackData = (FeedbackDataOutput) new FeedbackDataOutput().deserialize(JSON.serialize(ret.getFeedbackData()), (Map<String, Object>) jsonMap.get('feedback_data_serialized_name'), FeedbackDataOutput.class);
+      FeedbackDataOutput newFeedbackData = (FeedbackDataOutput) new FeedbackDataOutput().deserialize(JSON.serialize(ret.getFeedbackData()), (Map<String, Object>) jsonMap.get('feedbackData'), FeedbackDataOutput.class);
       ret.setFeedbackData(newFeedbackData);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('feedback_id', 'feedbackId');
+      mapping.put('user_id', 'userId');
+      mapping.put('feedback_data', 'feedbackData');
+      if (feedbackData != null) {
+        mapping.putAll(feedbackData.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5293,7 +5830,7 @@ public class IBMCompareComplyV1Models {
    */
   public class GetBatchOptions extends IBMWatsonOptionsModel {
     private String batchId;
- 
+
     /**
      * Gets the batchId.
      *
@@ -5320,6 +5857,11 @@ public class IBMCompareComplyV1Models {
       return new GetBatchOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('batchId', 'batch_id');
+      return mapping;
+    }
   }
 
   /**
@@ -5385,10 +5927,10 @@ public class IBMCompareComplyV1Models {
    * The results of a successful **Get Feedback** request for a single feedback entry.
    */
   public class GetFeedback extends IBMWatsonResponseModel {
-    private String feedback_id_serialized_name;
-    private Datetime created_serialized_name;
-    private String comment_serialized_name;
-    private FeedbackDataOutput feedback_data_serialized_name;
+    private String feedbackId;
+    private Datetime created;
+    private String comment;
+    private FeedbackDataOutput feedbackData;
  
     /**
      * Gets the feedbackId.
@@ -5399,7 +5941,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getFeedbackId() {
-      return feedback_id_serialized_name;
+      return feedbackId;
     }
  
     /**
@@ -5411,7 +5953,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -5423,7 +5965,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getComment() {
-      return comment_serialized_name;
+      return comment;
     }
  
     /**
@@ -5435,7 +5977,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public FeedbackDataOutput getFeedbackData() {
-      return feedback_data_serialized_name;
+      return feedbackData;
     }
 
     /**
@@ -5444,7 +5986,7 @@ public class IBMCompareComplyV1Models {
      * @param feedbackId the new feedbackId
      */
     public void setFeedbackId(final String feedbackId) {
-      this.feedback_id_serialized_name = feedbackId;
+      this.feedbackId = feedbackId;
     }
 
     /**
@@ -5453,7 +5995,7 @@ public class IBMCompareComplyV1Models {
      * @param created the new created
      */
     public void setCreated(final Datetime created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
     /**
@@ -5462,7 +6004,7 @@ public class IBMCompareComplyV1Models {
      * @param comment the new comment
      */
     public void setComment(final String comment) {
-      this.comment_serialized_name = comment;
+      this.comment = comment;
     }
 
     /**
@@ -5471,7 +6013,7 @@ public class IBMCompareComplyV1Models {
      * @param feedbackData the new feedbackData
      */
     public void setFeedbackData(final FeedbackDataOutput feedbackData) {
-      this.feedback_data_serialized_name = feedbackData;
+      this.feedbackData = feedbackData;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5482,10 +6024,20 @@ public class IBMCompareComplyV1Models {
       GetFeedback ret = (GetFeedback) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for feedbackData
-      FeedbackDataOutput newFeedbackData = (FeedbackDataOutput) new FeedbackDataOutput().deserialize(JSON.serialize(ret.getFeedbackData()), (Map<String, Object>) jsonMap.get('feedback_data_serialized_name'), FeedbackDataOutput.class);
+      FeedbackDataOutput newFeedbackData = (FeedbackDataOutput) new FeedbackDataOutput().deserialize(JSON.serialize(ret.getFeedbackData()), (Map<String, Object>) jsonMap.get('feedbackData'), FeedbackDataOutput.class);
       ret.setFeedbackData(newFeedbackData);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('feedback_id', 'feedbackId');
+      mapping.put('feedback_data', 'feedbackData');
+      if (feedbackData != null) {
+        mapping.putAll(feedbackData.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5495,7 +6047,7 @@ public class IBMCompareComplyV1Models {
   public class GetFeedbackOptions extends IBMWatsonOptionsModel {
     private String feedbackId;
     private String model;
- 
+
     /**
      * Gets the feedbackId.
      *
@@ -5506,7 +6058,7 @@ public class IBMCompareComplyV1Models {
     public String feedbackId() {
       return feedbackId;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -5536,6 +6088,11 @@ public class IBMCompareComplyV1Models {
       return new GetFeedbackOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('feedbackId', 'feedback_id');
+      return mapping;
+    }
   }
 
   /**
@@ -5614,11 +6171,11 @@ public class IBMCompareComplyV1Models {
    * The HTML converted from an input document.
    */
   public class HTMLReturn extends IBMWatsonResponseModel {
-    private String num_pages_serialized_name;
-    private String author_serialized_name;
-    private String publication_date_serialized_name;
-    private String title_serialized_name;
-    private String html_serialized_name;
+    private String numPages;
+    private String author;
+    private String publicationDate;
+    private String title;
+    private String html;
  
     /**
      * Gets the numPages.
@@ -5629,7 +6186,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getNumPages() {
-      return num_pages_serialized_name;
+      return numPages;
     }
  
     /**
@@ -5641,7 +6198,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getAuthor() {
-      return author_serialized_name;
+      return author;
     }
  
     /**
@@ -5653,7 +6210,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getPublicationDate() {
-      return publication_date_serialized_name;
+      return publicationDate;
     }
  
     /**
@@ -5665,7 +6222,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -5677,7 +6234,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getHtml() {
-      return html_serialized_name;
+      return html;
     }
 
     /**
@@ -5686,7 +6243,7 @@ public class IBMCompareComplyV1Models {
      * @param numPages the new numPages
      */
     public void setNumPages(final String numPages) {
-      this.num_pages_serialized_name = numPages;
+      this.numPages = numPages;
     }
 
     /**
@@ -5695,7 +6252,7 @@ public class IBMCompareComplyV1Models {
      * @param author the new author
      */
     public void setAuthor(final String author) {
-      this.author_serialized_name = author;
+      this.author = author;
     }
 
     /**
@@ -5704,7 +6261,7 @@ public class IBMCompareComplyV1Models {
      * @param publicationDate the new publicationDate
      */
     public void setPublicationDate(final String publicationDate) {
-      this.publication_date_serialized_name = publicationDate;
+      this.publicationDate = publicationDate;
     }
 
     /**
@@ -5713,7 +6270,7 @@ public class IBMCompareComplyV1Models {
      * @param title the new title
      */
     public void setTitle(final String title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     /**
@@ -5722,9 +6279,15 @@ public class IBMCompareComplyV1Models {
      * @param html the new html
      */
     public void setHtml(final String html) {
-      this.html_serialized_name = html;
+      this.html = html;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('num_pages', 'numPages');
+      mapping.put('publication_date', 'publicationDate');
+      return mapping;
+    }
   }
 
   /**
@@ -5732,9 +6295,9 @@ public class IBMCompareComplyV1Models {
    * only if normalized text exists.
    */
   public class Interpretation extends IBMWatsonGenericModel {
-    private String value_serialized_name;
-    private Double numeric_value_serialized_name;
-    private String unit_serialized_name;
+    private String value;
+    private Double numericValue;
+    private String unit;
  
     /**
      * Gets the value.
@@ -5745,7 +6308,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getValue() {
-      return value_serialized_name;
+      return value;
     }
  
     /**
@@ -5757,7 +6320,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Double getNumericValue() {
-      return numeric_value_serialized_name;
+      return numericValue;
     }
  
     /**
@@ -5773,7 +6336,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getUnit() {
-      return unit_serialized_name;
+      return unit;
     }
 
     /**
@@ -5782,7 +6345,7 @@ public class IBMCompareComplyV1Models {
      * @param value the new value
      */
     public void setValue(final String value) {
-      this.value_serialized_name = value;
+      this.value = value;
     }
 
     /**
@@ -5791,7 +6354,7 @@ public class IBMCompareComplyV1Models {
      * @param numericValue the new numericValue
      */
     public void setNumericValue(final Double numericValue) {
-      this.numeric_value_serialized_name = numericValue;
+      this.numericValue = numericValue;
     }
 
     /**
@@ -5800,18 +6363,23 @@ public class IBMCompareComplyV1Models {
      * @param unit the new unit
      */
     public void setUnit(final String unit) {
-      this.unit_serialized_name = unit;
+      this.unit = unit;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('numeric_value', 'numericValue');
+      return mapping;
+    }
   }
 
   /**
    * A key in a key-value pair.
    */
   public class Key extends IBMWatsonGenericModel {
-    private String cell_id_serialized_name;
-    private Location location_serialized_name;
-    private String text_serialized_name;
+    private String cellId;
+    private Location location;
+    private String text;
  
     /**
      * Gets the cellId.
@@ -5822,7 +6390,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getCellId() {
-      return cell_id_serialized_name;
+      return cellId;
     }
  
     /**
@@ -5835,7 +6403,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -5847,7 +6415,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -5856,7 +6424,7 @@ public class IBMCompareComplyV1Models {
      * @param cellId the new cellId
      */
     public void setCellId(final String cellId) {
-      this.cell_id_serialized_name = cellId;
+      this.cellId = cellId;
     }
 
     /**
@@ -5865,7 +6433,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -5874,7 +6442,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5885,10 +6453,19 @@ public class IBMCompareComplyV1Models {
       Key ret = (Key) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('cell_id', 'cellId');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5896,8 +6473,8 @@ public class IBMCompareComplyV1Models {
    * Key-value pairs detected across cell boundaries.
    */
   public class KeyValuePair extends IBMWatsonGenericModel {
-    private Key key_serialized_name;
-    private Value value_serialized_name;
+    private Key key;
+    private Value value;
  
     /**
      * Gets the key.
@@ -5908,7 +6485,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Key getKey() {
-      return key_serialized_name;
+      return key;
     }
  
     /**
@@ -5920,7 +6497,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Value getValue() {
-      return value_serialized_name;
+      return value;
     }
 
     /**
@@ -5929,7 +6506,7 @@ public class IBMCompareComplyV1Models {
      * @param key the new key
      */
     public void setKey(final Key key) {
-      this.key_serialized_name = key;
+      this.key = key;
     }
 
     /**
@@ -5938,7 +6515,7 @@ public class IBMCompareComplyV1Models {
      * @param value the new value
      */
     public void setValue(final Value value) {
-      this.value_serialized_name = value;
+      this.value = value;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5949,14 +6526,25 @@ public class IBMCompareComplyV1Models {
       KeyValuePair ret = (KeyValuePair) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for key
-      Key newKey = (Key) new Key().deserialize(JSON.serialize(ret.getKey()), (Map<String, Object>) jsonMap.get('key_serialized_name'), Key.class);
+      Key newKey = (Key) new Key().deserialize(JSON.serialize(ret.getKey()), (Map<String, Object>) jsonMap.get('key'), Key.class);
       ret.setKey(newKey);
 
       // calling custom deserializer for value
-      Value newValue = (Value) new Value().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value_serialized_name'), Value.class);
+      Value newValue = (Value) new Value().deserialize(JSON.serialize(ret.getValue()), (Map<String, Object>) jsonMap.get('value'), Value.class);
       ret.setValue(newValue);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (key != null) {
+        mapping.putAll(key.getApiToSdkMapping());
+      }
+      if (value != null) {
+        mapping.putAll(value.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5965,8 +6553,14 @@ public class IBMCompareComplyV1Models {
    * `party`, and the `party` object identifies the affected party.
    */
   public class Label extends IBMWatsonGenericModel {
-    private String nature_serialized_name;
-    private String party_serialized_name;
+    private String nature;
+    private String party;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Label() { }
  
     /**
      * Gets the nature.
@@ -5977,7 +6571,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getNature() {
-      return nature_serialized_name;
+      return nature;
     }
  
     /**
@@ -5989,36 +6583,94 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getParty() {
-      return party_serialized_name;
+      return party;
+    }
+  
+    private Label(LabelBuilder builder) {
+      IBMWatsonValidator.notNull(builder.nature, 'nature cannot be null');
+      IBMWatsonValidator.notNull(builder.party, 'party cannot be null');
+      this.nature = builder.nature;
+      this.party = builder.party;
     }
 
     /**
-     * Sets the nature.
+     * New builder.
      *
-     * @param nature the new nature
+     * @return a Label builder
      */
-    public void setNature(final String nature) {
-      this.nature_serialized_name = nature;
+    public LabelBuilder newBuilder() {
+      return new LabelBuilder(this);
+    }
+  }
+
+  /**
+   * Label Builder.
+   */
+  public class LabelBuilder {
+    private String nature;
+    private String party;
+
+    private LabelBuilder(Label label) {
+      this.nature = label.nature;
+      this.party = label.party;
     }
 
     /**
-     * Sets the party.
-     *
-     * @param party the new party
+     * Instantiates a new builder.
      */
-    public void setParty(final String party) {
-      this.party_serialized_name = party;
+    public LabelBuilder() {
     }
 
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param nature the nature
+     * @param party the party
+     */
+    public LabelBuilder(String nature, String party) {
+      this.nature = nature;
+      this.party = party;
+    }
+
+    /**
+     * Builds a Label.
+     *
+     * @return the label
+     */
+    public Label build() {
+      return new Label(this);
+    }
+
+    /**
+     * Set the nature.
+     *
+     * @param nature the nature
+     * @return the Label builder
+     */
+    public LabelBuilder setNature(String nature) {
+      this.nature = nature;
+      return this;
+    }
+
+    /**
+     * Set the party.
+     *
+     * @param party the party
+     * @return the Label builder
+     */
+    public LabelBuilder setParty(String party) {
+      this.party = party;
+      return this;
+    }
   }
 
   /**
    * The leading sentences in a section or subsection of the input document.
    */
   public class LeadingSentence extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private Location location_serialized_name;
-    private List<ElementLocations> element_locations_serialized_name;
+    private String text;
+    private Location location;
+    private List<ElementLocations> elementLocations;
  
     /**
      * Gets the text.
@@ -6029,7 +6681,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -6042,7 +6694,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -6054,7 +6706,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ElementLocations> getElementLocations() {
-      return element_locations_serialized_name;
+      return elementLocations;
     }
 
     /**
@@ -6063,7 +6715,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -6072,7 +6724,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -6081,7 +6733,7 @@ public class IBMCompareComplyV1Models {
      * @param elementLocations the new elementLocations
      */
     public void setElementLocations(final List<ElementLocations> elementLocations) {
-      this.element_locations_serialized_name = elementLocations;
+      this.elementLocations = elementLocations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6092,7 +6744,7 @@ public class IBMCompareComplyV1Models {
       LeadingSentence ret = (LeadingSentence) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       // calling custom deserializer for elementLocations
@@ -6101,14 +6753,26 @@ public class IBMCompareComplyV1Models {
       if (deserializedElementLocations != null) {
         for (Integer i = 0; i < deserializedElementLocations.size(); i++) {
           ElementLocations currentItem = ret.getElementLocations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('element_locations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('elementLocations');
           ElementLocations newItem = (ElementLocations) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ElementLocations.class);
           newElementLocations.add(newItem);
         }
-        ret.element_locations_serialized_name = newElementLocations;
+        ret.elementLocations = newElementLocations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      mapping.put('element_locations', 'elementLocations');
+      if (elementLocations != null && elementLocations[0] != null) {
+        mapping.putAll(elementLocations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -6129,7 +6793,6 @@ public class IBMCompareComplyV1Models {
     public ListBatchesOptionsBuilder newBuilder() {
       return new ListBatchesOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -6189,7 +6852,7 @@ public class IBMCompareComplyV1Models {
     private String cursor;
     private String xsort;
     private Boolean includeTotal;
- 
+
     /**
      * Gets the feedbackType.
      *
@@ -6201,7 +6864,7 @@ public class IBMCompareComplyV1Models {
     public String feedbackType() {
       return feedbackType;
     }
- 
+
     /**
      * Gets the before.
      *
@@ -6213,7 +6876,7 @@ public class IBMCompareComplyV1Models {
     public Datetime before() {
       return before;
     }
- 
+
     /**
      * Gets the after.
      *
@@ -6225,7 +6888,7 @@ public class IBMCompareComplyV1Models {
     public Datetime after() {
       return after;
     }
- 
+
     /**
      * Gets the documentTitle.
      *
@@ -6237,7 +6900,7 @@ public class IBMCompareComplyV1Models {
     public String documentTitle() {
       return documentTitle;
     }
- 
+
     /**
      * Gets the modelId.
      *
@@ -6249,7 +6912,7 @@ public class IBMCompareComplyV1Models {
     public String modelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the modelVersion.
      *
@@ -6260,7 +6923,7 @@ public class IBMCompareComplyV1Models {
     public String modelVersion() {
       return modelVersion;
     }
- 
+
     /**
      * Gets the categoryRemoved.
      *
@@ -6272,7 +6935,7 @@ public class IBMCompareComplyV1Models {
     public String categoryRemoved() {
       return categoryRemoved;
     }
- 
+
     /**
      * Gets the categoryAdded.
      *
@@ -6284,7 +6947,7 @@ public class IBMCompareComplyV1Models {
     public String categoryAdded() {
       return categoryAdded;
     }
- 
+
     /**
      * Gets the categoryNotChanged.
      *
@@ -6296,7 +6959,7 @@ public class IBMCompareComplyV1Models {
     public String categoryNotChanged() {
       return categoryNotChanged;
     }
- 
+
     /**
      * Gets the typeRemoved.
      *
@@ -6308,7 +6971,7 @@ public class IBMCompareComplyV1Models {
     public String typeRemoved() {
       return typeRemoved;
     }
- 
+
     /**
      * Gets the typeAdded.
      *
@@ -6320,7 +6983,7 @@ public class IBMCompareComplyV1Models {
     public String typeAdded() {
       return typeAdded;
     }
- 
+
     /**
      * Gets the typeNotChanged.
      *
@@ -6332,7 +6995,7 @@ public class IBMCompareComplyV1Models {
     public String typeNotChanged() {
       return typeNotChanged;
     }
- 
+
     /**
      * Gets the pageLimit.
      *
@@ -6343,7 +7006,7 @@ public class IBMCompareComplyV1Models {
     public Long pageLimit() {
       return pageLimit;
     }
- 
+
     /**
      * Gets the cursor.
      *
@@ -6355,7 +7018,7 @@ public class IBMCompareComplyV1Models {
     public String cursor() {
       return cursor;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -6368,7 +7031,7 @@ public class IBMCompareComplyV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the includeTotal.
      *
@@ -6410,6 +7073,23 @@ public class IBMCompareComplyV1Models {
       return new ListFeedbackOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('feedbackType', 'feedback_type');
+      mapping.put('documentTitle', 'document_title');
+      mapping.put('modelId', 'model_id');
+      mapping.put('modelVersion', 'model_version');
+      mapping.put('categoryRemoved', 'category_removed');
+      mapping.put('categoryAdded', 'category_added');
+      mapping.put('categoryNotChanged', 'category_not_changed');
+      mapping.put('typeRemoved', 'type_removed');
+      mapping.put('typeAdded', 'type_added');
+      mapping.put('typeNotChanged', 'type_not_changed');
+      mapping.put('pageLimit', 'page_limit');
+      mapping.put('xsort', 'sort');
+      mapping.put('includeTotal', 'include_total');
+      return mapping;
+    }
   }
 
   /**
@@ -6662,8 +7342,14 @@ public class IBMCompareComplyV1Models {
    * `end`.
    */
   public class Location extends IBMWatsonGenericModel {
-    private Long begin_serialized_name;
-    private Long end_serialized_name;
+    private Long xbegin;
+    private Long xend;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Location() { }
  
     /**
      * Gets the xbegin.
@@ -6674,7 +7360,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getXbegin() {
-      return begin_serialized_name;
+      return xbegin;
     }
  
     /**
@@ -6686,35 +7372,107 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getXend() {
-      return end_serialized_name;
+      return xend;
+    }
+  
+    private Location(LocationBuilder builder) {
+      IBMWatsonValidator.notNull(builder.xbegin, 'xbegin cannot be null');
+      IBMWatsonValidator.notNull(builder.xend, 'xend cannot be null');
+      this.xbegin = builder.xbegin;
+      this.xend = builder.xend;
     }
 
     /**
-     * Sets the xbegin.
+     * New builder.
      *
-     * @param xbegin the new xbegin
+     * @return a Location builder
      */
-    public void setXbegin(final long xbegin) {
-      this.begin_serialized_name = xbegin;
+    public LocationBuilder newBuilder() {
+      return new LocationBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xbegin', 'begin');
+      mapping.put('xend', 'end');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('begin', 'xbegin');
+      mapping.put('end', 'xend');
+      return mapping;
+    }
+  }
+
+  /**
+   * Location Builder.
+   */
+  public class LocationBuilder {
+    private Long xbegin;
+    private Long xend;
+
+    private LocationBuilder(Location location) {
+      this.xbegin = location.xbegin;
+      this.xend = location.xend;
     }
 
     /**
-     * Sets the xend.
-     *
-     * @param xend the new xend
+     * Instantiates a new builder.
      */
-    public void setXend(final long xend) {
-      this.end_serialized_name = xend;
+    public LocationBuilder() {
     }
 
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param xbegin the xbegin
+     * @param xend the xend
+     */
+    public LocationBuilder(Long xbegin, Long xend) {
+      this.xbegin = xbegin;
+      this.xend = xend;
+    }
+
+    /**
+     * Builds a Location.
+     *
+     * @return the location
+     */
+    public Location build() {
+      return new Location(this);
+    }
+
+    /**
+     * Set the xbegin.
+     *
+     * @param xbegin the xbegin
+     * @return the Location builder
+     */
+    public LocationBuilder setXbegin(Long xbegin) {
+      this.xbegin = xbegin;
+      return this;
+    }
+
+    /**
+     * Set the xend.
+     *
+     * @param xend the xend
+     * @return the Location builder
+     */
+    public LocationBuilder setXend(Long xend) {
+      this.xend = xend;
+      return this;
+    }
   }
 
   /**
    * A mention of a party.
    */
   public class Mention extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private Location location_serialized_name;
+    private String text;
+    private Location location;
  
     /**
      * Gets the text.
@@ -6725,7 +7483,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -6738,7 +7496,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -6747,7 +7505,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -6756,7 +7514,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6767,19 +7525,27 @@ public class IBMCompareComplyV1Models {
       Mention ret = (Mention) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
   /**
    * The original labeling from the input document, without the submitted feedback.
    */
-  public class OriginalLabelsIn {
-    private List<TypeLabel> types_serialized_name;
-    private List<Category> categories_serialized_name;
+  public class OriginalLabelsIn extends IBMWatsonGenericModel {
+    private List<TypeLabel> types;
+    private List<Category> categories;
  
     /**
      * Gets the types.
@@ -6789,7 +7555,7 @@ public class IBMCompareComplyV1Models {
      * @return the types
      */
     public List<TypeLabel> getTypes() {
-      return types_serialized_name;
+      return types;
     }
  
     /**
@@ -6800,36 +7566,137 @@ public class IBMCompareComplyV1Models {
      * @return the categories
      */
     public List<Category> getCategories() {
-      return categories_serialized_name;
+      return categories;
+    }
+  
+    private OriginalLabelsIn(OriginalLabelsInBuilder builder) {
+      IBMWatsonValidator.notNull(builder.types, 'types cannot be null');
+      IBMWatsonValidator.notNull(builder.categories, 'categories cannot be null');
+      this.types = builder.types;
+      this.categories = builder.categories;
     }
 
     /**
-     * Sets the types.
+     * New builder.
+     *
+     * @return a OriginalLabelsIn builder
+     */
+    public OriginalLabelsInBuilder newBuilder() {
+      return new OriginalLabelsInBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (types != null && types[0] != null) {
+        mapping.putAll(types[0].getSdkToApiMapping());
+      }
+      if (categories != null && categories[0] != null) {
+        mapping.putAll(categories[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * OriginalLabelsIn Builder.
+   */
+  public class OriginalLabelsInBuilder {
+    private List<TypeLabel> types;
+    private List<Category> categories;
+
+    private OriginalLabelsInBuilder(OriginalLabelsIn originalLabelsIn) {
+      this.types = originalLabelsIn.types;
+      this.categories = originalLabelsIn.categories;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public OriginalLabelsInBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param types the types
+     * @param categories the categories
+     */
+    public OriginalLabelsInBuilder(List<TypeLabel> types, List<Category> categories) {
+      this.types = types;
+      this.categories = categories;
+    }
+
+    /**
+     * Builds a OriginalLabelsIn.
+     *
+     * @return the originalLabelsIn
+     */
+    public OriginalLabelsIn build() {
+      return new OriginalLabelsIn(this);
+    }
+
+    /**
+     * Adds an types to types.
      *
      * @param types the new types
+     * @return the OriginalLabelsIn builder
      */
-    public void setTypes(final List<TypeLabel> types) {
-      this.types_serialized_name = types;
+    public OriginalLabelsInBuilder addTypes(TypeLabel types) {
+      IBMWatsonValidator.notNull(types, 'types cannot be null');
+      if (this.types == null) {
+        this.types = new List<TypeLabel>();
+      }
+      this.types.add(types);
+      return this;
     }
 
     /**
-     * Sets the categories.
+     * Adds an categories to categories.
      *
      * @param categories the new categories
+     * @return the OriginalLabelsIn builder
      */
-    public void setCategories(final List<Category> categories) {
-      this.categories_serialized_name = categories;
+    public OriginalLabelsInBuilder addCategories(Category categories) {
+      IBMWatsonValidator.notNull(categories, 'categories cannot be null');
+      if (this.categories == null) {
+        this.categories = new List<Category>();
+      }
+      this.categories.add(categories);
+      return this;
     }
 
+    /**
+     * Set the types.
+     * Existing types will be replaced.
+     *
+     * @param types the types
+     * @return the OriginalLabelsIn builder
+     */
+    public OriginalLabelsInBuilder setTypes(List<TypeLabel> types) {
+      this.types = types;
+      return this;
+    }
+
+    /**
+     * Set the categories.
+     * Existing categories will be replaced.
+     *
+     * @param categories the categories
+     * @return the OriginalLabelsIn builder
+     */
+    public OriginalLabelsInBuilder setCategories(List<Category> categories) {
+      this.categories = categories;
+      return this;
+    }
   }
 
   /**
    * The original labeling from the input document, without the submitted feedback.
    */
   public class OriginalLabelsOut extends IBMWatsonGenericModel {
-    private List<TypeLabel> types_serialized_name;
-    private List<Category> categories_serialized_name;
-    private String modification_serialized_name;
+    private List<TypeLabel> types;
+    private List<Category> categories;
+    private String modification;
  
     /**
      * Gets the types.
@@ -6840,7 +7707,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<TypeLabel> getTypes() {
-      return types_serialized_name;
+      return types;
     }
  
     /**
@@ -6852,7 +7719,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Category> getCategories() {
-      return categories_serialized_name;
+      return categories;
     }
  
     /**
@@ -6865,7 +7732,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModification() {
-      return modification_serialized_name;
+      return modification;
     }
 
     /**
@@ -6874,7 +7741,7 @@ public class IBMCompareComplyV1Models {
      * @param types the new types
      */
     public void setTypes(final List<TypeLabel> types) {
-      this.types_serialized_name = types;
+      this.types = types;
     }
 
     /**
@@ -6883,7 +7750,7 @@ public class IBMCompareComplyV1Models {
      * @param categories the new categories
      */
     public void setCategories(final List<Category> categories) {
-      this.categories_serialized_name = categories;
+      this.categories = categories;
     }
 
     /**
@@ -6892,7 +7759,7 @@ public class IBMCompareComplyV1Models {
      * @param modification the new modification
      */
     public void setModification(final String modification) {
-      this.modification_serialized_name = modification;
+      this.modification = modification;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6908,11 +7775,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedTypes != null) {
         for (Integer i = 0; i < deserializedTypes.size(); i++) {
           TypeLabel currentItem = ret.getTypes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('types_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('types');
           TypeLabel newItem = (TypeLabel) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TypeLabel.class);
           newTypes.add(newItem);
         }
-        ret.types_serialized_name = newTypes;
+        ret.types = newTypes;
       }
 
       // calling custom deserializer for categories
@@ -6921,14 +7788,25 @@ public class IBMCompareComplyV1Models {
       if (deserializedCategories != null) {
         for (Integer i = 0; i < deserializedCategories.size(); i++) {
           Category currentItem = ret.getCategories().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('categories_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('categories');
           Category newItem = (Category) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Category.class);
           newCategories.add(newItem);
         }
-        ret.categories_serialized_name = newCategories;
+        ret.categories = newCategories;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (types != null && types[0] != null) {
+        mapping.putAll(types[0].getApiToSdkMapping());
+      }
+      if (categories != null && categories[0] != null) {
+        mapping.putAll(categories[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -6936,11 +7814,11 @@ public class IBMCompareComplyV1Models {
    * Pagination details, if required by the length of the output.
    */
   public class Pagination extends IBMWatsonGenericModel {
-    private String refresh_cursor_serialized_name;
-    private String next_cursor_serialized_name;
-    private String refresh_url_serialized_name;
-    private String next_url_serialized_name;
-    private Long total_serialized_name;
+    private String refreshCursor;
+    private String nextCursor;
+    private String refreshUrl;
+    private String nextUrl;
+    private Long total;
  
     /**
      * Gets the refreshCursor.
@@ -6951,7 +7829,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getRefreshCursor() {
-      return refresh_cursor_serialized_name;
+      return refreshCursor;
     }
  
     /**
@@ -6963,7 +7841,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getNextCursor() {
-      return next_cursor_serialized_name;
+      return nextCursor;
     }
  
     /**
@@ -6975,7 +7853,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getRefreshUrl() {
-      return refresh_url_serialized_name;
+      return refreshUrl;
     }
  
     /**
@@ -6987,7 +7865,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getNextUrl() {
-      return next_url_serialized_name;
+      return nextUrl;
     }
  
     /**
@@ -6999,7 +7877,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getTotal() {
-      return total_serialized_name;
+      return total;
     }
 
     /**
@@ -7008,7 +7886,7 @@ public class IBMCompareComplyV1Models {
      * @param refreshCursor the new refreshCursor
      */
     public void setRefreshCursor(final String refreshCursor) {
-      this.refresh_cursor_serialized_name = refreshCursor;
+      this.refreshCursor = refreshCursor;
     }
 
     /**
@@ -7017,7 +7895,7 @@ public class IBMCompareComplyV1Models {
      * @param nextCursor the new nextCursor
      */
     public void setNextCursor(final String nextCursor) {
-      this.next_cursor_serialized_name = nextCursor;
+      this.nextCursor = nextCursor;
     }
 
     /**
@@ -7026,7 +7904,7 @@ public class IBMCompareComplyV1Models {
      * @param refreshUrl the new refreshUrl
      */
     public void setRefreshUrl(final String refreshUrl) {
-      this.refresh_url_serialized_name = refreshUrl;
+      this.refreshUrl = refreshUrl;
     }
 
     /**
@@ -7035,7 +7913,7 @@ public class IBMCompareComplyV1Models {
      * @param nextUrl the new nextUrl
      */
     public void setNextUrl(final String nextUrl) {
-      this.next_url_serialized_name = nextUrl;
+      this.nextUrl = nextUrl;
     }
 
     /**
@@ -7044,16 +7922,24 @@ public class IBMCompareComplyV1Models {
      * @param total the new total
      */
     public void setTotal(final long total) {
-      this.total_serialized_name = total;
+      this.total = total;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('refresh_cursor', 'refreshCursor');
+      mapping.put('next_cursor', 'nextCursor');
+      mapping.put('refresh_url', 'refreshUrl');
+      mapping.put('next_url', 'nextUrl');
+      return mapping;
+    }
   }
 
   /**
    * The locations of each paragraph in the input document.
    */
   public class Paragraphs extends IBMWatsonGenericModel {
-    private Location location_serialized_name;
+    private Location location;
  
     /**
      * Gets the location.
@@ -7065,7 +7951,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -7074,7 +7960,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7085,10 +7971,18 @@ public class IBMCompareComplyV1Models {
       Paragraphs ret = (Paragraphs) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7096,12 +7990,12 @@ public class IBMCompareComplyV1Models {
    * A party and its corresponding role, including address and contact information if identified.
    */
   public class Parties extends IBMWatsonGenericModel {
-    private String party_serialized_name;
-    private String role_serialized_name;
-    private String importance_serialized_name;
-    private List<Address> addresses_serialized_name;
-    private List<Contact> contacts_serialized_name;
-    private List<Mention> mentions_serialized_name;
+    private String party;
+    private String role;
+    private String importance;
+    private List<Address> addresses;
+    private List<Contact> contacts;
+    private List<Mention> mentions;
  
     /**
      * Gets the party.
@@ -7112,7 +8006,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getParty() {
-      return party_serialized_name;
+      return party;
     }
  
     /**
@@ -7124,7 +8018,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getRole() {
-      return role_serialized_name;
+      return role;
     }
  
     /**
@@ -7136,7 +8030,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getImportance() {
-      return importance_serialized_name;
+      return importance;
     }
  
     /**
@@ -7148,7 +8042,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Address> getAddresses() {
-      return addresses_serialized_name;
+      return addresses;
     }
  
     /**
@@ -7160,7 +8054,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Contact> getContacts() {
-      return contacts_serialized_name;
+      return contacts;
     }
  
     /**
@@ -7172,7 +8066,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Mention> getMentions() {
-      return mentions_serialized_name;
+      return mentions;
     }
 
     /**
@@ -7181,7 +8075,7 @@ public class IBMCompareComplyV1Models {
      * @param party the new party
      */
     public void setParty(final String party) {
-      this.party_serialized_name = party;
+      this.party = party;
     }
 
     /**
@@ -7190,7 +8084,7 @@ public class IBMCompareComplyV1Models {
      * @param role the new role
      */
     public void setRole(final String role) {
-      this.role_serialized_name = role;
+      this.role = role;
     }
 
     /**
@@ -7199,7 +8093,7 @@ public class IBMCompareComplyV1Models {
      * @param importance the new importance
      */
     public void setImportance(final String importance) {
-      this.importance_serialized_name = importance;
+      this.importance = importance;
     }
 
     /**
@@ -7208,7 +8102,7 @@ public class IBMCompareComplyV1Models {
      * @param addresses the new addresses
      */
     public void setAddresses(final List<Address> addresses) {
-      this.addresses_serialized_name = addresses;
+      this.addresses = addresses;
     }
 
     /**
@@ -7217,7 +8111,7 @@ public class IBMCompareComplyV1Models {
      * @param contacts the new contacts
      */
     public void setContacts(final List<Contact> contacts) {
-      this.contacts_serialized_name = contacts;
+      this.contacts = contacts;
     }
 
     /**
@@ -7226,7 +8120,7 @@ public class IBMCompareComplyV1Models {
      * @param mentions the new mentions
      */
     public void setMentions(final List<Mention> mentions) {
-      this.mentions_serialized_name = mentions;
+      this.mentions = mentions;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7242,11 +8136,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedAddresses != null) {
         for (Integer i = 0; i < deserializedAddresses.size(); i++) {
           Address currentItem = ret.getAddresses().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('addresses_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('addresses');
           Address newItem = (Address) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Address.class);
           newAddresses.add(newItem);
         }
-        ret.addresses_serialized_name = newAddresses;
+        ret.addresses = newAddresses;
       }
 
       // calling custom deserializer for contacts
@@ -7255,11 +8149,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedContacts != null) {
         for (Integer i = 0; i < deserializedContacts.size(); i++) {
           Contact currentItem = ret.getContacts().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('contacts_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('contacts');
           Contact newItem = (Contact) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Contact.class);
           newContacts.add(newItem);
         }
-        ret.contacts_serialized_name = newContacts;
+        ret.contacts = newContacts;
       }
 
       // calling custom deserializer for mentions
@@ -7268,14 +8162,25 @@ public class IBMCompareComplyV1Models {
       if (deserializedMentions != null) {
         for (Integer i = 0; i < deserializedMentions.size(); i++) {
           Mention currentItem = ret.getMentions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('mentions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('mentions');
           Mention newItem = (Mention) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Mention.class);
           newMentions.add(newItem);
         }
-        ret.mentions_serialized_name = newMentions;
+        ret.mentions = newMentions;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (addresses != null && addresses[0] != null) {
+        mapping.putAll(addresses[0].getApiToSdkMapping());
+      }
+      if (mentions != null && mentions[0] != null) {
+        mapping.putAll(mentions[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7283,12 +8188,12 @@ public class IBMCompareComplyV1Models {
    * The document's payment duration or durations.
    */
   public class PaymentTerms extends IBMWatsonGenericModel {
-    private String confidence_level_serialized_name;
-    private String text_serialized_name;
-    private String text_normalized_serialized_name;
-    private Interpretation interpretation_serialized_name;
-    private List<String> provenance_ids_serialized_name;
-    private Location location_serialized_name;
+    private String confidenceLevel;
+    private String text;
+    private String textNormalized;
+    private Interpretation interpretation;
+    private List<String> provenanceIds;
+    private Location location;
  
     /**
      * Gets the confidenceLevel.
@@ -7299,7 +8204,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getConfidenceLevel() {
-      return confidence_level_serialized_name;
+      return confidenceLevel;
     }
  
     /**
@@ -7311,7 +8216,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -7324,7 +8229,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTextNormalized() {
-      return text_normalized_serialized_name;
+      return textNormalized;
     }
  
     /**
@@ -7337,7 +8242,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Interpretation getInterpretation() {
-      return interpretation_serialized_name;
+      return interpretation;
     }
  
     /**
@@ -7349,7 +8254,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<String> getProvenanceIds() {
-      return provenance_ids_serialized_name;
+      return provenanceIds;
     }
  
     /**
@@ -7362,7 +8267,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -7371,7 +8276,7 @@ public class IBMCompareComplyV1Models {
      * @param confidenceLevel the new confidenceLevel
      */
     public void setConfidenceLevel(final String confidenceLevel) {
-      this.confidence_level_serialized_name = confidenceLevel;
+      this.confidenceLevel = confidenceLevel;
     }
 
     /**
@@ -7380,7 +8285,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -7389,7 +8294,7 @@ public class IBMCompareComplyV1Models {
      * @param textNormalized the new textNormalized
      */
     public void setTextNormalized(final String textNormalized) {
-      this.text_normalized_serialized_name = textNormalized;
+      this.textNormalized = textNormalized;
     }
 
     /**
@@ -7398,7 +8303,7 @@ public class IBMCompareComplyV1Models {
      * @param interpretation the new interpretation
      */
     public void setInterpretation(final Interpretation interpretation) {
-      this.interpretation_serialized_name = interpretation;
+      this.interpretation = interpretation;
     }
 
     /**
@@ -7407,7 +8312,7 @@ public class IBMCompareComplyV1Models {
      * @param provenanceIds the new provenanceIds
      */
     public void setProvenanceIds(final List<String> provenanceIds) {
-      this.provenance_ids_serialized_name = provenanceIds;
+      this.provenanceIds = provenanceIds;
     }
 
     /**
@@ -7416,7 +8321,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7427,14 +8332,28 @@ public class IBMCompareComplyV1Models {
       PaymentTerms ret = (PaymentTerms) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for interpretation
-      Interpretation newInterpretation = (Interpretation) new Interpretation().deserialize(JSON.serialize(ret.getInterpretation()), (Map<String, Object>) jsonMap.get('interpretation_serialized_name'), Interpretation.class);
+      Interpretation newInterpretation = (Interpretation) new Interpretation().deserialize(JSON.serialize(ret.getInterpretation()), (Map<String, Object>) jsonMap.get('interpretation'), Interpretation.class);
       ret.setInterpretation(newInterpretation);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('confidence_level', 'confidenceLevel');
+      mapping.put('text_normalized', 'textNormalized');
+      if (interpretation != null) {
+        mapping.putAll(interpretation.getApiToSdkMapping());
+      }
+      mapping.put('provenance_ids', 'provenanceIds');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7442,7 +8361,7 @@ public class IBMCompareComplyV1Models {
    * An array of values, each being the `id` value of a row header that is applicable to this body cell.
    */
   public class RowHeaderIds extends IBMWatsonGenericModel {
-    private String id_serialized_name;
+    private String id;
  
     /**
      * Gets the id.
@@ -7453,7 +8372,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getId() {
-      return id_serialized_name;
+      return id;
     }
 
     /**
@@ -7462,16 +8381,15 @@ public class IBMCompareComplyV1Models {
      * @param id the new id
      */
     public void setId(final String id) {
-      this.id_serialized_name = id;
+      this.id = id;
     }
-
   }
 
   /**
    * An array of values, each being the `text` value of a row header that is applicable to this body cell.
    */
   public class RowHeaderTexts extends IBMWatsonGenericModel {
-    private String text_serialized_name;
+    private String text;
  
     /**
      * Gets the text.
@@ -7482,7 +8400,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -7491,9 +8409,8 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
-
   }
 
   /**
@@ -7501,7 +8418,7 @@ public class IBMCompareComplyV1Models {
    * otherwise, the same value as `row_header_texts`.
    */
   public class RowHeaderTextsNormalized extends IBMWatsonGenericModel {
-    private String text_normalized_serialized_name;
+    private String textNormalized;
  
     /**
      * Gets the textNormalized.
@@ -7512,7 +8429,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTextNormalized() {
-      return text_normalized_serialized_name;
+      return textNormalized;
     }
 
     /**
@@ -7521,23 +8438,28 @@ public class IBMCompareComplyV1Models {
      * @param textNormalized the new textNormalized
      */
     public void setTextNormalized(final String textNormalized) {
-      this.text_normalized_serialized_name = textNormalized;
+      this.textNormalized = textNormalized;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('text_normalized', 'textNormalized');
+      return mapping;
+    }
   }
 
   /**
    * Row-level cells, each applicable as a header to other cells in the same row as itself, of the current table.
    */
   public class RowHeaders extends IBMWatsonGenericModel {
-    private String cell_id_serialized_name;
-    private Location location_serialized_name;
-    private String text_serialized_name;
-    private String text_normalized_serialized_name;
-    private Long row_index_begin_serialized_name;
-    private Long row_index_end_serialized_name;
-    private Long column_index_begin_serialized_name;
-    private Long column_index_end_serialized_name;
+    private String cellId;
+    private Location location;
+    private String text;
+    private String textNormalized;
+    private Long rowIndexBegin;
+    private Long rowIndexEnd;
+    private Long columnIndexBegin;
+    private Long columnIndexEnd;
  
     /**
      * Gets the cellId.
@@ -7548,7 +8470,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getCellId() {
-      return cell_id_serialized_name;
+      return cellId;
     }
  
     /**
@@ -7561,7 +8483,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -7573,7 +8495,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -7586,7 +8508,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTextNormalized() {
-      return text_normalized_serialized_name;
+      return textNormalized;
     }
  
     /**
@@ -7598,7 +8520,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getRowIndexBegin() {
-      return row_index_begin_serialized_name;
+      return rowIndexBegin;
     }
  
     /**
@@ -7610,7 +8532,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getRowIndexEnd() {
-      return row_index_end_serialized_name;
+      return rowIndexEnd;
     }
  
     /**
@@ -7622,7 +8544,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getColumnIndexBegin() {
-      return column_index_begin_serialized_name;
+      return columnIndexBegin;
     }
  
     /**
@@ -7634,7 +8556,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getColumnIndexEnd() {
-      return column_index_end_serialized_name;
+      return columnIndexEnd;
     }
 
     /**
@@ -7643,7 +8565,7 @@ public class IBMCompareComplyV1Models {
      * @param cellId the new cellId
      */
     public void setCellId(final String cellId) {
-      this.cell_id_serialized_name = cellId;
+      this.cellId = cellId;
     }
 
     /**
@@ -7652,7 +8574,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -7661,7 +8583,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -7670,7 +8592,7 @@ public class IBMCompareComplyV1Models {
      * @param textNormalized the new textNormalized
      */
     public void setTextNormalized(final String textNormalized) {
-      this.text_normalized_serialized_name = textNormalized;
+      this.textNormalized = textNormalized;
     }
 
     /**
@@ -7679,7 +8601,7 @@ public class IBMCompareComplyV1Models {
      * @param rowIndexBegin the new rowIndexBegin
      */
     public void setRowIndexBegin(final long rowIndexBegin) {
-      this.row_index_begin_serialized_name = rowIndexBegin;
+      this.rowIndexBegin = rowIndexBegin;
     }
 
     /**
@@ -7688,7 +8610,7 @@ public class IBMCompareComplyV1Models {
      * @param rowIndexEnd the new rowIndexEnd
      */
     public void setRowIndexEnd(final long rowIndexEnd) {
-      this.row_index_end_serialized_name = rowIndexEnd;
+      this.rowIndexEnd = rowIndexEnd;
     }
 
     /**
@@ -7697,7 +8619,7 @@ public class IBMCompareComplyV1Models {
      * @param columnIndexBegin the new columnIndexBegin
      */
     public void setColumnIndexBegin(final long columnIndexBegin) {
-      this.column_index_begin_serialized_name = columnIndexBegin;
+      this.columnIndexBegin = columnIndexBegin;
     }
 
     /**
@@ -7706,7 +8628,7 @@ public class IBMCompareComplyV1Models {
      * @param columnIndexEnd the new columnIndexEnd
      */
     public void setColumnIndexEnd(final long columnIndexEnd) {
-      this.column_index_end_serialized_name = columnIndexEnd;
+      this.columnIndexEnd = columnIndexEnd;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7717,10 +8639,24 @@ public class IBMCompareComplyV1Models {
       RowHeaders ret = (RowHeaders) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('cell_id', 'cellId');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      mapping.put('text_normalized', 'textNormalized');
+      mapping.put('row_index_begin', 'rowIndexBegin');
+      mapping.put('row_index_end', 'rowIndexEnd');
+      mapping.put('column_index_begin', 'columnIndexBegin');
+      mapping.put('column_index_end', 'columnIndexEnd');
+      return mapping;
     }
   }
 
@@ -7728,8 +8664,8 @@ public class IBMCompareComplyV1Models {
    * The table's section title, if identified.
    */
   public class SectionTitle extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private Location location_serialized_name;
+    private String text;
+    private Location location;
  
     /**
      * Gets the text.
@@ -7740,7 +8676,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -7753,7 +8689,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -7762,7 +8698,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -7771,7 +8707,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7782,10 +8718,18 @@ public class IBMCompareComplyV1Models {
       SectionTitle ret = (SectionTitle) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7795,10 +8739,10 @@ public class IBMCompareComplyV1Models {
    * values of the element and the `level` value of the section.
    */
   public class SectionTitles extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private Location location_serialized_name;
-    private Long level_serialized_name;
-    private List<ElementLocations> element_locations_serialized_name;
+    private String text;
+    private Location location;
+    private Long level;
+    private List<ElementLocations> elementLocations;
  
     /**
      * Gets the text.
@@ -7809,7 +8753,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -7822,7 +8766,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -7835,7 +8779,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getLevel() {
-      return level_serialized_name;
+      return level;
     }
  
     /**
@@ -7847,7 +8791,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ElementLocations> getElementLocations() {
-      return element_locations_serialized_name;
+      return elementLocations;
     }
 
     /**
@@ -7856,7 +8800,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -7865,7 +8809,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -7874,7 +8818,7 @@ public class IBMCompareComplyV1Models {
      * @param level the new level
      */
     public void setLevel(final long level) {
-      this.level_serialized_name = level;
+      this.level = level;
     }
 
     /**
@@ -7883,7 +8827,7 @@ public class IBMCompareComplyV1Models {
      * @param elementLocations the new elementLocations
      */
     public void setElementLocations(final List<ElementLocations> elementLocations) {
-      this.element_locations_serialized_name = elementLocations;
+      this.elementLocations = elementLocations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7894,7 +8838,7 @@ public class IBMCompareComplyV1Models {
       SectionTitles ret = (SectionTitles) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       // calling custom deserializer for elementLocations
@@ -7903,14 +8847,26 @@ public class IBMCompareComplyV1Models {
       if (deserializedElementLocations != null) {
         for (Integer i = 0; i < deserializedElementLocations.size(); i++) {
           ElementLocations currentItem = ret.getElementLocations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('element_locations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('elementLocations');
           ElementLocations newItem = (ElementLocations) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ElementLocations.class);
           newElementLocations.add(newItem);
         }
-        ret.element_locations_serialized_name = newElementLocations;
+        ret.elementLocations = newElementLocations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      mapping.put('element_locations', 'elementLocations');
+      if (elementLocations != null && elementLocations[0] != null) {
+        mapping.putAll(elementLocations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7918,8 +8874,14 @@ public class IBMCompareComplyV1Models {
    * Brief information about the input document.
    */
   public class ShortDoc extends IBMWatsonGenericModel {
-    private String title_serialized_name;
-    private String hash_serialized_name;
+    private String title;
+    private String hash;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public ShortDoc() { }
  
     /**
      * Gets the title.
@@ -7930,7 +8892,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -7942,40 +8904,85 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getHash() {
-      return hash_serialized_name;
+      return hash;
+    }
+  
+    private ShortDoc(ShortDocBuilder builder) {
+      this.title = builder.title;
+      this.hash = builder.hash;
     }
 
     /**
-     * Sets the title.
+     * New builder.
      *
-     * @param title the new title
+     * @return a ShortDoc builder
      */
-    public void setTitle(final String title) {
-      this.title_serialized_name = title;
+    public ShortDocBuilder newBuilder() {
+      return new ShortDocBuilder(this);
+    }
+  }
+
+  /**
+   * ShortDoc Builder.
+   */
+  public class ShortDocBuilder {
+    private String title;
+    private String hash;
+
+    private ShortDocBuilder(ShortDoc shortDoc) {
+      this.title = shortDoc.title;
+      this.hash = shortDoc.hash;
     }
 
     /**
-     * Sets the hash.
-     *
-     * @param hash the new hash
+     * Instantiates a new builder.
      */
-    public void setHash(final String hash) {
-      this.hash_serialized_name = hash;
+    public ShortDocBuilder() {
     }
 
+    /**
+     * Builds a ShortDoc.
+     *
+     * @return the shortDoc
+     */
+    public ShortDoc build() {
+      return new ShortDoc(this);
+    }
+
+    /**
+     * Set the title.
+     *
+     * @param title the title
+     * @return the ShortDoc builder
+     */
+    public ShortDocBuilder setTitle(String title) {
+      this.title = title;
+      return this;
+    }
+
+    /**
+     * Set the hash.
+     *
+     * @param hash the hash
+     * @return the ShortDoc builder
+     */
+    public ShortDocBuilder setHash(String hash) {
+      this.hash = hash;
+      return this;
+    }
   }
 
   /**
    * The contents of the current table's header.
    */
   public class TableHeaders extends IBMWatsonGenericModel {
-    private String cell_id_serialized_name;
-    private IBMWatsonMapModel location_serialized_name;
-    private String text_serialized_name;
-    private Long row_index_begin_serialized_name;
-    private Long row_index_end_serialized_name;
-    private Long column_index_begin_serialized_name;
-    private Long column_index_end_serialized_name;
+    private String cellId;
+    private IBMWatsonMapModel location;
+    private String text;
+    private Long rowIndexBegin;
+    private Long rowIndexEnd;
+    private Long columnIndexBegin;
+    private Long columnIndexEnd;
  
     /**
      * Gets the cellId.
@@ -7986,7 +8993,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getCellId() {
-      return cell_id_serialized_name;
+      return cellId;
     }
  
     /**
@@ -7999,7 +9006,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -8011,7 +9018,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -8023,7 +9030,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getRowIndexBegin() {
-      return row_index_begin_serialized_name;
+      return rowIndexBegin;
     }
  
     /**
@@ -8035,7 +9042,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getRowIndexEnd() {
-      return row_index_end_serialized_name;
+      return rowIndexEnd;
     }
  
     /**
@@ -8047,7 +9054,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getColumnIndexBegin() {
-      return column_index_begin_serialized_name;
+      return columnIndexBegin;
     }
  
     /**
@@ -8059,7 +9066,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Long getColumnIndexEnd() {
-      return column_index_end_serialized_name;
+      return columnIndexEnd;
     }
 
     /**
@@ -8068,7 +9075,7 @@ public class IBMCompareComplyV1Models {
      * @param cellId the new cellId
      */
     public void setCellId(final String cellId) {
-      this.cell_id_serialized_name = cellId;
+      this.cellId = cellId;
     }
 
     /**
@@ -8077,7 +9084,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final IBMWatsonMapModel location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -8086,7 +9093,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -8095,7 +9102,7 @@ public class IBMCompareComplyV1Models {
      * @param rowIndexBegin the new rowIndexBegin
      */
     public void setRowIndexBegin(final long rowIndexBegin) {
-      this.row_index_begin_serialized_name = rowIndexBegin;
+      this.rowIndexBegin = rowIndexBegin;
     }
 
     /**
@@ -8104,7 +9111,7 @@ public class IBMCompareComplyV1Models {
      * @param rowIndexEnd the new rowIndexEnd
      */
     public void setRowIndexEnd(final long rowIndexEnd) {
-      this.row_index_end_serialized_name = rowIndexEnd;
+      this.rowIndexEnd = rowIndexEnd;
     }
 
     /**
@@ -8113,7 +9120,7 @@ public class IBMCompareComplyV1Models {
      * @param columnIndexBegin the new columnIndexBegin
      */
     public void setColumnIndexBegin(final long columnIndexBegin) {
-      this.column_index_begin_serialized_name = columnIndexBegin;
+      this.columnIndexBegin = columnIndexBegin;
     }
 
     /**
@@ -8122,7 +9129,7 @@ public class IBMCompareComplyV1Models {
      * @param columnIndexEnd the new columnIndexEnd
      */
     public void setColumnIndexEnd(final long columnIndexEnd) {
-      this.column_index_end_serialized_name = columnIndexEnd;
+      this.columnIndexEnd = columnIndexEnd;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8133,10 +9140,20 @@ public class IBMCompareComplyV1Models {
       TableHeaders ret = (TableHeaders) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      IBMWatsonMapModel newLocation = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newLocation = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), IBMWatsonMapModel.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('cell_id', 'cellId');
+      mapping.put('row_index_begin', 'rowIndexBegin');
+      mapping.put('row_index_end', 'rowIndexEnd');
+      mapping.put('column_index_begin', 'columnIndexBegin');
+      mapping.put('column_index_end', 'columnIndexEnd');
+      return mapping;
     }
   }
 
@@ -8144,10 +9161,10 @@ public class IBMCompareComplyV1Models {
    * The analysis of the document's tables.
    */
   public class TableReturn extends IBMWatsonResponseModel {
-    private DocInfo document_serialized_name;
-    private String model_id_serialized_name;
-    private String model_version_serialized_name;
-    private List<Tables> tables_serialized_name;
+    private DocInfo document;
+    private String modelId;
+    private String modelVersion;
+    private List<Tables> tables;
  
     /**
      * Gets the document.
@@ -8158,7 +9175,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public DocInfo getDocument() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -8170,7 +9187,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModelId() {
-      return model_id_serialized_name;
+      return modelId;
     }
  
     /**
@@ -8182,7 +9199,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModelVersion() {
-      return model_version_serialized_name;
+      return modelVersion;
     }
  
     /**
@@ -8194,7 +9211,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Tables> getTables() {
-      return tables_serialized_name;
+      return tables;
     }
 
     /**
@@ -8203,7 +9220,7 @@ public class IBMCompareComplyV1Models {
      * @param document the new document
      */
     public void setDocument(final DocInfo document) {
-      this.document_serialized_name = document;
+      this.document = document;
     }
 
     /**
@@ -8212,7 +9229,7 @@ public class IBMCompareComplyV1Models {
      * @param modelId the new modelId
      */
     public void setModelId(final String modelId) {
-      this.model_id_serialized_name = modelId;
+      this.modelId = modelId;
     }
 
     /**
@@ -8221,7 +9238,7 @@ public class IBMCompareComplyV1Models {
      * @param modelVersion the new modelVersion
      */
     public void setModelVersion(final String modelVersion) {
-      this.model_version_serialized_name = modelVersion;
+      this.modelVersion = modelVersion;
     }
 
     /**
@@ -8230,7 +9247,7 @@ public class IBMCompareComplyV1Models {
      * @param tables the new tables
      */
     public void setTables(final List<Tables> tables) {
-      this.tables_serialized_name = tables;
+      this.tables = tables;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8241,7 +9258,7 @@ public class IBMCompareComplyV1Models {
       TableReturn ret = (TableReturn) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for document
-      DocInfo newDocument = (DocInfo) new DocInfo().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document_serialized_name'), DocInfo.class);
+      DocInfo newDocument = (DocInfo) new DocInfo().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document'), DocInfo.class);
       ret.setDocument(newDocument);
 
       // calling custom deserializer for tables
@@ -8250,14 +9267,24 @@ public class IBMCompareComplyV1Models {
       if (deserializedTables != null) {
         for (Integer i = 0; i < deserializedTables.size(); i++) {
           Tables currentItem = ret.getTables().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('tables_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('tables');
           Tables newItem = (Tables) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Tables.class);
           newTables.add(newItem);
         }
-        ret.tables_serialized_name = newTables;
+        ret.tables = newTables;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('model_id', 'modelId');
+      mapping.put('model_version', 'modelVersion');
+      if (tables != null && tables[0] != null) {
+        mapping.putAll(tables[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -8266,8 +9293,8 @@ public class IBMCompareComplyV1Models {
    * identified. When exposed, the `title` is also excluded from the `contexts` array of the same table.
    */
   public class TableTitle extends IBMWatsonGenericModel {
-    private Location location_serialized_name;
-    private String text_serialized_name;
+    private Location location;
+    private String text;
  
     /**
      * Gets the location.
@@ -8279,7 +9306,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -8291,7 +9318,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -8300,7 +9327,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -8309,7 +9336,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8320,10 +9347,18 @@ public class IBMCompareComplyV1Models {
       TableTitle ret = (TableTitle) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -8331,16 +9366,16 @@ public class IBMCompareComplyV1Models {
    * The contents of the tables extracted from a document.
    */
   public class Tables extends IBMWatsonGenericModel {
-    private Location location_serialized_name;
-    private String text_serialized_name;
-    private SectionTitle section_title_serialized_name;
-    private TableTitle title_serialized_name;
-    private List<TableHeaders> table_headers_serialized_name;
-    private List<RowHeaders> row_headers_serialized_name;
-    private List<ColumnHeaders> column_headers_serialized_name;
-    private List<BodyCells> body_cells_serialized_name;
-    private List<Contexts> contexts_serialized_name;
-    private List<KeyValuePair> key_value_pairs_serialized_name;
+    private Location location;
+    private String text;
+    private SectionTitle sectionTitle;
+    private TableTitle title;
+    private List<TableHeaders> tableHeaders;
+    private List<RowHeaders> rowHeaders;
+    private List<ColumnHeaders> columnHeaders;
+    private List<BodyCells> bodyCells;
+    private List<Contexts> contexts;
+    private List<KeyValuePair> keyValuePairs;
  
     /**
      * Gets the location.
@@ -8352,7 +9387,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -8364,7 +9399,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -8376,7 +9411,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public SectionTitle getSectionTitle() {
-      return section_title_serialized_name;
+      return sectionTitle;
     }
  
     /**
@@ -8389,7 +9424,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public TableTitle getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -8401,7 +9436,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<TableHeaders> getTableHeaders() {
-      return table_headers_serialized_name;
+      return tableHeaders;
     }
  
     /**
@@ -8414,7 +9449,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<RowHeaders> getRowHeaders() {
-      return row_headers_serialized_name;
+      return rowHeaders;
     }
  
     /**
@@ -8427,7 +9462,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<ColumnHeaders> getColumnHeaders() {
-      return column_headers_serialized_name;
+      return columnHeaders;
     }
  
     /**
@@ -8440,7 +9475,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<BodyCells> getBodyCells() {
-      return body_cells_serialized_name;
+      return bodyCells;
     }
  
     /**
@@ -8453,7 +9488,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Contexts> getContexts() {
-      return contexts_serialized_name;
+      return contexts;
     }
  
     /**
@@ -8465,7 +9500,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<KeyValuePair> getKeyValuePairs() {
-      return key_value_pairs_serialized_name;
+      return keyValuePairs;
     }
 
     /**
@@ -8474,7 +9509,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -8483,7 +9518,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -8492,7 +9527,7 @@ public class IBMCompareComplyV1Models {
      * @param sectionTitle the new sectionTitle
      */
     public void setSectionTitle(final SectionTitle sectionTitle) {
-      this.section_title_serialized_name = sectionTitle;
+      this.sectionTitle = sectionTitle;
     }
 
     /**
@@ -8501,7 +9536,7 @@ public class IBMCompareComplyV1Models {
      * @param title the new title
      */
     public void setTitle(final TableTitle title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     /**
@@ -8510,7 +9545,7 @@ public class IBMCompareComplyV1Models {
      * @param tableHeaders the new tableHeaders
      */
     public void setTableHeaders(final List<TableHeaders> tableHeaders) {
-      this.table_headers_serialized_name = tableHeaders;
+      this.tableHeaders = tableHeaders;
     }
 
     /**
@@ -8519,7 +9554,7 @@ public class IBMCompareComplyV1Models {
      * @param rowHeaders the new rowHeaders
      */
     public void setRowHeaders(final List<RowHeaders> rowHeaders) {
-      this.row_headers_serialized_name = rowHeaders;
+      this.rowHeaders = rowHeaders;
     }
 
     /**
@@ -8528,7 +9563,7 @@ public class IBMCompareComplyV1Models {
      * @param columnHeaders the new columnHeaders
      */
     public void setColumnHeaders(final List<ColumnHeaders> columnHeaders) {
-      this.column_headers_serialized_name = columnHeaders;
+      this.columnHeaders = columnHeaders;
     }
 
     /**
@@ -8537,7 +9572,7 @@ public class IBMCompareComplyV1Models {
      * @param bodyCells the new bodyCells
      */
     public void setBodyCells(final List<BodyCells> bodyCells) {
-      this.body_cells_serialized_name = bodyCells;
+      this.bodyCells = bodyCells;
     }
 
     /**
@@ -8546,7 +9581,7 @@ public class IBMCompareComplyV1Models {
      * @param contexts the new contexts
      */
     public void setContexts(final List<Contexts> contexts) {
-      this.contexts_serialized_name = contexts;
+      this.contexts = contexts;
     }
 
     /**
@@ -8555,7 +9590,7 @@ public class IBMCompareComplyV1Models {
      * @param keyValuePairs the new keyValuePairs
      */
     public void setKeyValuePairs(final List<KeyValuePair> keyValuePairs) {
-      this.key_value_pairs_serialized_name = keyValuePairs;
+      this.keyValuePairs = keyValuePairs;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8566,15 +9601,15 @@ public class IBMCompareComplyV1Models {
       Tables ret = (Tables) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       // calling custom deserializer for sectionTitle
-      SectionTitle newSectionTitle = (SectionTitle) new SectionTitle().deserialize(JSON.serialize(ret.getSectionTitle()), (Map<String, Object>) jsonMap.get('section_title_serialized_name'), SectionTitle.class);
+      SectionTitle newSectionTitle = (SectionTitle) new SectionTitle().deserialize(JSON.serialize(ret.getSectionTitle()), (Map<String, Object>) jsonMap.get('sectionTitle'), SectionTitle.class);
       ret.setSectionTitle(newSectionTitle);
 
       // calling custom deserializer for title
-      TableTitle newTitle = (TableTitle) new TableTitle().deserialize(JSON.serialize(ret.getTitle()), (Map<String, Object>) jsonMap.get('title_serialized_name'), TableTitle.class);
+      TableTitle newTitle = (TableTitle) new TableTitle().deserialize(JSON.serialize(ret.getTitle()), (Map<String, Object>) jsonMap.get('title'), TableTitle.class);
       ret.setTitle(newTitle);
 
       // calling custom deserializer for tableHeaders
@@ -8583,11 +9618,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedTableHeaders != null) {
         for (Integer i = 0; i < deserializedTableHeaders.size(); i++) {
           TableHeaders currentItem = ret.getTableHeaders().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('table_headers_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('tableHeaders');
           TableHeaders newItem = (TableHeaders) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TableHeaders.class);
           newTableHeaders.add(newItem);
         }
-        ret.table_headers_serialized_name = newTableHeaders;
+        ret.tableHeaders = newTableHeaders;
       }
 
       // calling custom deserializer for rowHeaders
@@ -8596,11 +9631,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedRowHeaders != null) {
         for (Integer i = 0; i < deserializedRowHeaders.size(); i++) {
           RowHeaders currentItem = ret.getRowHeaders().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('row_headers_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('rowHeaders');
           RowHeaders newItem = (RowHeaders) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RowHeaders.class);
           newRowHeaders.add(newItem);
         }
-        ret.row_headers_serialized_name = newRowHeaders;
+        ret.rowHeaders = newRowHeaders;
       }
 
       // calling custom deserializer for columnHeaders
@@ -8609,11 +9644,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedColumnHeaders != null) {
         for (Integer i = 0; i < deserializedColumnHeaders.size(); i++) {
           ColumnHeaders currentItem = ret.getColumnHeaders().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('column_headers_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('columnHeaders');
           ColumnHeaders newItem = (ColumnHeaders) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ColumnHeaders.class);
           newColumnHeaders.add(newItem);
         }
-        ret.column_headers_serialized_name = newColumnHeaders;
+        ret.columnHeaders = newColumnHeaders;
       }
 
       // calling custom deserializer for bodyCells
@@ -8622,11 +9657,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedBodyCells != null) {
         for (Integer i = 0; i < deserializedBodyCells.size(); i++) {
           BodyCells currentItem = ret.getBodyCells().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('body_cells_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('bodyCells');
           BodyCells newItem = (BodyCells) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), BodyCells.class);
           newBodyCells.add(newItem);
         }
-        ret.body_cells_serialized_name = newBodyCells;
+        ret.bodyCells = newBodyCells;
       }
 
       // calling custom deserializer for contexts
@@ -8635,11 +9670,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedContexts != null) {
         for (Integer i = 0; i < deserializedContexts.size(); i++) {
           Contexts currentItem = ret.getContexts().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('contexts_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('contexts');
           Contexts newItem = (Contexts) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Contexts.class);
           newContexts.add(newItem);
         }
-        ret.contexts_serialized_name = newContexts;
+        ret.contexts = newContexts;
       }
 
       // calling custom deserializer for keyValuePairs
@@ -8648,14 +9683,52 @@ public class IBMCompareComplyV1Models {
       if (deserializedKeyValuePairs != null) {
         for (Integer i = 0; i < deserializedKeyValuePairs.size(); i++) {
           KeyValuePair currentItem = ret.getKeyValuePairs().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('key_value_pairs_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('keyValuePairs');
           KeyValuePair newItem = (KeyValuePair) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), KeyValuePair.class);
           newKeyValuePairs.add(newItem);
         }
-        ret.key_value_pairs_serialized_name = newKeyValuePairs;
+        ret.keyValuePairs = newKeyValuePairs;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      mapping.put('section_title', 'sectionTitle');
+      if (sectionTitle != null) {
+        mapping.putAll(sectionTitle.getApiToSdkMapping());
+      }
+      if (title != null) {
+        mapping.putAll(title.getApiToSdkMapping());
+      }
+      mapping.put('table_headers', 'tableHeaders');
+      if (tableHeaders != null && tableHeaders[0] != null) {
+        mapping.putAll(tableHeaders[0].getApiToSdkMapping());
+      }
+      mapping.put('row_headers', 'rowHeaders');
+      if (rowHeaders != null && rowHeaders[0] != null) {
+        mapping.putAll(rowHeaders[0].getApiToSdkMapping());
+      }
+      mapping.put('column_headers', 'columnHeaders');
+      if (columnHeaders != null && columnHeaders[0] != null) {
+        mapping.putAll(columnHeaders[0].getApiToSdkMapping());
+      }
+      mapping.put('body_cells', 'bodyCells');
+      if (bodyCells != null && bodyCells[0] != null) {
+        mapping.putAll(bodyCells[0].getApiToSdkMapping());
+      }
+      if (contexts != null && contexts[0] != null) {
+        mapping.putAll(contexts[0].getApiToSdkMapping());
+      }
+      mapping.put('key_value_pairs', 'keyValuePairs');
+      if (keyValuePairs != null && keyValuePairs[0] != null) {
+        mapping.putAll(keyValuePairs[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -8663,11 +9736,11 @@ public class IBMCompareComplyV1Models {
    * Termination dates identified in the input document.
    */
   public class TerminationDates extends IBMWatsonGenericModel {
-    private String confidence_level_serialized_name;
-    private String text_serialized_name;
-    private String text_normalized_serialized_name;
-    private List<String> provenance_ids_serialized_name;
-    private Location location_serialized_name;
+    private String confidenceLevel;
+    private String text;
+    private String textNormalized;
+    private List<String> provenanceIds;
+    private Location location;
  
     /**
      * Gets the confidenceLevel.
@@ -8678,7 +9751,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getConfidenceLevel() {
-      return confidence_level_serialized_name;
+      return confidenceLevel;
     }
  
     /**
@@ -8690,7 +9763,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -8703,7 +9776,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getTextNormalized() {
-      return text_normalized_serialized_name;
+      return textNormalized;
     }
  
     /**
@@ -8715,7 +9788,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<String> getProvenanceIds() {
-      return provenance_ids_serialized_name;
+      return provenanceIds;
     }
  
     /**
@@ -8728,7 +9801,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -8737,7 +9810,7 @@ public class IBMCompareComplyV1Models {
      * @param confidenceLevel the new confidenceLevel
      */
     public void setConfidenceLevel(final String confidenceLevel) {
-      this.confidence_level_serialized_name = confidenceLevel;
+      this.confidenceLevel = confidenceLevel;
     }
 
     /**
@@ -8746,7 +9819,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -8755,7 +9828,7 @@ public class IBMCompareComplyV1Models {
      * @param textNormalized the new textNormalized
      */
     public void setTextNormalized(final String textNormalized) {
-      this.text_normalized_serialized_name = textNormalized;
+      this.textNormalized = textNormalized;
     }
 
     /**
@@ -8764,7 +9837,7 @@ public class IBMCompareComplyV1Models {
      * @param provenanceIds the new provenanceIds
      */
     public void setProvenanceIds(final List<String> provenanceIds) {
-      this.provenance_ids_serialized_name = provenanceIds;
+      this.provenanceIds = provenanceIds;
     }
 
     /**
@@ -8773,7 +9846,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8784,10 +9857,21 @@ public class IBMCompareComplyV1Models {
       TerminationDates ret = (TerminationDates) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('confidence_level', 'confidenceLevel');
+      mapping.put('text_normalized', 'textNormalized');
+      mapping.put('provenance_ids', 'provenanceIds');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -8795,8 +9879,14 @@ public class IBMCompareComplyV1Models {
    * Identification of a specific type.
    */
   public class TypeLabel extends IBMWatsonGenericModel {
-    private Label label_serialized_name;
-    private List<String> provenance_ids_serialized_name;
+    private Label label;
+    private List<String> provenanceIds;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public TypeLabel() { }
  
     /**
      * Gets the label.
@@ -8808,7 +9898,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Label getLabel() {
-      return label_serialized_name;
+      return label;
     }
  
     /**
@@ -8820,25 +9910,21 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<String> getProvenanceIds() {
-      return provenance_ids_serialized_name;
+      return provenanceIds;
+    }
+  
+    private TypeLabel(TypeLabelBuilder builder) {
+      this.label = builder.label;
+      this.provenanceIds = builder.provenanceIds;
     }
 
     /**
-     * Sets the label.
+     * New builder.
      *
-     * @param label the new label
+     * @return a TypeLabel builder
      */
-    public void setLabel(final Label label) {
-      this.label_serialized_name = label;
-    }
-
-    /**
-     * Sets the provenanceIds.
-     *
-     * @param provenanceIds the new provenanceIds
-     */
-    public void setProvenanceIds(final List<String> provenanceIds) {
-      this.provenance_ids_serialized_name = provenanceIds;
+    public TypeLabelBuilder newBuilder() {
+      return new TypeLabelBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8847,12 +9933,91 @@ public class IBMCompareComplyV1Models {
       }
 
       TypeLabel ret = (TypeLabel) super.deserialize(jsonString, jsonMap, classType);
+      TypeLabelBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for label
-      Label newLabel = (Label) new Label().deserialize(JSON.serialize(ret.getLabel()), (Map<String, Object>) jsonMap.get('label_serialized_name'), Label.class);
-      ret.setLabel(newLabel);
+      Label newLabel = (Label) new Label().deserialize(JSON.serialize(ret.getLabel()), (Map<String, Object>) jsonMap.get('label'), Label.class);
+      retBuilder.setLabel(newLabel);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('provenanceIds', 'provenance_ids');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('provenance_ids', 'provenanceIds');
+      return mapping;
+    }
+  }
+
+  /**
+   * TypeLabel Builder.
+   */
+  public class TypeLabelBuilder {
+    private Label label;
+    private List<String> provenanceIds;
+
+    private TypeLabelBuilder(TypeLabel typeLabel) {
+      this.label = typeLabel.label;
+      this.provenanceIds = typeLabel.provenanceIds;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public TypeLabelBuilder() {
+    }
+
+    /**
+     * Builds a TypeLabel.
+     *
+     * @return the typeLabel
+     */
+    public TypeLabel build() {
+      return new TypeLabel(this);
+    }
+
+    /**
+     * Adds an provenanceIds to provenanceIds.
+     *
+     * @param provenanceIds the new provenanceIds
+     * @return the TypeLabel builder
+     */
+    public TypeLabelBuilder addProvenanceIds(String provenanceIds) {
+      IBMWatsonValidator.notNull(provenanceIds, 'provenanceIds cannot be null');
+      if (this.provenanceIds == null) {
+        this.provenanceIds = new List<String>();
+      }
+      this.provenanceIds.add(provenanceIds);
+      return this;
+    }
+
+    /**
+     * Set the label.
+     *
+     * @param label the label
+     * @return the TypeLabel builder
+     */
+    public TypeLabelBuilder setLabel(Label label) {
+      this.label = label;
+      return this;
+    }
+
+    /**
+     * Set the provenanceIds.
+     * Existing provenanceIds will be replaced.
+     *
+     * @param provenanceIds the provenanceIds
+     * @return the TypeLabel builder
+     */
+    public TypeLabelBuilder setProvenanceIds(List<String> provenanceIds) {
+      this.provenanceIds = provenanceIds;
+      return this;
     }
   }
 
@@ -8860,7 +10025,7 @@ public class IBMCompareComplyV1Models {
    * Identification of a specific type.
    */
   public class TypeLabelComparison extends IBMWatsonGenericModel {
-    private Label label_serialized_name;
+    private Label label;
  
     /**
      * Gets the label.
@@ -8872,7 +10037,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Label getLabel() {
-      return label_serialized_name;
+      return label;
     }
 
     /**
@@ -8881,7 +10046,7 @@ public class IBMCompareComplyV1Models {
      * @param label the new label
      */
     public void setLabel(final Label label) {
-      this.label_serialized_name = label;
+      this.label = label;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8892,7 +10057,7 @@ public class IBMCompareComplyV1Models {
       TypeLabelComparison ret = (TypeLabelComparison) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for label
-      Label newLabel = (Label) new Label().deserialize(JSON.serialize(ret.getLabel()), (Map<String, Object>) jsonMap.get('label_serialized_name'), Label.class);
+      Label newLabel = (Label) new Label().deserialize(JSON.serialize(ret.getLabel()), (Map<String, Object>) jsonMap.get('label'), Label.class);
       ret.setLabel(newLabel);
 
       return ret;
@@ -8903,12 +10068,12 @@ public class IBMCompareComplyV1Models {
    * Element that does not align semantically between two compared documents.
    */
   public class UnalignedElement extends IBMWatsonGenericModel {
-    private String document_label_serialized_name;
-    private Location location_serialized_name;
-    private String text_serialized_name;
-    private List<TypeLabelComparison> types_serialized_name;
-    private List<CategoryComparison> categories_serialized_name;
-    private List<Attribute> attributes_serialized_name;
+    private String documentLabel;
+    private Location location;
+    private String text;
+    private List<TypeLabelComparison> types;
+    private List<CategoryComparison> categories;
+    private List<Attribute> attributes;
  
     /**
      * Gets the documentLabel.
@@ -8920,7 +10085,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getDocumentLabel() {
-      return document_label_serialized_name;
+      return documentLabel;
     }
  
     /**
@@ -8933,7 +10098,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -8945,7 +10110,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -8957,7 +10122,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<TypeLabelComparison> getTypes() {
-      return types_serialized_name;
+      return types;
     }
  
     /**
@@ -8969,7 +10134,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<CategoryComparison> getCategories() {
-      return categories_serialized_name;
+      return categories;
     }
  
     /**
@@ -8981,7 +10146,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Attribute> getAttributes() {
-      return attributes_serialized_name;
+      return attributes;
     }
 
     /**
@@ -8990,7 +10155,7 @@ public class IBMCompareComplyV1Models {
      * @param documentLabel the new documentLabel
      */
     public void setDocumentLabel(final String documentLabel) {
-      this.document_label_serialized_name = documentLabel;
+      this.documentLabel = documentLabel;
     }
 
     /**
@@ -8999,7 +10164,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -9008,7 +10173,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -9017,7 +10182,7 @@ public class IBMCompareComplyV1Models {
      * @param types the new types
      */
     public void setTypes(final List<TypeLabelComparison> types) {
-      this.types_serialized_name = types;
+      this.types = types;
     }
 
     /**
@@ -9026,7 +10191,7 @@ public class IBMCompareComplyV1Models {
      * @param categories the new categories
      */
     public void setCategories(final List<CategoryComparison> categories) {
-      this.categories_serialized_name = categories;
+      this.categories = categories;
     }
 
     /**
@@ -9035,7 +10200,7 @@ public class IBMCompareComplyV1Models {
      * @param attributes the new attributes
      */
     public void setAttributes(final List<Attribute> attributes) {
-      this.attributes_serialized_name = attributes;
+      this.attributes = attributes;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -9046,7 +10211,7 @@ public class IBMCompareComplyV1Models {
       UnalignedElement ret = (UnalignedElement) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       // calling custom deserializer for types
@@ -9055,11 +10220,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedTypes != null) {
         for (Integer i = 0; i < deserializedTypes.size(); i++) {
           TypeLabelComparison currentItem = ret.getTypes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('types_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('types');
           TypeLabelComparison newItem = (TypeLabelComparison) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TypeLabelComparison.class);
           newTypes.add(newItem);
         }
-        ret.types_serialized_name = newTypes;
+        ret.types = newTypes;
       }
 
       // calling custom deserializer for categories
@@ -9068,11 +10233,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedCategories != null) {
         for (Integer i = 0; i < deserializedCategories.size(); i++) {
           CategoryComparison currentItem = ret.getCategories().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('categories_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('categories');
           CategoryComparison newItem = (CategoryComparison) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CategoryComparison.class);
           newCategories.add(newItem);
         }
-        ret.categories_serialized_name = newCategories;
+        ret.categories = newCategories;
       }
 
       // calling custom deserializer for attributes
@@ -9081,14 +10246,26 @@ public class IBMCompareComplyV1Models {
       if (deserializedAttributes != null) {
         for (Integer i = 0; i < deserializedAttributes.size(); i++) {
           Attribute currentItem = ret.getAttributes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('attributes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('attributes');
           Attribute newItem = (Attribute) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Attribute.class);
           newAttributes.add(newItem);
         }
-        ret.attributes_serialized_name = newAttributes;
+        ret.attributes = newAttributes;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_label', 'documentLabel');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      if (attributes != null && attributes[0] != null) {
+        mapping.putAll(attributes[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -9099,7 +10276,7 @@ public class IBMCompareComplyV1Models {
     private String batchId;
     private String action;
     private String model;
- 
+
     /**
      * Gets the batchId.
      *
@@ -9110,7 +10287,7 @@ public class IBMCompareComplyV1Models {
     public String batchId() {
       return batchId;
     }
- 
+
     /**
      * Gets the action.
      *
@@ -9121,7 +10298,7 @@ public class IBMCompareComplyV1Models {
     public String action() {
       return action;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -9153,6 +10330,11 @@ public class IBMCompareComplyV1Models {
       return new UpdateBatchOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('batchId', 'batch_id');
+      return mapping;
+    }
   }
 
   /**
@@ -9245,9 +10427,9 @@ public class IBMCompareComplyV1Models {
   /**
    * The updated labeling from the input document, accounting for the submitted feedback.
    */
-  public class UpdatedLabelsIn {
-    private List<TypeLabel> types_serialized_name;
-    private List<Category> categories_serialized_name;
+  public class UpdatedLabelsIn extends IBMWatsonGenericModel {
+    private List<TypeLabel> types;
+    private List<Category> categories;
  
     /**
      * Gets the types.
@@ -9257,7 +10439,7 @@ public class IBMCompareComplyV1Models {
      * @return the types
      */
     public List<TypeLabel> getTypes() {
-      return types_serialized_name;
+      return types;
     }
  
     /**
@@ -9268,36 +10450,137 @@ public class IBMCompareComplyV1Models {
      * @return the categories
      */
     public List<Category> getCategories() {
-      return categories_serialized_name;
+      return categories;
+    }
+  
+    private UpdatedLabelsIn(UpdatedLabelsInBuilder builder) {
+      IBMWatsonValidator.notNull(builder.types, 'types cannot be null');
+      IBMWatsonValidator.notNull(builder.categories, 'categories cannot be null');
+      this.types = builder.types;
+      this.categories = builder.categories;
     }
 
     /**
-     * Sets the types.
+     * New builder.
+     *
+     * @return a UpdatedLabelsIn builder
+     */
+    public UpdatedLabelsInBuilder newBuilder() {
+      return new UpdatedLabelsInBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (types != null && types[0] != null) {
+        mapping.putAll(types[0].getSdkToApiMapping());
+      }
+      if (categories != null && categories[0] != null) {
+        mapping.putAll(categories[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * UpdatedLabelsIn Builder.
+   */
+  public class UpdatedLabelsInBuilder {
+    private List<TypeLabel> types;
+    private List<Category> categories;
+
+    private UpdatedLabelsInBuilder(UpdatedLabelsIn updatedLabelsIn) {
+      this.types = updatedLabelsIn.types;
+      this.categories = updatedLabelsIn.categories;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public UpdatedLabelsInBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param types the types
+     * @param categories the categories
+     */
+    public UpdatedLabelsInBuilder(List<TypeLabel> types, List<Category> categories) {
+      this.types = types;
+      this.categories = categories;
+    }
+
+    /**
+     * Builds a UpdatedLabelsIn.
+     *
+     * @return the updatedLabelsIn
+     */
+    public UpdatedLabelsIn build() {
+      return new UpdatedLabelsIn(this);
+    }
+
+    /**
+     * Adds an types to types.
      *
      * @param types the new types
+     * @return the UpdatedLabelsIn builder
      */
-    public void setTypes(final List<TypeLabel> types) {
-      this.types_serialized_name = types;
+    public UpdatedLabelsInBuilder addTypes(TypeLabel types) {
+      IBMWatsonValidator.notNull(types, 'types cannot be null');
+      if (this.types == null) {
+        this.types = new List<TypeLabel>();
+      }
+      this.types.add(types);
+      return this;
     }
 
     /**
-     * Sets the categories.
+     * Adds an categories to categories.
      *
      * @param categories the new categories
+     * @return the UpdatedLabelsIn builder
      */
-    public void setCategories(final List<Category> categories) {
-      this.categories_serialized_name = categories;
+    public UpdatedLabelsInBuilder addCategories(Category categories) {
+      IBMWatsonValidator.notNull(categories, 'categories cannot be null');
+      if (this.categories == null) {
+        this.categories = new List<Category>();
+      }
+      this.categories.add(categories);
+      return this;
     }
 
+    /**
+     * Set the types.
+     * Existing types will be replaced.
+     *
+     * @param types the types
+     * @return the UpdatedLabelsIn builder
+     */
+    public UpdatedLabelsInBuilder setTypes(List<TypeLabel> types) {
+      this.types = types;
+      return this;
+    }
+
+    /**
+     * Set the categories.
+     * Existing categories will be replaced.
+     *
+     * @param categories the categories
+     * @return the UpdatedLabelsIn builder
+     */
+    public UpdatedLabelsInBuilder setCategories(List<Category> categories) {
+      this.categories = categories;
+      return this;
+    }
   }
 
   /**
    * The updated labeling from the input document, accounting for the submitted feedback.
    */
   public class UpdatedLabelsOut extends IBMWatsonGenericModel {
-    private List<TypeLabel> types_serialized_name;
-    private List<Category> categories_serialized_name;
-    private String modification_serialized_name;
+    private List<TypeLabel> types;
+    private List<Category> categories;
+    private String modification;
  
     /**
      * Gets the types.
@@ -9308,7 +10591,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<TypeLabel> getTypes() {
-      return types_serialized_name;
+      return types;
     }
  
     /**
@@ -9320,7 +10603,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public List<Category> getCategories() {
-      return categories_serialized_name;
+      return categories;
     }
  
     /**
@@ -9333,7 +10616,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getModification() {
-      return modification_serialized_name;
+      return modification;
     }
 
     /**
@@ -9342,7 +10625,7 @@ public class IBMCompareComplyV1Models {
      * @param types the new types
      */
     public void setTypes(final List<TypeLabel> types) {
-      this.types_serialized_name = types;
+      this.types = types;
     }
 
     /**
@@ -9351,7 +10634,7 @@ public class IBMCompareComplyV1Models {
      * @param categories the new categories
      */
     public void setCategories(final List<Category> categories) {
-      this.categories_serialized_name = categories;
+      this.categories = categories;
     }
 
     /**
@@ -9360,7 +10643,7 @@ public class IBMCompareComplyV1Models {
      * @param modification the new modification
      */
     public void setModification(final String modification) {
-      this.modification_serialized_name = modification;
+      this.modification = modification;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -9376,11 +10659,11 @@ public class IBMCompareComplyV1Models {
       if (deserializedTypes != null) {
         for (Integer i = 0; i < deserializedTypes.size(); i++) {
           TypeLabel currentItem = ret.getTypes().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('types_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('types');
           TypeLabel newItem = (TypeLabel) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TypeLabel.class);
           newTypes.add(newItem);
         }
-        ret.types_serialized_name = newTypes;
+        ret.types = newTypes;
       }
 
       // calling custom deserializer for categories
@@ -9389,14 +10672,25 @@ public class IBMCompareComplyV1Models {
       if (deserializedCategories != null) {
         for (Integer i = 0; i < deserializedCategories.size(); i++) {
           Category currentItem = ret.getCategories().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('categories_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('categories');
           Category newItem = (Category) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Category.class);
           newCategories.add(newItem);
         }
-        ret.categories_serialized_name = newCategories;
+        ret.categories = newCategories;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (types != null && types[0] != null) {
+        mapping.putAll(types[0].getApiToSdkMapping());
+      }
+      if (categories != null && categories[0] != null) {
+        mapping.putAll(categories[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -9404,9 +10698,9 @@ public class IBMCompareComplyV1Models {
    * A value in a key-value pair.
    */
   public class Value extends IBMWatsonGenericModel {
-    private String cell_id_serialized_name;
-    private Location location_serialized_name;
-    private String text_serialized_name;
+    private String cellId;
+    private Location location;
+    private String text;
  
     /**
      * Gets the cellId.
@@ -9417,7 +10711,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getCellId() {
-      return cell_id_serialized_name;
+      return cellId;
     }
  
     /**
@@ -9430,7 +10724,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public Location getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -9442,7 +10736,7 @@ public class IBMCompareComplyV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -9451,7 +10745,7 @@ public class IBMCompareComplyV1Models {
      * @param cellId the new cellId
      */
     public void setCellId(final String cellId) {
-      this.cell_id_serialized_name = cellId;
+      this.cellId = cellId;
     }
 
     /**
@@ -9460,7 +10754,7 @@ public class IBMCompareComplyV1Models {
      * @param location the new location
      */
     public void setLocation(final Location location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -9469,7 +10763,7 @@ public class IBMCompareComplyV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -9480,10 +10774,19 @@ public class IBMCompareComplyV1Models {
       Value ret = (Value) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for location
-      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location_serialized_name'), Location.class);
+      Location newLocation = (Location) new Location().deserialize(JSON.serialize(ret.getLocation()), (Map<String, Object>) jsonMap.get('location'), Location.class);
       ret.setLocation(newLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('cell_id', 'cellId');
+      if (location != null) {
+        mapping.putAll(location.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 

--- a/force-app/main/default/classes/IBMCompareComplyV1Test.cls
+++ b/force-app/main/default/classes/IBMCompareComplyV1Test.cls
@@ -73,6 +73,8 @@ private class IBMCompareComplyV1Test {
   private static String UNIT;
   private static Double NUMERIC_VALUE;
 
+  private static IBMCompareComplyV1Models.Location LOCATION;
+
   static {
     VERSION = '2018-10-15';
     COMMENT = 'comment';
@@ -146,11 +148,34 @@ private class IBMCompareComplyV1Test {
     VALUE = 'value';
     UNIT = 'unit';
     NUMERIC_VALUE = 21.0;
+
+    LOCATION = new IBMCompareComplyV1Models.LocationBuilder()
+      .xbegin(TEST_BEGIN)
+      .xend(TEST_END)
+      .build();
   }
 
   static testMethod void testAddFeedbackOptions() {
     Test.startTest();
-    IBMCompareComplyV1Models.FeedbackDataInput feedbackDataInput = new IBMCompareComplyV1Models.FeedbackDataInput();
+    IBMCompareComplyV1Models.TypeLabel typeLabel = new IBMCompareComplyV1Models.TypeLabelBuilder().build();
+    List<IBMCompareComplyV1Models.TypeLabel> types = new List<IBMCompareComplyV1Models.TypeLabel>{ typeLabel };
+    IBMCompareComplyV1Models.Category category = new IBMCompareComplyV1Models.CategoryBuilder().build();
+    List<IBMCompareComplyV1Models.Category> categories = new List<IBMCompareComplyV1Models.Category>{ category };
+    IBMCompareComplyV1Models.OriginalLabelsIn originalLabels = new IBMCompareComplyV1Models.OriginalLabelsInBuilder()
+      .types(types)
+      .categories(categories)
+      .build();
+    IBMCompareComplyV1Models.UpdatedLabelsIn updatedLabels = new IBMCompareComplyV1Models.UpdatedLabelsInBuilder()
+      .types(types)
+      .categories(categories)
+      .build();
+    IBMCompareComplyV1Models.FeedbackDataInput feedbackDataInput = new IBMCompareComplyV1Models.FeedbackDataInputBuilder()
+      .feedbackType(FEEDBACK_TYPE)
+      .location(LOCATION)
+      .text(TEXT)
+      .originalLabels(originalLabels)
+      .updatedLabels(updatedLabels)
+      .build();
 
     IBMCompareComplyV1Models.AddFeedbackOptions addFeedbackOptions = new IBMCompareComplyV1Models.AddFeedbackOptionsBuilder()
       .comment(COMMENT)
@@ -168,9 +193,10 @@ private class IBMCompareComplyV1Test {
 
   static testMethod void testCategory() {
     Test.startTest();
-    IBMCompareComplyV1Models.Category category = new IBMCompareComplyV1Models.Category();
-    category.setLabel(AMENDMENTS);
-    category.setProvenanceIds(new List<String> { PROVENANCE_ID });
+    IBMCompareComplyV1Models.Category category = new IBMCompareComplyV1Models.CategoryBuilder()
+      .label(AMENDMENTS)
+      .provenanceIds(new List<String> { PROVENANCE_ID })
+      .build();
 
     System.assertEquals(AMENDMENTS, category.getLabel());
     Test.stopTest();
@@ -318,20 +344,31 @@ private class IBMCompareComplyV1Test {
 
   static testMethod void testFeedbackDataInput() {
     Test.startTest();
-    IBMCompareComplyV1Models.ShortDoc shortDoc = new IBMCompareComplyV1Models.ShortDoc();
+    IBMCompareComplyV1Models.ShortDoc shortDoc = new IBMCompareComplyV1Models.ShortDocBuilder().build();
     IBMCompareComplyV1Models.Location location = new IBMCompareComplyV1Models.Location();
-    IBMCompareComplyV1Models.OriginalLabelsIn originalLabelsIn = new IBMCompareComplyV1Models.OriginalLabelsIn();
-    IBMCompareComplyV1Models.UpdatedLabelsIn updatedLabelsIn = new IBMCompareComplyV1Models.UpdatedLabelsIn();
+    IBMCompareComplyV1Models.TypeLabel typeLabel = new IBMCompareComplyV1Models.TypeLabelBuilder().build();
+    List<IBMCompareComplyV1Models.TypeLabel> types = new List<IBMCompareComplyV1Models.TypeLabel> { typeLabel };
+    IBMCompareComplyV1Models.Category category = new IBMCompareComplyV1Models.CategoryBuilder().build();
+    List<IBMCompareComplyV1Models.Category> categories = new List<IBMCompareComplyV1Models.Category>{ category };
+    IBMCompareComplyV1Models.OriginalLabelsIn originalLabelsIn = new IBMCompareComplyV1Models.OriginalLabelsInBuilder()
+      .types(types)
+      .categories(categories)
+      .build();
+    IBMCompareComplyV1Models.UpdatedLabelsIn updatedLabelsIn = new IBMCompareComplyV1Models.UpdatedLabelsInBuilder()
+      .types(types)
+      .categories(categories)
+      .build();
 
-    IBMCompareComplyV1Models.FeedbackDataInput feedbackDataInput = new IBMCompareComplyV1Models.FeedbackDataInput();
-    feedbackDataInput.setDocument(shortDoc);
-    feedbackDataInput.setFeedbackType(FEEDBACK_TYPE);
-    feedbackDataInput.setLocation(location);
-    feedbackDataInput.setModelId(MODEL_ID);
-    feedbackDataInput.setModelVersion(MODEL_VERSION);
-    feedbackDataInput.setOriginalLabels(originalLabelsIn);
-    feedbackDataInput.setText(TEXT);
-    feedbackDataInput.setUpdatedLabels(updatedLabelsIn);
+    IBMCompareComplyV1Models.FeedbackDataInput feedbackDataInput = new IBMCompareComplyV1Models.FeedbackDataInputBuilder()
+      .document(shortDoc)
+      .feedbackType(FEEDBACK_TYPE)
+      .location(location)
+      .modelId(MODEL_ID)
+      .modelVersion(MODEL_VERSION)
+      .originalLabels(originalLabelsIn)
+      .text(TEXT)
+      .updatedLabels(updatedLabelsIn)
+      .build();
 
     System.assertEquals(shortDoc, feedbackDataInput.getDocument());
     System.assertEquals(FEEDBACK_TYPE, feedbackDataInput.getFeedbackType());
@@ -383,9 +420,10 @@ private class IBMCompareComplyV1Test {
 
   static testMethod void testLabel() {
     Test.startTest();
-    IBMCompareComplyV1Models.Label label = new IBMCompareComplyV1Models.Label();
-    label.setNature(NATURE);
-    label.setParty(PARTY);
+    IBMCompareComplyV1Models.Label label = new IBMCompareComplyV1Models.LabelBuilder()
+      .nature(NATURE)
+      .party(PARTY)
+      .build();
 
     System.assertEquals(NATURE, label.getNature());
     System.assertEquals(PARTY, label.getParty());
@@ -435,22 +473,19 @@ private class IBMCompareComplyV1Test {
 
   static testMethod void testLocation() {
     Test.startTest();
-    IBMCompareComplyV1Models.Location location = new IBMCompareComplyV1Models.Location();
-    location.setXbegin(TEST_BEGIN);
-    location.setXend(TEST_END);
-
-    System.assertEquals(TEST_BEGIN, location.getXbegin());
-    System.assertEquals(TEST_END, location.getXend());
+    System.assertEquals(TEST_BEGIN, LOCATION.getXbegin());
+    System.assertEquals(TEST_END, LOCATION.getXend());
     Test.stopTest();
   }
 
   static testMethod void testOriginalLabelsIn() {
     Test.startTest();
     IBMCompareComplyV1Models.Category category = new IBMCompareComplyV1Models.Category();
-    IBMCompareComplyV1Models.TypeLabel typeLabel = new IBMCompareComplyV1Models.TypeLabel();
-    IBMCompareComplyV1Models.OriginalLabelsIn originalLabelsIn = new IBMCompareComplyV1Models.OriginalLabelsIn();
-    originalLabelsIn.setCategories(new List<IBMCompareComplyV1Models.Category> { category });
-    originalLabelsIn.setTypes(new List<IBMCompareComplyV1Models.TypeLabel> { typeLabel });
+    IBMCompareComplyV1Models.TypeLabel typeLabel = new IBMCompareComplyV1Models.TypeLabelBuilder().build();
+    IBMCompareComplyV1Models.OriginalLabelsIn originalLabelsIn = new IBMCompareComplyV1Models.OriginalLabelsInBuilder()
+      .categories(new List<IBMCompareComplyV1Models.Category> { category })
+      .types(new List<IBMCompareComplyV1Models.TypeLabel> { typeLabel })
+      .build();
 
     System.assertEquals(category, originalLabelsIn.getCategories().get(0));
     System.assertEquals(typeLabel, originalLabelsIn.getTypes().get(0));
@@ -459,9 +494,10 @@ private class IBMCompareComplyV1Test {
 
   static testMethod void testShortDoc() {
     Test.startTest();
-    IBMCompareComplyV1Models.ShortDoc shortDoc = new IBMCompareComplyV1Models.ShortDoc();
-    shortDoc.setHash(HASH);
-    shortDoc.setTitle(TITLE);
+    IBMCompareComplyV1Models.ShortDoc shortDoc = new IBMCompareComplyV1Models.ShortDocBuilder()
+      .hash(HASH)
+      .title(TITLE)
+      .build();
 
     System.assertEquals(HASH, shortDoc.getHash());
     System.assertEquals(TITLE, shortDoc.getTitle());
@@ -470,10 +506,14 @@ private class IBMCompareComplyV1Test {
 
   static testMethod void testTypeLabel() {
     Test.startTest();
-    IBMCompareComplyV1Models.Label label = new IBMCompareComplyV1Models.Label();
-    IBMCompareComplyV1Models.TypeLabel typeLabel = new IBMCompareComplyV1Models.TypeLabel();
-    typeLabel.setLabel(label);
-    typeLabel.setProvenanceIds(new List<String> { PROVENANCE_ID });
+    IBMCompareComplyV1Models.Label label = new IBMCompareComplyV1Models.LabelBuilder()
+      .nature(NATURE)
+      .party(PARTY)
+      .build();
+    IBMCompareComplyV1Models.TypeLabel typeLabel = new IBMCompareComplyV1Models.TypeLabelBuilder()
+      .label(label)
+      .provenanceIds(new List<String> { PROVENANCE_ID })
+      .build();
 
     System.assertEquals(label, typeLabel.getLabel());
     Test.stopTest();
@@ -498,10 +538,11 @@ private class IBMCompareComplyV1Test {
   static testMethod void testUpdatedLabelsIn() {
     Test.startTest();
     IBMCompareComplyV1Models.Category category = new IBMCompareComplyV1Models.Category();
-    IBMCompareComplyV1Models.TypeLabel typeLabel = new IBMCompareComplyV1Models.TypeLabel();
-    IBMCompareComplyV1Models.UpdatedLabelsIn updatedLabelsIn = new IBMCompareComplyV1Models.UpdatedLabelsIn();
-    updatedLabelsIn.setCategories(new List<IBMCompareComplyV1Models.Category> { category });
-    updatedLabelsIn.setTypes(new List<IBMCompareComplyV1Models.TypeLabel> { typeLabel });
+    IBMCompareComplyV1Models.TypeLabel typeLabel = new IBMCompareComplyV1Models.TypeLabelBuilder().build();
+    IBMCompareComplyV1Models.UpdatedLabelsIn updatedLabelsIn = new IBMCompareComplyV1Models.UpdatedLabelsInBuilder()
+      .categories(new List<IBMCompareComplyV1Models.Category> { category })
+      .types(new List<IBMCompareComplyV1Models.TypeLabel> { typeLabel })
+      .build();
 
     System.assertEquals(category, updatedLabelsIn.getCategories().get(0));
     System.assertEquals(typeLabel, updatedLabelsIn.getTypes().get(0));
@@ -645,7 +686,7 @@ private class IBMCompareComplyV1Test {
     System.assertEquals(TEST_BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getXbegin());
     System.assertEquals(TEST_END, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getXend());
     System.assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getText());
-    System.assertEquals(CELL_ID, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getCellId());
+    System.assertEquals(CELL_ID, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getCellId());
     System.assertEquals(TEST_BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getXbegin());
     System.assertEquals(TEST_END, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getXend());
     System.assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getText());
@@ -818,7 +859,7 @@ private class IBMCompareComplyV1Test {
     System.assertEquals(TEST_BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getXbegin());
     System.assertEquals(TEST_END, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getXend());
     System.assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getText());
-    System.assertEquals(CELL_ID, response.getTables().get(0).getKeyValuePairs().get(0).getValue().getCellId());
+    System.assertEquals(CELL_ID, response.getTables().get(0).getKeyValuePairs().get(0).getValue().get(0).getCellId());
     System.assertEquals(TEST_BEGIN, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getXbegin());
     System.assertEquals(TEST_END, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getLocation().getXend());
     System.assertEquals(TEXT, response.getTables().get(0).getKeyValuePairs().get(0).getKey().getText());
@@ -910,9 +951,29 @@ private class IBMCompareComplyV1Test {
       .build();
     IBMCompareComplyV1 service = new IBMCompareComplyV1(VERSION, iamOptions);
 
+    IBMCompareComplyV1Models.TypeLabel typeLabel = new IBMCompareComplyV1Models.TypeLabelBuilder().build();
+    List<IBMCompareComplyV1Models.TypeLabel> types = new List<IBMCompareComplyV1Models.TypeLabel>{ typeLabel };
+    IBMCompareComplyV1Models.Category category = new IBMCompareComplyV1Models.CategoryBuilder().build();
+    List<IBMCompareComplyV1Models.Category> categories = new List<IBMCompareComplyV1Models.Category>{ category };
+    IBMCompareComplyV1Models.OriginalLabelsIn originalLabels = new IBMCompareComplyV1Models.OriginalLabelsInBuilder()
+      .types(types)
+      .categories(categories)
+      .build();
+    IBMCompareComplyV1Models.UpdatedLabelsIn updatedLabels = new IBMCompareComplyV1Models.UpdatedLabelsInBuilder()
+      .types(types)
+      .categories(categories)
+      .build();
+    IBMCompareComplyV1Models.FeedbackDataInput data = new IBMCompareComplyV1Models.FeedbackDataInputBuilder()
+      .feedbackType(FEEDBACK_TYPE)
+      .location(LOCATION)
+      .text(TEXT)
+      .originalLabels(originalLabels)
+      .updatedLabels(updatedLabels)
+      .build();
+
     IBMCompareComplyV1Models.AddFeedbackOptions addFeedbackOptions = new IBMCompareComplyV1Models.AddFeedbackOptionsBuilder()
       .comment(COMMENT)
-      .feedbackData(new IBMCompareComplyV1Models.FeedbackDataInput())
+      .feedbackData(data)
       .userId(USER_ID)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();

--- a/force-app/main/default/classes/IBMDiscoveryV1.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1.cls
@@ -85,7 +85,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (createEnvironmentOptions.size() != null) {
       contentJson.put('size', createEnvironmentOptions.size());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createEnvironmentOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Environment) createServiceCall(builder.build(), IBMDiscoveryV1Models.Environment.class);
   }
@@ -169,7 +169,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (updateEnvironmentOptions.size() != null) {
       contentJson.put('size', updateEnvironmentOptions.size());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateEnvironmentOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Environment) createServiceCall(builder.build(), IBMDiscoveryV1Models.Environment.class);
   }
@@ -268,7 +268,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (createConfigurationOptions.source() != null) {
       contentJson.put('source', createConfigurationOptions.source());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createConfigurationOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Configuration) createServiceCall(builder.build(), IBMDiscoveryV1Models.Configuration.class);
   }
@@ -365,7 +365,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (updateConfigurationOptions.source() != null) {
       contentJson.put('source', updateConfigurationOptions.source());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateConfigurationOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Configuration) createServiceCall(builder.build(), IBMDiscoveryV1Models.Configuration.class);
   }
@@ -474,7 +474,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (createCollectionOptions.language() != null) {
       contentJson.put('language', createCollectionOptions.language());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createCollectionOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Collection) createServiceCall(builder.build(), IBMDiscoveryV1Models.Collection.class);
   }
@@ -556,7 +556,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (updateCollectionOptions.configurationId() != null) {
       contentJson.put('configuration_id', updateCollectionOptions.configurationId());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateCollectionOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Collection) createServiceCall(builder.build(), IBMDiscoveryV1Models.Collection.class);
   }
@@ -656,7 +656,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('expansions', createExpansionsOptions.expansions());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createExpansionsOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Expansions) createServiceCall(builder.build(), IBMDiscoveryV1Models.Expansions.class);
   }
@@ -733,7 +733,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (createTokenizationDictionaryOptions.tokenizationRules() != null) {
       contentJson.put('tokenization_rules', createTokenizationDictionaryOptions.tokenizationRules());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createTokenizationDictionaryOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.TokenDictStatusResponse) createServiceCall(builder.build(), IBMDiscoveryV1Models.TokenDictStatusResponse.class);
   }
@@ -1072,7 +1072,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (queryOptions.bias() != null) {
       contentJson.put('bias', queryOptions.bias());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, queryOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.QueryResponse) createServiceCall(builder.build(), IBMDiscoveryV1Models.QueryResponse.class);
   }
@@ -1241,7 +1241,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (federatedQueryOptions.bias() != null) {
       contentJson.put('bias', federatedQueryOptions.bias());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, federatedQueryOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.QueryResponse) createServiceCall(builder.build(), IBMDiscoveryV1Models.QueryResponse.class);
   }
@@ -1352,7 +1352,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (queryEntitiesOptions.evidenceCount() != null) {
       contentJson.put('evidence_count', queryEntitiesOptions.evidenceCount());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, queryEntitiesOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.QueryEntitiesResponse) createServiceCall(builder.build(), IBMDiscoveryV1Models.QueryEntitiesResponse.class);
   }
@@ -1397,7 +1397,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (queryRelationsOptions.evidenceCount() != null) {
       contentJson.put('evidence_count', queryRelationsOptions.evidenceCount());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, queryRelationsOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.QueryRelationsResponse) createServiceCall(builder.build(), IBMDiscoveryV1Models.QueryRelationsResponse.class);
   }
@@ -1456,7 +1456,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (addTrainingDataOptions.examples() != null) {
       contentJson.put('examples', addTrainingDataOptions.examples());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, addTrainingDataOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.TrainingQuery) createServiceCall(builder.build(), IBMDiscoveryV1Models.TrainingQuery.class);
   }
@@ -1585,7 +1585,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (createTrainingExampleOptions.relevance() != null) {
       contentJson.put('relevance', createTrainingExampleOptions.relevance());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createTrainingExampleOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.TrainingExample) createServiceCall(builder.build(), IBMDiscoveryV1Models.TrainingExample.class);
   }
@@ -1640,7 +1640,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (updateTrainingExampleOptions.relevance() != null) {
       contentJson.put('relevance', updateTrainingExampleOptions.relevance());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateTrainingExampleOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.TrainingExample) createServiceCall(builder.build(), IBMDiscoveryV1Models.TrainingExample.class);
   }
@@ -1724,7 +1724,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('type', createEventOptions.xtype());
     contentJson.put('data', createEventOptions.data());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createEventOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.CreateEventResponse) createServiceCall(builder.build(), IBMDiscoveryV1Models.CreateEventResponse.class);
   }
@@ -1988,7 +1988,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (createCredentialsOptions.status() != null) {
       contentJson.put('status', createCredentialsOptions.status());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createCredentialsOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Credentials) createServiceCall(builder.build(), IBMDiscoveryV1Models.Credentials.class);
   }
@@ -2052,7 +2052,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (updateCredentialsOptions.status() != null) {
       contentJson.put('status', updateCredentialsOptions.status());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateCredentialsOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Credentials) createServiceCall(builder.build(), IBMDiscoveryV1Models.Credentials.class);
   }
@@ -2129,7 +2129,7 @@ public class IBMDiscoveryV1 extends IBMWatsonService {
     if (createGatewayOptions.name() != null) {
       contentJson.put('name', createGatewayOptions.name());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createGatewayOptions.getSdkToApiMapping()));
 
     return (IBMDiscoveryV1Models.Gateway) createServiceCall(builder.build(), IBMDiscoveryV1Models.Gateway.class);
   }

--- a/force-app/main/default/classes/IBMDiscoveryV1Models.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Models.cls
@@ -330,7 +330,7 @@ public class IBMDiscoveryV1Models {
       mapping.put('collectionId', 'collection_id');
       mapping.put('naturalLanguageQuery', 'natural_language_query');
       if (examples != null && examples[0] != null) {
-        mapping.putAll(examples[0].getSdkToApiMapping());
+        mapping.putAll(examples[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -472,7 +472,7 @@ public class IBMDiscoveryV1Models {
     private String key;
     private Long matchingResults;
     private List<QueryAggregation> aggregations;
- 
+
     /**
      * Gets the key.
      *
@@ -484,7 +484,7 @@ public class IBMDiscoveryV1Models {
     public String getKey() {
       return key;
     }
- 
+
     /**
      * Gets the matchingResults.
      *
@@ -496,7 +496,7 @@ public class IBMDiscoveryV1Models {
     public Long getMatchingResults() {
       return matchingResults;
     }
- 
+
     /**
      * Gets the aggregations.
      *
@@ -559,12 +559,9 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('matching_results', 'matchingResults');
-      if (aggregations != null && aggregations[0] != null) {
-        mapping.putAll(aggregations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'matching_results', 'matchingResults');
+      mapping.putAll(((IBMWatsonGenericModel) QueryAggregation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'aggregations/', mapping));
       return mapping;
     }
   }
@@ -586,7 +583,7 @@ public class IBMDiscoveryV1Models {
     private TrainingStatus trainingStatus;
     private CollectionCrawlStatus crawlStatus;
     private SduStatus smartDocumentUnderstanding;
- 
+
     /**
      * Gets the collectionId.
      *
@@ -598,7 +595,7 @@ public class IBMDiscoveryV1Models {
     public String getCollectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -610,7 +607,7 @@ public class IBMDiscoveryV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -622,7 +619,7 @@ public class IBMDiscoveryV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -634,7 +631,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -646,7 +643,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getUpdated() {
       return updated;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -658,7 +655,7 @@ public class IBMDiscoveryV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the configurationId.
      *
@@ -670,7 +667,7 @@ public class IBMDiscoveryV1Models {
     public String getConfigurationId() {
       return configurationId;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -683,7 +680,7 @@ public class IBMDiscoveryV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the documentCounts.
      *
@@ -693,7 +690,7 @@ public class IBMDiscoveryV1Models {
     public DocumentCounts getDocumentCounts() {
       return documentCounts;
     }
- 
+
     /**
      * Gets the diskUsage.
      *
@@ -705,7 +702,7 @@ public class IBMDiscoveryV1Models {
     public CollectionDiskUsage getDiskUsage() {
       return diskUsage;
     }
- 
+
     /**
      * Gets the trainingStatus.
      *
@@ -715,7 +712,7 @@ public class IBMDiscoveryV1Models {
     public TrainingStatus getTrainingStatus() {
       return trainingStatus;
     }
- 
+
     /**
      * Gets the crawlStatus.
      *
@@ -727,7 +724,7 @@ public class IBMDiscoveryV1Models {
     public CollectionCrawlStatus getCrawlStatus() {
       return crawlStatus;
     }
- 
+
     /**
      * Gets the smartDocumentUnderstanding.
      *
@@ -851,27 +848,22 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('collection_id', 'collectionId');
-      mapping.put('configuration_id', 'configurationId');
-      mapping.put('document_counts', 'documentCounts');
-      mapping.put('disk_usage', 'diskUsage');
-      if (diskUsage != null) {
-        mapping.putAll(diskUsage.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('training_status', 'trainingStatus');
-      if (trainingStatus != null) {
-        mapping.putAll(trainingStatus.getApiToSdkMapping());
-      }
-      mapping.put('crawl_status', 'crawlStatus');
-      if (crawlStatus != null) {
-        mapping.putAll(crawlStatus.getApiToSdkMapping());
-      }
-      mapping.put('smart_document_understanding', 'smartDocumentUnderstanding');
-      if (smartDocumentUnderstanding != null) {
-        mapping.putAll(smartDocumentUnderstanding.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'collection_id', 'collectionId');
+      mapping.put(parentLabel + 'configuration_id', 'configurationId');
+      mapping.put(parentLabel + 'document_counts', 'documentCounts');
+      mapping.put(parentLabel + 'disk_usage', 'diskUsage');
+      mapping.putAll(((IBMWatsonGenericModel) CollectionDiskUsage.class.newInstance()).addToApiToSdkMapping(parentLabel + 'disk_usage/', mapping));
+      mapping.put(parentLabel + 'training_status', 'trainingStatus');
+      mapping.putAll(((IBMWatsonGenericModel) TrainingStatus.class.newInstance()).addToApiToSdkMapping(parentLabel + 'training_status/', mapping));
+      mapping.put(parentLabel + 'crawl_status', 'crawlStatus');
+      mapping.putAll(((IBMWatsonGenericModel) CollectionCrawlStatus.class.newInstance()).addToApiToSdkMapping(parentLabel + 'crawl_status/', mapping));
+      mapping.put(parentLabel + 'smart_document_understanding', 'smartDocumentUnderstanding');
+      mapping.putAll(((IBMWatsonGenericModel) SduStatus.class.newInstance()).addToApiToSdkMapping(parentLabel + 'smart_document_understanding/', mapping));
       return mapping;
     }
   }
@@ -881,7 +873,7 @@ public class IBMDiscoveryV1Models {
    */
   public class CollectionCrawlStatus extends IBMWatsonGenericModel {
     private SourceStatus sourceCrawl;
- 
+
     /**
      * Gets the sourceCrawl.
      *
@@ -917,12 +909,13 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('source_crawl', 'sourceCrawl');
-      if (sourceCrawl != null) {
-        mapping.putAll(sourceCrawl.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'source_crawl', 'sourceCrawl');
+      mapping.putAll(((IBMWatsonGenericModel) SourceStatus.class.newInstance()).addToApiToSdkMapping(parentLabel + 'source_crawl/', mapping));
       return mapping;
     }
   }
@@ -932,7 +925,7 @@ public class IBMDiscoveryV1Models {
    */
   public class CollectionDiskUsage extends IBMWatsonGenericModel {
     private Long usedBytes;
- 
+
     /**
      * Gets the usedBytes.
      *
@@ -945,9 +938,12 @@ public class IBMDiscoveryV1Models {
       return usedBytes;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('used_bytes', 'usedBytes');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'used_bytes', 'usedBytes');
       return mapping;
     }
   }
@@ -958,7 +954,7 @@ public class IBMDiscoveryV1Models {
   public class CollectionUsage extends IBMWatsonGenericModel {
     private Long available;
     private Long maximumAllowed;
- 
+
     /**
      * Gets the available.
      *
@@ -970,7 +966,7 @@ public class IBMDiscoveryV1Models {
     public Long getAvailable() {
       return available;
     }
- 
+
     /**
      * Gets the maximumAllowed.
      *
@@ -983,9 +979,8 @@ public class IBMDiscoveryV1Models {
       return maximumAllowed;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('maximum_allowed', 'maximumAllowed');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'maximum_allowed', 'maximumAllowed');
       return mapping;
     }
   }
@@ -1009,7 +1004,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public Configuration() { }
- 
+
     /**
      * Gets the configurationId.
      *
@@ -1021,7 +1016,7 @@ public class IBMDiscoveryV1Models {
     public String getConfigurationId() {
       return configurationId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -1033,7 +1028,7 @@ public class IBMDiscoveryV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -1045,7 +1040,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -1057,7 +1052,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getUpdated() {
       return updated;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -1069,7 +1064,7 @@ public class IBMDiscoveryV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the conversions.
      *
@@ -1081,7 +1076,7 @@ public class IBMDiscoveryV1Models {
     public Conversions getConversions() {
       return conversions;
     }
- 
+
     /**
      * Gets the enrichments.
      *
@@ -1093,7 +1088,7 @@ public class IBMDiscoveryV1Models {
     public List<Enrichment> getEnrichments() {
       return enrichments;
     }
- 
+
     /**
      * Gets the normalizations.
      *
@@ -1106,7 +1101,7 @@ public class IBMDiscoveryV1Models {
     public List<NormalizationOperation> getNormalizations() {
       return normalizations;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -1151,7 +1146,7 @@ public class IBMDiscoveryV1Models {
 
       // calling custom deserializer for conversions
       Conversions newConversions = (Conversions) new Conversions().deserialize(JSON.serialize(ret.getConversions()), (Map<String, Object>) jsonMap.get('conversions'), Conversions.class);
-      retBuilder.setConversions(newConversions);
+      retBuilder.conversions(newConversions);
 
       // calling custom deserializer for enrichments
       List<Enrichment> newEnrichments = new List<Enrichment>();
@@ -1163,7 +1158,7 @@ public class IBMDiscoveryV1Models {
           Enrichment newItem = (Enrichment) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Enrichment.class);
           newEnrichments.add(newItem);
         }
-        retBuilder.setEnrichments(newEnrichments);
+        retBuilder.enrichments(newEnrichments);
       }
 
       // calling custom deserializer for normalizations
@@ -1176,49 +1171,47 @@ public class IBMDiscoveryV1Models {
           NormalizationOperation newItem = (NormalizationOperation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), NormalizationOperation.class);
           newNormalizations.add(newItem);
         }
-        retBuilder.setNormalizations(newNormalizations);
+        retBuilder.normalizations(newNormalizations);
       }
 
       // calling custom deserializer for source
       Source newSource = (Source) new Source().deserialize(JSON.serialize(ret.getSource()), (Map<String, Object>) jsonMap.get('source'), Source.class);
-      retBuilder.setSource(newSource);
+      retBuilder.source(newSource);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('configurationId', 'configuration_id');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'configurationId', 'configuration_id');
       if (conversions != null) {
-        mapping.putAll(conversions.getSdkToApiMapping());
+        mapping.putAll(conversions.addToSdkToApiMapping(parentLabel + 'conversions/', mapping));
       }
       if (enrichments != null && enrichments[0] != null) {
-        mapping.putAll(enrichments[0].getSdkToApiMapping());
+        mapping.putAll(enrichments[0].addToSdkToApiMapping(parentLabel + 'enrichments/', mapping));
       }
       if (normalizations != null && normalizations[0] != null) {
-        mapping.putAll(normalizations[0].getSdkToApiMapping());
+        mapping.putAll(normalizations[0].addToSdkToApiMapping(parentLabel + 'normalizations/', mapping));
       }
       if (source != null) {
-        mapping.putAll(source.getSdkToApiMapping());
+        mapping.putAll(source.addToSdkToApiMapping(parentLabel + 'source/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('configuration_id', 'configurationId');
-      if (conversions != null) {
-        mapping.putAll(conversions.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (enrichments != null && enrichments[0] != null) {
-        mapping.putAll(enrichments[0].getApiToSdkMapping());
-      }
-      if (normalizations != null && normalizations[0] != null) {
-        mapping.putAll(normalizations[0].getApiToSdkMapping());
-      }
-      if (source != null) {
-        mapping.putAll(source.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'configuration_id', 'configurationId');
+      mapping.putAll(((IBMWatsonGenericModel) Conversions.class.newInstance()).addToApiToSdkMapping(parentLabel + 'conversions/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Enrichment.class.newInstance()).addToApiToSdkMapping(parentLabel + 'enrichments/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) NormalizationOperation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'normalizations/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Source.class.newInstance()).addToApiToSdkMapping(parentLabel + 'source/', mapping));
       return mapping;
     }
   }
@@ -1309,7 +1302,7 @@ public class IBMDiscoveryV1Models {
      * @param configurationId the configurationId
      * @return the Configuration builder
      */
-    public ConfigurationBuilder setConfigurationId(String configurationId) {
+    public ConfigurationBuilder configurationId(String configurationId) {
       this.configurationId = configurationId;
       return this;
     }
@@ -1320,7 +1313,7 @@ public class IBMDiscoveryV1Models {
      * @param name the name
      * @return the Configuration builder
      */
-    public ConfigurationBuilder setName(String name) {
+    public ConfigurationBuilder name(String name) {
       this.name = name;
       return this;
     }
@@ -1331,7 +1324,7 @@ public class IBMDiscoveryV1Models {
      * @param created the created
      * @return the Configuration builder
      */
-    public ConfigurationBuilder setCreated(Datetime created) {
+    public ConfigurationBuilder created(Datetime created) {
       this.created = created;
       return this;
     }
@@ -1342,7 +1335,7 @@ public class IBMDiscoveryV1Models {
      * @param updated the updated
      * @return the Configuration builder
      */
-    public ConfigurationBuilder setUpdated(Datetime updated) {
+    public ConfigurationBuilder updated(Datetime updated) {
       this.updated = updated;
       return this;
     }
@@ -1353,7 +1346,7 @@ public class IBMDiscoveryV1Models {
      * @param description the description
      * @return the Configuration builder
      */
-    public ConfigurationBuilder setDescription(String description) {
+    public ConfigurationBuilder description(String description) {
       this.description = description;
       return this;
     }
@@ -1364,7 +1357,7 @@ public class IBMDiscoveryV1Models {
      * @param conversions the conversions
      * @return the Configuration builder
      */
-    public ConfigurationBuilder setConversions(Conversions conversions) {
+    public ConfigurationBuilder conversions(Conversions conversions) {
       this.conversions = conversions;
       return this;
     }
@@ -1376,7 +1369,7 @@ public class IBMDiscoveryV1Models {
      * @param enrichments the enrichments
      * @return the Configuration builder
      */
-    public ConfigurationBuilder setEnrichments(List<Enrichment> enrichments) {
+    public ConfigurationBuilder enrichments(List<Enrichment> enrichments) {
       this.enrichments = enrichments;
       return this;
     }
@@ -1388,7 +1381,7 @@ public class IBMDiscoveryV1Models {
      * @param normalizations the normalizations
      * @return the Configuration builder
      */
-    public ConfigurationBuilder setNormalizations(List<NormalizationOperation> normalizations) {
+    public ConfigurationBuilder normalizations(List<NormalizationOperation> normalizations) {
       this.normalizations = normalizations;
       return this;
     }
@@ -1399,7 +1392,7 @@ public class IBMDiscoveryV1Models {
      * @param source the source
      * @return the Configuration builder
      */
-    public ConfigurationBuilder setSource(Source source) {
+    public ConfigurationBuilder source(Source source) {
       this.source = source;
       return this;
     }
@@ -1421,7 +1414,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public Conversions() { }
- 
+
     /**
      * Gets the pdf.
      *
@@ -1433,7 +1426,7 @@ public class IBMDiscoveryV1Models {
     public PdfSettings getPdf() {
       return pdf;
     }
- 
+
     /**
      * Gets the word.
      *
@@ -1445,7 +1438,7 @@ public class IBMDiscoveryV1Models {
     public WordSettings getWord() {
       return word;
     }
- 
+
     /**
      * Gets the html.
      *
@@ -1457,7 +1450,7 @@ public class IBMDiscoveryV1Models {
     public HtmlSettings getHtml() {
       return html;
     }
- 
+
     /**
      * Gets the segment.
      *
@@ -1469,7 +1462,7 @@ public class IBMDiscoveryV1Models {
     public SegmentSettings getSegment() {
       return segment;
     }
- 
+
     /**
      * Gets the jsonNormalizations.
      *
@@ -1482,7 +1475,7 @@ public class IBMDiscoveryV1Models {
     public List<NormalizationOperation> getJsonNormalizations() {
       return jsonNormalizations;
     }
- 
+
     /**
      * Gets the imageTextRecognition.
      *
@@ -1526,19 +1519,19 @@ public class IBMDiscoveryV1Models {
 
       // calling custom deserializer for pdf
       PdfSettings newPdf = (PdfSettings) new PdfSettings().deserialize(JSON.serialize(ret.getPdf()), (Map<String, Object>) jsonMap.get('pdf'), PdfSettings.class);
-      retBuilder.setPdf(newPdf);
+      retBuilder.pdf(newPdf);
 
       // calling custom deserializer for word
       WordSettings newWord = (WordSettings) new WordSettings().deserialize(JSON.serialize(ret.getWord()), (Map<String, Object>) jsonMap.get('word'), WordSettings.class);
-      retBuilder.setWord(newWord);
+      retBuilder.word(newWord);
 
       // calling custom deserializer for html
       HtmlSettings newHtml = (HtmlSettings) new HtmlSettings().deserialize(JSON.serialize(ret.getHtml()), (Map<String, Object>) jsonMap.get('html'), HtmlSettings.class);
-      retBuilder.setHtml(newHtml);
+      retBuilder.html(newHtml);
 
       // calling custom deserializer for segment
       SegmentSettings newSegment = (SegmentSettings) new SegmentSettings().deserialize(JSON.serialize(ret.getSegment()), (Map<String, Object>) jsonMap.get('segment'), SegmentSettings.class);
-      retBuilder.setSegment(newSegment);
+      retBuilder.segment(newSegment);
 
       // calling custom deserializer for jsonNormalizations
       List<NormalizationOperation> newJsonNormalizations = new List<NormalizationOperation>();
@@ -1550,53 +1543,41 @@ public class IBMDiscoveryV1Models {
           NormalizationOperation newItem = (NormalizationOperation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), NormalizationOperation.class);
           newJsonNormalizations.add(newItem);
         }
-        retBuilder.setJsonNormalizations(newJsonNormalizations);
+        retBuilder.jsonNormalizations(newJsonNormalizations);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (pdf != null) {
-        mapping.putAll(pdf.getSdkToApiMapping());
+        mapping.putAll(pdf.addToSdkToApiMapping(parentLabel + 'pdf/', mapping));
       }
       if (word != null) {
-        mapping.putAll(word.getSdkToApiMapping());
+        mapping.putAll(word.addToSdkToApiMapping(parentLabel + 'word/', mapping));
       }
       if (html != null) {
-        mapping.putAll(html.getSdkToApiMapping());
+        mapping.putAll(html.addToSdkToApiMapping(parentLabel + 'html/', mapping));
       }
       if (segment != null) {
-        mapping.putAll(segment.getSdkToApiMapping());
+        mapping.putAll(segment.addToSdkToApiMapping(parentLabel + 'segment/', mapping));
       }
-      mapping.put('jsonNormalizations', 'json_normalizations');
+      mapping.put(parentLabel + 'jsonNormalizations', 'json_normalizations');
       if (jsonNormalizations != null && jsonNormalizations[0] != null) {
-        mapping.putAll(jsonNormalizations[0].getSdkToApiMapping());
+        mapping.putAll(jsonNormalizations[0].addToSdkToApiMapping(parentLabel + 'jsonNormalizations/', mapping));
       }
-      mapping.put('imageTextRecognition', 'image_text_recognition');
+      mapping.put(parentLabel + 'imageTextRecognition', 'image_text_recognition');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (pdf != null) {
-        mapping.putAll(pdf.getApiToSdkMapping());
-      }
-      if (word != null) {
-        mapping.putAll(word.getApiToSdkMapping());
-      }
-      if (html != null) {
-        mapping.putAll(html.getApiToSdkMapping());
-      }
-      if (segment != null) {
-        mapping.putAll(segment.getApiToSdkMapping());
-      }
-      mapping.put('json_normalizations', 'jsonNormalizations');
-      if (jsonNormalizations != null && jsonNormalizations[0] != null) {
-        mapping.putAll(jsonNormalizations[0].getApiToSdkMapping());
-      }
-      mapping.put('image_text_recognition', 'imageTextRecognition');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) PdfSettings.class.newInstance()).addToApiToSdkMapping(parentLabel + 'pdf/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) WordSettings.class.newInstance()).addToApiToSdkMapping(parentLabel + 'word/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) HtmlSettings.class.newInstance()).addToApiToSdkMapping(parentLabel + 'html/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) SegmentSettings.class.newInstance()).addToApiToSdkMapping(parentLabel + 'segment/', mapping));
+      mapping.put(parentLabel + 'json_normalizations', 'jsonNormalizations');
+      mapping.putAll(((IBMWatsonGenericModel) NormalizationOperation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'json_normalizations/', mapping));
+      mapping.put(parentLabel + 'image_text_recognition', 'imageTextRecognition');
       return mapping;
     }
   }
@@ -1657,7 +1638,7 @@ public class IBMDiscoveryV1Models {
      * @param pdf the pdf
      * @return the Conversions builder
      */
-    public ConversionsBuilder setPdf(PdfSettings pdf) {
+    public ConversionsBuilder pdf(PdfSettings pdf) {
       this.pdf = pdf;
       return this;
     }
@@ -1668,7 +1649,7 @@ public class IBMDiscoveryV1Models {
      * @param word the word
      * @return the Conversions builder
      */
-    public ConversionsBuilder setWord(WordSettings word) {
+    public ConversionsBuilder word(WordSettings word) {
       this.word = word;
       return this;
     }
@@ -1679,7 +1660,7 @@ public class IBMDiscoveryV1Models {
      * @param html the html
      * @return the Conversions builder
      */
-    public ConversionsBuilder setHtml(HtmlSettings html) {
+    public ConversionsBuilder html(HtmlSettings html) {
       this.html = html;
       return this;
     }
@@ -1690,7 +1671,7 @@ public class IBMDiscoveryV1Models {
      * @param segment the segment
      * @return the Conversions builder
      */
-    public ConversionsBuilder setSegment(SegmentSettings segment) {
+    public ConversionsBuilder segment(SegmentSettings segment) {
       this.segment = segment;
       return this;
     }
@@ -1702,7 +1683,7 @@ public class IBMDiscoveryV1Models {
      * @param jsonNormalizations the jsonNormalizations
      * @return the Conversions builder
      */
-    public ConversionsBuilder setJsonNormalizations(List<NormalizationOperation> jsonNormalizations) {
+    public ConversionsBuilder jsonNormalizations(List<NormalizationOperation> jsonNormalizations) {
       this.jsonNormalizations = jsonNormalizations;
       return this;
     }
@@ -1713,7 +1694,7 @@ public class IBMDiscoveryV1Models {
      * @param imageTextRecognition the imageTextRecognition
      * @return the Conversions builder
      */
-    public ConversionsBuilder setImageTextRecognition(Boolean imageTextRecognition) {
+    public ConversionsBuilder imageTextRecognition(Boolean imageTextRecognition) {
       this.imageTextRecognition = imageTextRecognition;
       return this;
     }
@@ -2041,16 +2022,16 @@ public class IBMDiscoveryV1Models {
       Map<String, String> mapping = new Map<String, String>();
       mapping.put('environmentId', 'environment_id');
       if (conversions != null) {
-        mapping.putAll(conversions.getSdkToApiMapping());
+        mapping.putAll(conversions.addToSdkToApiMapping('', mapping));
       }
       if (enrichments != null && enrichments[0] != null) {
-        mapping.putAll(enrichments[0].getSdkToApiMapping());
+        mapping.putAll(enrichments[0].addToSdkToApiMapping('', mapping));
       }
       if (normalizations != null && normalizations[0] != null) {
-        mapping.putAll(normalizations[0].getSdkToApiMapping());
+        mapping.putAll(normalizations[0].addToSdkToApiMapping('', mapping));
       }
       if (source != null) {
-        mapping.putAll(source.getSdkToApiMapping());
+        mapping.putAll(source.addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -2329,7 +2310,7 @@ public class IBMDiscoveryV1Models {
       mapping.put('sourceType', 'source_type');
       mapping.put('credentialDetails', 'credential_details');
       if (credentialDetails != null) {
-        mapping.putAll(credentialDetails.getSdkToApiMapping());
+        mapping.putAll(credentialDetails.addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -2641,7 +2622,7 @@ public class IBMDiscoveryV1Models {
       Map<String, String> mapping = new Map<String, String>();
       mapping.put('xtype', 'type');
       if (data != null) {
-        mapping.putAll(data.getSdkToApiMapping());
+        mapping.putAll(data.addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -2727,7 +2708,7 @@ public class IBMDiscoveryV1Models {
   public class CreateEventResponse extends IBMWatsonResponseModel {
     private String xtype;
     private EventData data;
- 
+
     /**
      * Gets the xtype.
      *
@@ -2739,7 +2720,7 @@ public class IBMDiscoveryV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the data.
      *
@@ -2784,12 +2765,13 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
-      if (data != null) {
-        mapping.putAll(data.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'type', 'xtype');
+      mapping.putAll(((IBMWatsonGenericModel) EventData.class.newInstance()).addToApiToSdkMapping(parentLabel + 'data/', mapping));
       return mapping;
     }
   }
@@ -2871,7 +2853,7 @@ public class IBMDiscoveryV1Models {
       mapping.put('environmentId', 'environment_id');
       mapping.put('collectionId', 'collection_id');
       if (expansions != null && expansions[0] != null) {
-        mapping.putAll(expansions[0].getSdkToApiMapping());
+        mapping.putAll(expansions[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -3371,7 +3353,7 @@ public class IBMDiscoveryV1Models {
       mapping.put('collectionId', 'collection_id');
       mapping.put('tokenizationRules', 'tokenization_rules');
       if (tokenizationRules != null && tokenizationRules[0] != null) {
-        mapping.putAll(tokenizationRules[0].getSdkToApiMapping());
+        mapping.putAll(tokenizationRules[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -3762,7 +3744,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public CredentialDetails() { }
- 
+
     /**
      * Gets the credentialType.
      *
@@ -3782,7 +3764,7 @@ public class IBMDiscoveryV1Models {
     public String getCredentialType() {
       return credentialType;
     }
- 
+
     /**
      * Gets the clientId.
      *
@@ -3795,7 +3777,7 @@ public class IBMDiscoveryV1Models {
     public String getClientId() {
       return clientId;
     }
- 
+
     /**
      * Gets the enterpriseId.
      *
@@ -3808,7 +3790,7 @@ public class IBMDiscoveryV1Models {
     public String getEnterpriseId() {
       return enterpriseId;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -3821,7 +3803,7 @@ public class IBMDiscoveryV1Models {
     public String getUrl() {
       return url;
     }
- 
+
     /**
      * Gets the username.
      *
@@ -3834,7 +3816,7 @@ public class IBMDiscoveryV1Models {
     public String getUsername() {
       return username;
     }
- 
+
     /**
      * Gets the organizationUrl.
      *
@@ -3847,7 +3829,7 @@ public class IBMDiscoveryV1Models {
     public String getOrganizationUrl() {
       return organizationUrl;
     }
- 
+
     /**
      * Gets the siteCollectionPath.
      *
@@ -3860,7 +3842,7 @@ public class IBMDiscoveryV1Models {
     public String getSiteCollectionPath() {
       return siteCollectionPath;
     }
- 
+
     /**
      * Gets the clientSecret.
      *
@@ -3874,7 +3856,7 @@ public class IBMDiscoveryV1Models {
     public String getClientSecret() {
       return clientSecret;
     }
- 
+
     /**
      * Gets the publicKeyId.
      *
@@ -3888,7 +3870,7 @@ public class IBMDiscoveryV1Models {
     public String getPublicKeyId() {
       return publicKeyId;
     }
- 
+
     /**
      * Gets the privateKey.
      *
@@ -3902,7 +3884,7 @@ public class IBMDiscoveryV1Models {
     public String getPrivateKey() {
       return privateKey;
     }
- 
+
     /**
      * Gets the passphrase.
      *
@@ -3916,7 +3898,7 @@ public class IBMDiscoveryV1Models {
     public String getPassphrase() {
       return passphrase;
     }
- 
+
     /**
      * Gets the password.
      *
@@ -3933,7 +3915,7 @@ public class IBMDiscoveryV1Models {
     public String getPassword() {
       return password;
     }
- 
+
     /**
      * Gets the gatewayId.
      *
@@ -3947,7 +3929,7 @@ public class IBMDiscoveryV1Models {
     public String getGatewayId() {
       return gatewayId;
     }
- 
+
     /**
      * Gets the sourceVersion.
      *
@@ -3960,7 +3942,7 @@ public class IBMDiscoveryV1Models {
     public String getSourceVersion() {
       return sourceVersion;
     }
- 
+
     /**
      * Gets the webApplicationUrl.
      *
@@ -3973,7 +3955,7 @@ public class IBMDiscoveryV1Models {
     public String getWebApplicationUrl() {
       return webApplicationUrl;
     }
- 
+
     /**
      * Gets the domain.
      *
@@ -3986,7 +3968,7 @@ public class IBMDiscoveryV1Models {
     public String getDomain() {
       return domain;
     }
- 
+
     /**
      * Gets the endpoint.
      *
@@ -3999,7 +3981,7 @@ public class IBMDiscoveryV1Models {
     public String getEndpoint() {
       return endpoint;
     }
- 
+
     /**
      * Gets the accessKeyId.
      *
@@ -4014,7 +3996,7 @@ public class IBMDiscoveryV1Models {
     public String getAccessKeyId() {
       return accessKeyId;
     }
- 
+
     /**
      * Gets the secretAccessKey.
      *
@@ -4061,39 +4043,45 @@ public class IBMDiscoveryV1Models {
       return new CredentialDetailsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('credentialType', 'credential_type');
-      mapping.put('clientId', 'client_id');
-      mapping.put('enterpriseId', 'enterprise_id');
-      mapping.put('organizationUrl', 'organization_url');
-      mapping.put('siteCollectionPath', 'site_collection.path');
-      mapping.put('clientSecret', 'client_secret');
-      mapping.put('publicKeyId', 'public_key_id');
-      mapping.put('privateKey', 'private_key');
-      mapping.put('gatewayId', 'gateway_id');
-      mapping.put('sourceVersion', 'source_version');
-      mapping.put('webApplicationUrl', 'web_application_url');
-      mapping.put('accessKeyId', 'access_key_id');
-      mapping.put('secretAccessKey', 'secret_access_key');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'credentialType', 'credential_type');
+      mapping.put(parentLabel + 'clientId', 'client_id');
+      mapping.put(parentLabel + 'enterpriseId', 'enterprise_id');
+      mapping.put(parentLabel + 'organizationUrl', 'organization_url');
+      mapping.put(parentLabel + 'siteCollectionPath', 'site_collection.path');
+      mapping.put(parentLabel + 'clientSecret', 'client_secret');
+      mapping.put(parentLabel + 'publicKeyId', 'public_key_id');
+      mapping.put(parentLabel + 'privateKey', 'private_key');
+      mapping.put(parentLabel + 'gatewayId', 'gateway_id');
+      mapping.put(parentLabel + 'sourceVersion', 'source_version');
+      mapping.put(parentLabel + 'webApplicationUrl', 'web_application_url');
+      mapping.put(parentLabel + 'accessKeyId', 'access_key_id');
+      mapping.put(parentLabel + 'secretAccessKey', 'secret_access_key');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('credential_type', 'credentialType');
-      mapping.put('client_id', 'clientId');
-      mapping.put('enterprise_id', 'enterpriseId');
-      mapping.put('organization_url', 'organizationUrl');
-      mapping.put('site_collection.path', 'siteCollectionPath');
-      mapping.put('client_secret', 'clientSecret');
-      mapping.put('public_key_id', 'publicKeyId');
-      mapping.put('private_key', 'privateKey');
-      mapping.put('gateway_id', 'gatewayId');
-      mapping.put('source_version', 'sourceVersion');
-      mapping.put('web_application_url', 'webApplicationUrl');
-      mapping.put('access_key_id', 'accessKeyId');
-      mapping.put('secret_access_key', 'secretAccessKey');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'credential_type', 'credentialType');
+      mapping.put(parentLabel + 'client_id', 'clientId');
+      mapping.put(parentLabel + 'enterprise_id', 'enterpriseId');
+      mapping.put(parentLabel + 'organization_url', 'organizationUrl');
+      mapping.put(parentLabel + 'site_collection.path', 'siteCollectionPath');
+      mapping.put(parentLabel + 'client_secret', 'clientSecret');
+      mapping.put(parentLabel + 'public_key_id', 'publicKeyId');
+      mapping.put(parentLabel + 'private_key', 'privateKey');
+      mapping.put(parentLabel + 'gateway_id', 'gatewayId');
+      mapping.put(parentLabel + 'source_version', 'sourceVersion');
+      mapping.put(parentLabel + 'web_application_url', 'webApplicationUrl');
+      mapping.put(parentLabel + 'access_key_id', 'accessKeyId');
+      mapping.put(parentLabel + 'secret_access_key', 'secretAccessKey');
       return mapping;
     }
   }
@@ -4165,7 +4153,7 @@ public class IBMDiscoveryV1Models {
      * @param credentialType the credentialType
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setCredentialType(String credentialType) {
+    public CredentialDetailsBuilder credentialType(String credentialType) {
       this.credentialType = credentialType;
       return this;
     }
@@ -4176,7 +4164,7 @@ public class IBMDiscoveryV1Models {
      * @param clientId the clientId
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setClientId(String clientId) {
+    public CredentialDetailsBuilder clientId(String clientId) {
       this.clientId = clientId;
       return this;
     }
@@ -4187,7 +4175,7 @@ public class IBMDiscoveryV1Models {
      * @param enterpriseId the enterpriseId
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setEnterpriseId(String enterpriseId) {
+    public CredentialDetailsBuilder enterpriseId(String enterpriseId) {
       this.enterpriseId = enterpriseId;
       return this;
     }
@@ -4198,7 +4186,7 @@ public class IBMDiscoveryV1Models {
      * @param url the url
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setUrl(String url) {
+    public CredentialDetailsBuilder url(String url) {
       this.url = url;
       return this;
     }
@@ -4209,7 +4197,7 @@ public class IBMDiscoveryV1Models {
      * @param username the username
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setUsername(String username) {
+    public CredentialDetailsBuilder username(String username) {
       this.username = username;
       return this;
     }
@@ -4220,7 +4208,7 @@ public class IBMDiscoveryV1Models {
      * @param organizationUrl the organizationUrl
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setOrganizationUrl(String organizationUrl) {
+    public CredentialDetailsBuilder organizationUrl(String organizationUrl) {
       this.organizationUrl = organizationUrl;
       return this;
     }
@@ -4231,7 +4219,7 @@ public class IBMDiscoveryV1Models {
      * @param siteCollectionPath the siteCollectionPath
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setSiteCollectionPath(String siteCollectionPath) {
+    public CredentialDetailsBuilder siteCollectionPath(String siteCollectionPath) {
       this.siteCollectionPath = siteCollectionPath;
       return this;
     }
@@ -4242,7 +4230,7 @@ public class IBMDiscoveryV1Models {
      * @param clientSecret the clientSecret
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setClientSecret(String clientSecret) {
+    public CredentialDetailsBuilder clientSecret(String clientSecret) {
       this.clientSecret = clientSecret;
       return this;
     }
@@ -4253,7 +4241,7 @@ public class IBMDiscoveryV1Models {
      * @param publicKeyId the publicKeyId
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setPublicKeyId(String publicKeyId) {
+    public CredentialDetailsBuilder publicKeyId(String publicKeyId) {
       this.publicKeyId = publicKeyId;
       return this;
     }
@@ -4264,7 +4252,7 @@ public class IBMDiscoveryV1Models {
      * @param privateKey the privateKey
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setPrivateKey(String privateKey) {
+    public CredentialDetailsBuilder privateKey(String privateKey) {
       this.privateKey = privateKey;
       return this;
     }
@@ -4275,7 +4263,7 @@ public class IBMDiscoveryV1Models {
      * @param passphrase the passphrase
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setPassphrase(String passphrase) {
+    public CredentialDetailsBuilder passphrase(String passphrase) {
       this.passphrase = passphrase;
       return this;
     }
@@ -4286,7 +4274,7 @@ public class IBMDiscoveryV1Models {
      * @param password the password
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setPassword(String password) {
+    public CredentialDetailsBuilder password(String password) {
       this.password = password;
       return this;
     }
@@ -4297,7 +4285,7 @@ public class IBMDiscoveryV1Models {
      * @param gatewayId the gatewayId
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setGatewayId(String gatewayId) {
+    public CredentialDetailsBuilder gatewayId(String gatewayId) {
       this.gatewayId = gatewayId;
       return this;
     }
@@ -4308,7 +4296,7 @@ public class IBMDiscoveryV1Models {
      * @param sourceVersion the sourceVersion
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setSourceVersion(String sourceVersion) {
+    public CredentialDetailsBuilder sourceVersion(String sourceVersion) {
       this.sourceVersion = sourceVersion;
       return this;
     }
@@ -4319,7 +4307,7 @@ public class IBMDiscoveryV1Models {
      * @param webApplicationUrl the webApplicationUrl
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setWebApplicationUrl(String webApplicationUrl) {
+    public CredentialDetailsBuilder webApplicationUrl(String webApplicationUrl) {
       this.webApplicationUrl = webApplicationUrl;
       return this;
     }
@@ -4330,7 +4318,7 @@ public class IBMDiscoveryV1Models {
      * @param domain the domain
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setDomain(String domain) {
+    public CredentialDetailsBuilder domain(String domain) {
       this.domain = domain;
       return this;
     }
@@ -4341,7 +4329,7 @@ public class IBMDiscoveryV1Models {
      * @param endpoint the endpoint
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setEndpoint(String endpoint) {
+    public CredentialDetailsBuilder endpoint(String endpoint) {
       this.endpoint = endpoint;
       return this;
     }
@@ -4352,7 +4340,7 @@ public class IBMDiscoveryV1Models {
      * @param accessKeyId the accessKeyId
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setAccessKeyId(String accessKeyId) {
+    public CredentialDetailsBuilder accessKeyId(String accessKeyId) {
       this.accessKeyId = accessKeyId;
       return this;
     }
@@ -4363,7 +4351,7 @@ public class IBMDiscoveryV1Models {
      * @param secretAccessKey the secretAccessKey
      * @return the CredentialDetails builder
      */
-    public CredentialDetailsBuilder setSecretAccessKey(String secretAccessKey) {
+    public CredentialDetailsBuilder secretAccessKey(String secretAccessKey) {
       this.secretAccessKey = secretAccessKey;
       return this;
     }
@@ -4383,7 +4371,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public Credentials() { }
- 
+
     /**
      * Gets the credentialId.
      *
@@ -4395,7 +4383,7 @@ public class IBMDiscoveryV1Models {
     public String getCredentialId() {
       return credentialId;
     }
- 
+
     /**
      * Gets the sourceType.
      *
@@ -4412,7 +4400,7 @@ public class IBMDiscoveryV1Models {
     public String getSourceType() {
       return sourceType;
     }
- 
+
     /**
      * Gets the credentialDetails.
      *
@@ -4426,7 +4414,7 @@ public class IBMDiscoveryV1Models {
     public CredentialDetails getCredentialDetails() {
       return credentialDetails;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -4467,30 +4455,34 @@ public class IBMDiscoveryV1Models {
 
       // calling custom deserializer for credentialDetails
       CredentialDetails newCredentialDetails = (CredentialDetails) new CredentialDetails().deserialize(JSON.serialize(ret.getCredentialDetails()), (Map<String, Object>) jsonMap.get('credentialDetails'), CredentialDetails.class);
-      retBuilder.setCredentialDetails(newCredentialDetails);
+      retBuilder.credentialDetails(newCredentialDetails);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('credentialId', 'credential_id');
-      mapping.put('sourceType', 'source_type');
-      mapping.put('credentialDetails', 'credential_details');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'credentialId', 'credential_id');
+      mapping.put(parentLabel + 'sourceType', 'source_type');
+      mapping.put(parentLabel + 'credentialDetails', 'credential_details');
       if (credentialDetails != null) {
-        mapping.putAll(credentialDetails.getSdkToApiMapping());
+        mapping.putAll(credentialDetails.addToSdkToApiMapping(parentLabel + 'credentialDetails/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('credential_id', 'credentialId');
-      mapping.put('source_type', 'sourceType');
-      mapping.put('credential_details', 'credentialDetails');
-      if (credentialDetails != null) {
-        mapping.putAll(credentialDetails.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'credential_id', 'credentialId');
+      mapping.put(parentLabel + 'source_type', 'sourceType');
+      mapping.put(parentLabel + 'credential_details', 'credentialDetails');
+      mapping.putAll(((IBMWatsonGenericModel) CredentialDetails.class.newInstance()).addToApiToSdkMapping(parentLabel + 'credential_details/', mapping));
       return mapping;
     }
   }
@@ -4532,7 +4524,7 @@ public class IBMDiscoveryV1Models {
      * @param credentialId the credentialId
      * @return the Credentials builder
      */
-    public CredentialsBuilder setCredentialId(String credentialId) {
+    public CredentialsBuilder credentialId(String credentialId) {
       this.credentialId = credentialId;
       return this;
     }
@@ -4543,7 +4535,7 @@ public class IBMDiscoveryV1Models {
      * @param sourceType the sourceType
      * @return the Credentials builder
      */
-    public CredentialsBuilder setSourceType(String sourceType) {
+    public CredentialsBuilder sourceType(String sourceType) {
       this.sourceType = sourceType;
       return this;
     }
@@ -4554,7 +4546,7 @@ public class IBMDiscoveryV1Models {
      * @param credentialDetails the credentialDetails
      * @return the Credentials builder
      */
-    public CredentialsBuilder setCredentialDetails(CredentialDetails credentialDetails) {
+    public CredentialsBuilder credentialDetails(CredentialDetails credentialDetails) {
       this.credentialDetails = credentialDetails;
       return this;
     }
@@ -4565,7 +4557,7 @@ public class IBMDiscoveryV1Models {
      * @param status the status
      * @return the Credentials builder
      */
-    public CredentialsBuilder setStatus(String status) {
+    public CredentialsBuilder status(String status) {
       this.status = status;
       return this;
     }
@@ -4576,7 +4568,7 @@ public class IBMDiscoveryV1Models {
    */
   public class CredentialsList extends IBMWatsonResponseModel {
     private List<Credentials> credentials;
- 
+
     /**
      * Gets the credentials.
      *
@@ -4621,11 +4613,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (credentials != null && credentials[0] != null) {
-        mapping.putAll(credentials[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Credentials.class.newInstance()).addToApiToSdkMapping(parentLabel + 'credentials/', mapping));
       return mapping;
     }
   }
@@ -6360,7 +6349,7 @@ public class IBMDiscoveryV1Models {
   public class DiskUsage extends IBMWatsonGenericModel {
     private Long usedBytes;
     private Long maximumAllowedBytes;
- 
+
     /**
      * Gets the usedBytes.
      *
@@ -6372,7 +6361,7 @@ public class IBMDiscoveryV1Models {
     public Long getUsedBytes() {
       return usedBytes;
     }
- 
+
     /**
      * Gets the maximumAllowedBytes.
      *
@@ -6385,10 +6374,13 @@ public class IBMDiscoveryV1Models {
       return maximumAllowedBytes;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('used_bytes', 'usedBytes');
-      mapping.put('maximum_allowed_bytes', 'maximumAllowedBytes');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'used_bytes', 'usedBytes');
+      mapping.put(parentLabel + 'maximum_allowed_bytes', 'maximumAllowedBytes');
       return mapping;
     }
   }
@@ -6400,7 +6392,7 @@ public class IBMDiscoveryV1Models {
     private String documentId;
     private String status;
     private List<Notice> notices;
- 
+
     /**
      * Gets the documentId.
      *
@@ -6412,7 +6404,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -6425,7 +6417,7 @@ public class IBMDiscoveryV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the notices.
      *
@@ -6488,12 +6480,13 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_id', 'documentId');
-      if (notices != null && notices[0] != null) {
-        mapping.putAll(notices[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.putAll(((IBMWatsonGenericModel) Notice.class.newInstance()).addToApiToSdkMapping(parentLabel + 'notices/', mapping));
       return mapping;
     }
   }
@@ -6506,7 +6499,7 @@ public class IBMDiscoveryV1Models {
     private Long processing;
     private Long failed;
     private Long pending;
- 
+
     /**
      * Gets the available.
      *
@@ -6518,7 +6511,7 @@ public class IBMDiscoveryV1Models {
     public Long getAvailable() {
       return available;
     }
- 
+
     /**
      * Gets the processing.
      *
@@ -6530,7 +6523,7 @@ public class IBMDiscoveryV1Models {
     public Long getProcessing() {
       return processing;
     }
- 
+
     /**
      * Gets the failed.
      *
@@ -6542,7 +6535,7 @@ public class IBMDiscoveryV1Models {
     public Long getFailed() {
       return failed;
     }
- 
+
     /**
      * Gets the pending.
      *
@@ -6562,7 +6555,7 @@ public class IBMDiscoveryV1Models {
   public class DocumentSnapshot extends IBMWatsonGenericModel {
     private String step;
     private IBMWatsonMapModel snapshot;
- 
+
     /**
      * Gets the step.
      *
@@ -6574,7 +6567,7 @@ public class IBMDiscoveryV1Models {
     public String getStep() {
       return step;
     }
- 
+
     /**
      * Gets the snapshot.
      *
@@ -6632,7 +6625,7 @@ public class IBMDiscoveryV1Models {
     private String fileType;
     private String sha1;
     private List<Notice> notices;
- 
+
     /**
      * Gets the documentId.
      *
@@ -6644,7 +6637,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the configurationId.
      *
@@ -6656,7 +6649,7 @@ public class IBMDiscoveryV1Models {
     public String getConfigurationId() {
       return configurationId;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -6668,7 +6661,7 @@ public class IBMDiscoveryV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the statusDescription.
      *
@@ -6680,7 +6673,7 @@ public class IBMDiscoveryV1Models {
     public String getStatusDescription() {
       return statusDescription;
     }
- 
+
     /**
      * Gets the filename.
      *
@@ -6692,7 +6685,7 @@ public class IBMDiscoveryV1Models {
     public String getFilename() {
       return filename;
     }
- 
+
     /**
      * Gets the fileType.
      *
@@ -6704,7 +6697,7 @@ public class IBMDiscoveryV1Models {
     public String getFileType() {
       return fileType;
     }
- 
+
     /**
      * Gets the sha1.
      *
@@ -6716,7 +6709,7 @@ public class IBMDiscoveryV1Models {
     public String getSha1() {
       return sha1;
     }
- 
+
     /**
      * Gets the notices.
      *
@@ -6779,15 +6772,16 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_id', 'documentId');
-      mapping.put('configuration_id', 'configurationId');
-      mapping.put('status_description', 'statusDescription');
-      mapping.put('file_type', 'fileType');
-      if (notices != null && notices[0] != null) {
-        mapping.putAll(notices[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.put(parentLabel + 'configuration_id', 'configurationId');
+      mapping.put(parentLabel + 'status_description', 'statusDescription');
+      mapping.put(parentLabel + 'file_type', 'fileType');
+      mapping.putAll(((IBMWatsonGenericModel) Notice.class.newInstance()).addToApiToSdkMapping(parentLabel + 'notices/', mapping));
       return mapping;
     }
   }
@@ -6809,7 +6803,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public Enrichment() { }
- 
+
     /**
      * Gets the description.
      *
@@ -6821,7 +6815,7 @@ public class IBMDiscoveryV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the destinationField.
      *
@@ -6835,7 +6829,7 @@ public class IBMDiscoveryV1Models {
     public String getDestinationField() {
       return destinationField;
     }
- 
+
     /**
      * Gets the sourceField.
      *
@@ -6850,7 +6844,7 @@ public class IBMDiscoveryV1Models {
     public String getSourceField() {
       return sourceField;
     }
- 
+
     /**
      * Gets the overwrite.
      *
@@ -6862,7 +6856,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getOverwrite() {
       return overwrite;
     }
- 
+
     /**
      * Gets the enrichmentName.
      *
@@ -6882,7 +6876,7 @@ public class IBMDiscoveryV1Models {
     public String getEnrichmentName() {
       return enrichmentName;
     }
- 
+
     /**
      * Gets the ignoreDownstreamErrors.
      *
@@ -6895,7 +6889,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getIgnoreDownstreamErrors() {
       return ignoreDownstreamErrors;
     }
- 
+
     /**
      * Gets the options.
      *
@@ -6940,32 +6934,28 @@ public class IBMDiscoveryV1Models {
 
       // calling custom deserializer for options
       EnrichmentOptions newOptions = (EnrichmentOptions) new EnrichmentOptions().deserialize(JSON.serialize(ret.getOptions()), (Map<String, Object>) jsonMap.get('options'), EnrichmentOptions.class);
-      retBuilder.setOptions(newOptions);
+      retBuilder.options(newOptions);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('destinationField', 'destination_field');
-      mapping.put('sourceField', 'source_field');
-      mapping.put('enrichmentName', 'enrichment');
-      mapping.put('ignoreDownstreamErrors', 'ignore_downstream_errors');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'destinationField', 'destination_field');
+      mapping.put(parentLabel + 'sourceField', 'source_field');
+      mapping.put(parentLabel + 'enrichmentName', 'enrichment');
+      mapping.put(parentLabel + 'ignoreDownstreamErrors', 'ignore_downstream_errors');
       if (options != null) {
-        mapping.putAll(options.getSdkToApiMapping());
+        mapping.putAll(options.addToSdkToApiMapping(parentLabel + 'options/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('destination_field', 'destinationField');
-      mapping.put('source_field', 'sourceField');
-      mapping.put('enrichment', 'enrichmentName');
-      mapping.put('ignore_downstream_errors', 'ignoreDownstreamErrors');
-      if (options != null) {
-        mapping.putAll(options.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'destination_field', 'destinationField');
+      mapping.put(parentLabel + 'source_field', 'sourceField');
+      mapping.put(parentLabel + 'enrichment', 'enrichmentName');
+      mapping.put(parentLabel + 'ignore_downstream_errors', 'ignoreDownstreamErrors');
+      mapping.putAll(((IBMWatsonGenericModel) EnrichmentOptions.class.newInstance()).addToApiToSdkMapping(parentLabel + 'options/', mapping));
       return mapping;
     }
   }
@@ -7026,7 +7016,7 @@ public class IBMDiscoveryV1Models {
      * @param description the description
      * @return the Enrichment builder
      */
-    public EnrichmentBuilder setDescription(String description) {
+    public EnrichmentBuilder description(String description) {
       this.description = description;
       return this;
     }
@@ -7037,7 +7027,7 @@ public class IBMDiscoveryV1Models {
      * @param destinationField the destinationField
      * @return the Enrichment builder
      */
-    public EnrichmentBuilder setDestinationField(String destinationField) {
+    public EnrichmentBuilder destinationField(String destinationField) {
       this.destinationField = destinationField;
       return this;
     }
@@ -7048,7 +7038,7 @@ public class IBMDiscoveryV1Models {
      * @param sourceField the sourceField
      * @return the Enrichment builder
      */
-    public EnrichmentBuilder setSourceField(String sourceField) {
+    public EnrichmentBuilder sourceField(String sourceField) {
       this.sourceField = sourceField;
       return this;
     }
@@ -7059,7 +7049,7 @@ public class IBMDiscoveryV1Models {
      * @param overwrite the overwrite
      * @return the Enrichment builder
      */
-    public EnrichmentBuilder setOverwrite(Boolean overwrite) {
+    public EnrichmentBuilder overwrite(Boolean overwrite) {
       this.overwrite = overwrite;
       return this;
     }
@@ -7070,7 +7060,7 @@ public class IBMDiscoveryV1Models {
      * @param enrichmentName the enrichmentName
      * @return the Enrichment builder
      */
-    public EnrichmentBuilder setEnrichmentName(String enrichmentName) {
+    public EnrichmentBuilder enrichmentName(String enrichmentName) {
       this.enrichmentName = enrichmentName;
       return this;
     }
@@ -7081,7 +7071,7 @@ public class IBMDiscoveryV1Models {
      * @param ignoreDownstreamErrors the ignoreDownstreamErrors
      * @return the Enrichment builder
      */
-    public EnrichmentBuilder setIgnoreDownstreamErrors(Boolean ignoreDownstreamErrors) {
+    public EnrichmentBuilder ignoreDownstreamErrors(Boolean ignoreDownstreamErrors) {
       this.ignoreDownstreamErrors = ignoreDownstreamErrors;
       return this;
     }
@@ -7092,7 +7082,7 @@ public class IBMDiscoveryV1Models {
      * @param options the options
      * @return the Enrichment builder
      */
-    public EnrichmentBuilder setOptions(EnrichmentOptions options) {
+    public EnrichmentBuilder options(EnrichmentOptions options) {
       this.options = options;
       return this;
     }
@@ -7111,7 +7101,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public EnrichmentOptions() { }
- 
+
     /**
      * Gets the features.
      *
@@ -7121,7 +7111,7 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentFeatures getFeatures() {
       return features;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -7136,7 +7126,7 @@ public class IBMDiscoveryV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -7180,19 +7170,15 @@ public class IBMDiscoveryV1Models {
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (features != null) {
-        mapping.putAll(features.getSdkToApiMapping());
+        mapping.putAll(features.addToSdkToApiMapping(parentLabel + 'features/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (features != null) {
-        mapping.putAll(features.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) NluEnrichmentFeatures.class.newInstance()).addToApiToSdkMapping(parentLabel + 'features/', mapping));
       return mapping;
     }
   }
@@ -7275,7 +7261,7 @@ public class IBMDiscoveryV1Models {
     private String requestedSize;
     private IndexCapacity indexCapacity;
     private SearchStatus searchStatus;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -7287,7 +7273,7 @@ public class IBMDiscoveryV1Models {
     public String getEnvironmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -7299,7 +7285,7 @@ public class IBMDiscoveryV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -7311,7 +7297,7 @@ public class IBMDiscoveryV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -7323,7 +7309,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -7335,7 +7321,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getUpdated() {
       return updated;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -7348,7 +7334,7 @@ public class IBMDiscoveryV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the readOnly.
      *
@@ -7360,7 +7346,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getReadOnly() {
       return readOnly;
     }
- 
+
     /**
      * Gets the size.
      *
@@ -7372,7 +7358,7 @@ public class IBMDiscoveryV1Models {
     public String getSize() {
       return size;
     }
- 
+
     /**
      * Gets the requestedSize.
      *
@@ -7386,7 +7372,7 @@ public class IBMDiscoveryV1Models {
     public String getRequestedSize() {
       return requestedSize;
     }
- 
+
     /**
      * Gets the indexCapacity.
      *
@@ -7398,7 +7384,7 @@ public class IBMDiscoveryV1Models {
     public IndexCapacity getIndexCapacity() {
       return indexCapacity;
     }
- 
+
     /**
      * Gets the searchStatus.
      *
@@ -7483,19 +7469,18 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('environment_id', 'environmentId');
-      mapping.put('read_only', 'readOnly');
-      mapping.put('requested_size', 'requestedSize');
-      mapping.put('index_capacity', 'indexCapacity');
-      if (indexCapacity != null) {
-        mapping.putAll(indexCapacity.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('search_status', 'searchStatus');
-      if (searchStatus != null) {
-        mapping.putAll(searchStatus.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'environment_id', 'environmentId');
+      mapping.put(parentLabel + 'read_only', 'readOnly');
+      mapping.put(parentLabel + 'requested_size', 'requestedSize');
+      mapping.put(parentLabel + 'index_capacity', 'indexCapacity');
+      mapping.putAll(((IBMWatsonGenericModel) IndexCapacity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'index_capacity/', mapping));
+      mapping.put(parentLabel + 'search_status', 'searchStatus');
+      mapping.putAll(((IBMWatsonGenericModel) SearchStatus.class.newInstance()).addToApiToSdkMapping(parentLabel + 'search_status/', mapping));
       return mapping;
     }
   }
@@ -7506,7 +7491,7 @@ public class IBMDiscoveryV1Models {
   public class EnvironmentDocuments extends IBMWatsonGenericModel {
     private Long indexed;
     private Long maximumAllowed;
- 
+
     /**
      * Gets the indexed.
      *
@@ -7518,7 +7503,7 @@ public class IBMDiscoveryV1Models {
     public Long getIndexed() {
       return indexed;
     }
- 
+
     /**
      * Gets the maximumAllowed.
      *
@@ -7531,9 +7516,8 @@ public class IBMDiscoveryV1Models {
       return maximumAllowed;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('maximum_allowed', 'maximumAllowed');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'maximum_allowed', 'maximumAllowed');
       return mapping;
     }
   }
@@ -7555,7 +7539,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public EventData() { }
- 
+
     /**
      * Gets the environmentId.
      *
@@ -7567,7 +7551,7 @@ public class IBMDiscoveryV1Models {
     public String getEnvironmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the sessionToken.
      *
@@ -7579,7 +7563,7 @@ public class IBMDiscoveryV1Models {
     public String getSessionToken() {
       return sessionToken;
     }
- 
+
     /**
      * Gets the clientTimestamp.
      *
@@ -7592,7 +7576,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getClientTimestamp() {
       return clientTimestamp;
     }
- 
+
     /**
      * Gets the displayRank.
      *
@@ -7604,7 +7588,7 @@ public class IBMDiscoveryV1Models {
     public Long getDisplayRank() {
       return displayRank;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -7616,7 +7600,7 @@ public class IBMDiscoveryV1Models {
     public String getCollectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the documentId.
      *
@@ -7628,7 +7612,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -7665,27 +7649,33 @@ public class IBMDiscoveryV1Models {
       return new EventDataBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('environmentId', 'environment_id');
-      mapping.put('sessionToken', 'session_token');
-      mapping.put('clientTimestamp', 'client_timestamp');
-      mapping.put('displayRank', 'display_rank');
-      mapping.put('collectionId', 'collection_id');
-      mapping.put('documentId', 'document_id');
-      mapping.put('queryId', 'query_id');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'environmentId', 'environment_id');
+      mapping.put(parentLabel + 'sessionToken', 'session_token');
+      mapping.put(parentLabel + 'clientTimestamp', 'client_timestamp');
+      mapping.put(parentLabel + 'displayRank', 'display_rank');
+      mapping.put(parentLabel + 'collectionId', 'collection_id');
+      mapping.put(parentLabel + 'documentId', 'document_id');
+      mapping.put(parentLabel + 'queryId', 'query_id');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('environment_id', 'environmentId');
-      mapping.put('session_token', 'sessionToken');
-      mapping.put('client_timestamp', 'clientTimestamp');
-      mapping.put('display_rank', 'displayRank');
-      mapping.put('collection_id', 'collectionId');
-      mapping.put('document_id', 'documentId');
-      mapping.put('query_id', 'queryId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'environment_id', 'environmentId');
+      mapping.put(parentLabel + 'session_token', 'sessionToken');
+      mapping.put(parentLabel + 'client_timestamp', 'clientTimestamp');
+      mapping.put(parentLabel + 'display_rank', 'displayRank');
+      mapping.put(parentLabel + 'collection_id', 'collectionId');
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.put(parentLabel + 'query_id', 'queryId');
       return mapping;
     }
   }
@@ -7748,7 +7738,7 @@ public class IBMDiscoveryV1Models {
      * @param environmentId the environmentId
      * @return the EventData builder
      */
-    public EventDataBuilder setEnvironmentId(String environmentId) {
+    public EventDataBuilder environmentId(String environmentId) {
       this.environmentId = environmentId;
       return this;
     }
@@ -7759,7 +7749,7 @@ public class IBMDiscoveryV1Models {
      * @param sessionToken the sessionToken
      * @return the EventData builder
      */
-    public EventDataBuilder setSessionToken(String sessionToken) {
+    public EventDataBuilder sessionToken(String sessionToken) {
       this.sessionToken = sessionToken;
       return this;
     }
@@ -7770,7 +7760,7 @@ public class IBMDiscoveryV1Models {
      * @param clientTimestamp the clientTimestamp
      * @return the EventData builder
      */
-    public EventDataBuilder setClientTimestamp(Datetime clientTimestamp) {
+    public EventDataBuilder clientTimestamp(Datetime clientTimestamp) {
       this.clientTimestamp = clientTimestamp;
       return this;
     }
@@ -7781,7 +7771,7 @@ public class IBMDiscoveryV1Models {
      * @param displayRank the displayRank
      * @return the EventData builder
      */
-    public EventDataBuilder setDisplayRank(Long displayRank) {
+    public EventDataBuilder displayRank(Long displayRank) {
       this.displayRank = displayRank;
       return this;
     }
@@ -7792,7 +7782,7 @@ public class IBMDiscoveryV1Models {
      * @param collectionId the collectionId
      * @return the EventData builder
      */
-    public EventDataBuilder setCollectionId(String collectionId) {
+    public EventDataBuilder collectionId(String collectionId) {
       this.collectionId = collectionId;
       return this;
     }
@@ -7803,7 +7793,7 @@ public class IBMDiscoveryV1Models {
      * @param documentId the documentId
      * @return the EventData builder
      */
-    public EventDataBuilder setDocumentId(String documentId) {
+    public EventDataBuilder documentId(String documentId) {
       this.documentId = documentId;
       return this;
     }
@@ -7814,7 +7804,7 @@ public class IBMDiscoveryV1Models {
      * @param queryId the queryId
      * @return the EventData builder
      */
-    public EventDataBuilder setQueryId(String queryId) {
+    public EventDataBuilder queryId(String queryId) {
       this.queryId = queryId;
       return this;
     }
@@ -7833,7 +7823,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public Expansion() { }
- 
+
     /**
      * Gets the inputTerms.
      *
@@ -7845,7 +7835,7 @@ public class IBMDiscoveryV1Models {
     public List<String> getInputTerms() {
       return inputTerms;
     }
- 
+
     /**
      * Gets the expandedTerms.
      *
@@ -7874,17 +7864,23 @@ public class IBMDiscoveryV1Models {
       return new ExpansionBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('inputTerms', 'input_terms');
-      mapping.put('expandedTerms', 'expanded_terms');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'inputTerms', 'input_terms');
+      mapping.put(parentLabel + 'expandedTerms', 'expanded_terms');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('input_terms', 'inputTerms');
-      mapping.put('expanded_terms', 'expandedTerms');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'input_terms', 'inputTerms');
+      mapping.put(parentLabel + 'expanded_terms', 'expandedTerms');
       return mapping;
     }
   }
@@ -7962,7 +7958,7 @@ public class IBMDiscoveryV1Models {
      * @param inputTerms the inputTerms
      * @return the Expansion builder
      */
-    public ExpansionBuilder setInputTerms(List<String> inputTerms) {
+    public ExpansionBuilder inputTerms(List<String> inputTerms) {
       this.inputTerms = inputTerms;
       return this;
     }
@@ -7974,7 +7970,7 @@ public class IBMDiscoveryV1Models {
      * @param expandedTerms the expandedTerms
      * @return the Expansion builder
      */
-    public ExpansionBuilder setExpandedTerms(List<String> expandedTerms) {
+    public ExpansionBuilder expandedTerms(List<String> expandedTerms) {
       this.expandedTerms = expandedTerms;
       return this;
     }
@@ -7991,7 +7987,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public Expansions() { }
- 
+
     /**
      * Gets the expansions.
      *
@@ -8048,25 +8044,21 @@ public class IBMDiscoveryV1Models {
           Expansion newItem = (Expansion) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Expansion.class);
           newExpansions.add(newItem);
         }
-        retBuilder.setExpansions(newExpansions);
+        retBuilder.expansions(newExpansions);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (expansions != null && expansions[0] != null) {
-        mapping.putAll(expansions[0].getSdkToApiMapping());
+        mapping.putAll(expansions[0].addToSdkToApiMapping(parentLabel + 'expansions/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (expansions != null && expansions[0] != null) {
-        mapping.putAll(expansions[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Expansion.class.newInstance()).addToApiToSdkMapping(parentLabel + 'expansions/', mapping));
       return mapping;
     }
   }
@@ -8127,7 +8119,7 @@ public class IBMDiscoveryV1Models {
      * @param expansions the expansions
      * @return the Expansions builder
      */
-    public ExpansionsBuilder setExpansions(List<Expansion> expansions) {
+    public ExpansionsBuilder expansions(List<Expansion> expansions) {
       this.expansions = expansions;
       return this;
     }
@@ -9390,7 +9382,7 @@ public class IBMDiscoveryV1Models {
   public class Field extends IBMWatsonGenericModel {
     private String fieldName;
     private String fieldType;
- 
+
     /**
      * Gets the fieldName.
      *
@@ -9402,7 +9394,7 @@ public class IBMDiscoveryV1Models {
     public String getFieldName() {
       return fieldName;
     }
- 
+
     /**
      * Gets the fieldType.
      *
@@ -9415,10 +9407,13 @@ public class IBMDiscoveryV1Models {
       return fieldType;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('field', 'fieldName');
-      mapping.put('type', 'fieldType');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'field', 'fieldName');
+      mapping.put(parentLabel + 'type', 'fieldType');
       return mapping;
     }
   }
@@ -9439,7 +9434,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public FontSetting() { }
- 
+
     /**
      * Gets the level.
      *
@@ -9451,7 +9446,7 @@ public class IBMDiscoveryV1Models {
     public Long getLevel() {
       return level;
     }
- 
+
     /**
      * Gets the minSize.
      *
@@ -9463,7 +9458,7 @@ public class IBMDiscoveryV1Models {
     public Long getMinSize() {
       return minSize;
     }
- 
+
     /**
      * Gets the maxSize.
      *
@@ -9475,7 +9470,7 @@ public class IBMDiscoveryV1Models {
     public Long getMaxSize() {
       return maxSize;
     }
- 
+
     /**
      * Gets the bold.
      *
@@ -9487,7 +9482,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getBold() {
       return bold;
     }
- 
+
     /**
      * Gets the italic.
      *
@@ -9499,7 +9494,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getItalic() {
       return italic;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -9530,17 +9525,15 @@ public class IBMDiscoveryV1Models {
       return new FontSettingBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('minSize', 'min_size');
-      mapping.put('maxSize', 'max_size');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'minSize', 'min_size');
+      mapping.put(parentLabel + 'maxSize', 'max_size');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('min_size', 'minSize');
-      mapping.put('max_size', 'maxSize');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'min_size', 'minSize');
+      mapping.put(parentLabel + 'max_size', 'maxSize');
       return mapping;
     }
   }
@@ -9586,7 +9579,7 @@ public class IBMDiscoveryV1Models {
      * @param level the level
      * @return the FontSetting builder
      */
-    public FontSettingBuilder setLevel(Long level) {
+    public FontSettingBuilder level(Long level) {
       this.level = level;
       return this;
     }
@@ -9597,7 +9590,7 @@ public class IBMDiscoveryV1Models {
      * @param minSize the minSize
      * @return the FontSetting builder
      */
-    public FontSettingBuilder setMinSize(Long minSize) {
+    public FontSettingBuilder minSize(Long minSize) {
       this.minSize = minSize;
       return this;
     }
@@ -9608,7 +9601,7 @@ public class IBMDiscoveryV1Models {
      * @param maxSize the maxSize
      * @return the FontSetting builder
      */
-    public FontSettingBuilder setMaxSize(Long maxSize) {
+    public FontSettingBuilder maxSize(Long maxSize) {
       this.maxSize = maxSize;
       return this;
     }
@@ -9619,7 +9612,7 @@ public class IBMDiscoveryV1Models {
      * @param bold the bold
      * @return the FontSetting builder
      */
-    public FontSettingBuilder setBold(Boolean bold) {
+    public FontSettingBuilder bold(Boolean bold) {
       this.bold = bold;
       return this;
     }
@@ -9630,7 +9623,7 @@ public class IBMDiscoveryV1Models {
      * @param italic the italic
      * @return the FontSetting builder
      */
-    public FontSettingBuilder setItalic(Boolean italic) {
+    public FontSettingBuilder italic(Boolean italic) {
       this.italic = italic;
       return this;
     }
@@ -9641,7 +9634,7 @@ public class IBMDiscoveryV1Models {
      * @param name the name
      * @return the FontSetting builder
      */
-    public FontSettingBuilder setName(String name) {
+    public FontSettingBuilder name(String name) {
       this.name = name;
       return this;
     }
@@ -9656,7 +9649,7 @@ public class IBMDiscoveryV1Models {
     private String status;
     private String token;
     private String tokenId;
- 
+
     /**
      * Gets the gatewayId.
      *
@@ -9668,7 +9661,7 @@ public class IBMDiscoveryV1Models {
     public String getGatewayId() {
       return gatewayId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -9680,7 +9673,7 @@ public class IBMDiscoveryV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -9693,7 +9686,7 @@ public class IBMDiscoveryV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the token.
      *
@@ -9706,7 +9699,7 @@ public class IBMDiscoveryV1Models {
     public String getToken() {
       return token;
     }
- 
+
     /**
      * Gets the tokenId.
      *
@@ -9765,10 +9758,13 @@ public class IBMDiscoveryV1Models {
       this.tokenId = tokenId;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('gateway_id', 'gatewayId');
-      mapping.put('token_id', 'tokenId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'gateway_id', 'gatewayId');
+      mapping.put(parentLabel + 'token_id', 'tokenId');
       return mapping;
     }
   }
@@ -9778,7 +9774,7 @@ public class IBMDiscoveryV1Models {
    */
   public class GatewayList extends IBMWatsonResponseModel {
     private List<Gateway> gateways;
- 
+
     /**
      * Gets the gateways.
      *
@@ -9823,11 +9819,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (gateways != null && gateways[0] != null) {
-        mapping.putAll(gateways[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Gateway.class.newInstance()).addToApiToSdkMapping(parentLabel + 'gateways/', mapping));
       return mapping;
     }
   }
@@ -11869,7 +11862,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public HtmlSettings() { }
- 
+
     /**
      * Gets the excludeTagsCompletely.
      *
@@ -11881,7 +11874,7 @@ public class IBMDiscoveryV1Models {
     public List<String> getExcludeTagsCompletely() {
       return excludeTagsCompletely;
     }
- 
+
     /**
      * Gets the excludeTagsKeepContent.
      *
@@ -11893,7 +11886,7 @@ public class IBMDiscoveryV1Models {
     public List<String> getExcludeTagsKeepContent() {
       return excludeTagsKeepContent;
     }
- 
+
     /**
      * Gets the keepContent.
      *
@@ -11903,7 +11896,7 @@ public class IBMDiscoveryV1Models {
     public XPathPatterns getKeepContent() {
       return keepContent;
     }
- 
+
     /**
      * Gets the excludeContent.
      *
@@ -11913,7 +11906,7 @@ public class IBMDiscoveryV1Models {
     public XPathPatterns getExcludeContent() {
       return excludeContent;
     }
- 
+
     /**
      * Gets the keepTagAttributes.
      *
@@ -11925,7 +11918,7 @@ public class IBMDiscoveryV1Models {
     public List<String> getKeepTagAttributes() {
       return keepTagAttributes;
     }
- 
+
     /**
      * Gets the excludeTagAttributes.
      *
@@ -11966,34 +11959,40 @@ public class IBMDiscoveryV1Models {
 
       // calling custom deserializer for keepContent
       XPathPatterns newKeepContent = (XPathPatterns) new XPathPatterns().deserialize(JSON.serialize(ret.getKeepContent()), (Map<String, Object>) jsonMap.get('keepContent'), XPathPatterns.class);
-      retBuilder.setKeepContent(newKeepContent);
+      retBuilder.keepContent(newKeepContent);
 
       // calling custom deserializer for excludeContent
       XPathPatterns newExcludeContent = (XPathPatterns) new XPathPatterns().deserialize(JSON.serialize(ret.getExcludeContent()), (Map<String, Object>) jsonMap.get('excludeContent'), XPathPatterns.class);
-      retBuilder.setExcludeContent(newExcludeContent);
+      retBuilder.excludeContent(newExcludeContent);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('excludeTagsCompletely', 'exclude_tags_completely');
-      mapping.put('excludeTagsKeepContent', 'exclude_tags_keep_content');
-      mapping.put('keepContent', 'keep_content');
-      mapping.put('excludeContent', 'exclude_content');
-      mapping.put('keepTagAttributes', 'keep_tag_attributes');
-      mapping.put('excludeTagAttributes', 'exclude_tag_attributes');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'excludeTagsCompletely', 'exclude_tags_completely');
+      mapping.put(parentLabel + 'excludeTagsKeepContent', 'exclude_tags_keep_content');
+      mapping.put(parentLabel + 'keepContent', 'keep_content');
+      mapping.put(parentLabel + 'excludeContent', 'exclude_content');
+      mapping.put(parentLabel + 'keepTagAttributes', 'keep_tag_attributes');
+      mapping.put(parentLabel + 'excludeTagAttributes', 'exclude_tag_attributes');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('exclude_tags_completely', 'excludeTagsCompletely');
-      mapping.put('exclude_tags_keep_content', 'excludeTagsKeepContent');
-      mapping.put('keep_content', 'keepContent');
-      mapping.put('exclude_content', 'excludeContent');
-      mapping.put('keep_tag_attributes', 'keepTagAttributes');
-      mapping.put('exclude_tag_attributes', 'excludeTagAttributes');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'exclude_tags_completely', 'excludeTagsCompletely');
+      mapping.put(parentLabel + 'exclude_tags_keep_content', 'excludeTagsKeepContent');
+      mapping.put(parentLabel + 'keep_content', 'keepContent');
+      mapping.put(parentLabel + 'exclude_content', 'excludeContent');
+      mapping.put(parentLabel + 'keep_tag_attributes', 'keepTagAttributes');
+      mapping.put(parentLabel + 'exclude_tag_attributes', 'excludeTagAttributes');
       return mapping;
     }
   }
@@ -12100,7 +12099,7 @@ public class IBMDiscoveryV1Models {
      * @param excludeTagsCompletely the excludeTagsCompletely
      * @return the HtmlSettings builder
      */
-    public HtmlSettingsBuilder setExcludeTagsCompletely(List<String> excludeTagsCompletely) {
+    public HtmlSettingsBuilder excludeTagsCompletely(List<String> excludeTagsCompletely) {
       this.excludeTagsCompletely = excludeTagsCompletely;
       return this;
     }
@@ -12112,7 +12111,7 @@ public class IBMDiscoveryV1Models {
      * @param excludeTagsKeepContent the excludeTagsKeepContent
      * @return the HtmlSettings builder
      */
-    public HtmlSettingsBuilder setExcludeTagsKeepContent(List<String> excludeTagsKeepContent) {
+    public HtmlSettingsBuilder excludeTagsKeepContent(List<String> excludeTagsKeepContent) {
       this.excludeTagsKeepContent = excludeTagsKeepContent;
       return this;
     }
@@ -12123,7 +12122,7 @@ public class IBMDiscoveryV1Models {
      * @param keepContent the keepContent
      * @return the HtmlSettings builder
      */
-    public HtmlSettingsBuilder setKeepContent(XPathPatterns keepContent) {
+    public HtmlSettingsBuilder keepContent(XPathPatterns keepContent) {
       this.keepContent = keepContent;
       return this;
     }
@@ -12134,7 +12133,7 @@ public class IBMDiscoveryV1Models {
      * @param excludeContent the excludeContent
      * @return the HtmlSettings builder
      */
-    public HtmlSettingsBuilder setExcludeContent(XPathPatterns excludeContent) {
+    public HtmlSettingsBuilder excludeContent(XPathPatterns excludeContent) {
       this.excludeContent = excludeContent;
       return this;
     }
@@ -12146,7 +12145,7 @@ public class IBMDiscoveryV1Models {
      * @param keepTagAttributes the keepTagAttributes
      * @return the HtmlSettings builder
      */
-    public HtmlSettingsBuilder setKeepTagAttributes(List<String> keepTagAttributes) {
+    public HtmlSettingsBuilder keepTagAttributes(List<String> keepTagAttributes) {
       this.keepTagAttributes = keepTagAttributes;
       return this;
     }
@@ -12158,7 +12157,7 @@ public class IBMDiscoveryV1Models {
      * @param excludeTagAttributes the excludeTagAttributes
      * @return the HtmlSettings builder
      */
-    public HtmlSettingsBuilder setExcludeTagAttributes(List<String> excludeTagAttributes) {
+    public HtmlSettingsBuilder excludeTagAttributes(List<String> excludeTagAttributes) {
       this.excludeTagAttributes = excludeTagAttributes;
       return this;
     }
@@ -12171,7 +12170,7 @@ public class IBMDiscoveryV1Models {
     private EnvironmentDocuments documents;
     private DiskUsage diskUsage;
     private CollectionUsage collections;
- 
+
     /**
      * Gets the documents.
      *
@@ -12183,7 +12182,7 @@ public class IBMDiscoveryV1Models {
     public EnvironmentDocuments getDocuments() {
       return documents;
     }
- 
+
     /**
      * Gets the diskUsage.
      *
@@ -12195,7 +12194,7 @@ public class IBMDiscoveryV1Models {
     public DiskUsage getDiskUsage() {
       return diskUsage;
     }
- 
+
     /**
      * Gets the collections.
      *
@@ -12257,18 +12256,11 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (documents != null) {
-        mapping.putAll(documents.getApiToSdkMapping());
-      }
-      mapping.put('disk_usage', 'diskUsage');
-      if (diskUsage != null) {
-        mapping.putAll(diskUsage.getApiToSdkMapping());
-      }
-      if (collections != null) {
-        mapping.putAll(collections.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) EnvironmentDocuments.class.newInstance()).addToApiToSdkMapping(parentLabel + 'documents/', mapping));
+      mapping.put(parentLabel + 'disk_usage', 'diskUsage');
+      mapping.putAll(((IBMWatsonGenericModel) DiskUsage.class.newInstance()).addToApiToSdkMapping(parentLabel + 'disk_usage/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) CollectionUsage.class.newInstance()).addToApiToSdkMapping(parentLabel + 'collections/', mapping));
       return mapping;
     }
   }
@@ -12417,7 +12409,7 @@ public class IBMDiscoveryV1Models {
    */
   public class ListCollectionFieldsResponse extends IBMWatsonResponseModel {
     private List<Field> fields;
- 
+
     /**
      * Gets the fields.
      *
@@ -12462,11 +12454,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (fields != null && fields[0] != null) {
-        mapping.putAll(fields[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Field.class.newInstance()).addToApiToSdkMapping(parentLabel + 'fields/', mapping));
       return mapping;
     }
   }
@@ -12600,7 +12589,7 @@ public class IBMDiscoveryV1Models {
    */
   public class ListCollectionsResponse extends IBMWatsonResponseModel {
     private List<Collection> collections;
- 
+
     /**
      * Gets the collections.
      *
@@ -12645,11 +12634,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (collections != null && collections[0] != null) {
-        mapping.putAll(collections[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Collection.class.newInstance()).addToApiToSdkMapping(parentLabel + 'collections/', mapping));
       return mapping;
     }
   }
@@ -12783,7 +12769,7 @@ public class IBMDiscoveryV1Models {
    */
   public class ListConfigurationsResponse extends IBMWatsonResponseModel {
     private List<Configuration> configurations;
- 
+
     /**
      * Gets the configurations.
      *
@@ -12828,11 +12814,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (configurations != null && configurations[0] != null) {
-        mapping.putAll(configurations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Configuration.class.newInstance()).addToApiToSdkMapping(parentLabel + 'configurations/', mapping));
       return mapping;
     }
   }
@@ -13022,7 +13005,7 @@ public class IBMDiscoveryV1Models {
    */
   public class ListEnvironmentsResponse extends IBMWatsonResponseModel {
     private List<Environment> environments;
- 
+
     /**
      * Gets the environments.
      *
@@ -13067,11 +13050,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (environments != null && environments[0] != null) {
-        mapping.putAll(environments[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Environment.class.newInstance()).addToApiToSdkMapping(parentLabel + 'environments/', mapping));
       return mapping;
     }
   }
@@ -13738,7 +13718,7 @@ public class IBMDiscoveryV1Models {
   public class LogQueryResponse extends IBMWatsonResponseModel {
     private Long matchingResults;
     private List<LogQueryResponseResult> results;
- 
+
     /**
      * Gets the matchingResults.
      *
@@ -13750,7 +13730,7 @@ public class IBMDiscoveryV1Models {
     public Long getMatchingResults() {
       return matchingResults;
     }
- 
+
     /**
      * Gets the results.
      *
@@ -13804,12 +13784,13 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('matching_results', 'matchingResults');
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'matching_results', 'matchingResults');
+      mapping.putAll(((IBMWatsonGenericModel) LogQueryResponseResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
       return mapping;
     }
   }
@@ -13833,7 +13814,7 @@ public class IBMDiscoveryV1Models {
     private String documentId;
     private String eventType;
     private String resultType;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -13845,7 +13826,7 @@ public class IBMDiscoveryV1Models {
     public String getEnvironmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the customerId.
      *
@@ -13858,7 +13839,7 @@ public class IBMDiscoveryV1Models {
     public String getCustomerId() {
       return customerId;
     }
- 
+
     /**
      * Gets the documentType.
      *
@@ -13874,7 +13855,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentType() {
       return documentType;
     }
- 
+
     /**
      * Gets the naturalLanguageQuery.
      *
@@ -13890,7 +13871,7 @@ public class IBMDiscoveryV1Models {
     public String getNaturalLanguageQuery() {
       return naturalLanguageQuery;
     }
- 
+
     /**
      * Gets the documentResults.
      *
@@ -13903,7 +13884,7 @@ public class IBMDiscoveryV1Models {
     public LogQueryResponseResultDocuments getDocumentResults() {
       return documentResults;
     }
- 
+
     /**
      * Gets the createdTimestamp.
      *
@@ -13915,7 +13896,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getCreatedTimestamp() {
       return createdTimestamp;
     }
- 
+
     /**
      * Gets the clientTimestamp.
      *
@@ -13928,7 +13909,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getClientTimestamp() {
       return clientTimestamp;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -13943,7 +13924,7 @@ public class IBMDiscoveryV1Models {
     public String getQueryId() {
       return queryId;
     }
- 
+
     /**
      * Gets the sessionToken.
      *
@@ -13962,7 +13943,7 @@ public class IBMDiscoveryV1Models {
     public String getSessionToken() {
       return sessionToken;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -13974,7 +13955,7 @@ public class IBMDiscoveryV1Models {
     public String getCollectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the displayRank.
      *
@@ -13986,7 +13967,7 @@ public class IBMDiscoveryV1Models {
     public Long getDisplayRank() {
       return displayRank;
     }
- 
+
     /**
      * Gets the documentId.
      *
@@ -13998,7 +13979,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the eventType.
      *
@@ -14014,7 +13995,7 @@ public class IBMDiscoveryV1Models {
     public String getEventType() {
       return eventType;
     }
- 
+
     /**
      * Gets the resultType.
      *
@@ -14167,25 +14148,26 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('environment_id', 'environmentId');
-      mapping.put('customer_id', 'customerId');
-      mapping.put('document_type', 'documentType');
-      mapping.put('natural_language_query', 'naturalLanguageQuery');
-      mapping.put('document_results', 'documentResults');
-      if (documentResults != null) {
-        mapping.putAll(documentResults.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('created_timestamp', 'createdTimestamp');
-      mapping.put('client_timestamp', 'clientTimestamp');
-      mapping.put('query_id', 'queryId');
-      mapping.put('session_token', 'sessionToken');
-      mapping.put('collection_id', 'collectionId');
-      mapping.put('display_rank', 'displayRank');
-      mapping.put('document_id', 'documentId');
-      mapping.put('event_type', 'eventType');
-      mapping.put('result_type', 'resultType');
+      mapping.put(parentLabel + 'environment_id', 'environmentId');
+      mapping.put(parentLabel + 'customer_id', 'customerId');
+      mapping.put(parentLabel + 'document_type', 'documentType');
+      mapping.put(parentLabel + 'natural_language_query', 'naturalLanguageQuery');
+      mapping.put(parentLabel + 'document_results', 'documentResults');
+      mapping.putAll(((IBMWatsonGenericModel) LogQueryResponseResultDocuments.class.newInstance()).addToApiToSdkMapping(parentLabel + 'document_results/', mapping));
+      mapping.put(parentLabel + 'created_timestamp', 'createdTimestamp');
+      mapping.put(parentLabel + 'client_timestamp', 'clientTimestamp');
+      mapping.put(parentLabel + 'query_id', 'queryId');
+      mapping.put(parentLabel + 'session_token', 'sessionToken');
+      mapping.put(parentLabel + 'collection_id', 'collectionId');
+      mapping.put(parentLabel + 'display_rank', 'displayRank');
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.put(parentLabel + 'event_type', 'eventType');
+      mapping.put(parentLabel + 'result_type', 'resultType');
       return mapping;
     }
   }
@@ -14197,7 +14179,7 @@ public class IBMDiscoveryV1Models {
   public class LogQueryResponseResultDocuments extends IBMWatsonGenericModel {
     private List<LogQueryResponseResultDocumentsResult> results;
     private Long count;
- 
+
     /**
      * Gets the results.
      *
@@ -14209,7 +14191,7 @@ public class IBMDiscoveryV1Models {
     public List<LogQueryResponseResultDocumentsResult> getResults() {
       return results;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -14263,11 +14245,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) LogQueryResponseResultDocumentsResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
       return mapping;
     }
   }
@@ -14281,7 +14260,7 @@ public class IBMDiscoveryV1Models {
     private Double score;
     private Double confidence;
     private String collectionId;
- 
+
     /**
      * Gets the position.
      *
@@ -14293,7 +14272,7 @@ public class IBMDiscoveryV1Models {
     public Long getPosition() {
       return position;
     }
- 
+
     /**
      * Gets the documentId.
      *
@@ -14305,7 +14284,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the score.
      *
@@ -14317,7 +14296,7 @@ public class IBMDiscoveryV1Models {
     public Double getScore() {
       return score;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -14329,7 +14308,7 @@ public class IBMDiscoveryV1Models {
     public Double getConfidence() {
       return confidence;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -14387,10 +14366,9 @@ public class IBMDiscoveryV1Models {
       this.collectionId = collectionId;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_id', 'documentId');
-      mapping.put('collection_id', 'collectionId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.put(parentLabel + 'collection_id', 'collectionId');
       return mapping;
     }
   }
@@ -14402,7 +14380,7 @@ public class IBMDiscoveryV1Models {
     private String interval;
     private String eventType;
     private List<MetricAggregationResult> results;
- 
+
     /**
      * Gets the interval.
      *
@@ -14414,7 +14392,7 @@ public class IBMDiscoveryV1Models {
     public String getInterval() {
       return interval;
     }
- 
+
     /**
      * Gets the eventType.
      *
@@ -14426,7 +14404,7 @@ public class IBMDiscoveryV1Models {
     public String getEventType() {
       return eventType;
     }
- 
+
     /**
      * Gets the results.
      *
@@ -14489,12 +14467,9 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('event_type', 'eventType');
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'event_type', 'eventType');
+      mapping.putAll(((IBMWatsonGenericModel) MetricAggregationResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
       return mapping;
     }
   }
@@ -14507,7 +14482,7 @@ public class IBMDiscoveryV1Models {
     private Long key;
     private Long matchingResults;
     private Double eventRate;
- 
+
     /**
      * Gets the keyAsString.
      *
@@ -14519,7 +14494,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getKeyAsString() {
       return keyAsString;
     }
- 
+
     /**
      * Gets the key.
      *
@@ -14531,7 +14506,7 @@ public class IBMDiscoveryV1Models {
     public Long getKey() {
       return key;
     }
- 
+
     /**
      * Gets the matchingResults.
      *
@@ -14543,7 +14518,7 @@ public class IBMDiscoveryV1Models {
     public Long getMatchingResults() {
       return matchingResults;
     }
- 
+
     /**
      * Gets the eventRate.
      *
@@ -14593,11 +14568,14 @@ public class IBMDiscoveryV1Models {
       this.eventRate = eventRate;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('key_as_string', 'keyAsString');
-      mapping.put('matching_results', 'matchingResults');
-      mapping.put('event_rate', 'eventRate');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'key_as_string', 'keyAsString');
+      mapping.put(parentLabel + 'matching_results', 'matchingResults');
+      mapping.put(parentLabel + 'event_rate', 'eventRate');
       return mapping;
     }
   }
@@ -14607,7 +14585,7 @@ public class IBMDiscoveryV1Models {
    */
   public class MetricResponse extends IBMWatsonResponseModel {
     private List<MetricAggregation> aggregations;
- 
+
     /**
      * Gets the aggregations.
      *
@@ -14652,11 +14630,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (aggregations != null && aggregations[0] != null) {
-        mapping.putAll(aggregations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) MetricAggregation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'aggregations/', mapping));
       return mapping;
     }
   }
@@ -14667,7 +14642,7 @@ public class IBMDiscoveryV1Models {
   public class MetricTokenAggregation extends IBMWatsonGenericModel {
     private String eventType;
     private List<MetricTokenAggregationResult> results;
- 
+
     /**
      * Gets the eventType.
      *
@@ -14679,7 +14654,7 @@ public class IBMDiscoveryV1Models {
     public String getEventType() {
       return eventType;
     }
- 
+
     /**
      * Gets the results.
      *
@@ -14733,12 +14708,13 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('event_type', 'eventType');
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'event_type', 'eventType');
+      mapping.putAll(((IBMWatsonGenericModel) MetricTokenAggregationResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
       return mapping;
     }
   }
@@ -14750,7 +14726,7 @@ public class IBMDiscoveryV1Models {
     private String key;
     private Long matchingResults;
     private Double eventRate;
- 
+
     /**
      * Gets the key.
      *
@@ -14762,7 +14738,7 @@ public class IBMDiscoveryV1Models {
     public String getKey() {
       return key;
     }
- 
+
     /**
      * Gets the matchingResults.
      *
@@ -14774,7 +14750,7 @@ public class IBMDiscoveryV1Models {
     public Long getMatchingResults() {
       return matchingResults;
     }
- 
+
     /**
      * Gets the eventRate.
      *
@@ -14815,10 +14791,9 @@ public class IBMDiscoveryV1Models {
       this.eventRate = eventRate;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('matching_results', 'matchingResults');
-      mapping.put('event_rate', 'eventRate');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'matching_results', 'matchingResults');
+      mapping.put(parentLabel + 'event_rate', 'eventRate');
       return mapping;
     }
   }
@@ -14828,7 +14803,7 @@ public class IBMDiscoveryV1Models {
    */
   public class MetricTokenResponse extends IBMWatsonResponseModel {
     private List<MetricTokenAggregation> aggregations;
- 
+
     /**
      * Gets the aggregations.
      *
@@ -14873,11 +14848,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (aggregations != null && aggregations[0] != null) {
-        mapping.putAll(aggregations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) MetricTokenAggregation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'aggregations/', mapping));
       return mapping;
     }
   }
@@ -14886,7 +14858,7 @@ public class IBMDiscoveryV1Models {
    * An object that indicates the Categories enrichment will be applied to the specified field.
    */
   public class NluEnrichmentCategories extends IBMWatsonDynamicModel {
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -14971,7 +14943,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public NluEnrichmentConcepts() { }
- 
+
     /**
      * Gets the xlimit.
      *
@@ -14997,15 +14969,21 @@ public class IBMDiscoveryV1Models {
       return new NluEnrichmentConceptsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('limit', 'xlimit');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'limit', 'xlimit');
       return mapping;
     }
   }
@@ -15041,7 +15019,7 @@ public class IBMDiscoveryV1Models {
      * @param xlimit the xlimit
      * @return the NluEnrichmentConcepts builder
      */
-    public NluEnrichmentConceptsBuilder setXlimit(Long xlimit) {
+    public NluEnrichmentConceptsBuilder xlimit(Long xlimit) {
       this.xlimit = xlimit;
       return this;
     }
@@ -15059,7 +15037,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public NluEnrichmentEmotion() { }
- 
+
     /**
      * Gets the document.
      *
@@ -15071,7 +15049,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getDocument() {
       return document;
     }
- 
+
     /**
      * Gets the targets.
      *
@@ -15182,7 +15160,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public NluEnrichmentEntities() { }
- 
+
     /**
      * Gets the sentiment.
      *
@@ -15194,7 +15172,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getSentiment() {
       return sentiment;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -15206,7 +15184,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getEmotion() {
       return emotion;
     }
- 
+
     /**
      * Gets the xlimit.
      *
@@ -15218,7 +15196,7 @@ public class IBMDiscoveryV1Models {
     public Long getXlimit() {
       return xlimit;
     }
- 
+
     /**
      * Gets the mentions.
      *
@@ -15230,7 +15208,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getMentions() {
       return mentions;
     }
- 
+
     /**
      * Gets the mentionTypes.
      *
@@ -15242,7 +15220,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getMentionTypes() {
       return mentionTypes;
     }
- 
+
     /**
      * Gets the sentenceLocations.
      *
@@ -15255,7 +15233,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getSentenceLocations() {
       return sentenceLocations;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -15288,19 +15266,17 @@ public class IBMDiscoveryV1Models {
       return new NluEnrichmentEntitiesBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
-      mapping.put('mentionTypes', 'mention_types');
-      mapping.put('sentenceLocations', 'sentence_locations');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'xlimit', 'limit');
+      mapping.put(parentLabel + 'mentionTypes', 'mention_types');
+      mapping.put(parentLabel + 'sentenceLocations', 'sentence_locations');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('limit', 'xlimit');
-      mapping.put('mention_types', 'mentionTypes');
-      mapping.put('sentence_locations', 'sentenceLocations');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'limit', 'xlimit');
+      mapping.put(parentLabel + 'mention_types', 'mentionTypes');
+      mapping.put(parentLabel + 'sentence_locations', 'sentenceLocations');
       return mapping;
     }
   }
@@ -15438,7 +15414,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public NluEnrichmentFeatures() { }
- 
+
     /**
      * Gets the keywords.
      *
@@ -15450,7 +15426,7 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentKeywords getKeywords() {
       return keywords;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -15462,7 +15438,7 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentEntities getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the sentiment.
      *
@@ -15474,7 +15450,7 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentSentiment getSentiment() {
       return sentiment;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -15486,7 +15462,7 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentEmotion getEmotion() {
       return emotion;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -15498,7 +15474,7 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentCategories getCategories() {
       return categories;
     }
- 
+
     /**
      * Gets the semanticRoles.
      *
@@ -15510,7 +15486,7 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentSemanticRoles getSemanticRoles() {
       return semanticRoles;
     }
- 
+
     /**
      * Gets the relations.
      *
@@ -15522,7 +15498,7 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentRelations getRelations() {
       return relations;
     }
- 
+
     /**
      * Gets the concepts.
      *
@@ -15598,39 +15574,29 @@ public class IBMDiscoveryV1Models {
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (keywords != null) {
-        mapping.putAll(keywords.getSdkToApiMapping());
+        mapping.putAll(keywords.addToSdkToApiMapping(parentLabel + 'keywords/', mapping));
       }
       if (entities != null) {
-        mapping.putAll(entities.getSdkToApiMapping());
+        mapping.putAll(entities.addToSdkToApiMapping(parentLabel + 'entities/', mapping));
       }
-      mapping.put('semanticRoles', 'semantic_roles');
+      mapping.put(parentLabel + 'semanticRoles', 'semantic_roles');
       if (semanticRoles != null) {
-        mapping.putAll(semanticRoles.getSdkToApiMapping());
+        mapping.putAll(semanticRoles.addToSdkToApiMapping(parentLabel + 'semanticRoles/', mapping));
       }
       if (concepts != null) {
-        mapping.putAll(concepts.getSdkToApiMapping());
+        mapping.putAll(concepts.addToSdkToApiMapping(parentLabel + 'concepts/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (keywords != null) {
-        mapping.putAll(keywords.getApiToSdkMapping());
-      }
-      if (entities != null) {
-        mapping.putAll(entities.getApiToSdkMapping());
-      }
-      mapping.put('semantic_roles', 'semanticRoles');
-      if (semanticRoles != null) {
-        mapping.putAll(semanticRoles.getApiToSdkMapping());
-      }
-      if (concepts != null) {
-        mapping.putAll(concepts.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) NluEnrichmentKeywords.class.newInstance()).addToApiToSdkMapping(parentLabel + 'keywords/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) NluEnrichmentEntities.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
+      mapping.put(parentLabel + 'semantic_roles', 'semanticRoles');
+      mapping.putAll(((IBMWatsonGenericModel) NluEnrichmentSemanticRoles.class.newInstance()).addToApiToSdkMapping(parentLabel + 'semantic_roles/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) NluEnrichmentConcepts.class.newInstance()).addToApiToSdkMapping(parentLabel + 'concepts/', mapping));
       return mapping;
     }
   }
@@ -15776,7 +15742,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public NluEnrichmentKeywords() { }
- 
+
     /**
      * Gets the sentiment.
      *
@@ -15788,7 +15754,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getSentiment() {
       return sentiment;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -15800,7 +15766,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getEmotion() {
       return emotion;
     }
- 
+
     /**
      * Gets the xlimit.
      *
@@ -15828,15 +15794,13 @@ public class IBMDiscoveryV1Models {
       return new NluEnrichmentKeywordsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('limit', 'xlimit');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'limit', 'xlimit');
       return mapping;
     }
   }
@@ -15915,7 +15879,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public NluEnrichmentRelations() { }
- 
+
     /**
      * Gets the model.
      *
@@ -15975,7 +15939,7 @@ public class IBMDiscoveryV1Models {
      * @param model the model
      * @return the NluEnrichmentRelations builder
      */
-    public NluEnrichmentRelationsBuilder setModel(String model) {
+    public NluEnrichmentRelationsBuilder model(String model) {
       this.model = model;
       return this;
     }
@@ -15994,7 +15958,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public NluEnrichmentSemanticRoles() { }
- 
+
     /**
      * Gets the entities.
      *
@@ -16006,7 +15970,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the keywords.
      *
@@ -16018,7 +15982,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getKeywords() {
       return keywords;
     }
- 
+
     /**
      * Gets the xlimit.
      *
@@ -16046,15 +16010,13 @@ public class IBMDiscoveryV1Models {
       return new NluEnrichmentSemanticRolesBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('limit', 'xlimit');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'limit', 'xlimit');
       return mapping;
     }
   }
@@ -16134,7 +16096,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public NluEnrichmentSentiment() { }
- 
+
     /**
      * Gets the document.
      *
@@ -16146,7 +16108,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getDocument() {
       return document;
     }
- 
+
     /**
      * Gets the targets.
      *
@@ -16253,7 +16215,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public NormalizationOperation() { }
- 
+
     /**
      * Gets the operation.
      *
@@ -16288,7 +16250,7 @@ public class IBMDiscoveryV1Models {
     public String getOperation() {
       return operation;
     }
- 
+
     /**
      * Gets the sourceField.
      *
@@ -16300,7 +16262,7 @@ public class IBMDiscoveryV1Models {
     public String getSourceField() {
       return sourceField;
     }
- 
+
     /**
      * Gets the destinationField.
      *
@@ -16328,17 +16290,15 @@ public class IBMDiscoveryV1Models {
       return new NormalizationOperationBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('sourceField', 'source_field');
-      mapping.put('destinationField', 'destination_field');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'sourceField', 'source_field');
+      mapping.put(parentLabel + 'destinationField', 'destination_field');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('source_field', 'sourceField');
-      mapping.put('destination_field', 'destinationField');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'source_field', 'sourceField');
+      mapping.put(parentLabel + 'destination_field', 'destinationField');
       return mapping;
     }
   }
@@ -16378,7 +16338,7 @@ public class IBMDiscoveryV1Models {
      * @param operation the operation
      * @return the NormalizationOperation builder
      */
-    public NormalizationOperationBuilder setOperation(String operation) {
+    public NormalizationOperationBuilder operation(String operation) {
       this.operation = operation;
       return this;
     }
@@ -16389,7 +16349,7 @@ public class IBMDiscoveryV1Models {
      * @param sourceField the sourceField
      * @return the NormalizationOperation builder
      */
-    public NormalizationOperationBuilder setSourceField(String sourceField) {
+    public NormalizationOperationBuilder sourceField(String sourceField) {
       this.sourceField = sourceField;
       return this;
     }
@@ -16400,7 +16360,7 @@ public class IBMDiscoveryV1Models {
      * @param destinationField the destinationField
      * @return the NormalizationOperation builder
      */
-    public NormalizationOperationBuilder setDestinationField(String destinationField) {
+    public NormalizationOperationBuilder destinationField(String destinationField) {
       this.destinationField = destinationField;
       return this;
     }
@@ -16417,7 +16377,7 @@ public class IBMDiscoveryV1Models {
     private String severity;
     private String step;
     private String description;
- 
+
     /**
      * Gets the noticeId.
      *
@@ -16437,7 +16397,7 @@ public class IBMDiscoveryV1Models {
     public String getNoticeId() {
       return noticeId;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -16449,7 +16409,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the documentId.
      *
@@ -16461,7 +16421,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -16473,7 +16433,7 @@ public class IBMDiscoveryV1Models {
     public String getQueryId() {
       return queryId;
     }
- 
+
     /**
      * Gets the severity.
      *
@@ -16485,7 +16445,7 @@ public class IBMDiscoveryV1Models {
     public String getSeverity() {
       return severity;
     }
- 
+
     /**
      * Gets the step.
      *
@@ -16499,7 +16459,7 @@ public class IBMDiscoveryV1Models {
     public String getStep() {
       return step;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -16512,11 +16472,14 @@ public class IBMDiscoveryV1Models {
       return description;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('notice_id', 'noticeId');
-      mapping.put('document_id', 'documentId');
-      mapping.put('query_id', 'queryId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'notice_id', 'noticeId');
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.put(parentLabel + 'query_id', 'queryId');
       return mapping;
     }
   }
@@ -16532,7 +16495,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public PdfHeadingDetection() { }
- 
+
     /**
      * Gets the fonts.
      *
@@ -16574,25 +16537,21 @@ public class IBMDiscoveryV1Models {
           FontSetting newItem = (FontSetting) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), FontSetting.class);
           newFonts.add(newItem);
         }
-        retBuilder.setFonts(newFonts);
+        retBuilder.fonts(newFonts);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (fonts != null && fonts[0] != null) {
-        mapping.putAll(fonts[0].getSdkToApiMapping());
+        mapping.putAll(fonts[0].addToSdkToApiMapping(parentLabel + 'fonts/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (fonts != null && fonts[0] != null) {
-        mapping.putAll(fonts[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) FontSetting.class.newInstance()).addToApiToSdkMapping(parentLabel + 'fonts/', mapping));
       return mapping;
     }
   }
@@ -16644,7 +16603,7 @@ public class IBMDiscoveryV1Models {
      * @param fonts the fonts
      * @return the PdfHeadingDetection builder
      */
-    public PdfHeadingDetectionBuilder setFonts(List<FontSetting> fonts) {
+    public PdfHeadingDetectionBuilder fonts(List<FontSetting> fonts) {
       this.fonts = fonts;
       return this;
     }
@@ -16661,7 +16620,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public PdfSettings() { }
- 
+
     /**
      * Gets the heading.
      *
@@ -16695,24 +16654,20 @@ public class IBMDiscoveryV1Models {
 
       // calling custom deserializer for heading
       PdfHeadingDetection newHeading = (PdfHeadingDetection) new PdfHeadingDetection().deserialize(JSON.serialize(ret.getHeading()), (Map<String, Object>) jsonMap.get('heading'), PdfHeadingDetection.class);
-      retBuilder.setHeading(newHeading);
+      retBuilder.heading(newHeading);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (heading != null) {
-        mapping.putAll(heading.getSdkToApiMapping());
+        mapping.putAll(heading.addToSdkToApiMapping(parentLabel + 'heading/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (heading != null) {
-        mapping.putAll(heading.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) PdfHeadingDetection.class.newInstance()).addToApiToSdkMapping(parentLabel + 'heading/', mapping));
       return mapping;
     }
   }
@@ -16748,7 +16703,7 @@ public class IBMDiscoveryV1Models {
      * @param heading the heading
      * @return the PdfSettings builder
      */
-    public PdfSettingsBuilder setHeading(PdfHeadingDetection heading) {
+    public PdfSettingsBuilder heading(PdfHeadingDetection heading) {
       this.heading = heading;
       return this;
     }
@@ -16772,7 +16727,7 @@ public class IBMDiscoveryV1Models {
     private Boolean anomaly;
     private Long size;
     private TopHitsResults hits;
- 
+
     /**
      * Gets the xtype.
      *
@@ -16784,7 +16739,7 @@ public class IBMDiscoveryV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the results.
      *
@@ -16796,7 +16751,7 @@ public class IBMDiscoveryV1Models {
     public List<AggregationResult> getResults() {
       return results;
     }
- 
+
     /**
      * Gets the matchingResults.
      *
@@ -16808,7 +16763,7 @@ public class IBMDiscoveryV1Models {
     public Long getMatchingResults() {
       return matchingResults;
     }
- 
+
     /**
      * Gets the aggregations.
      *
@@ -16820,7 +16775,7 @@ public class IBMDiscoveryV1Models {
     public List<QueryAggregation> getAggregations() {
       return aggregations;
     }
- 
+
     /**
      * Gets the field.
      *
@@ -16832,7 +16787,7 @@ public class IBMDiscoveryV1Models {
     public String getField() {
       return field;
     }
- 
+
     /**
      * Gets the histogramInterval.
      *
@@ -16844,7 +16799,7 @@ public class IBMDiscoveryV1Models {
     public Long getHistogramInterval() {
       return histogramInterval;
     }
- 
+
     /**
      * Gets the value.
      *
@@ -16856,7 +16811,7 @@ public class IBMDiscoveryV1Models {
     public Double getValue() {
       return value;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -16866,7 +16821,7 @@ public class IBMDiscoveryV1Models {
     public Long getCount() {
       return count;
     }
- 
+
     /**
      * Gets the match.
      *
@@ -16878,7 +16833,7 @@ public class IBMDiscoveryV1Models {
     public String getMatch() {
       return match;
     }
- 
+
     /**
      * Gets the path.
      *
@@ -16890,7 +16845,7 @@ public class IBMDiscoveryV1Models {
     public String getPath() {
       return path;
     }
- 
+
     /**
      * Gets the timesliceInterval.
      *
@@ -16903,7 +16858,7 @@ public class IBMDiscoveryV1Models {
     public String getTimesliceInterval() {
       return timesliceInterval;
     }
- 
+
     /**
      * Gets the anomaly.
      *
@@ -16916,7 +16871,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getAnomaly() {
       return anomaly;
     }
- 
+
     /**
      * Gets the size.
      *
@@ -16928,7 +16883,7 @@ public class IBMDiscoveryV1Models {
     public Long getSize() {
       return size;
     }
- 
+
     /**
      * Gets the hits.
      *
@@ -17105,21 +17060,18 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('matching_results', 'matchingResults');
-      if (aggregations != null && aggregations[0] != null) {
-        mapping.putAll(aggregations[0].getApiToSdkMapping());
-      }
-      mapping.put('histogram_interval', 'histogramInterval');
-      mapping.put('timeslice_interval', 'timesliceInterval');
-      if (hits != null) {
-        mapping.putAll(hits.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'type', 'xtype');
+      mapping.putAll(((IBMWatsonGenericModel) AggregationResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
+      mapping.put(parentLabel + 'matching_results', 'matchingResults');
+      mapping.putAll(((IBMWatsonGenericModel) QueryAggregation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'aggregations/', mapping));
+      mapping.put(parentLabel + 'histogram_interval', 'histogramInterval');
+      mapping.put(parentLabel + 'timeslice_interval', 'timesliceInterval');
+      mapping.putAll(((IBMWatsonGenericModel) TopHitsResults.class.newInstance()).addToApiToSdkMapping(parentLabel + 'hits/', mapping));
       return mapping;
     }
   }
@@ -17130,7 +17082,7 @@ public class IBMDiscoveryV1Models {
    */
   public class QueryEntitiesContext extends IBMWatsonGenericModel {
     private String text;
- 
+
     /**
      * Gets the text.
      *
@@ -17188,7 +17140,7 @@ public class IBMDiscoveryV1Models {
      * @param text the text
      * @return the QueryEntitiesContext builder
      */
-    public QueryEntitiesContextBuilder setText(String text) {
+    public QueryEntitiesContextBuilder text(String text) {
       this.text = text;
       return this;
     }
@@ -17206,7 +17158,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public QueryEntitiesEntity() { }
- 
+
     /**
      * Gets the text.
      *
@@ -17218,7 +17170,7 @@ public class IBMDiscoveryV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the xtype.
      *
@@ -17245,15 +17197,13 @@ public class IBMDiscoveryV1Models {
       return new QueryEntitiesEntityBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xtype', 'type');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'xtype', 'type');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'type', 'xtype');
       return mapping;
     }
   }
@@ -17291,7 +17241,7 @@ public class IBMDiscoveryV1Models {
      * @param text the text
      * @return the QueryEntitiesEntity builder
      */
-    public QueryEntitiesEntityBuilder setText(String text) {
+    public QueryEntitiesEntityBuilder text(String text) {
       this.text = text;
       return this;
     }
@@ -17302,7 +17252,7 @@ public class IBMDiscoveryV1Models {
      * @param xtype the xtype
      * @return the QueryEntitiesEntity builder
      */
-    public QueryEntitiesEntityBuilder setXtype(String xtype) {
+    public QueryEntitiesEntityBuilder xtype(String xtype) {
       this.xtype = xtype;
       return this;
     }
@@ -17426,7 +17376,7 @@ public class IBMDiscoveryV1Models {
       mapping.put('environmentId', 'environment_id');
       mapping.put('collectionId', 'collection_id');
       if (entity != null) {
-        mapping.putAll(entity.getSdkToApiMapping());
+        mapping.putAll(entity.addToSdkToApiMapping('', mapping));
       }
       mapping.put('evidenceCount', 'evidence_count');
       return mapping;
@@ -17577,7 +17527,7 @@ public class IBMDiscoveryV1Models {
    */
   public class QueryEntitiesResponse extends IBMWatsonResponseModel {
     private List<QueryEntitiesResponseItem> entities;
- 
+
     /**
      * Gets the entities.
      *
@@ -17622,11 +17572,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) QueryEntitiesResponseItem.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
       return mapping;
     }
   }
@@ -17638,7 +17585,7 @@ public class IBMDiscoveryV1Models {
     private String text;
     private String xtype;
     private List<QueryEvidence> evidence;
- 
+
     /**
      * Gets the text.
      *
@@ -17650,7 +17597,7 @@ public class IBMDiscoveryV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the xtype.
      *
@@ -17662,7 +17609,7 @@ public class IBMDiscoveryV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the evidence.
      *
@@ -17725,12 +17672,9 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
-      if (evidence != null && evidence[0] != null) {
-        mapping.putAll(evidence[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'type', 'xtype');
+      mapping.putAll(((IBMWatsonGenericModel) QueryEvidence.class.newInstance()).addToApiToSdkMapping(parentLabel + 'evidence/', mapping));
       return mapping;
     }
   }
@@ -17744,7 +17688,7 @@ public class IBMDiscoveryV1Models {
     private Long startOffset;
     private Long endOffset;
     private List<QueryEvidenceEntity> entities;
- 
+
     /**
      * Gets the documentId.
      *
@@ -17756,7 +17700,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the field.
      *
@@ -17768,7 +17712,7 @@ public class IBMDiscoveryV1Models {
     public String getField() {
       return field;
     }
- 
+
     /**
      * Gets the startOffset.
      *
@@ -17780,7 +17724,7 @@ public class IBMDiscoveryV1Models {
     public Long getStartOffset() {
       return startOffset;
     }
- 
+
     /**
      * Gets the endOffset.
      *
@@ -17792,7 +17736,7 @@ public class IBMDiscoveryV1Models {
     public Long getEndOffset() {
       return endOffset;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -17873,14 +17817,15 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_id', 'documentId');
-      mapping.put('start_offset', 'startOffset');
-      mapping.put('end_offset', 'endOffset');
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.put(parentLabel + 'start_offset', 'startOffset');
+      mapping.put(parentLabel + 'end_offset', 'endOffset');
+      mapping.putAll(((IBMWatsonGenericModel) QueryEvidenceEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
       return mapping;
     }
   }
@@ -17893,7 +17838,7 @@ public class IBMDiscoveryV1Models {
     private String text;
     private Long startOffset;
     private Long endOffset;
- 
+
     /**
      * Gets the xtype.
      *
@@ -17905,7 +17850,7 @@ public class IBMDiscoveryV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -17917,7 +17862,7 @@ public class IBMDiscoveryV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the startOffset.
      *
@@ -17929,7 +17874,7 @@ public class IBMDiscoveryV1Models {
     public Long getStartOffset() {
       return startOffset;
     }
- 
+
     /**
      * Gets the endOffset.
      *
@@ -17978,11 +17923,14 @@ public class IBMDiscoveryV1Models {
       this.endOffset = endOffset;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
-      mapping.put('start_offset', 'startOffset');
-      mapping.put('end_offset', 'endOffset');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'type', 'xtype');
+      mapping.put(parentLabel + 'start_offset', 'startOffset');
+      mapping.put(parentLabel + 'end_offset', 'endOffset');
       return mapping;
     }
   }
@@ -17993,7 +17941,7 @@ public class IBMDiscoveryV1Models {
   public class QueryFilterType extends IBMWatsonGenericModel {
     private List<String> exclude;
     private List<String> include;
- 
+
     /**
      * Gets the exclude.
      *
@@ -18004,7 +17952,7 @@ public class IBMDiscoveryV1Models {
     public List<String> getExclude() {
       return exclude;
     }
- 
+
     /**
      * Gets the include.
      *
@@ -18095,7 +18043,7 @@ public class IBMDiscoveryV1Models {
      * @param exclude the exclude
      * @return the QueryFilterType builder
      */
-    public QueryFilterTypeBuilder setExclude(List<String> exclude) {
+    public QueryFilterTypeBuilder exclude(List<String> exclude) {
       this.exclude = exclude;
       return this;
     }
@@ -18107,7 +18055,7 @@ public class IBMDiscoveryV1Models {
      * @param include the include
      * @return the QueryFilterType builder
      */
-    public QueryFilterTypeBuilder setInclude(List<String> include) {
+    public QueryFilterTypeBuilder include(List<String> include) {
       this.include = include;
       return this;
     }
@@ -19016,7 +18964,7 @@ public class IBMDiscoveryV1Models {
     private List<QueryAggregation> aggregations;
     private List<QueryPassages> passages;
     private Long duplicatesRemoved;
- 
+
     /**
      * Gets the matchingResults.
      *
@@ -19028,7 +18976,7 @@ public class IBMDiscoveryV1Models {
     public Long getMatchingResults() {
       return matchingResults;
     }
- 
+
     /**
      * Gets the results.
      *
@@ -19040,7 +18988,7 @@ public class IBMDiscoveryV1Models {
     public List<QueryNoticesResult> getResults() {
       return results;
     }
- 
+
     /**
      * Gets the aggregations.
      *
@@ -19052,7 +19000,7 @@ public class IBMDiscoveryV1Models {
     public List<QueryAggregation> getAggregations() {
       return aggregations;
     }
- 
+
     /**
      * Gets the passages.
      *
@@ -19064,7 +19012,7 @@ public class IBMDiscoveryV1Models {
     public List<QueryPassages> getPassages() {
       return passages;
     }
- 
+
     /**
      * Gets the duplicatesRemoved.
      *
@@ -19171,19 +19119,16 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('matching_results', 'matchingResults');
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (aggregations != null && aggregations[0] != null) {
-        mapping.putAll(aggregations[0].getApiToSdkMapping());
-      }
-      if (passages != null && passages[0] != null) {
-        mapping.putAll(passages[0].getApiToSdkMapping());
-      }
-      mapping.put('duplicates_removed', 'duplicatesRemoved');
+      mapping.put(parentLabel + 'matching_results', 'matchingResults');
+      mapping.putAll(((IBMWatsonGenericModel) QueryNoticesResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) QueryAggregation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'aggregations/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) QueryPassages.class.newInstance()).addToApiToSdkMapping(parentLabel + 'passages/', mapping));
+      mapping.put(parentLabel + 'duplicates_removed', 'duplicatesRemoved');
       return mapping;
     }
   }
@@ -19202,7 +19147,7 @@ public class IBMDiscoveryV1Models {
     private String fileType;
     private String sha1;
     private List<Notice> notices;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * Gets the id.
@@ -19443,14 +19388,11 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('collection_id', 'collectionId');
-      mapping.put('result_metadata', 'resultMetadata');
-      mapping.put('file_type', 'fileType');
-      if (notices != null && notices[0] != null) {
-        mapping.putAll(notices[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'collection_id', 'collectionId');
+      mapping.put(parentLabel + 'result_metadata', 'resultMetadata');
+      mapping.put(parentLabel + 'file_type', 'fileType');
+      mapping.putAll(((IBMWatsonGenericModel) Notice.class.newInstance()).addToApiToSdkMapping(parentLabel + 'notices/', mapping));
       return mapping;
     }
   }
@@ -20175,7 +20117,7 @@ public class IBMDiscoveryV1Models {
     private Long startOffset;
     private Long endOffset;
     private String field;
- 
+
     /**
      * Gets the documentId.
      *
@@ -20187,7 +20129,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the passageScore.
      *
@@ -20199,7 +20141,7 @@ public class IBMDiscoveryV1Models {
     public Double getPassageScore() {
       return passageScore;
     }
- 
+
     /**
      * Gets the passageText.
      *
@@ -20211,7 +20153,7 @@ public class IBMDiscoveryV1Models {
     public String getPassageText() {
       return passageText;
     }
- 
+
     /**
      * Gets the startOffset.
      *
@@ -20223,7 +20165,7 @@ public class IBMDiscoveryV1Models {
     public Long getStartOffset() {
       return startOffset;
     }
- 
+
     /**
      * Gets the endOffset.
      *
@@ -20235,7 +20177,7 @@ public class IBMDiscoveryV1Models {
     public Long getEndOffset() {
       return endOffset;
     }
- 
+
     /**
      * Gets the field.
      *
@@ -20302,13 +20244,16 @@ public class IBMDiscoveryV1Models {
       this.field = field;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_id', 'documentId');
-      mapping.put('passage_score', 'passageScore');
-      mapping.put('passage_text', 'passageText');
-      mapping.put('start_offset', 'startOffset');
-      mapping.put('end_offset', 'endOffset');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.put(parentLabel + 'passage_score', 'passageScore');
+      mapping.put(parentLabel + 'passage_text', 'passageText');
+      mapping.put(parentLabel + 'start_offset', 'startOffset');
+      mapping.put(parentLabel + 'end_offset', 'endOffset');
       return mapping;
     }
   }
@@ -20318,7 +20263,7 @@ public class IBMDiscoveryV1Models {
    */
   public class QueryRelationsArgument extends IBMWatsonGenericModel {
     private List<QueryEntitiesEntity> entities;
- 
+
     /**
      * Gets the entities.
      *
@@ -20363,11 +20308,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) QueryEntitiesEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
       return mapping;
     }
   }
@@ -20379,7 +20321,7 @@ public class IBMDiscoveryV1Models {
     private String text;
     private String xtype;
     private Boolean exact;
- 
+
     /**
      * Gets the text.
      *
@@ -20390,7 +20332,7 @@ public class IBMDiscoveryV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the xtype.
      *
@@ -20401,7 +20343,7 @@ public class IBMDiscoveryV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the exact.
      *
@@ -20428,9 +20370,8 @@ public class IBMDiscoveryV1Models {
       return new QueryRelationsEntityBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xtype', 'type');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'xtype', 'type');
       return mapping;
     }
   }
@@ -20470,7 +20411,7 @@ public class IBMDiscoveryV1Models {
      * @param text the text
      * @return the QueryRelationsEntity builder
      */
-    public QueryRelationsEntityBuilder setText(String text) {
+    public QueryRelationsEntityBuilder text(String text) {
       this.text = text;
       return this;
     }
@@ -20481,7 +20422,7 @@ public class IBMDiscoveryV1Models {
      * @param xtype the xtype
      * @return the QueryRelationsEntity builder
      */
-    public QueryRelationsEntityBuilder setXtype(String xtype) {
+    public QueryRelationsEntityBuilder xtype(String xtype) {
       this.xtype = xtype;
       return this;
     }
@@ -20492,7 +20433,7 @@ public class IBMDiscoveryV1Models {
      * @param exact the exact
      * @return the QueryRelationsEntity builder
      */
-    public QueryRelationsEntityBuilder setExact(Boolean exact) {
+    public QueryRelationsEntityBuilder exact(Boolean exact) {
       this.exact = exact;
       return this;
     }
@@ -20505,7 +20446,7 @@ public class IBMDiscoveryV1Models {
     private QueryFilterType relationTypes;
     private QueryFilterType entityTypes;
     private List<String> documentIds;
- 
+
     /**
      * Gets the relationTypes.
      *
@@ -20514,7 +20455,7 @@ public class IBMDiscoveryV1Models {
     public QueryFilterType getRelationTypes() {
       return relationTypes;
     }
- 
+
     /**
      * Gets the entityTypes.
      *
@@ -20523,7 +20464,7 @@ public class IBMDiscoveryV1Models {
     public QueryFilterType getEntityTypes() {
       return entityTypes;
     }
- 
+
     /**
      * Gets the documentIds.
      *
@@ -20550,11 +20491,14 @@ public class IBMDiscoveryV1Models {
       return new QueryRelationsFilterBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('relationTypes', 'relation_types');
-      mapping.put('entityTypes', 'entity_types');
-      mapping.put('documentIds', 'document_ids');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'relationTypes', 'relation_types');
+      mapping.put(parentLabel + 'entityTypes', 'entity_types');
+      mapping.put(parentLabel + 'documentIds', 'document_ids');
       return mapping;
     }
   }
@@ -20609,7 +20553,7 @@ public class IBMDiscoveryV1Models {
      * @param relationTypes the relationTypes
      * @return the QueryRelationsFilter builder
      */
-    public QueryRelationsFilterBuilder setRelationTypes(QueryFilterType relationTypes) {
+    public QueryRelationsFilterBuilder relationTypes(QueryFilterType relationTypes) {
       this.relationTypes = relationTypes;
       return this;
     }
@@ -20620,7 +20564,7 @@ public class IBMDiscoveryV1Models {
      * @param entityTypes the entityTypes
      * @return the QueryRelationsFilter builder
      */
-    public QueryRelationsFilterBuilder setEntityTypes(QueryFilterType entityTypes) {
+    public QueryRelationsFilterBuilder entityTypes(QueryFilterType entityTypes) {
       this.entityTypes = entityTypes;
       return this;
     }
@@ -20632,7 +20576,7 @@ public class IBMDiscoveryV1Models {
      * @param documentIds the documentIds
      * @return the QueryRelationsFilter builder
      */
-    public QueryRelationsFilterBuilder setDocumentIds(List<String> documentIds) {
+    public QueryRelationsFilterBuilder documentIds(List<String> documentIds) {
       this.documentIds = documentIds;
       return this;
     }
@@ -20769,11 +20713,11 @@ public class IBMDiscoveryV1Models {
       mapping.put('environmentId', 'environment_id');
       mapping.put('collectionId', 'collection_id');
       if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getSdkToApiMapping());
+        mapping.putAll(entities[0].addToSdkToApiMapping('', mapping));
       }
       mapping.put('xsort', 'sort');
       if (filter != null) {
-        mapping.putAll(filter.getSdkToApiMapping());
+        mapping.putAll(filter.addToSdkToApiMapping('', mapping));
       }
       mapping.put('evidenceCount', 'evidence_count');
       return mapping;
@@ -20956,7 +20900,7 @@ public class IBMDiscoveryV1Models {
     private Long frequency;
     private List<QueryRelationsArgument> arguments;
     private List<QueryEvidence> evidence;
- 
+
     /**
      * Gets the xtype.
      *
@@ -20968,7 +20912,7 @@ public class IBMDiscoveryV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the frequency.
      *
@@ -20980,7 +20924,7 @@ public class IBMDiscoveryV1Models {
     public Long getFrequency() {
       return frequency;
     }
- 
+
     /**
      * Gets the arguments.
      *
@@ -20992,7 +20936,7 @@ public class IBMDiscoveryV1Models {
     public List<QueryRelationsArgument> getArguments() {
       return arguments;
     }
- 
+
     /**
      * Gets the evidence.
      *
@@ -21077,15 +21021,14 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
-      if (arguments != null && arguments[0] != null) {
-        mapping.putAll(arguments[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (evidence != null && evidence[0] != null) {
-        mapping.putAll(evidence[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'type', 'xtype');
+      mapping.putAll(((IBMWatsonGenericModel) QueryRelationsArgument.class.newInstance()).addToApiToSdkMapping(parentLabel + 'arguments/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) QueryEvidence.class.newInstance()).addToApiToSdkMapping(parentLabel + 'evidence/', mapping));
       return mapping;
     }
   }
@@ -21095,7 +21038,7 @@ public class IBMDiscoveryV1Models {
    */
   public class QueryRelationsResponse extends IBMWatsonResponseModel {
     private List<QueryRelationsRelationship> relations;
- 
+
     /**
      * Gets the relations.
      *
@@ -21140,11 +21083,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (relations != null && relations[0] != null) {
-        mapping.putAll(relations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) QueryRelationsRelationship.class.newInstance()).addToApiToSdkMapping(parentLabel + 'relations/', mapping));
       return mapping;
     }
   }
@@ -21160,7 +21100,7 @@ public class IBMDiscoveryV1Models {
     private Long duplicatesRemoved;
     private String sessionToken;
     private RetrievalDetails retrievalDetails;
- 
+
     /**
      * Gets the matchingResults.
      *
@@ -21172,7 +21112,7 @@ public class IBMDiscoveryV1Models {
     public Long getMatchingResults() {
       return matchingResults;
     }
- 
+
     /**
      * Gets the results.
      *
@@ -21184,7 +21124,7 @@ public class IBMDiscoveryV1Models {
     public List<QueryResult> getResults() {
       return results;
     }
- 
+
     /**
      * Gets the aggregations.
      *
@@ -21196,7 +21136,7 @@ public class IBMDiscoveryV1Models {
     public List<QueryAggregation> getAggregations() {
       return aggregations;
     }
- 
+
     /**
      * Gets the passages.
      *
@@ -21208,7 +21148,7 @@ public class IBMDiscoveryV1Models {
     public List<QueryPassages> getPassages() {
       return passages;
     }
- 
+
     /**
      * Gets the duplicatesRemoved.
      *
@@ -21220,7 +21160,7 @@ public class IBMDiscoveryV1Models {
     public Long getDuplicatesRemoved() {
       return duplicatesRemoved;
     }
- 
+
     /**
      * Gets the sessionToken.
      *
@@ -21235,7 +21175,7 @@ public class IBMDiscoveryV1Models {
     public String getSessionToken() {
       return sessionToken;
     }
- 
+
     /**
      * Gets the retrievalDetails.
      *
@@ -21364,24 +21304,19 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('matching_results', 'matchingResults');
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (aggregations != null && aggregations[0] != null) {
-        mapping.putAll(aggregations[0].getApiToSdkMapping());
-      }
-      if (passages != null && passages[0] != null) {
-        mapping.putAll(passages[0].getApiToSdkMapping());
-      }
-      mapping.put('duplicates_removed', 'duplicatesRemoved');
-      mapping.put('session_token', 'sessionToken');
-      mapping.put('retrieval_details', 'retrievalDetails');
-      if (retrievalDetails != null) {
-        mapping.putAll(retrievalDetails.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'matching_results', 'matchingResults');
+      mapping.putAll(((IBMWatsonGenericModel) QueryResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) QueryAggregation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'aggregations/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) QueryPassages.class.newInstance()).addToApiToSdkMapping(parentLabel + 'passages/', mapping));
+      mapping.put(parentLabel + 'duplicates_removed', 'duplicatesRemoved');
+      mapping.put(parentLabel + 'session_token', 'sessionToken');
+      mapping.put(parentLabel + 'retrieval_details', 'retrievalDetails');
+      mapping.putAll(((IBMWatsonGenericModel) RetrievalDetails.class.newInstance()).addToApiToSdkMapping(parentLabel + 'retrieval_details/', mapping));
       return mapping;
     }
   }
@@ -21395,7 +21330,7 @@ public class IBMDiscoveryV1Models {
     private String collectionId;
     private QueryResultMetadata resultMetadata;
     private String title;
-    private Map<String, Object> additional_properties_serialized_name;
+    private Map<String, Object> additionalProperties;
 
     /**
      * Gets the id.
@@ -21528,10 +21463,9 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('collection_id', 'collectionId');
-      mapping.put('result_metadata', 'resultMetadata');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'collection_id', 'collectionId');
+      mapping.put(parentLabel + 'result_metadata', 'resultMetadata');
       return mapping;
     }
   }
@@ -21542,7 +21476,7 @@ public class IBMDiscoveryV1Models {
   public class QueryResultMetadata extends IBMWatsonGenericModel {
     private Double score;
     private Double confidence;
- 
+
     /**
      * Gets the score.
      *
@@ -21555,7 +21489,7 @@ public class IBMDiscoveryV1Models {
     public Double getScore() {
       return score;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -21595,7 +21529,7 @@ public class IBMDiscoveryV1Models {
    */
   public class RetrievalDetails extends IBMWatsonGenericModel {
     private String documentRetrievalStrategy;
- 
+
     /**
      * Gets the documentRetrievalStrategy.
      *
@@ -21623,9 +21557,12 @@ public class IBMDiscoveryV1Models {
       this.documentRetrievalStrategy = documentRetrievalStrategy;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_retrieval_strategy', 'documentRetrievalStrategy');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'document_retrieval_strategy', 'documentRetrievalStrategy');
       return mapping;
     }
   }
@@ -21639,7 +21576,7 @@ public class IBMDiscoveryV1Models {
     private Long totalPages;
     private Long totalDocuments;
     private SduStatusCustomFields customFields;
- 
+
     /**
      * Gets the enabled.
      *
@@ -21654,7 +21591,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getEnabled() {
       return enabled;
     }
- 
+
     /**
      * Gets the totalAnnotatedPages.
      *
@@ -21666,7 +21603,7 @@ public class IBMDiscoveryV1Models {
     public Long getTotalAnnotatedPages() {
       return totalAnnotatedPages;
     }
- 
+
     /**
      * Gets the totalPages.
      *
@@ -21679,7 +21616,7 @@ public class IBMDiscoveryV1Models {
     public Long getTotalPages() {
       return totalPages;
     }
- 
+
     /**
      * Gets the totalDocuments.
      *
@@ -21695,7 +21632,7 @@ public class IBMDiscoveryV1Models {
     public Long getTotalDocuments() {
       return totalDocuments;
     }
- 
+
     /**
      * Gets the customFields.
      *
@@ -21767,15 +21704,12 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('total_annotated_pages', 'totalAnnotatedPages');
-      mapping.put('total_pages', 'totalPages');
-      mapping.put('total_documents', 'totalDocuments');
-      mapping.put('custom_fields', 'customFields');
-      if (customFields != null) {
-        mapping.putAll(customFields.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'total_annotated_pages', 'totalAnnotatedPages');
+      mapping.put(parentLabel + 'total_pages', 'totalPages');
+      mapping.put(parentLabel + 'total_documents', 'totalDocuments');
+      mapping.put(parentLabel + 'custom_fields', 'customFields');
+      mapping.putAll(((IBMWatsonGenericModel) SduStatusCustomFields.class.newInstance()).addToApiToSdkMapping(parentLabel + 'custom_fields/', mapping));
       return mapping;
     }
   }
@@ -21786,7 +21720,7 @@ public class IBMDiscoveryV1Models {
   public class SduStatusCustomFields extends IBMWatsonGenericModel {
     private Long defined;
     private Long maximumAllowed;
- 
+
     /**
      * Gets the defined.
      *
@@ -21798,7 +21732,7 @@ public class IBMDiscoveryV1Models {
     public Long getDefined() {
       return defined;
     }
- 
+
     /**
      * Gets the maximumAllowed.
      *
@@ -21829,9 +21763,8 @@ public class IBMDiscoveryV1Models {
       this.maximumAllowed = maximumAllowed;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('maximum_allowed', 'maximumAllowed');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'maximum_allowed', 'maximumAllowed');
       return mapping;
     }
   }
@@ -21844,7 +21777,7 @@ public class IBMDiscoveryV1Models {
     private String status;
     private String statusDescription;
     private Datetime lastTrained;
- 
+
     /**
      * Gets the scope.
      *
@@ -21856,7 +21789,7 @@ public class IBMDiscoveryV1Models {
     public String getScope() {
       return scope;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -21868,7 +21801,7 @@ public class IBMDiscoveryV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the statusDescription.
      *
@@ -21880,7 +21813,7 @@ public class IBMDiscoveryV1Models {
     public String getStatusDescription() {
       return statusDescription;
     }
- 
+
     /**
      * Gets the lastTrained.
      *
@@ -21929,10 +21862,9 @@ public class IBMDiscoveryV1Models {
       this.lastTrained = lastTrained;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('status_description', 'statusDescription');
-      mapping.put('last_trained', 'lastTrained');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'status_description', 'statusDescription');
+      mapping.put(parentLabel + 'last_trained', 'lastTrained');
       return mapping;
     }
   }
@@ -21950,7 +21882,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public SegmentSettings() { }
- 
+
     /**
      * Gets the enabled.
      *
@@ -21962,7 +21894,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getEnabled() {
       return enabled;
     }
- 
+
     /**
      * Gets the selectorTags.
      *
@@ -21977,7 +21909,7 @@ public class IBMDiscoveryV1Models {
     public List<String> getSelectorTags() {
       return selectorTags;
     }
- 
+
     /**
      * Gets the annotatedFields.
      *
@@ -22011,17 +21943,15 @@ public class IBMDiscoveryV1Models {
       return new SegmentSettingsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('selectorTags', 'selector_tags');
-      mapping.put('annotatedFields', 'annotated_fields');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'selectorTags', 'selector_tags');
+      mapping.put(parentLabel + 'annotatedFields', 'annotated_fields');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('selector_tags', 'selectorTags');
-      mapping.put('annotated_fields', 'annotatedFields');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'selector_tags', 'selectorTags');
+      mapping.put(parentLabel + 'annotated_fields', 'annotatedFields');
       return mapping;
     }
   }
@@ -22091,7 +22021,7 @@ public class IBMDiscoveryV1Models {
      * @param enabled the enabled
      * @return the SegmentSettings builder
      */
-    public SegmentSettingsBuilder setEnabled(Boolean enabled) {
+    public SegmentSettingsBuilder enabled(Boolean enabled) {
       this.enabled = enabled;
       return this;
     }
@@ -22103,7 +22033,7 @@ public class IBMDiscoveryV1Models {
      * @param selectorTags the selectorTags
      * @return the SegmentSettings builder
      */
-    public SegmentSettingsBuilder setSelectorTags(List<String> selectorTags) {
+    public SegmentSettingsBuilder selectorTags(List<String> selectorTags) {
       this.selectorTags = selectorTags;
       return this;
     }
@@ -22115,7 +22045,7 @@ public class IBMDiscoveryV1Models {
      * @param annotatedFields the annotatedFields
      * @return the SegmentSettings builder
      */
-    public SegmentSettingsBuilder setAnnotatedFields(List<String> annotatedFields) {
+    public SegmentSettingsBuilder annotatedFields(List<String> annotatedFields) {
       this.annotatedFields = annotatedFields;
       return this;
     }
@@ -22135,7 +22065,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public Source() { }
- 
+
     /**
      * Gets the xtype.
      *
@@ -22152,7 +22082,7 @@ public class IBMDiscoveryV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the credentialId.
      *
@@ -22166,7 +22096,7 @@ public class IBMDiscoveryV1Models {
     public String getCredentialId() {
       return credentialId;
     }
- 
+
     /**
      * Gets the schedule.
      *
@@ -22178,7 +22108,7 @@ public class IBMDiscoveryV1Models {
     public SourceSchedule getSchedule() {
       return schedule;
     }
- 
+
     /**
      * Gets the options.
      *
@@ -22217,38 +22147,40 @@ public class IBMDiscoveryV1Models {
 
       // calling custom deserializer for schedule
       SourceSchedule newSchedule = (SourceSchedule) new SourceSchedule().deserialize(JSON.serialize(ret.getSchedule()), (Map<String, Object>) jsonMap.get('schedule'), SourceSchedule.class);
-      retBuilder.setSchedule(newSchedule);
+      retBuilder.schedule(newSchedule);
 
       // calling custom deserializer for options
       SourceOptions newOptions = (SourceOptions) new SourceOptions().deserialize(JSON.serialize(ret.getOptions()), (Map<String, Object>) jsonMap.get('options'), SourceOptions.class);
-      retBuilder.setOptions(newOptions);
+      retBuilder.options(newOptions);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xtype', 'type');
-      mapping.put('credentialId', 'credential_id');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xtype', 'type');
+      mapping.put(parentLabel + 'credentialId', 'credential_id');
       if (schedule != null) {
-        mapping.putAll(schedule.getSdkToApiMapping());
+        mapping.putAll(schedule.addToSdkToApiMapping(parentLabel + 'schedule/', mapping));
       }
       if (options != null) {
-        mapping.putAll(options.getSdkToApiMapping());
+        mapping.putAll(options.addToSdkToApiMapping(parentLabel + 'options/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
-      mapping.put('credential_id', 'credentialId');
-      if (schedule != null) {
-        mapping.putAll(schedule.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (options != null) {
-        mapping.putAll(options.getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'type', 'xtype');
+      mapping.put(parentLabel + 'credential_id', 'credentialId');
+      mapping.putAll(((IBMWatsonGenericModel) SourceSchedule.class.newInstance()).addToApiToSdkMapping(parentLabel + 'schedule/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) SourceOptions.class.newInstance()).addToApiToSdkMapping(parentLabel + 'options/', mapping));
       return mapping;
     }
   }
@@ -22290,7 +22222,7 @@ public class IBMDiscoveryV1Models {
      * @param xtype the xtype
      * @return the Source builder
      */
-    public SourceBuilder setXtype(String xtype) {
+    public SourceBuilder xtype(String xtype) {
       this.xtype = xtype;
       return this;
     }
@@ -22301,7 +22233,7 @@ public class IBMDiscoveryV1Models {
      * @param credentialId the credentialId
      * @return the Source builder
      */
-    public SourceBuilder setCredentialId(String credentialId) {
+    public SourceBuilder credentialId(String credentialId) {
       this.credentialId = credentialId;
       return this;
     }
@@ -22312,7 +22244,7 @@ public class IBMDiscoveryV1Models {
      * @param schedule the schedule
      * @return the Source builder
      */
-    public SourceBuilder setSchedule(SourceSchedule schedule) {
+    public SourceBuilder schedule(SourceSchedule schedule) {
       this.schedule = schedule;
       return this;
     }
@@ -22323,7 +22255,7 @@ public class IBMDiscoveryV1Models {
      * @param options the options
      * @return the Source builder
      */
-    public SourceBuilder setOptions(SourceOptions options) {
+    public SourceBuilder options(SourceOptions options) {
       this.options = options;
       return this;
     }
@@ -22345,7 +22277,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public SourceOptions() { }
- 
+
     /**
      * Gets the folders.
      *
@@ -22358,7 +22290,7 @@ public class IBMDiscoveryV1Models {
     public List<SourceOptionsFolder> getFolders() {
       return folders;
     }
- 
+
     /**
      * Gets the objects.
      *
@@ -22371,7 +22303,7 @@ public class IBMDiscoveryV1Models {
     public List<SourceOptionsObject> getObjects() {
       return objects;
     }
- 
+
     /**
      * Gets the siteCollections.
      *
@@ -22384,7 +22316,7 @@ public class IBMDiscoveryV1Models {
     public List<SourceOptionsSiteColl> getSiteCollections() {
       return siteCollections;
     }
- 
+
     /**
      * Gets the urls.
      *
@@ -22397,7 +22329,7 @@ public class IBMDiscoveryV1Models {
     public List<SourceOptionsWebCrawl> getUrls() {
       return urls;
     }
- 
+
     /**
      * Gets the buckets.
      *
@@ -22411,7 +22343,7 @@ public class IBMDiscoveryV1Models {
     public List<SourceOptionsBuckets> getBuckets() {
       return buckets;
     }
- 
+
     /**
      * Gets the crawlAllBuckets.
      *
@@ -22461,7 +22393,7 @@ public class IBMDiscoveryV1Models {
           SourceOptionsFolder newItem = (SourceOptionsFolder) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsFolder.class);
           newFolders.add(newItem);
         }
-        retBuilder.setFolders(newFolders);
+        retBuilder.folders(newFolders);
       }
 
       // calling custom deserializer for objects
@@ -22474,7 +22406,7 @@ public class IBMDiscoveryV1Models {
           SourceOptionsObject newItem = (SourceOptionsObject) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsObject.class);
           newObjects.add(newItem);
         }
-        retBuilder.setObjects(newObjects);
+        retBuilder.objects(newObjects);
       }
 
       // calling custom deserializer for siteCollections
@@ -22487,7 +22419,7 @@ public class IBMDiscoveryV1Models {
           SourceOptionsSiteColl newItem = (SourceOptionsSiteColl) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsSiteColl.class);
           newSiteCollections.add(newItem);
         }
-        retBuilder.setSiteCollections(newSiteCollections);
+        retBuilder.siteCollections(newSiteCollections);
       }
 
       // calling custom deserializer for urls
@@ -22500,7 +22432,7 @@ public class IBMDiscoveryV1Models {
           SourceOptionsWebCrawl newItem = (SourceOptionsWebCrawl) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsWebCrawl.class);
           newUrls.add(newItem);
         }
-        retBuilder.setUrls(newUrls);
+        retBuilder.urls(newUrls);
       }
 
       // calling custom deserializer for buckets
@@ -22513,53 +22445,41 @@ public class IBMDiscoveryV1Models {
           SourceOptionsBuckets newItem = (SourceOptionsBuckets) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsBuckets.class);
           newBuckets.add(newItem);
         }
-        retBuilder.setBuckets(newBuckets);
+        retBuilder.buckets(newBuckets);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (folders != null && folders[0] != null) {
-        mapping.putAll(folders[0].getSdkToApiMapping());
+        mapping.putAll(folders[0].addToSdkToApiMapping(parentLabel + 'folders/', mapping));
       }
       if (objects != null && objects[0] != null) {
-        mapping.putAll(objects[0].getSdkToApiMapping());
+        mapping.putAll(objects[0].addToSdkToApiMapping(parentLabel + 'objects/', mapping));
       }
-      mapping.put('siteCollections', 'site_collections');
+      mapping.put(parentLabel + 'siteCollections', 'site_collections');
       if (siteCollections != null && siteCollections[0] != null) {
-        mapping.putAll(siteCollections[0].getSdkToApiMapping());
+        mapping.putAll(siteCollections[0].addToSdkToApiMapping(parentLabel + 'siteCollections/', mapping));
       }
       if (urls != null && urls[0] != null) {
-        mapping.putAll(urls[0].getSdkToApiMapping());
+        mapping.putAll(urls[0].addToSdkToApiMapping(parentLabel + 'urls/', mapping));
       }
       if (buckets != null && buckets[0] != null) {
-        mapping.putAll(buckets[0].getSdkToApiMapping());
+        mapping.putAll(buckets[0].addToSdkToApiMapping(parentLabel + 'buckets/', mapping));
       }
-      mapping.put('crawlAllBuckets', 'crawl_all_buckets');
+      mapping.put(parentLabel + 'crawlAllBuckets', 'crawl_all_buckets');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (folders != null && folders[0] != null) {
-        mapping.putAll(folders[0].getApiToSdkMapping());
-      }
-      if (objects != null && objects[0] != null) {
-        mapping.putAll(objects[0].getApiToSdkMapping());
-      }
-      mapping.put('site_collections', 'siteCollections');
-      if (siteCollections != null && siteCollections[0] != null) {
-        mapping.putAll(siteCollections[0].getApiToSdkMapping());
-      }
-      if (urls != null && urls[0] != null) {
-        mapping.putAll(urls[0].getApiToSdkMapping());
-      }
-      if (buckets != null && buckets[0] != null) {
-        mapping.putAll(buckets[0].getApiToSdkMapping());
-      }
-      mapping.put('crawl_all_buckets', 'crawlAllBuckets');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) SourceOptionsFolder.class.newInstance()).addToApiToSdkMapping(parentLabel + 'folders/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) SourceOptionsObject.class.newInstance()).addToApiToSdkMapping(parentLabel + 'objects/', mapping));
+      mapping.put(parentLabel + 'site_collections', 'siteCollections');
+      mapping.putAll(((IBMWatsonGenericModel) SourceOptionsSiteColl.class.newInstance()).addToApiToSdkMapping(parentLabel + 'site_collections/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) SourceOptionsWebCrawl.class.newInstance()).addToApiToSdkMapping(parentLabel + 'urls/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) SourceOptionsBuckets.class.newInstance()).addToApiToSdkMapping(parentLabel + 'buckets/', mapping));
+      mapping.put(parentLabel + 'crawl_all_buckets', 'crawlAllBuckets');
       return mapping;
     }
   }
@@ -22681,7 +22601,7 @@ public class IBMDiscoveryV1Models {
      * @param folders the folders
      * @return the SourceOptions builder
      */
-    public SourceOptionsBuilder setFolders(List<SourceOptionsFolder> folders) {
+    public SourceOptionsBuilder folders(List<SourceOptionsFolder> folders) {
       this.folders = folders;
       return this;
     }
@@ -22693,7 +22613,7 @@ public class IBMDiscoveryV1Models {
      * @param objects the objects
      * @return the SourceOptions builder
      */
-    public SourceOptionsBuilder setObjects(List<SourceOptionsObject> objects) {
+    public SourceOptionsBuilder objects(List<SourceOptionsObject> objects) {
       this.objects = objects;
       return this;
     }
@@ -22705,7 +22625,7 @@ public class IBMDiscoveryV1Models {
      * @param siteCollections the siteCollections
      * @return the SourceOptions builder
      */
-    public SourceOptionsBuilder setSiteCollections(List<SourceOptionsSiteColl> siteCollections) {
+    public SourceOptionsBuilder siteCollections(List<SourceOptionsSiteColl> siteCollections) {
       this.siteCollections = siteCollections;
       return this;
     }
@@ -22717,7 +22637,7 @@ public class IBMDiscoveryV1Models {
      * @param urls the urls
      * @return the SourceOptions builder
      */
-    public SourceOptionsBuilder setUrls(List<SourceOptionsWebCrawl> urls) {
+    public SourceOptionsBuilder urls(List<SourceOptionsWebCrawl> urls) {
       this.urls = urls;
       return this;
     }
@@ -22729,7 +22649,7 @@ public class IBMDiscoveryV1Models {
      * @param buckets the buckets
      * @return the SourceOptions builder
      */
-    public SourceOptionsBuilder setBuckets(List<SourceOptionsBuckets> buckets) {
+    public SourceOptionsBuilder buckets(List<SourceOptionsBuckets> buckets) {
       this.buckets = buckets;
       return this;
     }
@@ -22740,7 +22660,7 @@ public class IBMDiscoveryV1Models {
      * @param crawlAllBuckets the crawlAllBuckets
      * @return the SourceOptions builder
      */
-    public SourceOptionsBuilder setCrawlAllBuckets(Boolean crawlAllBuckets) {
+    public SourceOptionsBuilder crawlAllBuckets(Boolean crawlAllBuckets) {
       this.crawlAllBuckets = crawlAllBuckets;
       return this;
     }
@@ -22758,7 +22678,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public SourceOptionsBuckets() { }
- 
+
     /**
      * Gets the name.
      *
@@ -22770,7 +22690,7 @@ public class IBMDiscoveryV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the xlimit.
      *
@@ -22799,15 +22719,13 @@ public class IBMDiscoveryV1Models {
       return new SourceOptionsBucketsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('limit', 'xlimit');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'limit', 'xlimit');
       return mapping;
     }
   }
@@ -22854,7 +22772,7 @@ public class IBMDiscoveryV1Models {
      * @param name the name
      * @return the SourceOptionsBuckets builder
      */
-    public SourceOptionsBucketsBuilder setName(String name) {
+    public SourceOptionsBucketsBuilder name(String name) {
       this.name = name;
       return this;
     }
@@ -22865,7 +22783,7 @@ public class IBMDiscoveryV1Models {
      * @param xlimit the xlimit
      * @return the SourceOptionsBuckets builder
      */
-    public SourceOptionsBucketsBuilder setXlimit(Long xlimit) {
+    public SourceOptionsBucketsBuilder xlimit(Long xlimit) {
       this.xlimit = xlimit;
       return this;
     }
@@ -22884,7 +22802,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public SourceOptionsFolder() { }
- 
+
     /**
      * Gets the ownerUserId.
      *
@@ -22896,7 +22814,7 @@ public class IBMDiscoveryV1Models {
     public String getOwnerUserId() {
       return ownerUserId;
     }
- 
+
     /**
      * Gets the folderId.
      *
@@ -22908,7 +22826,7 @@ public class IBMDiscoveryV1Models {
     public String getFolderId() {
       return folderId;
     }
- 
+
     /**
      * Gets the xlimit.
      *
@@ -22938,19 +22856,25 @@ public class IBMDiscoveryV1Models {
       return new SourceOptionsFolderBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('ownerUserId', 'owner_user_id');
-      mapping.put('folderId', 'folder_id');
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'ownerUserId', 'owner_user_id');
+      mapping.put(parentLabel + 'folderId', 'folder_id');
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('owner_user_id', 'ownerUserId');
-      mapping.put('folder_id', 'folderId');
-      mapping.put('limit', 'xlimit');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'owner_user_id', 'ownerUserId');
+      mapping.put(parentLabel + 'folder_id', 'folderId');
+      mapping.put(parentLabel + 'limit', 'xlimit');
       return mapping;
     }
   }
@@ -23001,7 +22925,7 @@ public class IBMDiscoveryV1Models {
      * @param ownerUserId the ownerUserId
      * @return the SourceOptionsFolder builder
      */
-    public SourceOptionsFolderBuilder setOwnerUserId(String ownerUserId) {
+    public SourceOptionsFolderBuilder ownerUserId(String ownerUserId) {
       this.ownerUserId = ownerUserId;
       return this;
     }
@@ -23012,7 +22936,7 @@ public class IBMDiscoveryV1Models {
      * @param folderId the folderId
      * @return the SourceOptionsFolder builder
      */
-    public SourceOptionsFolderBuilder setFolderId(String folderId) {
+    public SourceOptionsFolderBuilder folderId(String folderId) {
       this.folderId = folderId;
       return this;
     }
@@ -23023,7 +22947,7 @@ public class IBMDiscoveryV1Models {
      * @param xlimit the xlimit
      * @return the SourceOptionsFolder builder
      */
-    public SourceOptionsFolderBuilder setXlimit(Long xlimit) {
+    public SourceOptionsFolderBuilder xlimit(Long xlimit) {
       this.xlimit = xlimit;
       return this;
     }
@@ -23041,7 +22965,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public SourceOptionsObject() { }
- 
+
     /**
      * Gets the name.
      *
@@ -23053,7 +22977,7 @@ public class IBMDiscoveryV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the xlimit.
      *
@@ -23082,15 +23006,13 @@ public class IBMDiscoveryV1Models {
       return new SourceOptionsObjectBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('limit', 'xlimit');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'limit', 'xlimit');
       return mapping;
     }
   }
@@ -23137,7 +23059,7 @@ public class IBMDiscoveryV1Models {
      * @param name the name
      * @return the SourceOptionsObject builder
      */
-    public SourceOptionsObjectBuilder setName(String name) {
+    public SourceOptionsObjectBuilder name(String name) {
       this.name = name;
       return this;
     }
@@ -23148,7 +23070,7 @@ public class IBMDiscoveryV1Models {
      * @param xlimit the xlimit
      * @return the SourceOptionsObject builder
      */
-    public SourceOptionsObjectBuilder setXlimit(Long xlimit) {
+    public SourceOptionsObjectBuilder xlimit(Long xlimit) {
       this.xlimit = xlimit;
       return this;
     }
@@ -23166,7 +23088,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public SourceOptionsSiteColl() { }
- 
+
     /**
      * Gets the siteCollectionPath.
      *
@@ -23179,7 +23101,7 @@ public class IBMDiscoveryV1Models {
     public String getSiteCollectionPath() {
       return siteCollectionPath;
     }
- 
+
     /**
      * Gets the xlimit.
      *
@@ -23208,17 +23130,23 @@ public class IBMDiscoveryV1Models {
       return new SourceOptionsSiteCollBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('siteCollectionPath', 'site_collection_path');
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'siteCollectionPath', 'site_collection_path');
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('site_collection_path', 'siteCollectionPath');
-      mapping.put('limit', 'xlimit');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'site_collection_path', 'siteCollectionPath');
+      mapping.put(parentLabel + 'limit', 'xlimit');
       return mapping;
     }
   }
@@ -23265,7 +23193,7 @@ public class IBMDiscoveryV1Models {
      * @param siteCollectionPath the siteCollectionPath
      * @return the SourceOptionsSiteColl builder
      */
-    public SourceOptionsSiteCollBuilder setSiteCollectionPath(String siteCollectionPath) {
+    public SourceOptionsSiteCollBuilder siteCollectionPath(String siteCollectionPath) {
       this.siteCollectionPath = siteCollectionPath;
       return this;
     }
@@ -23276,7 +23204,7 @@ public class IBMDiscoveryV1Models {
      * @param xlimit the xlimit
      * @return the SourceOptionsSiteColl builder
      */
-    public SourceOptionsSiteCollBuilder setXlimit(Long xlimit) {
+    public SourceOptionsSiteCollBuilder xlimit(Long xlimit) {
       this.xlimit = xlimit;
       return this;
     }
@@ -23300,7 +23228,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public SourceOptionsWebCrawl() { }
- 
+
     /**
      * Gets the url.
      *
@@ -23312,7 +23240,7 @@ public class IBMDiscoveryV1Models {
     public String getUrl() {
       return url;
     }
- 
+
     /**
      * Gets the limitToStartingHosts.
      *
@@ -23324,7 +23252,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getLimitToStartingHosts() {
       return limitToStartingHosts;
     }
- 
+
     /**
      * Gets the crawlSpeed.
      *
@@ -23338,7 +23266,7 @@ public class IBMDiscoveryV1Models {
     public String getCrawlSpeed() {
       return crawlSpeed;
     }
- 
+
     /**
      * Gets the allowUntrustedCertificate.
      *
@@ -23350,7 +23278,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getAllowUntrustedCertificate() {
       return allowUntrustedCertificate;
     }
- 
+
     /**
      * Gets the maximumHops.
      *
@@ -23364,7 +23292,7 @@ public class IBMDiscoveryV1Models {
     public Long getMaximumHops() {
       return maximumHops;
     }
- 
+
     /**
      * Gets the requestTimeout.
      *
@@ -23376,7 +23304,7 @@ public class IBMDiscoveryV1Models {
     public Long getRequestTimeout() {
       return requestTimeout;
     }
- 
+
     /**
      * Gets the overrideRobotsTxt.
      *
@@ -23390,7 +23318,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getOverrideRobotsTxt() {
       return overrideRobotsTxt;
     }
- 
+
     /**
      * Gets the blacklist.
      *
@@ -23425,25 +23353,23 @@ public class IBMDiscoveryV1Models {
       return new SourceOptionsWebCrawlBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('limitToStartingHosts', 'limit_to_starting_hosts');
-      mapping.put('crawlSpeed', 'crawl_speed');
-      mapping.put('allowUntrustedCertificate', 'allow_untrusted_certificate');
-      mapping.put('maximumHops', 'maximum_hops');
-      mapping.put('requestTimeout', 'request_timeout');
-      mapping.put('overrideRobotsTxt', 'override_robots_txt');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'limitToStartingHosts', 'limit_to_starting_hosts');
+      mapping.put(parentLabel + 'crawlSpeed', 'crawl_speed');
+      mapping.put(parentLabel + 'allowUntrustedCertificate', 'allow_untrusted_certificate');
+      mapping.put(parentLabel + 'maximumHops', 'maximum_hops');
+      mapping.put(parentLabel + 'requestTimeout', 'request_timeout');
+      mapping.put(parentLabel + 'overrideRobotsTxt', 'override_robots_txt');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('limit_to_starting_hosts', 'limitToStartingHosts');
-      mapping.put('crawl_speed', 'crawlSpeed');
-      mapping.put('allow_untrusted_certificate', 'allowUntrustedCertificate');
-      mapping.put('maximum_hops', 'maximumHops');
-      mapping.put('request_timeout', 'requestTimeout');
-      mapping.put('override_robots_txt', 'overrideRobotsTxt');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'limit_to_starting_hosts', 'limitToStartingHosts');
+      mapping.put(parentLabel + 'crawl_speed', 'crawlSpeed');
+      mapping.put(parentLabel + 'allow_untrusted_certificate', 'allowUntrustedCertificate');
+      mapping.put(parentLabel + 'maximum_hops', 'maximumHops');
+      mapping.put(parentLabel + 'request_timeout', 'requestTimeout');
+      mapping.put(parentLabel + 'override_robots_txt', 'overrideRobotsTxt');
       return mapping;
     }
   }
@@ -23517,7 +23443,7 @@ public class IBMDiscoveryV1Models {
      * @param url the url
      * @return the SourceOptionsWebCrawl builder
      */
-    public SourceOptionsWebCrawlBuilder setUrl(String url) {
+    public SourceOptionsWebCrawlBuilder url(String url) {
       this.url = url;
       return this;
     }
@@ -23528,7 +23454,7 @@ public class IBMDiscoveryV1Models {
      * @param limitToStartingHosts the limitToStartingHosts
      * @return the SourceOptionsWebCrawl builder
      */
-    public SourceOptionsWebCrawlBuilder setLimitToStartingHosts(Boolean limitToStartingHosts) {
+    public SourceOptionsWebCrawlBuilder limitToStartingHosts(Boolean limitToStartingHosts) {
       this.limitToStartingHosts = limitToStartingHosts;
       return this;
     }
@@ -23539,7 +23465,7 @@ public class IBMDiscoveryV1Models {
      * @param crawlSpeed the crawlSpeed
      * @return the SourceOptionsWebCrawl builder
      */
-    public SourceOptionsWebCrawlBuilder setCrawlSpeed(String crawlSpeed) {
+    public SourceOptionsWebCrawlBuilder crawlSpeed(String crawlSpeed) {
       this.crawlSpeed = crawlSpeed;
       return this;
     }
@@ -23550,7 +23476,7 @@ public class IBMDiscoveryV1Models {
      * @param allowUntrustedCertificate the allowUntrustedCertificate
      * @return the SourceOptionsWebCrawl builder
      */
-    public SourceOptionsWebCrawlBuilder setAllowUntrustedCertificate(Boolean allowUntrustedCertificate) {
+    public SourceOptionsWebCrawlBuilder allowUntrustedCertificate(Boolean allowUntrustedCertificate) {
       this.allowUntrustedCertificate = allowUntrustedCertificate;
       return this;
     }
@@ -23561,7 +23487,7 @@ public class IBMDiscoveryV1Models {
      * @param maximumHops the maximumHops
      * @return the SourceOptionsWebCrawl builder
      */
-    public SourceOptionsWebCrawlBuilder setMaximumHops(Long maximumHops) {
+    public SourceOptionsWebCrawlBuilder maximumHops(Long maximumHops) {
       this.maximumHops = maximumHops;
       return this;
     }
@@ -23572,7 +23498,7 @@ public class IBMDiscoveryV1Models {
      * @param requestTimeout the requestTimeout
      * @return the SourceOptionsWebCrawl builder
      */
-    public SourceOptionsWebCrawlBuilder setRequestTimeout(Long requestTimeout) {
+    public SourceOptionsWebCrawlBuilder requestTimeout(Long requestTimeout) {
       this.requestTimeout = requestTimeout;
       return this;
     }
@@ -23583,7 +23509,7 @@ public class IBMDiscoveryV1Models {
      * @param overrideRobotsTxt the overrideRobotsTxt
      * @return the SourceOptionsWebCrawl builder
      */
-    public SourceOptionsWebCrawlBuilder setOverrideRobotsTxt(Boolean overrideRobotsTxt) {
+    public SourceOptionsWebCrawlBuilder overrideRobotsTxt(Boolean overrideRobotsTxt) {
       this.overrideRobotsTxt = overrideRobotsTxt;
       return this;
     }
@@ -23595,7 +23521,7 @@ public class IBMDiscoveryV1Models {
      * @param blacklist the blacklist
      * @return the SourceOptionsWebCrawl builder
      */
-    public SourceOptionsWebCrawlBuilder setBlacklist(List<String> blacklist) {
+    public SourceOptionsWebCrawlBuilder blacklist(List<String> blacklist) {
       this.blacklist = blacklist;
       return this;
     }
@@ -23614,7 +23540,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public SourceSchedule() { }
- 
+
     /**
      * Gets the enabled.
      *
@@ -23627,7 +23553,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getEnabled() {
       return enabled;
     }
- 
+
     /**
      * Gets the timeZone.
      *
@@ -23640,7 +23566,7 @@ public class IBMDiscoveryV1Models {
     public String getTimeZone() {
       return timeZone;
     }
- 
+
     /**
      * Gets the frequency.
      *
@@ -23674,15 +23600,13 @@ public class IBMDiscoveryV1Models {
       return new SourceScheduleBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('timeZone', 'time_zone');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'timeZone', 'time_zone');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('time_zone', 'timeZone');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'time_zone', 'timeZone');
       return mapping;
     }
   }
@@ -23722,7 +23646,7 @@ public class IBMDiscoveryV1Models {
      * @param enabled the enabled
      * @return the SourceSchedule builder
      */
-    public SourceScheduleBuilder setEnabled(Boolean enabled) {
+    public SourceScheduleBuilder enabled(Boolean enabled) {
       this.enabled = enabled;
       return this;
     }
@@ -23733,7 +23657,7 @@ public class IBMDiscoveryV1Models {
      * @param timeZone the timeZone
      * @return the SourceSchedule builder
      */
-    public SourceScheduleBuilder setTimeZone(String timeZone) {
+    public SourceScheduleBuilder timeZone(String timeZone) {
       this.timeZone = timeZone;
       return this;
     }
@@ -23744,7 +23668,7 @@ public class IBMDiscoveryV1Models {
      * @param frequency the frequency
      * @return the SourceSchedule builder
      */
-    public SourceScheduleBuilder setFrequency(String frequency) {
+    public SourceScheduleBuilder frequency(String frequency) {
       this.frequency = frequency;
       return this;
     }
@@ -23756,7 +23680,7 @@ public class IBMDiscoveryV1Models {
   public class SourceStatus extends IBMWatsonGenericModel {
     private String status;
     private Datetime nextCrawl;
- 
+
     /**
      * Gets the status.
      *
@@ -23774,7 +23698,7 @@ public class IBMDiscoveryV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the nextCrawl.
      *
@@ -23805,9 +23729,8 @@ public class IBMDiscoveryV1Models {
       this.nextCrawl = nextCrawl;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('next_crawl', 'nextCrawl');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'next_crawl', 'nextCrawl');
       return mapping;
     }
   }
@@ -24117,7 +24040,7 @@ public class IBMDiscoveryV1Models {
     private String originalMediaType;
     private List<DocumentSnapshot> snapshots;
     private List<Notice> notices;
- 
+
     /**
      * Gets the configurationId.
      *
@@ -24129,7 +24052,7 @@ public class IBMDiscoveryV1Models {
     public String getConfigurationId() {
       return configurationId;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -24141,7 +24064,7 @@ public class IBMDiscoveryV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the enrichedFieldUnits.
      *
@@ -24154,7 +24077,7 @@ public class IBMDiscoveryV1Models {
     public Long getEnrichedFieldUnits() {
       return enrichedFieldUnits;
     }
- 
+
     /**
      * Gets the originalMediaType.
      *
@@ -24166,7 +24089,7 @@ public class IBMDiscoveryV1Models {
     public String getOriginalMediaType() {
       return originalMediaType;
     }
- 
+
     /**
      * Gets the snapshots.
      *
@@ -24178,7 +24101,7 @@ public class IBMDiscoveryV1Models {
     public List<DocumentSnapshot> getSnapshots() {
       return snapshots;
     }
- 
+
     /**
      * Gets the notices.
      *
@@ -24227,14 +24150,15 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('configuration_id', 'configurationId');
-      mapping.put('enriched_field_units', 'enrichedFieldUnits');
-      mapping.put('original_media_type', 'originalMediaType');
-      if (notices != null && notices[0] != null) {
-        mapping.putAll(notices[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'configuration_id', 'configurationId');
+      mapping.put(parentLabel + 'enriched_field_units', 'enrichedFieldUnits');
+      mapping.put(parentLabel + 'original_media_type', 'originalMediaType');
+      mapping.putAll(((IBMWatsonGenericModel) Notice.class.newInstance()).addToApiToSdkMapping(parentLabel + 'notices/', mapping));
       return mapping;
     }
   }
@@ -24247,7 +24171,7 @@ public class IBMDiscoveryV1Models {
     private List<String> tokens;
     private List<String> readings;
     private String partOfSpeech;
- 
+
     /**
      * Gets the text.
      *
@@ -24258,7 +24182,7 @@ public class IBMDiscoveryV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the tokens.
      *
@@ -24269,7 +24193,7 @@ public class IBMDiscoveryV1Models {
     public List<String> getTokens() {
       return tokens;
     }
- 
+
     /**
      * Gets the readings.
      *
@@ -24280,7 +24204,7 @@ public class IBMDiscoveryV1Models {
     public List<String> getReadings() {
       return readings;
     }
- 
+
     /**
      * Gets the partOfSpeech.
      *
@@ -24312,9 +24236,8 @@ public class IBMDiscoveryV1Models {
       return new TokenDictRuleBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('partOfSpeech', 'part_of_speech');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'partOfSpeech', 'part_of_speech');
       return mapping;
     }
   }
@@ -24399,7 +24322,7 @@ public class IBMDiscoveryV1Models {
      * @param text the text
      * @return the TokenDictRule builder
      */
-    public TokenDictRuleBuilder setText(String text) {
+    public TokenDictRuleBuilder text(String text) {
       this.text = text;
       return this;
     }
@@ -24411,7 +24334,7 @@ public class IBMDiscoveryV1Models {
      * @param tokens the tokens
      * @return the TokenDictRule builder
      */
-    public TokenDictRuleBuilder setTokens(List<String> tokens) {
+    public TokenDictRuleBuilder tokens(List<String> tokens) {
       this.tokens = tokens;
       return this;
     }
@@ -24423,7 +24346,7 @@ public class IBMDiscoveryV1Models {
      * @param readings the readings
      * @return the TokenDictRule builder
      */
-    public TokenDictRuleBuilder setReadings(List<String> readings) {
+    public TokenDictRuleBuilder readings(List<String> readings) {
       this.readings = readings;
       return this;
     }
@@ -24434,7 +24357,7 @@ public class IBMDiscoveryV1Models {
      * @param partOfSpeech the partOfSpeech
      * @return the TokenDictRule builder
      */
-    public TokenDictRuleBuilder setPartOfSpeech(String partOfSpeech) {
+    public TokenDictRuleBuilder partOfSpeech(String partOfSpeech) {
       this.partOfSpeech = partOfSpeech;
       return this;
     }
@@ -24446,7 +24369,7 @@ public class IBMDiscoveryV1Models {
   public class TokenDictStatusResponse extends IBMWatsonResponseModel {
     private String status;
     private String xtype;
- 
+
     /**
      * Gets the status.
      *
@@ -24458,7 +24381,7 @@ public class IBMDiscoveryV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the xtype.
      *
@@ -24489,9 +24412,8 @@ public class IBMDiscoveryV1Models {
       this.xtype = xtype;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'type', 'xtype');
       return mapping;
     }
   }
@@ -24502,7 +24424,7 @@ public class IBMDiscoveryV1Models {
   public class TopHitsResults extends IBMWatsonGenericModel {
     private Long matchingResults;
     private List<QueryResult> hits;
- 
+
     /**
      * Gets the matchingResults.
      *
@@ -24514,7 +24436,7 @@ public class IBMDiscoveryV1Models {
     public Long getMatchingResults() {
       return matchingResults;
     }
- 
+
     /**
      * Gets the hits.
      *
@@ -24568,12 +24490,13 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('matching_results', 'matchingResults');
-      if (hits != null && hits[0] != null) {
-        mapping.putAll(hits[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'matching_results', 'matchingResults');
+      mapping.putAll(((IBMWatsonGenericModel) QueryResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'hits/', mapping));
       return mapping;
     }
   }
@@ -24585,7 +24508,7 @@ public class IBMDiscoveryV1Models {
     private String environmentId;
     private String collectionId;
     private List<TrainingQuery> queries;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -24597,7 +24520,7 @@ public class IBMDiscoveryV1Models {
     public String getEnvironmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -24609,7 +24532,7 @@ public class IBMDiscoveryV1Models {
     public String getCollectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the queries.
      *
@@ -24672,13 +24595,14 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('environment_id', 'environmentId');
-      mapping.put('collection_id', 'collectionId');
-      if (queries != null && queries[0] != null) {
-        mapping.putAll(queries[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'environment_id', 'environmentId');
+      mapping.put(parentLabel + 'collection_id', 'collectionId');
+      mapping.putAll(((IBMWatsonGenericModel) TrainingQuery.class.newInstance()).addToApiToSdkMapping(parentLabel + 'queries/', mapping));
       return mapping;
     }
   }
@@ -24696,7 +24620,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public TrainingExample() { }
- 
+
     /**
      * Gets the documentId.
      *
@@ -24708,7 +24632,7 @@ public class IBMDiscoveryV1Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the crossReference.
      *
@@ -24720,7 +24644,7 @@ public class IBMDiscoveryV1Models {
     public String getCrossReference() {
       return crossReference;
     }
- 
+
     /**
      * Gets the relevance.
      *
@@ -24748,17 +24672,23 @@ public class IBMDiscoveryV1Models {
       return new TrainingExampleBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('documentId', 'document_id');
-      mapping.put('crossReference', 'cross_reference');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'documentId', 'document_id');
+      mapping.put(parentLabel + 'crossReference', 'cross_reference');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_id', 'documentId');
-      mapping.put('cross_reference', 'crossReference');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.put(parentLabel + 'cross_reference', 'crossReference');
       return mapping;
     }
   }
@@ -24798,7 +24728,7 @@ public class IBMDiscoveryV1Models {
      * @param documentId the documentId
      * @return the TrainingExample builder
      */
-    public TrainingExampleBuilder setDocumentId(String documentId) {
+    public TrainingExampleBuilder documentId(String documentId) {
       this.documentId = documentId;
       return this;
     }
@@ -24809,7 +24739,7 @@ public class IBMDiscoveryV1Models {
      * @param crossReference the crossReference
      * @return the TrainingExample builder
      */
-    public TrainingExampleBuilder setCrossReference(String crossReference) {
+    public TrainingExampleBuilder crossReference(String crossReference) {
       this.crossReference = crossReference;
       return this;
     }
@@ -24820,7 +24750,7 @@ public class IBMDiscoveryV1Models {
      * @param relevance the relevance
      * @return the TrainingExample builder
      */
-    public TrainingExampleBuilder setRelevance(Long relevance) {
+    public TrainingExampleBuilder relevance(Long relevance) {
       this.relevance = relevance;
       return this;
     }
@@ -24831,7 +24761,7 @@ public class IBMDiscoveryV1Models {
    */
   public class TrainingExampleList extends IBMWatsonResponseModel {
     private List<TrainingExample> examples;
- 
+
     /**
      * Gets the examples.
      *
@@ -24876,11 +24806,8 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (examples != null && examples[0] != null) {
-        mapping.putAll(examples[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) TrainingExample.class.newInstance()).addToApiToSdkMapping(parentLabel + 'examples/', mapping));
       return mapping;
     }
   }
@@ -24893,7 +24820,7 @@ public class IBMDiscoveryV1Models {
     private String naturalLanguageQuery;
     private String filter;
     private List<TrainingExample> examples;
- 
+
     /**
      * Gets the queryId.
      *
@@ -24905,7 +24832,7 @@ public class IBMDiscoveryV1Models {
     public String getQueryId() {
       return queryId;
     }
- 
+
     /**
      * Gets the naturalLanguageQuery.
      *
@@ -24917,7 +24844,7 @@ public class IBMDiscoveryV1Models {
     public String getNaturalLanguageQuery() {
       return naturalLanguageQuery;
     }
- 
+
     /**
      * Gets the filter.
      *
@@ -24929,7 +24856,7 @@ public class IBMDiscoveryV1Models {
     public String getFilter() {
       return filter;
     }
- 
+
     /**
      * Gets the examples.
      *
@@ -25001,13 +24928,14 @@ public class IBMDiscoveryV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('query_id', 'queryId');
-      mapping.put('natural_language_query', 'naturalLanguageQuery');
-      if (examples != null && examples[0] != null) {
-        mapping.putAll(examples[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'query_id', 'queryId');
+      mapping.put(parentLabel + 'natural_language_query', 'naturalLanguageQuery');
+      mapping.putAll(((IBMWatsonGenericModel) TrainingExample.class.newInstance()).addToApiToSdkMapping(parentLabel + 'examples/', mapping));
       return mapping;
     }
   }
@@ -25025,7 +24953,7 @@ public class IBMDiscoveryV1Models {
     private Long notices;
     private Datetime successfullyTrained;
     private Datetime dataUpdated;
- 
+
     /**
      * Gets the totalExamples.
      *
@@ -25037,7 +24965,7 @@ public class IBMDiscoveryV1Models {
     public Long getTotalExamples() {
       return totalExamples;
     }
- 
+
     /**
      * Gets the available.
      *
@@ -25049,7 +24977,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getAvailable() {
       return available;
     }
- 
+
     /**
      * Gets the processing.
      *
@@ -25061,7 +24989,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getProcessing() {
       return processing;
     }
- 
+
     /**
      * Gets the minimumQueriesAdded.
      *
@@ -25073,7 +25001,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getMinimumQueriesAdded() {
       return minimumQueriesAdded;
     }
- 
+
     /**
      * Gets the minimumExamplesAdded.
      *
@@ -25085,7 +25013,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getMinimumExamplesAdded() {
       return minimumExamplesAdded;
     }
- 
+
     /**
      * Gets the sufficientLabelDiversity.
      *
@@ -25097,7 +25025,7 @@ public class IBMDiscoveryV1Models {
     public Boolean getSufficientLabelDiversity() {
       return sufficientLabelDiversity;
     }
- 
+
     /**
      * Gets the notices.
      *
@@ -25109,7 +25037,7 @@ public class IBMDiscoveryV1Models {
     public Long getNotices() {
       return notices;
     }
- 
+
     /**
      * Gets the successfullyTrained.
      *
@@ -25121,7 +25049,7 @@ public class IBMDiscoveryV1Models {
     public Datetime getSuccessfullyTrained() {
       return successfullyTrained;
     }
- 
+
     /**
      * Gets the dataUpdated.
      *
@@ -25215,14 +25143,17 @@ public class IBMDiscoveryV1Models {
       this.dataUpdated = dataUpdated;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('total_examples', 'totalExamples');
-      mapping.put('minimum_queries_added', 'minimumQueriesAdded');
-      mapping.put('minimum_examples_added', 'minimumExamplesAdded');
-      mapping.put('sufficient_label_diversity', 'sufficientLabelDiversity');
-      mapping.put('successfully_trained', 'successfullyTrained');
-      mapping.put('data_updated', 'dataUpdated');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'total_examples', 'totalExamples');
+      mapping.put(parentLabel + 'minimum_queries_added', 'minimumQueriesAdded');
+      mapping.put(parentLabel + 'minimum_examples_added', 'minimumExamplesAdded');
+      mapping.put(parentLabel + 'sufficient_label_diversity', 'sufficientLabelDiversity');
+      mapping.put(parentLabel + 'successfully_trained', 'successfullyTrained');
+      mapping.put(parentLabel + 'data_updated', 'dataUpdated');
       return mapping;
     }
   }
@@ -25565,16 +25496,16 @@ public class IBMDiscoveryV1Models {
       mapping.put('environmentId', 'environment_id');
       mapping.put('configurationId', 'configuration_id');
       if (conversions != null) {
-        mapping.putAll(conversions.getSdkToApiMapping());
+        mapping.putAll(conversions.addToSdkToApiMapping('', mapping));
       }
       if (enrichments != null && enrichments[0] != null) {
-        mapping.putAll(enrichments[0].getSdkToApiMapping());
+        mapping.putAll(enrichments[0].addToSdkToApiMapping('', mapping));
       }
       if (normalizations != null && normalizations[0] != null) {
-        mapping.putAll(normalizations[0].getSdkToApiMapping());
+        mapping.putAll(normalizations[0].addToSdkToApiMapping('', mapping));
       }
       if (source != null) {
-        mapping.putAll(source.getSdkToApiMapping());
+        mapping.putAll(source.addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -25883,7 +25814,7 @@ public class IBMDiscoveryV1Models {
       mapping.put('sourceType', 'source_type');
       mapping.put('credentialDetails', 'credential_details');
       if (credentialDetails != null) {
-        mapping.putAll(credentialDetails.getSdkToApiMapping());
+        mapping.putAll(credentialDetails.addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -26715,7 +26646,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public WordHeadingDetection() { }
- 
+
     /**
      * Gets the fonts.
      *
@@ -26725,7 +26656,7 @@ public class IBMDiscoveryV1Models {
     public List<FontSetting> getFonts() {
       return fonts;
     }
- 
+
     /**
      * Gets the styles.
      *
@@ -26768,7 +26699,7 @@ public class IBMDiscoveryV1Models {
           FontSetting newItem = (FontSetting) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), FontSetting.class);
           newFonts.add(newItem);
         }
-        retBuilder.setFonts(newFonts);
+        retBuilder.fonts(newFonts);
       }
 
       // calling custom deserializer for styles
@@ -26781,25 +26712,21 @@ public class IBMDiscoveryV1Models {
           WordStyle newItem = (WordStyle) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), WordStyle.class);
           newStyles.add(newItem);
         }
-        retBuilder.setStyles(newStyles);
+        retBuilder.styles(newStyles);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (fonts != null && fonts[0] != null) {
-        mapping.putAll(fonts[0].getSdkToApiMapping());
+        mapping.putAll(fonts[0].addToSdkToApiMapping(parentLabel + 'fonts/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (fonts != null && fonts[0] != null) {
-        mapping.putAll(fonts[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) FontSetting.class.newInstance()).addToApiToSdkMapping(parentLabel + 'fonts/', mapping));
       return mapping;
     }
   }
@@ -26868,7 +26795,7 @@ public class IBMDiscoveryV1Models {
      * @param fonts the fonts
      * @return the WordHeadingDetection builder
      */
-    public WordHeadingDetectionBuilder setFonts(List<FontSetting> fonts) {
+    public WordHeadingDetectionBuilder fonts(List<FontSetting> fonts) {
       this.fonts = fonts;
       return this;
     }
@@ -26880,7 +26807,7 @@ public class IBMDiscoveryV1Models {
      * @param styles the styles
      * @return the WordHeadingDetection builder
      */
-    public WordHeadingDetectionBuilder setStyles(List<WordStyle> styles) {
+    public WordHeadingDetectionBuilder styles(List<WordStyle> styles) {
       this.styles = styles;
       return this;
     }
@@ -26897,7 +26824,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public WordSettings() { }
- 
+
     /**
      * Gets the heading.
      *
@@ -26931,24 +26858,20 @@ public class IBMDiscoveryV1Models {
 
       // calling custom deserializer for heading
       WordHeadingDetection newHeading = (WordHeadingDetection) new WordHeadingDetection().deserialize(JSON.serialize(ret.getHeading()), (Map<String, Object>) jsonMap.get('heading'), WordHeadingDetection.class);
-      retBuilder.setHeading(newHeading);
+      retBuilder.heading(newHeading);
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (heading != null) {
-        mapping.putAll(heading.getSdkToApiMapping());
+        mapping.putAll(heading.addToSdkToApiMapping(parentLabel + 'heading/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (heading != null) {
-        mapping.putAll(heading.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) WordHeadingDetection.class.newInstance()).addToApiToSdkMapping(parentLabel + 'heading/', mapping));
       return mapping;
     }
   }
@@ -26984,7 +26907,7 @@ public class IBMDiscoveryV1Models {
      * @param heading the heading
      * @return the WordSettings builder
      */
-    public WordSettingsBuilder setHeading(WordHeadingDetection heading) {
+    public WordSettingsBuilder heading(WordHeadingDetection heading) {
       this.heading = heading;
       return this;
     }
@@ -27002,7 +26925,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public WordStyle() { }
- 
+
     /**
      * Gets the level.
      *
@@ -27014,7 +26937,7 @@ public class IBMDiscoveryV1Models {
     public Long getLevel() {
       return level;
     }
- 
+
     /**
      * Gets the names.
      *
@@ -27090,7 +27013,7 @@ public class IBMDiscoveryV1Models {
      * @param level the level
      * @return the WordStyle builder
      */
-    public WordStyleBuilder setLevel(Long level) {
+    public WordStyleBuilder level(Long level) {
       this.level = level;
       return this;
     }
@@ -27102,7 +27025,7 @@ public class IBMDiscoveryV1Models {
      * @param names the names
      * @return the WordStyle builder
      */
-    public WordStyleBuilder setNames(List<String> names) {
+    public WordStyleBuilder names(List<String> names) {
       this.names = names;
       return this;
     }
@@ -27119,7 +27042,7 @@ public class IBMDiscoveryV1Models {
      * and should not be called by the client.
      */
     public XPathPatterns() { }
- 
+
     /**
      * Gets the xpaths.
      *
@@ -27193,7 +27116,7 @@ public class IBMDiscoveryV1Models {
      * @param xpaths the xpaths
      * @return the XPathPatterns builder
      */
-    public XPathPatternsBuilder setXpaths(List<String> xpaths) {
+    public XPathPatternsBuilder xpaths(List<String> xpaths) {
       this.xpaths = xpaths;
       return this;
     }

--- a/force-app/main/default/classes/IBMDiscoveryV1Models.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Models.cls
@@ -9,7 +9,7 @@ public class IBMDiscoveryV1Models {
     private String filename;
     private String fileContentType;
     private String metadata;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -20,7 +20,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -31,7 +31,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the file.
      *
@@ -44,7 +44,7 @@ public class IBMDiscoveryV1Models {
     public IBMWatsonFile file() {
       return file;
     }
- 
+
     /**
      * Gets the filename.
      *
@@ -55,7 +55,7 @@ public class IBMDiscoveryV1Models {
     public String filename() {
       return filename;
     }
- 
+
     /**
      * Gets the fileContentType.
      *
@@ -66,7 +66,7 @@ public class IBMDiscoveryV1Models {
     public String fileContentType() {
       return fileContentType;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -104,6 +104,13 @@ public class IBMDiscoveryV1Models {
       return new AddDocumentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('fileContentType', 'file_content_type');
+      return mapping;
+    }
   }
 
   /**
@@ -241,7 +248,7 @@ public class IBMDiscoveryV1Models {
     private String naturalLanguageQuery;
     private String filter;
     private List<TrainingExample> examples;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -252,7 +259,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -263,7 +270,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the naturalLanguageQuery.
      *
@@ -274,7 +281,7 @@ public class IBMDiscoveryV1Models {
     public String naturalLanguageQuery() {
       return naturalLanguageQuery;
     }
- 
+
     /**
      * Gets the filter.
      *
@@ -285,7 +292,7 @@ public class IBMDiscoveryV1Models {
     public String filter() {
       return filter;
     }
- 
+
     /**
      * Gets the examples.
      *
@@ -317,6 +324,16 @@ public class IBMDiscoveryV1Models {
       return new AddTrainingDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('naturalLanguageQuery', 'natural_language_query');
+      if (examples != null && examples[0] != null) {
+        mapping.putAll(examples[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -452,9 +469,9 @@ public class IBMDiscoveryV1Models {
    * AggregationResult.
    */
   public class AggregationResult extends IBMWatsonGenericModel {
-    private String key_serialized_name;
-    private Long matching_results_serialized_name;
-    private List<QueryAggregation> aggregations_serialized_name;
+    private String key;
+    private Long matchingResults;
+    private List<QueryAggregation> aggregations;
  
     /**
      * Gets the key.
@@ -465,7 +482,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getKey() {
-      return key_serialized_name;
+      return key;
     }
  
     /**
@@ -477,7 +494,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMatchingResults() {
-      return matching_results_serialized_name;
+      return matchingResults;
     }
  
     /**
@@ -489,7 +506,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryAggregation> getAggregations() {
-      return aggregations_serialized_name;
+      return aggregations;
     }
 
     /**
@@ -498,7 +515,7 @@ public class IBMDiscoveryV1Models {
      * @param key the new key
      */
     public void setKey(final String key) {
-      this.key_serialized_name = key;
+      this.key = key;
     }
 
     /**
@@ -507,7 +524,7 @@ public class IBMDiscoveryV1Models {
      * @param matchingResults the new matchingResults
      */
     public void setMatchingResults(final long matchingResults) {
-      this.matching_results_serialized_name = matchingResults;
+      this.matchingResults = matchingResults;
     }
 
     /**
@@ -516,7 +533,7 @@ public class IBMDiscoveryV1Models {
      * @param aggregations the new aggregations
      */
     public void setAggregations(final List<QueryAggregation> aggregations) {
-      this.aggregations_serialized_name = aggregations;
+      this.aggregations = aggregations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -532,14 +549,23 @@ public class IBMDiscoveryV1Models {
       if (deserializedAggregations != null) {
         for (Integer i = 0; i < deserializedAggregations.size(); i++) {
           QueryAggregation currentItem = ret.getAggregations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations');
           QueryAggregation newItem = (QueryAggregation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryAggregation.class);
           newAggregations.add(newItem);
         }
-        ret.aggregations_serialized_name = newAggregations;
+        ret.aggregations = newAggregations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('matching_results', 'matchingResults');
+      if (aggregations != null && aggregations[0] != null) {
+        mapping.putAll(aggregations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -547,19 +573,19 @@ public class IBMDiscoveryV1Models {
    * A collection for storing documents.
    */
   public class Collection extends IBMWatsonResponseModel {
-    private String collection_id_serialized_name;
-    private String name_serialized_name;
-    private String description_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
-    private String status_serialized_name;
-    private String configuration_id_serialized_name;
-    private String language_serialized_name;
-    private DocumentCounts document_counts_serialized_name;
-    private CollectionDiskUsage disk_usage_serialized_name;
-    private TrainingStatus training_status_serialized_name;
-    private CollectionCrawlStatus crawl_status_serialized_name;
-    private SduStatus smart_document_understanding_serialized_name;
+    private String collectionId;
+    private String name;
+    private String description;
+    private Datetime created;
+    private Datetime updated;
+    private String status;
+    private String configurationId;
+    private String language;
+    private DocumentCounts documentCounts;
+    private CollectionDiskUsage diskUsage;
+    private TrainingStatus trainingStatus;
+    private CollectionCrawlStatus crawlStatus;
+    private SduStatus smartDocumentUnderstanding;
  
     /**
      * Gets the collectionId.
@@ -570,7 +596,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCollectionId() {
-      return collection_id_serialized_name;
+      return collectionId;
     }
  
     /**
@@ -582,7 +608,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -594,7 +620,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -606,7 +632,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -618,7 +644,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -630,7 +656,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -642,7 +668,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getConfigurationId() {
-      return configuration_id_serialized_name;
+      return configurationId;
     }
  
     /**
@@ -655,7 +681,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -665,7 +691,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public DocumentCounts getDocumentCounts() {
-      return document_counts_serialized_name;
+      return documentCounts;
     }
  
     /**
@@ -677,7 +703,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public CollectionDiskUsage getDiskUsage() {
-      return disk_usage_serialized_name;
+      return diskUsage;
     }
  
     /**
@@ -687,7 +713,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public TrainingStatus getTrainingStatus() {
-      return training_status_serialized_name;
+      return trainingStatus;
     }
  
     /**
@@ -699,7 +725,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public CollectionCrawlStatus getCrawlStatus() {
-      return crawl_status_serialized_name;
+      return crawlStatus;
     }
  
     /**
@@ -711,7 +737,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public SduStatus getSmartDocumentUnderstanding() {
-      return smart_document_understanding_serialized_name;
+      return smartDocumentUnderstanding;
     }
 
     /**
@@ -720,7 +746,7 @@ public class IBMDiscoveryV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -729,7 +755,7 @@ public class IBMDiscoveryV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -738,7 +764,7 @@ public class IBMDiscoveryV1Models {
      * @param configurationId the new configurationId
      */
     public void setConfigurationId(final String configurationId) {
-      this.configuration_id_serialized_name = configurationId;
+      this.configurationId = configurationId;
     }
 
     /**
@@ -747,7 +773,7 @@ public class IBMDiscoveryV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -756,7 +782,7 @@ public class IBMDiscoveryV1Models {
      * @param documentCounts the new documentCounts
      */
     public void setDocumentCounts(final DocumentCounts documentCounts) {
-      this.document_counts_serialized_name = documentCounts;
+      this.documentCounts = documentCounts;
     }
 
     /**
@@ -765,7 +791,7 @@ public class IBMDiscoveryV1Models {
      * @param diskUsage the new diskUsage
      */
     public void setDiskUsage(final CollectionDiskUsage diskUsage) {
-      this.disk_usage_serialized_name = diskUsage;
+      this.diskUsage = diskUsage;
     }
 
     /**
@@ -774,7 +800,7 @@ public class IBMDiscoveryV1Models {
      * @param trainingStatus the new trainingStatus
      */
     public void setTrainingStatus(final TrainingStatus trainingStatus) {
-      this.training_status_serialized_name = trainingStatus;
+      this.trainingStatus = trainingStatus;
     }
 
     /**
@@ -783,7 +809,7 @@ public class IBMDiscoveryV1Models {
      * @param crawlStatus the new crawlStatus
      */
     public void setCrawlStatus(final CollectionCrawlStatus crawlStatus) {
-      this.crawl_status_serialized_name = crawlStatus;
+      this.crawlStatus = crawlStatus;
     }
 
     /**
@@ -792,7 +818,7 @@ public class IBMDiscoveryV1Models {
      * @param smartDocumentUnderstanding the new smartDocumentUnderstanding
      */
     public void setSmartDocumentUnderstanding(final SduStatus smartDocumentUnderstanding) {
-      this.smart_document_understanding_serialized_name = smartDocumentUnderstanding;
+      this.smartDocumentUnderstanding = smartDocumentUnderstanding;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -800,30 +826,53 @@ public class IBMDiscoveryV1Models {
         return null;
       }
 
-      Map<String, Object> trainingStatus = (Map<String, Object>) jsonMap.remove('training_status_serialized_name');
-      Collection ret = (Collection) super.deserialize(JSON.serialize(jsonMap), jsonMap, classType);
+      Collection ret = (Collection) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for documentCounts
-      DocumentCounts newDocumentCounts = (DocumentCounts) new DocumentCounts().deserialize(JSON.serialize(ret.getDocumentCounts()), (Map<String, Object>) jsonMap.get('document_counts_serialized_name'), DocumentCounts.class);
+      DocumentCounts newDocumentCounts = (DocumentCounts) new DocumentCounts().deserialize(JSON.serialize(ret.getDocumentCounts()), (Map<String, Object>) jsonMap.get('documentCounts'), DocumentCounts.class);
       ret.setDocumentCounts(newDocumentCounts);
 
       // calling custom deserializer for diskUsage
-      CollectionDiskUsage newDiskUsage = (CollectionDiskUsage) new CollectionDiskUsage().deserialize(JSON.serialize(ret.getDiskUsage()), (Map<String, Object>) jsonMap.get('disk_usage_serialized_name'), CollectionDiskUsage.class);
+      CollectionDiskUsage newDiskUsage = (CollectionDiskUsage) new CollectionDiskUsage().deserialize(JSON.serialize(ret.getDiskUsage()), (Map<String, Object>) jsonMap.get('diskUsage'), CollectionDiskUsage.class);
       ret.setDiskUsage(newDiskUsage);
 
       // calling custom deserializer for trainingStatus
-      TrainingStatus newTrainingStatus = (TrainingStatus) new TrainingStatus().deserialize(JSON.serialize(trainingStatus), trainingStatus, TrainingStatus.class);
+      TrainingStatus newTrainingStatus = (TrainingStatus) new TrainingStatus().deserialize(JSON.serialize(ret.getTrainingStatus()), (Map<String, Object>) jsonMap.get('trainingStatus'), TrainingStatus.class);
       ret.setTrainingStatus(newTrainingStatus);
 
       // calling custom deserializer for crawlStatus
-      CollectionCrawlStatus newCrawlStatus = (CollectionCrawlStatus) new CollectionCrawlStatus().deserialize(JSON.serialize(ret.getCrawlStatus()), (Map<String, Object>) jsonMap.get('crawl_status_serialized_name'), CollectionCrawlStatus.class);
+      CollectionCrawlStatus newCrawlStatus = (CollectionCrawlStatus) new CollectionCrawlStatus().deserialize(JSON.serialize(ret.getCrawlStatus()), (Map<String, Object>) jsonMap.get('crawlStatus'), CollectionCrawlStatus.class);
       ret.setCrawlStatus(newCrawlStatus);
 
       // calling custom deserializer for smartDocumentUnderstanding
-      SduStatus newSmartDocumentUnderstanding = (SduStatus) new SduStatus().deserialize(JSON.serialize(ret.getSmartDocumentUnderstanding()), (Map<String, Object>) jsonMap.get('smart_document_understanding_serialized_name'), SduStatus.class);
+      SduStatus newSmartDocumentUnderstanding = (SduStatus) new SduStatus().deserialize(JSON.serialize(ret.getSmartDocumentUnderstanding()), (Map<String, Object>) jsonMap.get('smartDocumentUnderstanding'), SduStatus.class);
       ret.setSmartDocumentUnderstanding(newSmartDocumentUnderstanding);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('collection_id', 'collectionId');
+      mapping.put('configuration_id', 'configurationId');
+      mapping.put('document_counts', 'documentCounts');
+      mapping.put('disk_usage', 'diskUsage');
+      if (diskUsage != null) {
+        mapping.putAll(diskUsage.getApiToSdkMapping());
+      }
+      mapping.put('training_status', 'trainingStatus');
+      if (trainingStatus != null) {
+        mapping.putAll(trainingStatus.getApiToSdkMapping());
+      }
+      mapping.put('crawl_status', 'crawlStatus');
+      if (crawlStatus != null) {
+        mapping.putAll(crawlStatus.getApiToSdkMapping());
+      }
+      mapping.put('smart_document_understanding', 'smartDocumentUnderstanding');
+      if (smartDocumentUnderstanding != null) {
+        mapping.putAll(smartDocumentUnderstanding.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -831,7 +880,7 @@ public class IBMDiscoveryV1Models {
    * Object containing information about the crawl status of this collection.
    */
   public class CollectionCrawlStatus extends IBMWatsonGenericModel {
-    private SourceStatus source_crawl_serialized_name;
+    private SourceStatus sourceCrawl;
  
     /**
      * Gets the sourceCrawl.
@@ -840,8 +889,9 @@ public class IBMDiscoveryV1Models {
      *
      * @return the sourceCrawl
      */
+    @AuraEnabled
     public SourceStatus getSourceCrawl() {
-      return source_crawl_serialized_name;
+      return sourceCrawl;
     }
 
     /**
@@ -850,7 +900,7 @@ public class IBMDiscoveryV1Models {
      * @param sourceCrawl the new sourceCrawl
      */
     public void setSourceCrawl(final SourceStatus sourceCrawl) {
-      this.source_crawl_serialized_name = sourceCrawl;
+      this.sourceCrawl = sourceCrawl;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -861,10 +911,19 @@ public class IBMDiscoveryV1Models {
       CollectionCrawlStatus ret = (CollectionCrawlStatus) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for sourceCrawl
-      SourceStatus newSourceCrawl = (SourceStatus) new SourceStatus().deserialize(JSON.serialize(ret.getSourceCrawl()), (Map<String, Object>) jsonMap.get('source_crawl_serialized_name'), SourceStatus.class);
+      SourceStatus newSourceCrawl = (SourceStatus) new SourceStatus().deserialize(JSON.serialize(ret.getSourceCrawl()), (Map<String, Object>) jsonMap.get('sourceCrawl'), SourceStatus.class);
       ret.setSourceCrawl(newSourceCrawl);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('source_crawl', 'sourceCrawl');
+      if (sourceCrawl != null) {
+        mapping.putAll(sourceCrawl.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -872,7 +931,7 @@ public class IBMDiscoveryV1Models {
    * Summary of the disk usage statistics for this collection.
    */
   public class CollectionDiskUsage extends IBMWatsonGenericModel {
-    private Long used_bytes_serialized_name;
+    private Long usedBytes;
  
     /**
      * Gets the usedBytes.
@@ -883,17 +942,22 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getUsedBytes() {
-      return used_bytes_serialized_name;
+      return usedBytes;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('used_bytes', 'usedBytes');
+      return mapping;
+    }
   }
 
   /**
    * Summary of the collection usage in the environment.
    */
   public class CollectionUsage extends IBMWatsonGenericModel {
-    private Long available_serialized_name;
-    private Long maximum_allowed_serialized_name;
+    private Long available;
+    private Long maximumAllowed;
  
     /**
      * Gets the available.
@@ -904,7 +968,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getAvailable() {
-      return available_serialized_name;
+      return available;
     }
  
     /**
@@ -916,24 +980,35 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMaximumAllowed() {
-      return maximum_allowed_serialized_name;
+      return maximumAllowed;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('maximum_allowed', 'maximumAllowed');
+      return mapping;
+    }
   }
 
   /**
    * A custom configuration for the environment.
    */
   public class Configuration extends IBMWatsonResponseModel {
-    private String configuration_id_serialized_name;
-    private String name_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
-    private String description_serialized_name;
-    private Conversions conversions_serialized_name;
-    private List<Enrichment> enrichments_serialized_name;
-    private List<NormalizationOperation> normalizations_serialized_name;
-    private Source source_serialized_name;
+    private String configurationId;
+    private String name;
+    private Datetime created;
+    private Datetime updated;
+    private String description;
+    private Conversions conversions;
+    private List<Enrichment> enrichments;
+    private List<NormalizationOperation> normalizations;
+    private Source source;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Configuration() { }
  
     /**
      * Gets the configurationId.
@@ -944,7 +1019,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getConfigurationId() {
-      return configuration_id_serialized_name;
+      return configurationId;
     }
  
     /**
@@ -956,7 +1031,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -968,7 +1043,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -980,7 +1055,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -992,7 +1067,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -1004,7 +1079,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Conversions getConversions() {
-      return conversions_serialized_name;
+      return conversions;
     }
  
     /**
@@ -1016,7 +1091,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Enrichment> getEnrichments() {
-      return enrichments_serialized_name;
+      return enrichments;
     }
  
     /**
@@ -1029,7 +1104,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<NormalizationOperation> getNormalizations() {
-      return normalizations_serialized_name;
+      return normalizations;
     }
  
     /**
@@ -1041,61 +1116,29 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Source getSource() {
-      return source_serialized_name;
+      return source;
+    }
+  
+    private Configuration(ConfigurationBuilder builder) {
+      IBMWatsonValidator.notNull(builder.name, 'name cannot be null');
+      this.configurationId = builder.configurationId;
+      this.name = builder.name;
+      this.created = builder.created;
+      this.updated = builder.updated;
+      this.description = builder.description;
+      this.conversions = builder.conversions;
+      this.enrichments = builder.enrichments;
+      this.normalizations = builder.normalizations;
+      this.source = builder.source;
     }
 
     /**
-     * Sets the name.
+     * New builder.
      *
-     * @param name the new name
+     * @return a Configuration builder
      */
-    public void setName(final String name) {
-      this.name_serialized_name = name;
-    }
-
-    /**
-     * Sets the description.
-     *
-     * @param description the new description
-     */
-    public void setDescription(final String description) {
-      this.description_serialized_name = description;
-    }
-
-    /**
-     * Sets the conversions.
-     *
-     * @param conversions the new conversions
-     */
-    public void setConversions(final Conversions conversions) {
-      this.conversions_serialized_name = conversions;
-    }
-
-    /**
-     * Sets the enrichments.
-     *
-     * @param enrichments the new enrichments
-     */
-    public void setEnrichments(final List<Enrichment> enrichments) {
-      this.enrichments_serialized_name = enrichments;
-    }
-
-    /**
-     * Sets the normalizations.
-     *
-     * @param normalizations the new normalizations
-     */
-    public void setNormalizations(final List<NormalizationOperation> normalizations) {
-      this.normalizations_serialized_name = normalizations;
-    }
-
-    /**
-     * Sets the source.
-     *
-     * @param source the new source
-     */
-    public void setSource(final Source source) {
-      this.source_serialized_name = source;
+    public ConfigurationBuilder newBuilder() {
+      return new ConfigurationBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1104,10 +1147,11 @@ public class IBMDiscoveryV1Models {
       }
 
       Configuration ret = (Configuration) super.deserialize(jsonString, jsonMap, classType);
+      ConfigurationBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for conversions
-      Conversions newConversions = (Conversions) new Conversions().deserialize(JSON.serialize(ret.getConversions()), (Map<String, Object>) jsonMap.get('conversions_serialized_name'), Conversions.class);
-      ret.setConversions(newConversions);
+      Conversions newConversions = (Conversions) new Conversions().deserialize(JSON.serialize(ret.getConversions()), (Map<String, Object>) jsonMap.get('conversions'), Conversions.class);
+      retBuilder.setConversions(newConversions);
 
       // calling custom deserializer for enrichments
       List<Enrichment> newEnrichments = new List<Enrichment>();
@@ -1115,11 +1159,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedEnrichments != null) {
         for (Integer i = 0; i < deserializedEnrichments.size(); i++) {
           Enrichment currentItem = ret.getEnrichments().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('enrichments_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('enrichments');
           Enrichment newItem = (Enrichment) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Enrichment.class);
           newEnrichments.add(newItem);
         }
-        ret.enrichments_serialized_name = newEnrichments;
+        retBuilder.setEnrichments(newEnrichments);
       }
 
       // calling custom deserializer for normalizations
@@ -1128,18 +1172,236 @@ public class IBMDiscoveryV1Models {
       if (deserializedNormalizations != null) {
         for (Integer i = 0; i < deserializedNormalizations.size(); i++) {
           NormalizationOperation currentItem = ret.getNormalizations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('normalizations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('normalizations');
           NormalizationOperation newItem = (NormalizationOperation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), NormalizationOperation.class);
           newNormalizations.add(newItem);
         }
-        ret.normalizations_serialized_name = newNormalizations;
+        retBuilder.setNormalizations(newNormalizations);
       }
 
       // calling custom deserializer for source
-      Source newSource = (Source) new Source().deserialize(JSON.serialize(ret.getSource()), (Map<String, Object>) jsonMap.get('source_serialized_name'), Source.class);
-      ret.setSource(newSource);
+      Source newSource = (Source) new Source().deserialize(JSON.serialize(ret.getSource()), (Map<String, Object>) jsonMap.get('source'), Source.class);
+      retBuilder.setSource(newSource);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('configurationId', 'configuration_id');
+      if (conversions != null) {
+        mapping.putAll(conversions.getSdkToApiMapping());
+      }
+      if (enrichments != null && enrichments[0] != null) {
+        mapping.putAll(enrichments[0].getSdkToApiMapping());
+      }
+      if (normalizations != null && normalizations[0] != null) {
+        mapping.putAll(normalizations[0].getSdkToApiMapping());
+      }
+      if (source != null) {
+        mapping.putAll(source.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('configuration_id', 'configurationId');
+      if (conversions != null) {
+        mapping.putAll(conversions.getApiToSdkMapping());
+      }
+      if (enrichments != null && enrichments[0] != null) {
+        mapping.putAll(enrichments[0].getApiToSdkMapping());
+      }
+      if (normalizations != null && normalizations[0] != null) {
+        mapping.putAll(normalizations[0].getApiToSdkMapping());
+      }
+      if (source != null) {
+        mapping.putAll(source.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * Configuration Builder.
+   */
+  public class ConfigurationBuilder {
+    private String configurationId;
+    private String name;
+    private Datetime created;
+    private Datetime updated;
+    private String description;
+    private Conversions conversions;
+    private List<Enrichment> enrichments;
+    private List<NormalizationOperation> normalizations;
+    private Source source;
+
+    private ConfigurationBuilder(Configuration configuration) {
+      this.configurationId = configuration.configurationId;
+      this.name = configuration.name;
+      this.created = configuration.created;
+      this.updated = configuration.updated;
+      this.description = configuration.description;
+      this.conversions = configuration.conversions;
+      this.enrichments = configuration.enrichments;
+      this.normalizations = configuration.normalizations;
+      this.source = configuration.source;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public ConfigurationBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param name the name
+     */
+    public ConfigurationBuilder(String name) {
+      this.name = name;
+    }
+
+    /**
+     * Builds a Configuration.
+     *
+     * @return the configuration
+     */
+    public Configuration build() {
+      return new Configuration(this);
+    }
+
+    /**
+     * Adds an enrichments to enrichments.
+     *
+     * @param enrichments the new enrichments
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder addEnrichments(Enrichment enrichments) {
+      IBMWatsonValidator.notNull(enrichments, 'enrichments cannot be null');
+      if (this.enrichments == null) {
+        this.enrichments = new List<Enrichment>();
+      }
+      this.enrichments.add(enrichments);
+      return this;
+    }
+
+    /**
+     * Adds an normalizations to normalizations.
+     *
+     * @param normalizations the new normalizations
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder addNormalizations(NormalizationOperation normalizations) {
+      IBMWatsonValidator.notNull(normalizations, 'normalizations cannot be null');
+      if (this.normalizations == null) {
+        this.normalizations = new List<NormalizationOperation>();
+      }
+      this.normalizations.add(normalizations);
+      return this;
+    }
+
+    /**
+     * Set the configurationId.
+     *
+     * @param configurationId the configurationId
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder setConfigurationId(String configurationId) {
+      this.configurationId = configurationId;
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the created.
+     *
+     * @param created the created
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder setCreated(Datetime created) {
+      this.created = created;
+      return this;
+    }
+
+    /**
+     * Set the updated.
+     *
+     * @param updated the updated
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder setUpdated(Datetime updated) {
+      this.updated = updated;
+      return this;
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the conversions.
+     *
+     * @param conversions the conversions
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder setConversions(Conversions conversions) {
+      this.conversions = conversions;
+      return this;
+    }
+
+    /**
+     * Set the enrichments.
+     * Existing enrichments will be replaced.
+     *
+     * @param enrichments the enrichments
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder setEnrichments(List<Enrichment> enrichments) {
+      this.enrichments = enrichments;
+      return this;
+    }
+
+    /**
+     * Set the normalizations.
+     * Existing normalizations will be replaced.
+     *
+     * @param normalizations the normalizations
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder setNormalizations(List<NormalizationOperation> normalizations) {
+      this.normalizations = normalizations;
+      return this;
+    }
+
+    /**
+     * Set the source.
+     *
+     * @param source the source
+     * @return the Configuration builder
+     */
+    public ConfigurationBuilder setSource(Source source) {
+      this.source = source;
+      return this;
     }
   }
 
@@ -1147,12 +1409,18 @@ public class IBMDiscoveryV1Models {
    * Document conversion settings.
    */
   public class Conversions extends IBMWatsonGenericModel {
-    private PdfSettings pdf_serialized_name;
-    private WordSettings word_serialized_name;
-    private HtmlSettings html_serialized_name;
-    private SegmentSettings segment_serialized_name;
-    private List<NormalizationOperation> json_normalizations_serialized_name;
-    private Boolean image_text_recognition_serialized_name;
+    private PdfSettings pdf;
+    private WordSettings word;
+    private HtmlSettings html;
+    private SegmentSettings segment;
+    private List<NormalizationOperation> jsonNormalizations;
+    private Boolean imageTextRecognition;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Conversions() { }
  
     /**
      * Gets the pdf.
@@ -1163,7 +1431,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public PdfSettings getPdf() {
-      return pdf_serialized_name;
+      return pdf;
     }
  
     /**
@@ -1175,7 +1443,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public WordSettings getWord() {
-      return word_serialized_name;
+      return word;
     }
  
     /**
@@ -1187,7 +1455,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public HtmlSettings getHtml() {
-      return html_serialized_name;
+      return html;
     }
  
     /**
@@ -1199,7 +1467,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public SegmentSettings getSegment() {
-      return segment_serialized_name;
+      return segment;
     }
  
     /**
@@ -1212,7 +1480,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<NormalizationOperation> getJsonNormalizations() {
-      return json_normalizations_serialized_name;
+      return jsonNormalizations;
     }
  
     /**
@@ -1227,61 +1495,25 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getImageTextRecognition() {
-      return image_text_recognition_serialized_name;
+      return imageTextRecognition;
+    }
+  
+    private Conversions(ConversionsBuilder builder) {
+      this.pdf = builder.pdf;
+      this.word = builder.word;
+      this.html = builder.html;
+      this.segment = builder.segment;
+      this.jsonNormalizations = builder.jsonNormalizations;
+      this.imageTextRecognition = builder.imageTextRecognition;
     }
 
     /**
-     * Sets the pdf.
+     * New builder.
      *
-     * @param pdf the new pdf
+     * @return a Conversions builder
      */
-    public void setPdf(final PdfSettings pdf) {
-      this.pdf_serialized_name = pdf;
-    }
-
-    /**
-     * Sets the word.
-     *
-     * @param word the new word
-     */
-    public void setWord(final WordSettings word) {
-      this.word_serialized_name = word;
-    }
-
-    /**
-     * Sets the html.
-     *
-     * @param html the new html
-     */
-    public void setHtml(final HtmlSettings html) {
-      this.html_serialized_name = html;
-    }
-
-    /**
-     * Sets the segment.
-     *
-     * @param segment the new segment
-     */
-    public void setSegment(final SegmentSettings segment) {
-      this.segment_serialized_name = segment;
-    }
-
-    /**
-     * Sets the jsonNormalizations.
-     *
-     * @param jsonNormalizations the new jsonNormalizations
-     */
-    public void setJsonNormalizations(final List<NormalizationOperation> jsonNormalizations) {
-      this.json_normalizations_serialized_name = jsonNormalizations;
-    }
-
-    /**
-     * Sets the imageTextRecognition.
-     *
-     * @param imageTextRecognition the new imageTextRecognition
-     */
-    public void setImageTextRecognition(final Boolean imageTextRecognition) {
-      this.image_text_recognition_serialized_name = imageTextRecognition;
+    public ConversionsBuilder newBuilder() {
+      return new ConversionsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1290,22 +1522,23 @@ public class IBMDiscoveryV1Models {
       }
 
       Conversions ret = (Conversions) super.deserialize(jsonString, jsonMap, classType);
+      ConversionsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for pdf
-      PdfSettings newPdf = (PdfSettings) new PdfSettings().deserialize(JSON.serialize(ret.getPdf()), (Map<String, Object>) jsonMap.get('pdf_serialized_name'), PdfSettings.class);
-      ret.setPdf(newPdf);
+      PdfSettings newPdf = (PdfSettings) new PdfSettings().deserialize(JSON.serialize(ret.getPdf()), (Map<String, Object>) jsonMap.get('pdf'), PdfSettings.class);
+      retBuilder.setPdf(newPdf);
 
       // calling custom deserializer for word
-      WordSettings newWord = (WordSettings) new WordSettings().deserialize(JSON.serialize(ret.getWord()), (Map<String, Object>) jsonMap.get('word_serialized_name'), WordSettings.class);
-      ret.setWord(newWord);
+      WordSettings newWord = (WordSettings) new WordSettings().deserialize(JSON.serialize(ret.getWord()), (Map<String, Object>) jsonMap.get('word'), WordSettings.class);
+      retBuilder.setWord(newWord);
 
       // calling custom deserializer for html
-      HtmlSettings newHtml = (HtmlSettings) new HtmlSettings().deserialize(JSON.serialize(ret.getHtml()), (Map<String, Object>) jsonMap.get('html_serialized_name'), HtmlSettings.class);
-      ret.setHtml(newHtml);
+      HtmlSettings newHtml = (HtmlSettings) new HtmlSettings().deserialize(JSON.serialize(ret.getHtml()), (Map<String, Object>) jsonMap.get('html'), HtmlSettings.class);
+      retBuilder.setHtml(newHtml);
 
       // calling custom deserializer for segment
-      SegmentSettings newSegment = (SegmentSettings) new SegmentSettings().deserialize(JSON.serialize(ret.getSegment()), (Map<String, Object>) jsonMap.get('segment_serialized_name'), SegmentSettings.class);
-      ret.setSegment(newSegment);
+      SegmentSettings newSegment = (SegmentSettings) new SegmentSettings().deserialize(JSON.serialize(ret.getSegment()), (Map<String, Object>) jsonMap.get('segment'), SegmentSettings.class);
+      retBuilder.setSegment(newSegment);
 
       // calling custom deserializer for jsonNormalizations
       List<NormalizationOperation> newJsonNormalizations = new List<NormalizationOperation>();
@@ -1313,14 +1546,176 @@ public class IBMDiscoveryV1Models {
       if (deserializedJsonNormalizations != null) {
         for (Integer i = 0; i < deserializedJsonNormalizations.size(); i++) {
           NormalizationOperation currentItem = ret.getJsonNormalizations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('json_normalizations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('jsonNormalizations');
           NormalizationOperation newItem = (NormalizationOperation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), NormalizationOperation.class);
           newJsonNormalizations.add(newItem);
         }
-        ret.json_normalizations_serialized_name = newJsonNormalizations;
+        retBuilder.setJsonNormalizations(newJsonNormalizations);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (pdf != null) {
+        mapping.putAll(pdf.getSdkToApiMapping());
+      }
+      if (word != null) {
+        mapping.putAll(word.getSdkToApiMapping());
+      }
+      if (html != null) {
+        mapping.putAll(html.getSdkToApiMapping());
+      }
+      if (segment != null) {
+        mapping.putAll(segment.getSdkToApiMapping());
+      }
+      mapping.put('jsonNormalizations', 'json_normalizations');
+      if (jsonNormalizations != null && jsonNormalizations[0] != null) {
+        mapping.putAll(jsonNormalizations[0].getSdkToApiMapping());
+      }
+      mapping.put('imageTextRecognition', 'image_text_recognition');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (pdf != null) {
+        mapping.putAll(pdf.getApiToSdkMapping());
+      }
+      if (word != null) {
+        mapping.putAll(word.getApiToSdkMapping());
+      }
+      if (html != null) {
+        mapping.putAll(html.getApiToSdkMapping());
+      }
+      if (segment != null) {
+        mapping.putAll(segment.getApiToSdkMapping());
+      }
+      mapping.put('json_normalizations', 'jsonNormalizations');
+      if (jsonNormalizations != null && jsonNormalizations[0] != null) {
+        mapping.putAll(jsonNormalizations[0].getApiToSdkMapping());
+      }
+      mapping.put('image_text_recognition', 'imageTextRecognition');
+      return mapping;
+    }
+  }
+
+  /**
+   * Conversions Builder.
+   */
+  public class ConversionsBuilder {
+    private PdfSettings pdf;
+    private WordSettings word;
+    private HtmlSettings html;
+    private SegmentSettings segment;
+    private List<NormalizationOperation> jsonNormalizations;
+    private Boolean imageTextRecognition;
+
+    private ConversionsBuilder(Conversions conversions) {
+      this.pdf = conversions.pdf;
+      this.word = conversions.word;
+      this.html = conversions.html;
+      this.segment = conversions.segment;
+      this.jsonNormalizations = conversions.jsonNormalizations;
+      this.imageTextRecognition = conversions.imageTextRecognition;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public ConversionsBuilder() {
+    }
+
+    /**
+     * Builds a Conversions.
+     *
+     * @return the conversions
+     */
+    public Conversions build() {
+      return new Conversions(this);
+    }
+
+    /**
+     * Adds an jsonNormalizations to jsonNormalizations.
+     *
+     * @param jsonNormalizations the new jsonNormalizations
+     * @return the Conversions builder
+     */
+    public ConversionsBuilder addJsonNormalizations(NormalizationOperation jsonNormalizations) {
+      IBMWatsonValidator.notNull(jsonNormalizations, 'jsonNormalizations cannot be null');
+      if (this.jsonNormalizations == null) {
+        this.jsonNormalizations = new List<NormalizationOperation>();
+      }
+      this.jsonNormalizations.add(jsonNormalizations);
+      return this;
+    }
+
+    /**
+     * Set the pdf.
+     *
+     * @param pdf the pdf
+     * @return the Conversions builder
+     */
+    public ConversionsBuilder setPdf(PdfSettings pdf) {
+      this.pdf = pdf;
+      return this;
+    }
+
+    /**
+     * Set the word.
+     *
+     * @param word the word
+     * @return the Conversions builder
+     */
+    public ConversionsBuilder setWord(WordSettings word) {
+      this.word = word;
+      return this;
+    }
+
+    /**
+     * Set the html.
+     *
+     * @param html the html
+     * @return the Conversions builder
+     */
+    public ConversionsBuilder setHtml(HtmlSettings html) {
+      this.html = html;
+      return this;
+    }
+
+    /**
+     * Set the segment.
+     *
+     * @param segment the segment
+     * @return the Conversions builder
+     */
+    public ConversionsBuilder setSegment(SegmentSettings segment) {
+      this.segment = segment;
+      return this;
+    }
+
+    /**
+     * Set the jsonNormalizations.
+     * Existing jsonNormalizations will be replaced.
+     *
+     * @param jsonNormalizations the jsonNormalizations
+     * @return the Conversions builder
+     */
+    public ConversionsBuilder setJsonNormalizations(List<NormalizationOperation> jsonNormalizations) {
+      this.jsonNormalizations = jsonNormalizations;
+      return this;
+    }
+
+    /**
+     * Set the imageTextRecognition.
+     *
+     * @param imageTextRecognition the imageTextRecognition
+     * @return the Conversions builder
+     */
+    public ConversionsBuilder setImageTextRecognition(Boolean imageTextRecognition) {
+      this.imageTextRecognition = imageTextRecognition;
+      return this;
     }
   }
 
@@ -1333,7 +1728,7 @@ public class IBMDiscoveryV1Models {
     private String description;
     private String configurationId;
     private String language;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -1344,7 +1739,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -1355,7 +1750,7 @@ public class IBMDiscoveryV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -1366,7 +1761,7 @@ public class IBMDiscoveryV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the configurationId.
      *
@@ -1377,7 +1772,7 @@ public class IBMDiscoveryV1Models {
     public String configurationId() {
       return configurationId;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -1409,6 +1804,12 @@ public class IBMDiscoveryV1Models {
       return new CreateCollectionOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('configurationId', 'configuration_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1535,7 +1936,7 @@ public class IBMDiscoveryV1Models {
     private List<Enrichment> enrichments;
     private List<NormalizationOperation> normalizations;
     private Source source;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -1546,7 +1947,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -1557,7 +1958,7 @@ public class IBMDiscoveryV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -1568,7 +1969,7 @@ public class IBMDiscoveryV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the conversions.
      *
@@ -1579,7 +1980,7 @@ public class IBMDiscoveryV1Models {
     public Conversions conversions() {
       return conversions;
     }
- 
+
     /**
      * Gets the enrichments.
      *
@@ -1590,7 +1991,7 @@ public class IBMDiscoveryV1Models {
     public List<Enrichment> enrichments() {
       return enrichments;
     }
- 
+
     /**
      * Gets the normalizations.
      *
@@ -1602,7 +2003,7 @@ public class IBMDiscoveryV1Models {
     public List<NormalizationOperation> normalizations() {
       return normalizations;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -1636,6 +2037,23 @@ public class IBMDiscoveryV1Models {
       return new CreateConfigurationOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      if (conversions != null) {
+        mapping.putAll(conversions.getSdkToApiMapping());
+      }
+      if (enrichments != null && enrichments[0] != null) {
+        mapping.putAll(enrichments[0].getSdkToApiMapping());
+      }
+      if (normalizations != null && normalizations[0] != null) {
+        mapping.putAll(normalizations[0].getSdkToApiMapping());
+      }
+      if (source != null) {
+        mapping.putAll(source.getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -1833,7 +2251,7 @@ public class IBMDiscoveryV1Models {
     private String sourceType;
     private CredentialDetails credentialDetails;
     private String status;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -1844,7 +2262,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the sourceType.
      *
@@ -1860,7 +2278,7 @@ public class IBMDiscoveryV1Models {
     public String sourceType() {
       return sourceType;
     }
- 
+
     /**
      * Gets the credentialDetails.
      *
@@ -1873,7 +2291,7 @@ public class IBMDiscoveryV1Models {
     public CredentialDetails credentialDetails() {
       return credentialDetails;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -1905,6 +2323,16 @@ public class IBMDiscoveryV1Models {
       return new CreateCredentialsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('sourceType', 'source_type');
+      mapping.put('credentialDetails', 'credential_details');
+      if (credentialDetails != null) {
+        mapping.putAll(credentialDetails.getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -2025,7 +2453,7 @@ public class IBMDiscoveryV1Models {
     private String name;
     private String description;
     private String size;
- 
+
     /**
      * Gets the name.
      *
@@ -2036,7 +2464,7 @@ public class IBMDiscoveryV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -2047,7 +2475,7 @@ public class IBMDiscoveryV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the size.
      *
@@ -2076,7 +2504,6 @@ public class IBMDiscoveryV1Models {
     public CreateEnvironmentOptionsBuilder newBuilder() {
       return new CreateEnvironmentOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -2170,7 +2597,7 @@ public class IBMDiscoveryV1Models {
   public class CreateEventOptions extends IBMWatsonOptionsModel {
     private String xtype;
     private EventData data;
- 
+
     /**
      * Gets the xtype.
      *
@@ -2181,7 +2608,7 @@ public class IBMDiscoveryV1Models {
     public String xtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the data.
      *
@@ -2210,6 +2637,14 @@ public class IBMDiscoveryV1Models {
       return new CreateEventOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xtype', 'type');
+      if (data != null) {
+        mapping.putAll(data.getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -2290,8 +2725,8 @@ public class IBMDiscoveryV1Models {
    * An object defining the event being created.
    */
   public class CreateEventResponse extends IBMWatsonResponseModel {
-    private String type_serialized_name;
-    private EventData data_serialized_name;
+    private String xtype;
+    private EventData data;
  
     /**
      * Gets the xtype.
@@ -2302,7 +2737,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -2314,7 +2749,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public EventData getData() {
-      return data_serialized_name;
+      return data;
     }
 
     /**
@@ -2323,7 +2758,7 @@ public class IBMDiscoveryV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -2332,7 +2767,7 @@ public class IBMDiscoveryV1Models {
      * @param data the new data
      */
     public void setData(final EventData data) {
-      this.data_serialized_name = data;
+      this.data = data;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2343,10 +2778,19 @@ public class IBMDiscoveryV1Models {
       CreateEventResponse ret = (CreateEventResponse) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for data
-      EventData newData = (EventData) new EventData().deserialize(JSON.serialize(ret.getData()), (Map<String, Object>) jsonMap.get('data_serialized_name'), EventData.class);
+      EventData newData = (EventData) new EventData().deserialize(JSON.serialize(ret.getData()), (Map<String, Object>) jsonMap.get('data'), EventData.class);
       ret.setData(newData);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      if (data != null) {
+        mapping.putAll(data.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2357,7 +2801,7 @@ public class IBMDiscoveryV1Models {
     private String environmentId;
     private String collectionId;
     private List<Expansion> expansions;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -2368,7 +2812,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -2379,7 +2823,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the expansions.
      *
@@ -2422,6 +2866,15 @@ public class IBMDiscoveryV1Models {
       return new CreateExpansionsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      if (expansions != null && expansions[0] != null) {
+        mapping.putAll(expansions[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -2546,7 +2999,7 @@ public class IBMDiscoveryV1Models {
   public class CreateGatewayOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String name;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -2557,7 +3010,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -2585,6 +3038,11 @@ public class IBMDiscoveryV1Models {
       return new CreateGatewayOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      return mapping;
+    }
   }
 
   /**
@@ -2667,7 +3125,7 @@ public class IBMDiscoveryV1Models {
     private String collectionId;
     private IBMWatsonFile stopwordFile;
     private String stopwordFilename;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -2678,7 +3136,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -2689,7 +3147,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the stopwordFile.
      *
@@ -2700,7 +3158,7 @@ public class IBMDiscoveryV1Models {
     public IBMWatsonFile stopwordFile() {
       return stopwordFile;
     }
- 
+
     /**
      * Gets the stopwordFilename.
      *
@@ -2733,6 +3191,14 @@ public class IBMDiscoveryV1Models {
       return new CreateStopwordListOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('stopwordFile', 'stopword_file');
+      mapping.put('stopwordFilename', 'stopword_filename');
+      return mapping;
+    }
   }
 
   /**
@@ -2846,7 +3312,7 @@ public class IBMDiscoveryV1Models {
     private String environmentId;
     private String collectionId;
     private List<TokenDictRule> tokenizationRules;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -2857,7 +3323,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -2868,7 +3334,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the tokenizationRules.
      *
@@ -2899,6 +3365,16 @@ public class IBMDiscoveryV1Models {
       return new CreateTokenizationDictionaryOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('tokenizationRules', 'tokenization_rules');
+      if (tokenizationRules != null && tokenizationRules[0] != null) {
+        mapping.putAll(tokenizationRules[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -3014,7 +3490,7 @@ public class IBMDiscoveryV1Models {
     private String documentId;
     private String crossReference;
     private Long relevance;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -3025,7 +3501,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -3036,7 +3512,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -3047,7 +3523,7 @@ public class IBMDiscoveryV1Models {
     public String queryId() {
       return queryId;
     }
- 
+
     /**
      * Gets the documentId.
      *
@@ -3058,7 +3534,7 @@ public class IBMDiscoveryV1Models {
     public String documentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the crossReference.
      *
@@ -3069,7 +3545,7 @@ public class IBMDiscoveryV1Models {
     public String crossReference() {
       return crossReference;
     }
- 
+
     /**
      * Gets the relevance.
      *
@@ -3103,6 +3579,15 @@ public class IBMDiscoveryV1Models {
       return new CreateTrainingExampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('queryId', 'query_id');
+      mapping.put('documentId', 'document_id');
+      mapping.put('crossReference', 'cross_reference');
+      return mapping;
+    }
   }
 
   /**
@@ -3252,25 +3737,31 @@ public class IBMDiscoveryV1Models {
    * Obtain credentials for your source from the administrator of the source.
    */
   public class CredentialDetails extends IBMWatsonGenericModel {
-    private String credential_type_serialized_name;
-    private String client_id_serialized_name;
-    private String enterprise_id_serialized_name;
-    private String url_serialized_name;
-    private String username_serialized_name;
-    private String organization_url_serialized_name;
-    private String site_collection_path_serialized_name;
-    private String client_secret_serialized_name;
-    private String public_key_id_serialized_name;
-    private String private_key_serialized_name;
-    private String passphrase_serialized_name;
-    private String password_serialized_name;
-    private String gateway_id_serialized_name;
-    private String source_version_serialized_name;
-    private String web_application_url_serialized_name;
-    private String domain_serialized_name;
-    private String endpoint_serialized_name;
-    private String access_key_id_serialized_name;
-    private String secret_access_key_serialized_name;
+    private String credentialType;
+    private String clientId;
+    private String enterpriseId;
+    private String url;
+    private String username;
+    private String organizationUrl;
+    private String siteCollectionPath;
+    private String clientSecret;
+    private String publicKeyId;
+    private String privateKey;
+    private String passphrase;
+    private String password;
+    private String gatewayId;
+    private String sourceVersion;
+    private String webApplicationUrl;
+    private String domain;
+    private String endpoint;
+    private String accessKeyId;
+    private String secretAccessKey;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public CredentialDetails() { }
  
     /**
      * Gets the credentialType.
@@ -3289,7 +3780,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCredentialType() {
-      return credential_type_serialized_name;
+      return credentialType;
     }
  
     /**
@@ -3302,7 +3793,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getClientId() {
-      return client_id_serialized_name;
+      return clientId;
     }
  
     /**
@@ -3315,7 +3806,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEnterpriseId() {
-      return enterprise_id_serialized_name;
+      return enterpriseId;
     }
  
     /**
@@ -3328,7 +3819,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
  
     /**
@@ -3341,7 +3832,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getUsername() {
-      return username_serialized_name;
+      return username;
     }
  
     /**
@@ -3354,7 +3845,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getOrganizationUrl() {
-      return organization_url_serialized_name;
+      return organizationUrl;
     }
  
     /**
@@ -3367,7 +3858,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSiteCollectionPath() {
-      return site_collection_path_serialized_name;
+      return siteCollectionPath;
     }
  
     /**
@@ -3381,7 +3872,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getClientSecret() {
-      return client_secret_serialized_name;
+      return clientSecret;
     }
  
     /**
@@ -3395,7 +3886,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getPublicKeyId() {
-      return public_key_id_serialized_name;
+      return publicKeyId;
     }
  
     /**
@@ -3409,7 +3900,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getPrivateKey() {
-      return private_key_serialized_name;
+      return privateKey;
     }
  
     /**
@@ -3423,7 +3914,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getPassphrase() {
-      return passphrase_serialized_name;
+      return passphrase;
     }
  
     /**
@@ -3440,7 +3931,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getPassword() {
-      return password_serialized_name;
+      return password;
     }
  
     /**
@@ -3454,7 +3945,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getGatewayId() {
-      return gateway_id_serialized_name;
+      return gatewayId;
     }
  
     /**
@@ -3467,7 +3958,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSourceVersion() {
-      return source_version_serialized_name;
+      return sourceVersion;
     }
  
     /**
@@ -3480,7 +3971,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getWebApplicationUrl() {
-      return web_application_url_serialized_name;
+      return webApplicationUrl;
     }
  
     /**
@@ -3493,7 +3984,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDomain() {
-      return domain_serialized_name;
+      return domain;
     }
  
     /**
@@ -3506,7 +3997,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEndpoint() {
-      return endpoint_serialized_name;
+      return endpoint;
     }
  
     /**
@@ -3521,7 +4012,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getAccessKeyId() {
-      return access_key_id_serialized_name;
+      return accessKeyId;
     }
  
     /**
@@ -3536,190 +4027,362 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSecretAccessKey() {
-      return secret_access_key_serialized_name;
+      return secretAccessKey;
+    }
+  
+    private CredentialDetails(CredentialDetailsBuilder builder) {
+      this.credentialType = builder.credentialType;
+      this.clientId = builder.clientId;
+      this.enterpriseId = builder.enterpriseId;
+      this.url = builder.url;
+      this.username = builder.username;
+      this.organizationUrl = builder.organizationUrl;
+      this.siteCollectionPath = builder.siteCollectionPath;
+      this.clientSecret = builder.clientSecret;
+      this.publicKeyId = builder.publicKeyId;
+      this.privateKey = builder.privateKey;
+      this.passphrase = builder.passphrase;
+      this.password = builder.password;
+      this.gatewayId = builder.gatewayId;
+      this.sourceVersion = builder.sourceVersion;
+      this.webApplicationUrl = builder.webApplicationUrl;
+      this.domain = builder.domain;
+      this.endpoint = builder.endpoint;
+      this.accessKeyId = builder.accessKeyId;
+      this.secretAccessKey = builder.secretAccessKey;
     }
 
     /**
-     * Sets the credentialType.
+     * New builder.
      *
-     * @param credentialType the new credentialType
+     * @return a CredentialDetails builder
      */
-    public void setCredentialType(final String credentialType) {
-      this.credential_type_serialized_name = credentialType;
+    public CredentialDetailsBuilder newBuilder() {
+      return new CredentialDetailsBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('credentialType', 'credential_type');
+      mapping.put('clientId', 'client_id');
+      mapping.put('enterpriseId', 'enterprise_id');
+      mapping.put('organizationUrl', 'organization_url');
+      mapping.put('siteCollectionPath', 'site_collection.path');
+      mapping.put('clientSecret', 'client_secret');
+      mapping.put('publicKeyId', 'public_key_id');
+      mapping.put('privateKey', 'private_key');
+      mapping.put('gatewayId', 'gateway_id');
+      mapping.put('sourceVersion', 'source_version');
+      mapping.put('webApplicationUrl', 'web_application_url');
+      mapping.put('accessKeyId', 'access_key_id');
+      mapping.put('secretAccessKey', 'secret_access_key');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('credential_type', 'credentialType');
+      mapping.put('client_id', 'clientId');
+      mapping.put('enterprise_id', 'enterpriseId');
+      mapping.put('organization_url', 'organizationUrl');
+      mapping.put('site_collection.path', 'siteCollectionPath');
+      mapping.put('client_secret', 'clientSecret');
+      mapping.put('public_key_id', 'publicKeyId');
+      mapping.put('private_key', 'privateKey');
+      mapping.put('gateway_id', 'gatewayId');
+      mapping.put('source_version', 'sourceVersion');
+      mapping.put('web_application_url', 'webApplicationUrl');
+      mapping.put('access_key_id', 'accessKeyId');
+      mapping.put('secret_access_key', 'secretAccessKey');
+      return mapping;
+    }
+  }
+
+  /**
+   * CredentialDetails Builder.
+   */
+  public class CredentialDetailsBuilder {
+    private String credentialType;
+    private String clientId;
+    private String enterpriseId;
+    private String url;
+    private String username;
+    private String organizationUrl;
+    private String siteCollectionPath;
+    private String clientSecret;
+    private String publicKeyId;
+    private String privateKey;
+    private String passphrase;
+    private String password;
+    private String gatewayId;
+    private String sourceVersion;
+    private String webApplicationUrl;
+    private String domain;
+    private String endpoint;
+    private String accessKeyId;
+    private String secretAccessKey;
+
+    private CredentialDetailsBuilder(CredentialDetails credentialDetails) {
+      this.credentialType = credentialDetails.credentialType;
+      this.clientId = credentialDetails.clientId;
+      this.enterpriseId = credentialDetails.enterpriseId;
+      this.url = credentialDetails.url;
+      this.username = credentialDetails.username;
+      this.organizationUrl = credentialDetails.organizationUrl;
+      this.siteCollectionPath = credentialDetails.siteCollectionPath;
+      this.clientSecret = credentialDetails.clientSecret;
+      this.publicKeyId = credentialDetails.publicKeyId;
+      this.privateKey = credentialDetails.privateKey;
+      this.passphrase = credentialDetails.passphrase;
+      this.password = credentialDetails.password;
+      this.gatewayId = credentialDetails.gatewayId;
+      this.sourceVersion = credentialDetails.sourceVersion;
+      this.webApplicationUrl = credentialDetails.webApplicationUrl;
+      this.domain = credentialDetails.domain;
+      this.endpoint = credentialDetails.endpoint;
+      this.accessKeyId = credentialDetails.accessKeyId;
+      this.secretAccessKey = credentialDetails.secretAccessKey;
     }
 
     /**
-     * Sets the clientId.
-     *
-     * @param clientId the new clientId
+     * Instantiates a new builder.
      */
-    public void setClientId(final String clientId) {
-      this.client_id_serialized_name = clientId;
+    public CredentialDetailsBuilder() {
     }
 
     /**
-     * Sets the enterpriseId.
+     * Builds a CredentialDetails.
      *
-     * @param enterpriseId the new enterpriseId
+     * @return the credentialDetails
      */
-    public void setEnterpriseId(final String enterpriseId) {
-      this.enterprise_id_serialized_name = enterpriseId;
+    public CredentialDetails build() {
+      return new CredentialDetails(this);
     }
 
     /**
-     * Sets the url.
+     * Set the credentialType.
      *
-     * @param url the new url
+     * @param credentialType the credentialType
+     * @return the CredentialDetails builder
      */
-    public void setUrl(final String url) {
-      this.url_serialized_name = url;
+    public CredentialDetailsBuilder setCredentialType(String credentialType) {
+      this.credentialType = credentialType;
+      return this;
     }
 
     /**
-     * Sets the username.
+     * Set the clientId.
      *
-     * @param username the new username
+     * @param clientId the clientId
+     * @return the CredentialDetails builder
      */
-    public void setUsername(final String username) {
-      this.username_serialized_name = username;
+    public CredentialDetailsBuilder setClientId(String clientId) {
+      this.clientId = clientId;
+      return this;
     }
 
     /**
-     * Sets the organizationUrl.
+     * Set the enterpriseId.
      *
-     * @param organizationUrl the new organizationUrl
+     * @param enterpriseId the enterpriseId
+     * @return the CredentialDetails builder
      */
-    public void setOrganizationUrl(final String organizationUrl) {
-      this.organization_url_serialized_name = organizationUrl;
+    public CredentialDetailsBuilder setEnterpriseId(String enterpriseId) {
+      this.enterpriseId = enterpriseId;
+      return this;
     }
 
     /**
-     * Sets the siteCollectionPath.
+     * Set the url.
      *
-     * @param siteCollectionPath the new siteCollectionPath
+     * @param url the url
+     * @return the CredentialDetails builder
      */
-    public void setSiteCollectionPath(final String siteCollectionPath) {
-      this.site_collection_path_serialized_name = siteCollectionPath;
+    public CredentialDetailsBuilder setUrl(String url) {
+      this.url = url;
+      return this;
     }
 
     /**
-     * Sets the clientSecret.
+     * Set the username.
      *
-     * @param clientSecret the new clientSecret
+     * @param username the username
+     * @return the CredentialDetails builder
      */
-    public void setClientSecret(final String clientSecret) {
-      this.client_secret_serialized_name = clientSecret;
+    public CredentialDetailsBuilder setUsername(String username) {
+      this.username = username;
+      return this;
     }
 
     /**
-     * Sets the publicKeyId.
+     * Set the organizationUrl.
      *
-     * @param publicKeyId the new publicKeyId
+     * @param organizationUrl the organizationUrl
+     * @return the CredentialDetails builder
      */
-    public void setPublicKeyId(final String publicKeyId) {
-      this.public_key_id_serialized_name = publicKeyId;
+    public CredentialDetailsBuilder setOrganizationUrl(String organizationUrl) {
+      this.organizationUrl = organizationUrl;
+      return this;
     }
 
     /**
-     * Sets the privateKey.
+     * Set the siteCollectionPath.
      *
-     * @param privateKey the new privateKey
+     * @param siteCollectionPath the siteCollectionPath
+     * @return the CredentialDetails builder
      */
-    public void setPrivateKey(final String privateKey) {
-      this.private_key_serialized_name = privateKey;
+    public CredentialDetailsBuilder setSiteCollectionPath(String siteCollectionPath) {
+      this.siteCollectionPath = siteCollectionPath;
+      return this;
     }
 
     /**
-     * Sets the passphrase.
+     * Set the clientSecret.
      *
-     * @param passphrase the new passphrase
+     * @param clientSecret the clientSecret
+     * @return the CredentialDetails builder
      */
-    public void setPassphrase(final String passphrase) {
-      this.passphrase_serialized_name = passphrase;
+    public CredentialDetailsBuilder setClientSecret(String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
     }
 
     /**
-     * Sets the password.
+     * Set the publicKeyId.
      *
-     * @param password the new password
+     * @param publicKeyId the publicKeyId
+     * @return the CredentialDetails builder
      */
-    public void setPassword(final String password) {
-      this.password_serialized_name = password;
+    public CredentialDetailsBuilder setPublicKeyId(String publicKeyId) {
+      this.publicKeyId = publicKeyId;
+      return this;
     }
 
     /**
-     * Sets the gatewayId.
+     * Set the privateKey.
      *
-     * @param gatewayId the new gatewayId
+     * @param privateKey the privateKey
+     * @return the CredentialDetails builder
      */
-    public void setGatewayId(final String gatewayId) {
-      this.gateway_id_serialized_name = gatewayId;
+    public CredentialDetailsBuilder setPrivateKey(String privateKey) {
+      this.privateKey = privateKey;
+      return this;
     }
 
     /**
-     * Sets the sourceVersion.
+     * Set the passphrase.
      *
-     * @param sourceVersion the new sourceVersion
+     * @param passphrase the passphrase
+     * @return the CredentialDetails builder
      */
-    public void setSourceVersion(final String sourceVersion) {
-      this.source_version_serialized_name = sourceVersion;
+    public CredentialDetailsBuilder setPassphrase(String passphrase) {
+      this.passphrase = passphrase;
+      return this;
     }
 
     /**
-     * Sets the webApplicationUrl.
+     * Set the password.
      *
-     * @param webApplicationUrl the new webApplicationUrl
+     * @param password the password
+     * @return the CredentialDetails builder
      */
-    public void setWebApplicationUrl(final String webApplicationUrl) {
-      this.web_application_url_serialized_name = webApplicationUrl;
+    public CredentialDetailsBuilder setPassword(String password) {
+      this.password = password;
+      return this;
     }
 
     /**
-     * Sets the domain.
+     * Set the gatewayId.
      *
-     * @param domain the new domain
+     * @param gatewayId the gatewayId
+     * @return the CredentialDetails builder
      */
-    public void setDomain(final String domain) {
-      this.domain_serialized_name = domain;
+    public CredentialDetailsBuilder setGatewayId(String gatewayId) {
+      this.gatewayId = gatewayId;
+      return this;
     }
 
     /**
-     * Sets the endpoint.
+     * Set the sourceVersion.
      *
-     * @param endpoint the new endpoint
+     * @param sourceVersion the sourceVersion
+     * @return the CredentialDetails builder
      */
-    public void setEndpoint(final String endpoint) {
-      this.endpoint_serialized_name = endpoint;
+    public CredentialDetailsBuilder setSourceVersion(String sourceVersion) {
+      this.sourceVersion = sourceVersion;
+      return this;
     }
 
     /**
-     * Sets the accessKeyId.
+     * Set the webApplicationUrl.
      *
-     * @param accessKeyId the new accessKeyId
+     * @param webApplicationUrl the webApplicationUrl
+     * @return the CredentialDetails builder
      */
-    public void setAccessKeyId(final String accessKeyId) {
-      this.access_key_id_serialized_name = accessKeyId;
+    public CredentialDetailsBuilder setWebApplicationUrl(String webApplicationUrl) {
+      this.webApplicationUrl = webApplicationUrl;
+      return this;
     }
 
     /**
-     * Sets the secretAccessKey.
+     * Set the domain.
      *
-     * @param secretAccessKey the new secretAccessKey
+     * @param domain the domain
+     * @return the CredentialDetails builder
      */
-    public void setSecretAccessKey(final String secretAccessKey) {
-      this.secret_access_key_serialized_name = secretAccessKey;
+    public CredentialDetailsBuilder setDomain(String domain) {
+      this.domain = domain;
+      return this;
     }
 
+    /**
+     * Set the endpoint.
+     *
+     * @param endpoint the endpoint
+     * @return the CredentialDetails builder
+     */
+    public CredentialDetailsBuilder setEndpoint(String endpoint) {
+      this.endpoint = endpoint;
+      return this;
+    }
+
+    /**
+     * Set the accessKeyId.
+     *
+     * @param accessKeyId the accessKeyId
+     * @return the CredentialDetails builder
+     */
+    public CredentialDetailsBuilder setAccessKeyId(String accessKeyId) {
+      this.accessKeyId = accessKeyId;
+      return this;
+    }
+
+    /**
+     * Set the secretAccessKey.
+     *
+     * @param secretAccessKey the secretAccessKey
+     * @return the CredentialDetails builder
+     */
+    public CredentialDetailsBuilder setSecretAccessKey(String secretAccessKey) {
+      this.secretAccessKey = secretAccessKey;
+      return this;
+    }
   }
 
   /**
    * Object containing credential information.
    */
   public class Credentials extends IBMWatsonResponseModel {
-    private String credential_id_serialized_name;
-    private String source_type_serialized_name;
-    private CredentialDetails credential_details_serialized_name;
-    private String status_serialized_name;
+    private String credentialId;
+    private String sourceType;
+    private CredentialDetails credentialDetails;
+    private String status;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Credentials() { }
  
     /**
      * Gets the credentialId.
@@ -3730,7 +4393,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCredentialId() {
-      return credential_id_serialized_name;
+      return credentialId;
     }
  
     /**
@@ -3747,7 +4410,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSourceType() {
-      return source_type_serialized_name;
+      return sourceType;
     }
  
     /**
@@ -3761,7 +4424,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public CredentialDetails getCredentialDetails() {
-      return credential_details_serialized_name;
+      return credentialDetails;
     }
  
     /**
@@ -3775,34 +4438,23 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
+    }
+  
+    private Credentials(CredentialsBuilder builder) {
+      this.credentialId = builder.credentialId;
+      this.sourceType = builder.sourceType;
+      this.credentialDetails = builder.credentialDetails;
+      this.status = builder.status;
     }
 
     /**
-     * Sets the sourceType.
+     * New builder.
      *
-     * @param sourceType the new sourceType
+     * @return a Credentials builder
      */
-    public void setSourceType(final String sourceType) {
-      this.source_type_serialized_name = sourceType;
-    }
-
-    /**
-     * Sets the credentialDetails.
-     *
-     * @param credentialDetails the new credentialDetails
-     */
-    public void setCredentialDetails(final CredentialDetails credentialDetails) {
-      this.credential_details_serialized_name = credentialDetails;
-    }
-
-    /**
-     * Sets the status.
-     *
-     * @param status the new status
-     */
-    public void setStatus(final String status) {
-      this.status_serialized_name = status;
+    public CredentialsBuilder newBuilder() {
+      return new CredentialsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3811,12 +4463,111 @@ public class IBMDiscoveryV1Models {
       }
 
       Credentials ret = (Credentials) super.deserialize(jsonString, jsonMap, classType);
+      CredentialsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for credentialDetails
-      CredentialDetails newCredentialDetails = (CredentialDetails) new CredentialDetails().deserialize(JSON.serialize(ret.getCredentialDetails()), (Map<String, Object>) jsonMap.get('credential_details_serialized_name'), CredentialDetails.class);
-      ret.setCredentialDetails(newCredentialDetails);
+      CredentialDetails newCredentialDetails = (CredentialDetails) new CredentialDetails().deserialize(JSON.serialize(ret.getCredentialDetails()), (Map<String, Object>) jsonMap.get('credentialDetails'), CredentialDetails.class);
+      retBuilder.setCredentialDetails(newCredentialDetails);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('credentialId', 'credential_id');
+      mapping.put('sourceType', 'source_type');
+      mapping.put('credentialDetails', 'credential_details');
+      if (credentialDetails != null) {
+        mapping.putAll(credentialDetails.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('credential_id', 'credentialId');
+      mapping.put('source_type', 'sourceType');
+      mapping.put('credential_details', 'credentialDetails');
+      if (credentialDetails != null) {
+        mapping.putAll(credentialDetails.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * Credentials Builder.
+   */
+  public class CredentialsBuilder {
+    private String credentialId;
+    private String sourceType;
+    private CredentialDetails credentialDetails;
+    private String status;
+
+    private CredentialsBuilder(Credentials credentials) {
+      this.credentialId = credentials.credentialId;
+      this.sourceType = credentials.sourceType;
+      this.credentialDetails = credentials.credentialDetails;
+      this.status = credentials.status;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public CredentialsBuilder() {
+    }
+
+    /**
+     * Builds a Credentials.
+     *
+     * @return the credentials
+     */
+    public Credentials build() {
+      return new Credentials(this);
+    }
+
+    /**
+     * Set the credentialId.
+     *
+     * @param credentialId the credentialId
+     * @return the Credentials builder
+     */
+    public CredentialsBuilder setCredentialId(String credentialId) {
+      this.credentialId = credentialId;
+      return this;
+    }
+
+    /**
+     * Set the sourceType.
+     *
+     * @param sourceType the sourceType
+     * @return the Credentials builder
+     */
+    public CredentialsBuilder setSourceType(String sourceType) {
+      this.sourceType = sourceType;
+      return this;
+    }
+
+    /**
+     * Set the credentialDetails.
+     *
+     * @param credentialDetails the credentialDetails
+     * @return the Credentials builder
+     */
+    public CredentialsBuilder setCredentialDetails(CredentialDetails credentialDetails) {
+      this.credentialDetails = credentialDetails;
+      return this;
+    }
+
+    /**
+     * Set the status.
+     *
+     * @param status the status
+     * @return the Credentials builder
+     */
+    public CredentialsBuilder setStatus(String status) {
+      this.status = status;
+      return this;
     }
   }
 
@@ -3824,7 +4575,7 @@ public class IBMDiscoveryV1Models {
    * CredentialsList.
    */
   public class CredentialsList extends IBMWatsonResponseModel {
-    private List<Credentials> credentials_serialized_name;
+    private List<Credentials> credentials;
  
     /**
      * Gets the credentials.
@@ -3835,7 +4586,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Credentials> getCredentials() {
-      return credentials_serialized_name;
+      return credentials;
     }
 
     /**
@@ -3844,7 +4595,7 @@ public class IBMDiscoveryV1Models {
      * @param credentials the new credentials
      */
     public void setCredentials(final List<Credentials> credentials) {
-      this.credentials_serialized_name = credentials;
+      this.credentials = credentials;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3860,14 +4611,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedCredentials != null) {
         for (Integer i = 0; i < deserializedCredentials.size(); i++) {
           Credentials currentItem = ret.getCredentials().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('credentials_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('credentials');
           Credentials newItem = (Credentials) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Credentials.class);
           newCredentials.add(newItem);
         }
-        ret.credentials_serialized_name = newCredentials;
+        ret.credentials = newCredentials;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (credentials != null && credentials[0] != null) {
+        mapping.putAll(credentials[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -3877,7 +4636,7 @@ public class IBMDiscoveryV1Models {
   public class DeleteAllTrainingDataOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -3888,7 +4647,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -3917,6 +4676,12 @@ public class IBMDiscoveryV1Models {
       return new DeleteAllTrainingDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -3999,7 +4764,7 @@ public class IBMDiscoveryV1Models {
   public class DeleteCollectionOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -4010,7 +4775,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -4039,6 +4804,12 @@ public class IBMDiscoveryV1Models {
       return new DeleteCollectionOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4121,7 +4892,7 @@ public class IBMDiscoveryV1Models {
   public class DeleteConfigurationOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String configurationId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -4132,7 +4903,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the configurationId.
      *
@@ -4161,6 +4932,12 @@ public class IBMDiscoveryV1Models {
       return new DeleteConfigurationOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('configurationId', 'configuration_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4243,7 +5020,7 @@ public class IBMDiscoveryV1Models {
   public class DeleteCredentialsOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String credentialId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -4254,7 +5031,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the credentialId.
      *
@@ -4283,6 +5060,12 @@ public class IBMDiscoveryV1Models {
       return new DeleteCredentialsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('credentialId', 'credential_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4366,7 +5149,7 @@ public class IBMDiscoveryV1Models {
     private String environmentId;
     private String collectionId;
     private String documentId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -4377,7 +5160,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -4388,7 +5171,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the documentId.
      *
@@ -4419,6 +5202,13 @@ public class IBMDiscoveryV1Models {
       return new DeleteDocumentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('documentId', 'document_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4515,7 +5305,7 @@ public class IBMDiscoveryV1Models {
    */
   public class DeleteEnvironmentOptions extends IBMWatsonOptionsModel {
     private String environmentId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -4542,6 +5332,11 @@ public class IBMDiscoveryV1Models {
       return new DeleteEnvironmentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4609,7 +5404,7 @@ public class IBMDiscoveryV1Models {
   public class DeleteExpansionsOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -4620,7 +5415,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -4649,6 +5444,12 @@ public class IBMDiscoveryV1Models {
       return new DeleteExpansionsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4731,7 +5532,7 @@ public class IBMDiscoveryV1Models {
   public class DeleteGatewayOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String gatewayId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -4742,7 +5543,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the gatewayId.
      *
@@ -4771,6 +5572,12 @@ public class IBMDiscoveryV1Models {
       return new DeleteGatewayOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('gatewayId', 'gateway_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4853,7 +5660,7 @@ public class IBMDiscoveryV1Models {
   public class DeleteStopwordListOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -4864,7 +5671,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -4893,6 +5700,12 @@ public class IBMDiscoveryV1Models {
       return new DeleteStopwordListOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4975,7 +5788,7 @@ public class IBMDiscoveryV1Models {
   public class DeleteTokenizationDictionaryOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -4986,7 +5799,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -5015,6 +5828,12 @@ public class IBMDiscoveryV1Models {
       return new DeleteTokenizationDictionaryOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -5098,7 +5917,7 @@ public class IBMDiscoveryV1Models {
     private String environmentId;
     private String collectionId;
     private String queryId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -5109,7 +5928,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -5120,7 +5939,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -5151,6 +5970,13 @@ public class IBMDiscoveryV1Models {
       return new DeleteTrainingDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('queryId', 'query_id');
+      return mapping;
+    }
   }
 
   /**
@@ -5250,7 +6076,7 @@ public class IBMDiscoveryV1Models {
     private String collectionId;
     private String queryId;
     private String exampleId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -5261,7 +6087,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -5272,7 +6098,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -5283,7 +6109,7 @@ public class IBMDiscoveryV1Models {
     public String queryId() {
       return queryId;
     }
- 
+
     /**
      * Gets the exampleId.
      *
@@ -5316,6 +6142,14 @@ public class IBMDiscoveryV1Models {
       return new DeleteTrainingExampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('queryId', 'query_id');
+      mapping.put('exampleId', 'example_id');
+      return mapping;
+    }
   }
 
   /**
@@ -5427,7 +6261,7 @@ public class IBMDiscoveryV1Models {
    */
   public class DeleteUserDataOptions extends IBMWatsonOptionsModel {
     private String customerId;
- 
+
     /**
      * Gets the customerId.
      *
@@ -5454,6 +6288,11 @@ public class IBMDiscoveryV1Models {
       return new DeleteUserDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customerId', 'customer_id');
+      return mapping;
+    }
   }
 
   /**
@@ -5519,8 +6358,8 @@ public class IBMDiscoveryV1Models {
    * Summary of the disk usage statistics for the environment.
    */
   public class DiskUsage extends IBMWatsonGenericModel {
-    private Long used_bytes_serialized_name;
-    private Long maximum_allowed_bytes_serialized_name;
+    private Long usedBytes;
+    private Long maximumAllowedBytes;
  
     /**
      * Gets the usedBytes.
@@ -5531,7 +6370,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getUsedBytes() {
-      return used_bytes_serialized_name;
+      return usedBytes;
     }
  
     /**
@@ -5543,18 +6382,24 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMaximumAllowedBytes() {
-      return maximum_allowed_bytes_serialized_name;
+      return maximumAllowedBytes;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('used_bytes', 'usedBytes');
+      mapping.put('maximum_allowed_bytes', 'maximumAllowedBytes');
+      return mapping;
+    }
   }
 
   /**
    * DocumentAccepted.
    */
   public class DocumentAccepted extends IBMWatsonResponseModel {
-    private String document_id_serialized_name;
-    private String status_serialized_name;
-    private List<Notice> notices_serialized_name;
+    private String documentId;
+    private String status;
+    private List<Notice> notices;
  
     /**
      * Gets the documentId.
@@ -5565,7 +6410,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -5578,7 +6423,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -5590,7 +6435,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Notice> getNotices() {
-      return notices_serialized_name;
+      return notices;
     }
 
     /**
@@ -5599,7 +6444,7 @@ public class IBMDiscoveryV1Models {
      * @param documentId the new documentId
      */
     public void setDocumentId(final String documentId) {
-      this.document_id_serialized_name = documentId;
+      this.documentId = documentId;
     }
 
     /**
@@ -5608,7 +6453,7 @@ public class IBMDiscoveryV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -5617,7 +6462,7 @@ public class IBMDiscoveryV1Models {
      * @param notices the new notices
      */
     public void setNotices(final List<Notice> notices) {
-      this.notices_serialized_name = notices;
+      this.notices = notices;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5633,14 +6478,23 @@ public class IBMDiscoveryV1Models {
       if (deserializedNotices != null) {
         for (Integer i = 0; i < deserializedNotices.size(); i++) {
           Notice currentItem = ret.getNotices().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('notices_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('notices');
           Notice newItem = (Notice) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Notice.class);
           newNotices.add(newItem);
         }
-        ret.notices_serialized_name = newNotices;
+        ret.notices = newNotices;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_id', 'documentId');
+      if (notices != null && notices[0] != null) {
+        mapping.putAll(notices[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5648,10 +6502,10 @@ public class IBMDiscoveryV1Models {
    * DocumentCounts.
    */
   public class DocumentCounts extends IBMWatsonGenericModel {
-    private Long available_serialized_name;
-    private Long processing_serialized_name;
-    private Long failed_serialized_name;
-    private Long pending_serialized_name;
+    private Long available;
+    private Long processing;
+    private Long failed;
+    private Long pending;
  
     /**
      * Gets the available.
@@ -5662,7 +6516,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getAvailable() {
-      return available_serialized_name;
+      return available;
     }
  
     /**
@@ -5674,7 +6528,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getProcessing() {
-      return processing_serialized_name;
+      return processing;
     }
  
     /**
@@ -5686,7 +6540,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getFailed() {
-      return failed_serialized_name;
+      return failed;
     }
  
     /**
@@ -5698,17 +6552,16 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getPending() {
-      return pending_serialized_name;
+      return pending;
     }
-
   }
 
   /**
    * DocumentSnapshot.
    */
   public class DocumentSnapshot extends IBMWatsonGenericModel {
-    private String step_serialized_name;
-    private IBMWatsonMapModel snapshot_serialized_name;
+    private String step;
+    private IBMWatsonMapModel snapshot;
  
     /**
      * Gets the step.
@@ -5719,7 +6572,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStep() {
-      return step_serialized_name;
+      return step;
     }
  
     /**
@@ -5731,7 +6584,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getSnapshot() {
-      return snapshot_serialized_name;
+      return snapshot;
     }
 
     /**
@@ -5740,7 +6593,7 @@ public class IBMDiscoveryV1Models {
      * @param step the new step
      */
     public void setStep(final String step) {
-      this.step_serialized_name = step;
+      this.step = step;
     }
 
     /**
@@ -5749,7 +6602,7 @@ public class IBMDiscoveryV1Models {
      * @param snapshot the new snapshot
      */
     public void setSnapshot(final IBMWatsonMapModel snapshot) {
-      this.snapshot_serialized_name = snapshot;
+      this.snapshot = snapshot;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5760,7 +6613,7 @@ public class IBMDiscoveryV1Models {
       DocumentSnapshot ret = (DocumentSnapshot) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for snapshot
-      IBMWatsonMapModel newSnapshot = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getSnapshot()), (Map<String, Object>) jsonMap.get('snapshot_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newSnapshot = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getSnapshot()), (Map<String, Object>) jsonMap.get('snapshot'), IBMWatsonMapModel.class);
       ret.setSnapshot(newSnapshot);
 
       return ret;
@@ -5771,14 +6624,14 @@ public class IBMDiscoveryV1Models {
    * Status information about a submitted document.
    */
   public class DocumentStatus extends IBMWatsonResponseModel {
-    private String document_id_serialized_name;
-    private String configuration_id_serialized_name;
-    private String status_serialized_name;
-    private String status_description_serialized_name;
-    private String filename_serialized_name;
-    private String file_type_serialized_name;
-    private String sha1_serialized_name;
-    private List<Notice> notices_serialized_name;
+    private String documentId;
+    private String configurationId;
+    private String status;
+    private String statusDescription;
+    private String filename;
+    private String fileType;
+    private String sha1;
+    private List<Notice> notices;
  
     /**
      * Gets the documentId.
@@ -5789,7 +6642,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -5801,7 +6654,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getConfigurationId() {
-      return configuration_id_serialized_name;
+      return configurationId;
     }
  
     /**
@@ -5813,7 +6666,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -5825,7 +6678,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatusDescription() {
-      return status_description_serialized_name;
+      return statusDescription;
     }
  
     /**
@@ -5837,7 +6690,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getFilename() {
-      return filename_serialized_name;
+      return filename;
     }
  
     /**
@@ -5849,7 +6702,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getFileType() {
-      return file_type_serialized_name;
+      return fileType;
     }
  
     /**
@@ -5861,7 +6714,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSha1() {
-      return sha1_serialized_name;
+      return sha1;
     }
  
     /**
@@ -5873,7 +6726,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Notice> getNotices() {
-      return notices_serialized_name;
+      return notices;
     }
 
     /**
@@ -5882,7 +6735,7 @@ public class IBMDiscoveryV1Models {
      * @param filename the new filename
      */
     public void setFilename(final String filename) {
-      this.filename_serialized_name = filename;
+      this.filename = filename;
     }
 
     /**
@@ -5891,7 +6744,7 @@ public class IBMDiscoveryV1Models {
      * @param fileType the new fileType
      */
     public void setFileType(final String fileType) {
-      this.file_type_serialized_name = fileType;
+      this.fileType = fileType;
     }
 
     /**
@@ -5900,7 +6753,7 @@ public class IBMDiscoveryV1Models {
      * @param sha1 the new sha1
      */
     public void setSha1(final String sha1) {
-      this.sha1_serialized_name = sha1;
+      this.sha1 = sha1;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5916,14 +6769,26 @@ public class IBMDiscoveryV1Models {
       if (deserializedNotices != null) {
         for (Integer i = 0; i < deserializedNotices.size(); i++) {
           Notice currentItem = ret.getNotices().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('notices_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('notices');
           Notice newItem = (Notice) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Notice.class);
           newNotices.add(newItem);
         }
-        ret.notices_serialized_name = newNotices;
+        ret.notices = newNotices;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_id', 'documentId');
+      mapping.put('configuration_id', 'configurationId');
+      mapping.put('status_description', 'statusDescription');
+      mapping.put('file_type', 'fileType');
+      if (notices != null && notices[0] != null) {
+        mapping.putAll(notices[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5931,13 +6796,19 @@ public class IBMDiscoveryV1Models {
    * Enrichment.
    */
   public class Enrichment extends IBMWatsonGenericModel {
-    private String description_serialized_name;
-    private String destination_field_serialized_name;
-    private String source_field_serialized_name;
-    private Boolean overwrite_serialized_name;
-    private String enrichment_serialized_name;
-    private Boolean ignore_downstream_errors_serialized_name;
-    private EnrichmentOptions options_serialized_name;
+    private String description;
+    private String destinationField;
+    private String sourceField;
+    private Boolean overwrite;
+    private String enrichmentName;
+    private Boolean ignoreDownstreamErrors;
+    private EnrichmentOptions options;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Enrichment() { }
  
     /**
      * Gets the description.
@@ -5948,7 +6819,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -5962,7 +6833,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDestinationField() {
-      return destination_field_serialized_name;
+      return destinationField;
     }
  
     /**
@@ -5977,7 +6848,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSourceField() {
-      return source_field_serialized_name;
+      return sourceField;
     }
  
     /**
@@ -5989,7 +6860,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getOverwrite() {
-      return overwrite_serialized_name;
+      return overwrite;
     }
  
     /**
@@ -6009,7 +6880,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEnrichmentName() {
-      return enrichment_serialized_name;
+      return enrichmentName;
     }
  
     /**
@@ -6022,7 +6893,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getIgnoreDownstreamErrors() {
-      return ignore_downstream_errors_serialized_name;
+      return ignoreDownstreamErrors;
     }
  
     /**
@@ -6034,70 +6905,29 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public EnrichmentOptions getOptions() {
-      return options_serialized_name;
+      return options;
+    }
+  
+    private Enrichment(EnrichmentBuilder builder) {
+      IBMWatsonValidator.notNull(builder.destinationField, 'destinationField cannot be null');
+      IBMWatsonValidator.notNull(builder.sourceField, 'sourceField cannot be null');
+      IBMWatsonValidator.notNull(builder.enrichmentName, 'enrichmentName cannot be null');
+      this.description = builder.description;
+      this.destinationField = builder.destinationField;
+      this.sourceField = builder.sourceField;
+      this.overwrite = builder.overwrite;
+      this.enrichmentName = builder.enrichmentName;
+      this.ignoreDownstreamErrors = builder.ignoreDownstreamErrors;
+      this.options = builder.options;
     }
 
     /**
-     * Sets the description.
+     * New builder.
      *
-     * @param description the new description
+     * @return a Enrichment builder
      */
-    public void setDescription(final String description) {
-      this.description_serialized_name = description;
-    }
-
-    /**
-     * Sets the destinationField.
-     *
-     * @param destinationField the new destinationField
-     */
-    public void setDestinationField(final String destinationField) {
-      this.destination_field_serialized_name = destinationField;
-    }
-
-    /**
-     * Sets the sourceField.
-     *
-     * @param sourceField the new sourceField
-     */
-    public void setSourceField(final String sourceField) {
-      this.source_field_serialized_name = sourceField;
-    }
-
-    /**
-     * Sets the overwrite.
-     *
-     * @param overwrite the new overwrite
-     */
-    public void setOverwrite(final Boolean overwrite) {
-      this.overwrite_serialized_name = overwrite;
-    }
-
-    /**
-     * Sets the enrichmentName.
-     *
-     * @param enrichmentName the new enrichmentName
-     */
-    public void setEnrichmentName(final String enrichmentName) {
-      this.enrichment_serialized_name = enrichmentName;
-    }
-
-    /**
-     * Sets the ignoreDownstreamErrors.
-     *
-     * @param ignoreDownstreamErrors the new ignoreDownstreamErrors
-     */
-    public void setIgnoreDownstreamErrors(final Boolean ignoreDownstreamErrors) {
-      this.ignore_downstream_errors_serialized_name = ignoreDownstreamErrors;
-    }
-
-    /**
-     * Sets the options.
-     *
-     * @param options the new options
-     */
-    public void setOptions(final EnrichmentOptions options) {
-      this.options_serialized_name = options;
+    public EnrichmentBuilder newBuilder() {
+      return new EnrichmentBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6106,12 +6936,165 @@ public class IBMDiscoveryV1Models {
       }
 
       Enrichment ret = (Enrichment) super.deserialize(jsonString, jsonMap, classType);
+      EnrichmentBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for options
-      EnrichmentOptions newOptions = (EnrichmentOptions) new EnrichmentOptions().deserialize(JSON.serialize(ret.getOptions()), (Map<String, Object>) jsonMap.get('options_serialized_name'), EnrichmentOptions.class);
-      ret.setOptions(newOptions);
+      EnrichmentOptions newOptions = (EnrichmentOptions) new EnrichmentOptions().deserialize(JSON.serialize(ret.getOptions()), (Map<String, Object>) jsonMap.get('options'), EnrichmentOptions.class);
+      retBuilder.setOptions(newOptions);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('destinationField', 'destination_field');
+      mapping.put('sourceField', 'source_field');
+      mapping.put('enrichmentName', 'enrichment');
+      mapping.put('ignoreDownstreamErrors', 'ignore_downstream_errors');
+      if (options != null) {
+        mapping.putAll(options.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('destination_field', 'destinationField');
+      mapping.put('source_field', 'sourceField');
+      mapping.put('enrichment', 'enrichmentName');
+      mapping.put('ignore_downstream_errors', 'ignoreDownstreamErrors');
+      if (options != null) {
+        mapping.putAll(options.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * Enrichment Builder.
+   */
+  public class EnrichmentBuilder {
+    private String description;
+    private String destinationField;
+    private String sourceField;
+    private Boolean overwrite;
+    private String enrichmentName;
+    private Boolean ignoreDownstreamErrors;
+    private EnrichmentOptions options;
+
+    private EnrichmentBuilder(Enrichment enrichment) {
+      this.description = enrichment.description;
+      this.destinationField = enrichment.destinationField;
+      this.sourceField = enrichment.sourceField;
+      this.overwrite = enrichment.overwrite;
+      this.enrichmentName = enrichment.enrichmentName;
+      this.ignoreDownstreamErrors = enrichment.ignoreDownstreamErrors;
+      this.options = enrichment.options;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public EnrichmentBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param destinationField the destinationField
+     * @param sourceField the sourceField
+     * @param enrichmentName the enrichmentName
+     */
+    public EnrichmentBuilder(String destinationField, String sourceField, String enrichmentName) {
+      this.destinationField = destinationField;
+      this.sourceField = sourceField;
+      this.enrichmentName = enrichmentName;
+    }
+
+    /**
+     * Builds a Enrichment.
+     *
+     * @return the enrichment
+     */
+    public Enrichment build() {
+      return new Enrichment(this);
+    }
+
+    /**
+     * Set the description.
+     *
+     * @param description the description
+     * @return the Enrichment builder
+     */
+    public EnrichmentBuilder setDescription(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /**
+     * Set the destinationField.
+     *
+     * @param destinationField the destinationField
+     * @return the Enrichment builder
+     */
+    public EnrichmentBuilder setDestinationField(String destinationField) {
+      this.destinationField = destinationField;
+      return this;
+    }
+
+    /**
+     * Set the sourceField.
+     *
+     * @param sourceField the sourceField
+     * @return the Enrichment builder
+     */
+    public EnrichmentBuilder setSourceField(String sourceField) {
+      this.sourceField = sourceField;
+      return this;
+    }
+
+    /**
+     * Set the overwrite.
+     *
+     * @param overwrite the overwrite
+     * @return the Enrichment builder
+     */
+    public EnrichmentBuilder setOverwrite(Boolean overwrite) {
+      this.overwrite = overwrite;
+      return this;
+    }
+
+    /**
+     * Set the enrichmentName.
+     *
+     * @param enrichmentName the enrichmentName
+     * @return the Enrichment builder
+     */
+    public EnrichmentBuilder setEnrichmentName(String enrichmentName) {
+      this.enrichmentName = enrichmentName;
+      return this;
+    }
+
+    /**
+     * Set the ignoreDownstreamErrors.
+     *
+     * @param ignoreDownstreamErrors the ignoreDownstreamErrors
+     * @return the Enrichment builder
+     */
+    public EnrichmentBuilder setIgnoreDownstreamErrors(Boolean ignoreDownstreamErrors) {
+      this.ignoreDownstreamErrors = ignoreDownstreamErrors;
+      return this;
+    }
+
+    /**
+     * Set the options.
+     *
+     * @param options the options
+     * @return the Enrichment builder
+     */
+    public EnrichmentBuilder setOptions(EnrichmentOptions options) {
+      this.options = options;
+      return this;
     }
   }
 
@@ -6119,9 +7102,9 @@ public class IBMDiscoveryV1Models {
    * Options which are specific to a particular enrichment.
    */
   public class EnrichmentOptions extends IBMWatsonGenericModel {
-    private NluEnrichmentFeatures features_serialized_name;
-    private String language_serialized_name;
-    private String model_serialized_name;
+    private NluEnrichmentFeatures features;
+    private String language;
+    private String model;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -6136,7 +7119,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public NluEnrichmentFeatures getFeatures() {
-      return features_serialized_name;
+      return features;
     }
  
     /**
@@ -6151,7 +7134,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -6164,13 +7147,13 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getModel() {
-      return model_serialized_name;
+      return model;
     }
   
     private EnrichmentOptions(EnrichmentOptionsBuilder builder) {
-      this.features_serialized_name = builder.features;
-      this.language_serialized_name = builder.language;
-      this.model_serialized_name = builder.model;
+      this.features = builder.features;
+      this.language = builder.language;
+      this.model = builder.model;
     }
 
     /**
@@ -6191,10 +7174,26 @@ public class IBMDiscoveryV1Models {
       EnrichmentOptionsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for features
-      NluEnrichmentFeatures newFeatures = (NluEnrichmentFeatures) new NluEnrichmentFeatures().deserialize(JSON.serialize(ret.getFeatures()), (Map<String, Object>) jsonMap.get('features_serialized_name'), NluEnrichmentFeatures.class);
+      NluEnrichmentFeatures newFeatures = (NluEnrichmentFeatures) new NluEnrichmentFeatures().deserialize(JSON.serialize(ret.getFeatures()), (Map<String, Object>) jsonMap.get('features'), NluEnrichmentFeatures.class);
       retBuilder.features(newFeatures);
 
       return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (features != null) {
+        mapping.putAll(features.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (features != null) {
+        mapping.putAll(features.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -6207,9 +7206,9 @@ public class IBMDiscoveryV1Models {
     private String model;
 
     private EnrichmentOptionsBuilder(EnrichmentOptions enrichmentOptions) {
-      this.features = enrichmentOptions.features_serialized_name;
-      this.language = enrichmentOptions.language_serialized_name;
-      this.model = enrichmentOptions.model_serialized_name;
+      this.features = enrichmentOptions.features;
+      this.language = enrichmentOptions.language;
+      this.model = enrichmentOptions.model;
     }
 
     /**
@@ -6265,17 +7264,17 @@ public class IBMDiscoveryV1Models {
    * Details about an environment.
    */
   public class Environment extends IBMWatsonResponseModel {
-    private String environment_id_serialized_name;
-    private String name_serialized_name;
-    private String description_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime updated_serialized_name;
-    private String status_serialized_name;
-    private Boolean read_only_serialized_name;
-    private String size_serialized_name;
-    private String requested_size_serialized_name;
-    private IndexCapacity index_capacity_serialized_name;
-    private SearchStatus search_status_serialized_name;
+    private String environmentId;
+    private String name;
+    private String description;
+    private Datetime created;
+    private Datetime updated;
+    private String status;
+    private Boolean readOnly;
+    private String size;
+    private String requestedSize;
+    private IndexCapacity indexCapacity;
+    private SearchStatus searchStatus;
  
     /**
      * Gets the environmentId.
@@ -6286,7 +7285,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEnvironmentId() {
-      return environment_id_serialized_name;
+      return environmentId;
     }
  
     /**
@@ -6298,7 +7297,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -6310,7 +7309,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -6322,7 +7321,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -6334,7 +7333,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -6347,7 +7346,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -6359,7 +7358,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getReadOnly() {
-      return read_only_serialized_name;
+      return readOnly;
     }
  
     /**
@@ -6371,7 +7370,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSize() {
-      return size_serialized_name;
+      return size;
     }
  
     /**
@@ -6385,7 +7384,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getRequestedSize() {
-      return requested_size_serialized_name;
+      return requestedSize;
     }
  
     /**
@@ -6397,7 +7396,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public IndexCapacity getIndexCapacity() {
-      return index_capacity_serialized_name;
+      return indexCapacity;
     }
  
     /**
@@ -6409,7 +7408,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public SearchStatus getSearchStatus() {
-      return search_status_serialized_name;
+      return searchStatus;
     }
 
     /**
@@ -6418,7 +7417,7 @@ public class IBMDiscoveryV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -6427,7 +7426,7 @@ public class IBMDiscoveryV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -6436,7 +7435,7 @@ public class IBMDiscoveryV1Models {
      * @param size the new size
      */
     public void setSize(final String size) {
-      this.size_serialized_name = size;
+      this.size = size;
     }
 
     /**
@@ -6445,7 +7444,7 @@ public class IBMDiscoveryV1Models {
      * @param requestedSize the new requestedSize
      */
     public void setRequestedSize(final String requestedSize) {
-      this.requested_size_serialized_name = requestedSize;
+      this.requestedSize = requestedSize;
     }
 
     /**
@@ -6454,7 +7453,7 @@ public class IBMDiscoveryV1Models {
      * @param indexCapacity the new indexCapacity
      */
     public void setIndexCapacity(final IndexCapacity indexCapacity) {
-      this.index_capacity_serialized_name = indexCapacity;
+      this.indexCapacity = indexCapacity;
     }
 
     /**
@@ -6463,7 +7462,7 @@ public class IBMDiscoveryV1Models {
      * @param searchStatus the new searchStatus
      */
     public void setSearchStatus(final SearchStatus searchStatus) {
-      this.search_status_serialized_name = searchStatus;
+      this.searchStatus = searchStatus;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6471,19 +7470,33 @@ public class IBMDiscoveryV1Models {
         return null;
       }
 
-      jsonString = jsonString.replace('"last_trained_serialized_name":"",', '');
-      jsonString = jsonString.replace('"last_trained_serialized_name":""', '');
       Environment ret = (Environment) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for indexCapacity
-      IndexCapacity newIndexCapacity = (IndexCapacity) new IndexCapacity().deserialize(JSON.serialize(ret.getIndexCapacity()), (Map<String, Object>) jsonMap.get('index_capacity_serialized_name'), IndexCapacity.class);
+      IndexCapacity newIndexCapacity = (IndexCapacity) new IndexCapacity().deserialize(JSON.serialize(ret.getIndexCapacity()), (Map<String, Object>) jsonMap.get('indexCapacity'), IndexCapacity.class);
       ret.setIndexCapacity(newIndexCapacity);
 
       // calling custom deserializer for searchStatus
-      SearchStatus newSearchStatus = (SearchStatus) new SearchStatus().deserialize(JSON.serialize(ret.getSearchStatus()), (Map<String, Object>) jsonMap.get('search_status_serialized_name'), SearchStatus.class);
+      SearchStatus newSearchStatus = (SearchStatus) new SearchStatus().deserialize(JSON.serialize(ret.getSearchStatus()), (Map<String, Object>) jsonMap.get('searchStatus'), SearchStatus.class);
       ret.setSearchStatus(newSearchStatus);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environment_id', 'environmentId');
+      mapping.put('read_only', 'readOnly');
+      mapping.put('requested_size', 'requestedSize');
+      mapping.put('index_capacity', 'indexCapacity');
+      if (indexCapacity != null) {
+        mapping.putAll(indexCapacity.getApiToSdkMapping());
+      }
+      mapping.put('search_status', 'searchStatus');
+      if (searchStatus != null) {
+        mapping.putAll(searchStatus.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -6491,8 +7504,8 @@ public class IBMDiscoveryV1Models {
    * Summary of the document usage statistics for the environment.
    */
   public class EnvironmentDocuments extends IBMWatsonGenericModel {
-    private Long indexed_serialized_name;
-    private Long maximum_allowed_serialized_name;
+    private Long indexed;
+    private Long maximumAllowed;
  
     /**
      * Gets the indexed.
@@ -6503,7 +7516,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getIndexed() {
-      return indexed_serialized_name;
+      return indexed;
     }
  
     /**
@@ -6515,22 +7528,33 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMaximumAllowed() {
-      return maximum_allowed_serialized_name;
+      return maximumAllowed;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('maximum_allowed', 'maximumAllowed');
+      return mapping;
+    }
   }
 
   /**
    * Query event data object.
    */
   public class EventData extends IBMWatsonGenericModel {
-    private String environment_id_serialized_name;
-    private String session_token_serialized_name;
-    private Datetime client_timestamp_serialized_name;
-    private Long display_rank_serialized_name;
-    private String collection_id_serialized_name;
-    private String document_id_serialized_name;
-    private String query_id_serialized_name;
+    private String environmentId;
+    private String sessionToken;
+    private Datetime clientTimestamp;
+    private Long displayRank;
+    private String collectionId;
+    private String documentId;
+    private String queryId;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public EventData() { }
  
     /**
      * Gets the environmentId.
@@ -6541,7 +7565,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEnvironmentId() {
-      return environment_id_serialized_name;
+      return environmentId;
     }
  
     /**
@@ -6553,7 +7577,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSessionToken() {
-      return session_token_serialized_name;
+      return sessionToken;
     }
  
     /**
@@ -6566,7 +7590,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getClientTimestamp() {
-      return client_timestamp_serialized_name;
+      return clientTimestamp;
     }
  
     /**
@@ -6578,7 +7602,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getDisplayRank() {
-      return display_rank_serialized_name;
+      return displayRank;
     }
  
     /**
@@ -6590,7 +7614,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCollectionId() {
-      return collection_id_serialized_name;
+      return collectionId;
     }
  
     /**
@@ -6602,7 +7626,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -6615,63 +7639,185 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getQueryId() {
-      return query_id_serialized_name;
+      return queryId;
+    }
+  
+    private EventData(EventDataBuilder builder) {
+      IBMWatsonValidator.notNull(builder.environmentId, 'environmentId cannot be null');
+      IBMWatsonValidator.notNull(builder.sessionToken, 'sessionToken cannot be null');
+      IBMWatsonValidator.notNull(builder.collectionId, 'collectionId cannot be null');
+      IBMWatsonValidator.notNull(builder.documentId, 'documentId cannot be null');
+      this.environmentId = builder.environmentId;
+      this.sessionToken = builder.sessionToken;
+      this.clientTimestamp = builder.clientTimestamp;
+      this.displayRank = builder.displayRank;
+      this.collectionId = builder.collectionId;
+      this.documentId = builder.documentId;
+      this.queryId = builder.queryId;
     }
 
     /**
-     * Sets the environmentId.
+     * New builder.
      *
-     * @param environmentId the new environmentId
+     * @return a EventData builder
      */
-    public void setEnvironmentId(final String environmentId) {
-      this.environment_id_serialized_name = environmentId;
+    public EventDataBuilder newBuilder() {
+      return new EventDataBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('sessionToken', 'session_token');
+      mapping.put('clientTimestamp', 'client_timestamp');
+      mapping.put('displayRank', 'display_rank');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('documentId', 'document_id');
+      mapping.put('queryId', 'query_id');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environment_id', 'environmentId');
+      mapping.put('session_token', 'sessionToken');
+      mapping.put('client_timestamp', 'clientTimestamp');
+      mapping.put('display_rank', 'displayRank');
+      mapping.put('collection_id', 'collectionId');
+      mapping.put('document_id', 'documentId');
+      mapping.put('query_id', 'queryId');
+      return mapping;
+    }
+  }
+
+  /**
+   * EventData Builder.
+   */
+  public class EventDataBuilder {
+    private String environmentId;
+    private String sessionToken;
+    private Datetime clientTimestamp;
+    private Long displayRank;
+    private String collectionId;
+    private String documentId;
+    private String queryId;
+
+    private EventDataBuilder(EventData eventData) {
+      this.environmentId = eventData.environmentId;
+      this.sessionToken = eventData.sessionToken;
+      this.clientTimestamp = eventData.clientTimestamp;
+      this.displayRank = eventData.displayRank;
+      this.collectionId = eventData.collectionId;
+      this.documentId = eventData.documentId;
+      this.queryId = eventData.queryId;
     }
 
     /**
-     * Sets the sessionToken.
-     *
-     * @param sessionToken the new sessionToken
+     * Instantiates a new builder.
      */
-    public void setSessionToken(final String sessionToken) {
-      this.session_token_serialized_name = sessionToken;
+    public EventDataBuilder() {
     }
 
     /**
-     * Sets the clientTimestamp.
+     * Instantiates a new builder with required properties.
      *
-     * @param clientTimestamp the new clientTimestamp
+     * @param environmentId the environmentId
+     * @param sessionToken the sessionToken
+     * @param collectionId the collectionId
+     * @param documentId the documentId
      */
-    public void setClientTimestamp(final Datetime clientTimestamp) {
-      this.client_timestamp_serialized_name = clientTimestamp;
+    public EventDataBuilder(String environmentId, String sessionToken, String collectionId, String documentId) {
+      this.environmentId = environmentId;
+      this.sessionToken = sessionToken;
+      this.collectionId = collectionId;
+      this.documentId = documentId;
     }
 
     /**
-     * Sets the displayRank.
+     * Builds a EventData.
      *
-     * @param displayRank the new displayRank
+     * @return the eventData
      */
-    public void setDisplayRank(final long displayRank) {
-      this.display_rank_serialized_name = displayRank;
+    public EventData build() {
+      return new EventData(this);
     }
 
     /**
-     * Sets the collectionId.
+     * Set the environmentId.
      *
-     * @param collectionId the new collectionId
+     * @param environmentId the environmentId
+     * @return the EventData builder
      */
-    public void setCollectionId(final String collectionId) {
-      this.collection_id_serialized_name = collectionId;
+    public EventDataBuilder setEnvironmentId(String environmentId) {
+      this.environmentId = environmentId;
+      return this;
     }
 
     /**
-     * Sets the documentId.
+     * Set the sessionToken.
      *
-     * @param documentId the new documentId
+     * @param sessionToken the sessionToken
+     * @return the EventData builder
      */
-    public void setDocumentId(final String documentId) {
-      this.document_id_serialized_name = documentId;
+    public EventDataBuilder setSessionToken(String sessionToken) {
+      this.sessionToken = sessionToken;
+      return this;
     }
 
+    /**
+     * Set the clientTimestamp.
+     *
+     * @param clientTimestamp the clientTimestamp
+     * @return the EventData builder
+     */
+    public EventDataBuilder setClientTimestamp(Datetime clientTimestamp) {
+      this.clientTimestamp = clientTimestamp;
+      return this;
+    }
+
+    /**
+     * Set the displayRank.
+     *
+     * @param displayRank the displayRank
+     * @return the EventData builder
+     */
+    public EventDataBuilder setDisplayRank(Long displayRank) {
+      this.displayRank = displayRank;
+      return this;
+    }
+
+    /**
+     * Set the collectionId.
+     *
+     * @param collectionId the collectionId
+     * @return the EventData builder
+     */
+    public EventDataBuilder setCollectionId(String collectionId) {
+      this.collectionId = collectionId;
+      return this;
+    }
+
+    /**
+     * Set the documentId.
+     *
+     * @param documentId the documentId
+     * @return the EventData builder
+     */
+    public EventDataBuilder setDocumentId(String documentId) {
+      this.documentId = documentId;
+      return this;
+    }
+
+    /**
+     * Set the queryId.
+     *
+     * @param queryId the queryId
+     * @return the EventData builder
+     */
+    public EventDataBuilder setQueryId(String queryId) {
+      this.queryId = queryId;
+      return this;
+    }
   }
 
   /**
@@ -6679,8 +7825,14 @@ public class IBMDiscoveryV1Models {
    * expansions for the word `hot` in one object, and expansions for the word `cold` in another.
    */
   public class Expansion extends IBMWatsonGenericModel {
-    private List<String> input_terms_serialized_name;
-    private List<String> expanded_terms_serialized_name;
+    private List<String> inputTerms;
+    private List<String> expandedTerms;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Expansion() { }
  
     /**
      * Gets the inputTerms.
@@ -6691,7 +7843,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getInputTerms() {
-      return input_terms_serialized_name;
+      return inputTerms;
     }
  
     /**
@@ -6704,34 +7856,141 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getExpandedTerms() {
-      return expanded_terms_serialized_name;
+      return expandedTerms;
+    }
+  
+    private Expansion(ExpansionBuilder builder) {
+      IBMWatsonValidator.notNull(builder.expandedTerms, 'expandedTerms cannot be null');
+      this.inputTerms = builder.inputTerms;
+      this.expandedTerms = builder.expandedTerms;
     }
 
     /**
-     * Sets the inputTerms.
+     * New builder.
+     *
+     * @return a Expansion builder
+     */
+    public ExpansionBuilder newBuilder() {
+      return new ExpansionBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('inputTerms', 'input_terms');
+      mapping.put('expandedTerms', 'expanded_terms');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('input_terms', 'inputTerms');
+      mapping.put('expanded_terms', 'expandedTerms');
+      return mapping;
+    }
+  }
+
+  /**
+   * Expansion Builder.
+   */
+  public class ExpansionBuilder {
+    private List<String> inputTerms;
+    private List<String> expandedTerms;
+
+    private ExpansionBuilder(Expansion expansion) {
+      this.inputTerms = expansion.inputTerms;
+      this.expandedTerms = expansion.expandedTerms;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public ExpansionBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param expandedTerms the expandedTerms
+     */
+    public ExpansionBuilder(List<String> expandedTerms) {
+      this.expandedTerms = expandedTerms;
+    }
+
+    /**
+     * Builds a Expansion.
+     *
+     * @return the expansion
+     */
+    public Expansion build() {
+      return new Expansion(this);
+    }
+
+    /**
+     * Adds an inputTerms to inputTerms.
      *
      * @param inputTerms the new inputTerms
+     * @return the Expansion builder
      */
-    public void setInputTerms(final List<String> inputTerms) {
-      this.input_terms_serialized_name = inputTerms;
+    public ExpansionBuilder addInputTerms(String inputTerms) {
+      IBMWatsonValidator.notNull(inputTerms, 'inputTerms cannot be null');
+      if (this.inputTerms == null) {
+        this.inputTerms = new List<String>();
+      }
+      this.inputTerms.add(inputTerms);
+      return this;
     }
 
     /**
-     * Sets the expandedTerms.
+     * Adds an expandedTerms to expandedTerms.
      *
      * @param expandedTerms the new expandedTerms
+     * @return the Expansion builder
      */
-    public void setExpandedTerms(final List<String> expandedTerms) {
-      this.expanded_terms_serialized_name = expandedTerms;
+    public ExpansionBuilder addExpandedTerms(String expandedTerms) {
+      IBMWatsonValidator.notNull(expandedTerms, 'expandedTerms cannot be null');
+      if (this.expandedTerms == null) {
+        this.expandedTerms = new List<String>();
+      }
+      this.expandedTerms.add(expandedTerms);
+      return this;
     }
 
+    /**
+     * Set the inputTerms.
+     * Existing inputTerms will be replaced.
+     *
+     * @param inputTerms the inputTerms
+     * @return the Expansion builder
+     */
+    public ExpansionBuilder setInputTerms(List<String> inputTerms) {
+      this.inputTerms = inputTerms;
+      return this;
+    }
+
+    /**
+     * Set the expandedTerms.
+     * Existing expandedTerms will be replaced.
+     *
+     * @param expandedTerms the expandedTerms
+     * @return the Expansion builder
+     */
+    public ExpansionBuilder setExpandedTerms(List<String> expandedTerms) {
+      this.expandedTerms = expandedTerms;
+      return this;
+    }
   }
 
   /**
    * The query expansion definitions for the specified collection.
    */
   public class Expansions extends IBMWatsonResponseModel {
-    private List<Expansion> expansions_serialized_name;
+    private List<Expansion> expansions;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Expansions() { }
  
     /**
      * Gets the expansions.
@@ -6754,16 +8013,21 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Expansion> getExpansions() {
-      return expansions_serialized_name;
+      return expansions;
+    }
+  
+    private Expansions(ExpansionsBuilder builder) {
+      IBMWatsonValidator.notNull(builder.expansions, 'expansions cannot be null');
+      this.expansions = builder.expansions;
     }
 
     /**
-     * Sets the expansions.
+     * New builder.
      *
-     * @param expansions the new expansions
+     * @return a Expansions builder
      */
-    public void setExpansions(final List<Expansion> expansions) {
-      this.expansions_serialized_name = expansions;
+    public ExpansionsBuilder newBuilder() {
+      return new ExpansionsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6772,6 +8036,7 @@ public class IBMDiscoveryV1Models {
       }
 
       Expansions ret = (Expansions) super.deserialize(jsonString, jsonMap, classType);
+      ExpansionsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for expansions
       List<Expansion> newExpansions = new List<Expansion>();
@@ -6779,14 +8044,92 @@ public class IBMDiscoveryV1Models {
       if (deserializedExpansions != null) {
         for (Integer i = 0; i < deserializedExpansions.size(); i++) {
           Expansion currentItem = ret.getExpansions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('expansions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('expansions');
           Expansion newItem = (Expansion) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Expansion.class);
           newExpansions.add(newItem);
         }
-        ret.expansions_serialized_name = newExpansions;
+        retBuilder.setExpansions(newExpansions);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (expansions != null && expansions[0] != null) {
+        mapping.putAll(expansions[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (expansions != null && expansions[0] != null) {
+        mapping.putAll(expansions[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * Expansions Builder.
+   */
+  public class ExpansionsBuilder {
+    private List<Expansion> expansions;
+
+    private ExpansionsBuilder(Expansions expansions) {
+      this.expansions = expansions.expansions;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public ExpansionsBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param expansions the expansions
+     */
+    public ExpansionsBuilder(List<Expansion> expansions) {
+      this.expansions = expansions;
+    }
+
+    /**
+     * Builds a Expansions.
+     *
+     * @return the expansions
+     */
+    public Expansions build() {
+      return new Expansions(this);
+    }
+
+    /**
+     * Adds an expansions to expansions.
+     *
+     * @param expansions the new expansions
+     * @return the Expansions builder
+     */
+    public ExpansionsBuilder addExpansions(Expansion expansions) {
+      IBMWatsonValidator.notNull(expansions, 'expansions cannot be null');
+      if (this.expansions == null) {
+        this.expansions = new List<Expansion>();
+      }
+      this.expansions.add(expansions);
+      return this;
+    }
+
+    /**
+     * Set the expansions.
+     * Existing expansions will be replaced.
+     *
+     * @param expansions the expansions
+     * @return the Expansions builder
+     */
+    public ExpansionsBuilder setExpansions(List<Expansion> expansions) {
+      this.expansions = expansions;
+      return this;
     }
   }
 
@@ -6809,7 +8152,7 @@ public class IBMDiscoveryV1Models {
     private Boolean similar;
     private List<String> similarDocumentIds;
     private List<String> similarFields;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -6820,7 +8163,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionIds.
      *
@@ -6831,7 +8174,7 @@ public class IBMDiscoveryV1Models {
     public List<String> collectionIds() {
       return collectionIds;
     }
- 
+
     /**
      * Gets the filter.
      *
@@ -6843,7 +8186,7 @@ public class IBMDiscoveryV1Models {
     public String filter() {
       return filter;
     }
- 
+
     /**
      * Gets the query.
      *
@@ -6855,7 +8198,7 @@ public class IBMDiscoveryV1Models {
     public String query() {
       return query;
     }
- 
+
     /**
      * Gets the naturalLanguageQuery.
      *
@@ -6867,7 +8210,7 @@ public class IBMDiscoveryV1Models {
     public String naturalLanguageQuery() {
       return naturalLanguageQuery;
     }
- 
+
     /**
      * Gets the aggregation.
      *
@@ -6880,7 +8223,7 @@ public class IBMDiscoveryV1Models {
     public String aggregation() {
       return aggregation;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -6892,7 +8235,7 @@ public class IBMDiscoveryV1Models {
     public Long count() {
       return count;
     }
- 
+
     /**
      * Gets the returnFields.
      *
@@ -6903,7 +8246,7 @@ public class IBMDiscoveryV1Models {
     public List<String> returnFields() {
       return returnFields;
     }
- 
+
     /**
      * Gets the offset.
      *
@@ -6916,7 +8259,7 @@ public class IBMDiscoveryV1Models {
     public Long offset() {
       return offset;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -6929,7 +8272,7 @@ public class IBMDiscoveryV1Models {
     public List<String> xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the highlight.
      *
@@ -6941,7 +8284,7 @@ public class IBMDiscoveryV1Models {
     public Boolean highlight() {
       return highlight;
     }
- 
+
     /**
      * Gets the deduplicateField.
      *
@@ -6954,7 +8297,7 @@ public class IBMDiscoveryV1Models {
     public String deduplicateField() {
       return deduplicateField;
     }
- 
+
     /**
      * Gets the similar.
      *
@@ -6966,7 +8309,7 @@ public class IBMDiscoveryV1Models {
     public Boolean similar() {
       return similar;
     }
- 
+
     /**
      * Gets the similarDocumentIds.
      *
@@ -6981,7 +8324,7 @@ public class IBMDiscoveryV1Models {
     public List<String> similarDocumentIds() {
       return similarDocumentIds;
     }
- 
+
     /**
      * Gets the similarFields.
      *
@@ -7024,6 +8367,18 @@ public class IBMDiscoveryV1Models {
       return new FederatedQueryNoticesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionIds', 'collection_ids');
+      mapping.put('naturalLanguageQuery', 'natural_language_query');
+      mapping.put('returnFields', 'return');
+      mapping.put('xsort', 'sort');
+      mapping.put('deduplicateField', 'deduplicate.field');
+      mapping.put('similarDocumentIds', 'similar.document_ids');
+      mapping.put('similarFields', 'similar.fields');
+      return mapping;
+    }
   }
 
   /**
@@ -7375,7 +8730,7 @@ public class IBMDiscoveryV1Models {
     private String similarFields;
     private String bias;
     private Boolean loggingOptOut;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -7386,7 +8741,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the filter.
      *
@@ -7398,7 +8753,7 @@ public class IBMDiscoveryV1Models {
     public String filter() {
       return filter;
     }
- 
+
     /**
      * Gets the query.
      *
@@ -7410,7 +8765,7 @@ public class IBMDiscoveryV1Models {
     public String query() {
       return query;
     }
- 
+
     /**
      * Gets the naturalLanguageQuery.
      *
@@ -7422,7 +8777,7 @@ public class IBMDiscoveryV1Models {
     public String naturalLanguageQuery() {
       return naturalLanguageQuery;
     }
- 
+
     /**
      * Gets the passages.
      *
@@ -7433,7 +8788,7 @@ public class IBMDiscoveryV1Models {
     public Boolean passages() {
       return passages;
     }
- 
+
     /**
      * Gets the aggregation.
      *
@@ -7446,7 +8801,7 @@ public class IBMDiscoveryV1Models {
     public String aggregation() {
       return aggregation;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -7457,7 +8812,7 @@ public class IBMDiscoveryV1Models {
     public Long count() {
       return count;
     }
- 
+
     /**
      * Gets the returnFields.
      *
@@ -7468,7 +8823,7 @@ public class IBMDiscoveryV1Models {
     public String returnFields() {
       return returnFields;
     }
- 
+
     /**
      * Gets the offset.
      *
@@ -7480,7 +8835,7 @@ public class IBMDiscoveryV1Models {
     public Long offset() {
       return offset;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -7493,7 +8848,7 @@ public class IBMDiscoveryV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the highlight.
      *
@@ -7505,7 +8860,7 @@ public class IBMDiscoveryV1Models {
     public Boolean highlight() {
       return highlight;
     }
- 
+
     /**
      * Gets the passagesFields.
      *
@@ -7517,7 +8872,7 @@ public class IBMDiscoveryV1Models {
     public String passagesFields() {
       return passagesFields;
     }
- 
+
     /**
      * Gets the passagesCount.
      *
@@ -7529,7 +8884,7 @@ public class IBMDiscoveryV1Models {
     public Long passagesCount() {
       return passagesCount;
     }
- 
+
     /**
      * Gets the passagesCharacters.
      *
@@ -7540,7 +8895,7 @@ public class IBMDiscoveryV1Models {
     public Long passagesCharacters() {
       return passagesCharacters;
     }
- 
+
     /**
      * Gets the deduplicate.
      *
@@ -7553,7 +8908,7 @@ public class IBMDiscoveryV1Models {
     public Boolean deduplicate() {
       return deduplicate;
     }
- 
+
     /**
      * Gets the deduplicateField.
      *
@@ -7566,7 +8921,7 @@ public class IBMDiscoveryV1Models {
     public String deduplicateField() {
       return deduplicateField;
     }
- 
+
     /**
      * Gets the collectionIds.
      *
@@ -7578,7 +8933,7 @@ public class IBMDiscoveryV1Models {
     public String collectionIds() {
       return collectionIds;
     }
- 
+
     /**
      * Gets the similar.
      *
@@ -7590,7 +8945,7 @@ public class IBMDiscoveryV1Models {
     public Boolean similar() {
       return similar;
     }
- 
+
     /**
      * Gets the similarDocumentIds.
      *
@@ -7605,7 +8960,7 @@ public class IBMDiscoveryV1Models {
     public String similarDocumentIds() {
       return similarDocumentIds;
     }
- 
+
     /**
      * Gets the similarFields.
      *
@@ -7617,7 +8972,7 @@ public class IBMDiscoveryV1Models {
     public String similarFields() {
       return similarFields;
     }
- 
+
     /**
      * Gets the bias.
      *
@@ -7631,7 +8986,7 @@ public class IBMDiscoveryV1Models {
     public String bias() {
       return bias;
     }
- 
+
     /**
      * Gets the loggingOptOut.
      *
@@ -7679,6 +9034,22 @@ public class IBMDiscoveryV1Models {
       return new FederatedQueryOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('naturalLanguageQuery', 'natural_language_query');
+      mapping.put('returnFields', 'return');
+      mapping.put('xsort', 'sort');
+      mapping.put('passagesFields', 'passages.fields');
+      mapping.put('passagesCount', 'passages.count');
+      mapping.put('passagesCharacters', 'passages.characters');
+      mapping.put('deduplicateField', 'deduplicate.field');
+      mapping.put('collectionIds', 'collection_ids');
+      mapping.put('similarDocumentIds', 'similar.document_ids');
+      mapping.put('similarFields', 'similar.fields');
+      mapping.put('loggingOptOut', 'X-Watson-Logging-Opt-Out');
+      return mapping;
+    }
   }
 
   /**
@@ -8017,8 +9388,8 @@ public class IBMDiscoveryV1Models {
    * Field.
    */
   public class Field extends IBMWatsonGenericModel {
-    private String field_serialized_name;
-    private String type_serialized_name;
+    private String fieldName;
+    private String fieldType;
  
     /**
      * Gets the fieldName.
@@ -8029,7 +9400,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getFieldName() {
-      return field_serialized_name;
+      return fieldName;
     }
  
     /**
@@ -8041,21 +9412,33 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getFieldType() {
-      return type_serialized_name;
+      return fieldType;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('field', 'fieldName');
+      mapping.put('type', 'fieldType');
+      return mapping;
+    }
   }
 
   /**
    * FontSetting.
    */
   public class FontSetting extends IBMWatsonGenericModel {
-    private Long level_serialized_name;
-    private Long min_size_serialized_name;
-    private Long max_size_serialized_name;
-    private Boolean bold_serialized_name;
-    private Boolean italic_serialized_name;
-    private String name_serialized_name;
+    private Long level;
+    private Long minSize;
+    private Long maxSize;
+    private Boolean bold;
+    private Boolean italic;
+    private String name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public FontSetting() { }
  
     /**
      * Gets the level.
@@ -8066,7 +9449,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getLevel() {
-      return level_serialized_name;
+      return level;
     }
  
     /**
@@ -8078,7 +9461,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMinSize() {
-      return min_size_serialized_name;
+      return minSize;
     }
  
     /**
@@ -8090,7 +9473,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMaxSize() {
-      return max_size_serialized_name;
+      return maxSize;
     }
  
     /**
@@ -8102,7 +9485,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getBold() {
-      return bold_serialized_name;
+      return bold;
     }
  
     /**
@@ -8114,7 +9497,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getItalic() {
-      return italic_serialized_name;
+      return italic;
     }
  
     /**
@@ -8126,74 +9509,153 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
+    }
+  
+    private FontSetting(FontSettingBuilder builder) {
+      this.level = builder.level;
+      this.minSize = builder.minSize;
+      this.maxSize = builder.maxSize;
+      this.bold = builder.bold;
+      this.italic = builder.italic;
+      this.name = builder.name;
     }
 
     /**
-     * Sets the level.
+     * New builder.
      *
-     * @param level the new level
+     * @return a FontSetting builder
      */
-    public void setLevel(final long level) {
-      this.level_serialized_name = level;
+    public FontSettingBuilder newBuilder() {
+      return new FontSettingBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('minSize', 'min_size');
+      mapping.put('maxSize', 'max_size');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('min_size', 'minSize');
+      mapping.put('max_size', 'maxSize');
+      return mapping;
+    }
+  }
+
+  /**
+   * FontSetting Builder.
+   */
+  public class FontSettingBuilder {
+    private Long level;
+    private Long minSize;
+    private Long maxSize;
+    private Boolean bold;
+    private Boolean italic;
+    private String name;
+
+    private FontSettingBuilder(FontSetting fontSetting) {
+      this.level = fontSetting.level;
+      this.minSize = fontSetting.minSize;
+      this.maxSize = fontSetting.maxSize;
+      this.bold = fontSetting.bold;
+      this.italic = fontSetting.italic;
+      this.name = fontSetting.name;
     }
 
     /**
-     * Sets the minSize.
-     *
-     * @param minSize the new minSize
+     * Instantiates a new builder.
      */
-    public void setMinSize(final long minSize) {
-      this.min_size_serialized_name = minSize;
+    public FontSettingBuilder() {
     }
 
     /**
-     * Sets the maxSize.
+     * Builds a FontSetting.
      *
-     * @param maxSize the new maxSize
+     * @return the fontSetting
      */
-    public void setMaxSize(final long maxSize) {
-      this.max_size_serialized_name = maxSize;
+    public FontSetting build() {
+      return new FontSetting(this);
     }
 
     /**
-     * Sets the bold.
+     * Set the level.
      *
-     * @param bold the new bold
+     * @param level the level
+     * @return the FontSetting builder
      */
-    public void setBold(final Boolean bold) {
-      this.bold_serialized_name = bold;
+    public FontSettingBuilder setLevel(Long level) {
+      this.level = level;
+      return this;
     }
 
     /**
-     * Sets the italic.
+     * Set the minSize.
      *
-     * @param italic the new italic
+     * @param minSize the minSize
+     * @return the FontSetting builder
      */
-    public void setItalic(final Boolean italic) {
-      this.italic_serialized_name = italic;
+    public FontSettingBuilder setMinSize(Long minSize) {
+      this.minSize = minSize;
+      return this;
     }
 
     /**
-     * Sets the name.
+     * Set the maxSize.
      *
-     * @param name the new name
+     * @param maxSize the maxSize
+     * @return the FontSetting builder
      */
-    public void setName(final String name) {
-      this.name_serialized_name = name;
+    public FontSettingBuilder setMaxSize(Long maxSize) {
+      this.maxSize = maxSize;
+      return this;
     }
 
+    /**
+     * Set the bold.
+     *
+     * @param bold the bold
+     * @return the FontSetting builder
+     */
+    public FontSettingBuilder setBold(Boolean bold) {
+      this.bold = bold;
+      return this;
+    }
+
+    /**
+     * Set the italic.
+     *
+     * @param italic the italic
+     * @return the FontSetting builder
+     */
+    public FontSettingBuilder setItalic(Boolean italic) {
+      this.italic = italic;
+      return this;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the FontSetting builder
+     */
+    public FontSettingBuilder setName(String name) {
+      this.name = name;
+      return this;
+    }
   }
 
   /**
    * Object describing a specific gateway.
    */
   public class Gateway extends IBMWatsonResponseModel {
-    private String gateway_id_serialized_name;
-    private String name_serialized_name;
-    private String status_serialized_name;
-    private String token_serialized_name;
-    private String token_id_serialized_name;
+    private String gatewayId;
+    private String name;
+    private String status;
+    private String token;
+    private String tokenId;
  
     /**
      * Gets the gatewayId.
@@ -8204,7 +9666,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getGatewayId() {
-      return gateway_id_serialized_name;
+      return gatewayId;
     }
  
     /**
@@ -8216,7 +9678,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -8229,7 +9691,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -8242,7 +9704,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getToken() {
-      return token_serialized_name;
+      return token;
     }
  
     /**
@@ -8255,7 +9717,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getTokenId() {
-      return token_id_serialized_name;
+      return tokenId;
     }
 
     /**
@@ -8264,7 +9726,7 @@ public class IBMDiscoveryV1Models {
      * @param gatewayId the new gatewayId
      */
     public void setGatewayId(final String gatewayId) {
-      this.gateway_id_serialized_name = gatewayId;
+      this.gatewayId = gatewayId;
     }
 
     /**
@@ -8273,7 +9735,7 @@ public class IBMDiscoveryV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -8282,7 +9744,7 @@ public class IBMDiscoveryV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -8291,7 +9753,7 @@ public class IBMDiscoveryV1Models {
      * @param token the new token
      */
     public void setToken(final String token) {
-      this.token_serialized_name = token;
+      this.token = token;
     }
 
     /**
@@ -8300,16 +9762,22 @@ public class IBMDiscoveryV1Models {
      * @param tokenId the new tokenId
      */
     public void setTokenId(final String tokenId) {
-      this.token_id_serialized_name = tokenId;
+      this.tokenId = tokenId;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('gateway_id', 'gatewayId');
+      mapping.put('token_id', 'tokenId');
+      return mapping;
+    }
   }
 
   /**
    * Object containing gateways array.
    */
   public class GatewayList extends IBMWatsonResponseModel {
-    private List<Gateway> gateways_serialized_name;
+    private List<Gateway> gateways;
  
     /**
      * Gets the gateways.
@@ -8320,7 +9788,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Gateway> getGateways() {
-      return gateways_serialized_name;
+      return gateways;
     }
 
     /**
@@ -8329,7 +9797,7 @@ public class IBMDiscoveryV1Models {
      * @param gateways the new gateways
      */
     public void setGateways(final List<Gateway> gateways) {
-      this.gateways_serialized_name = gateways;
+      this.gateways = gateways;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8345,14 +9813,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedGateways != null) {
         for (Integer i = 0; i < deserializedGateways.size(); i++) {
           Gateway currentItem = ret.getGateways().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('gateways_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('gateways');
           Gateway newItem = (Gateway) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Gateway.class);
           newGateways.add(newItem);
         }
-        ret.gateways_serialized_name = newGateways;
+        ret.gateways = newGateways;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (gateways != null && gateways[0] != null) {
+        mapping.putAll(gateways[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -8362,7 +9838,7 @@ public class IBMDiscoveryV1Models {
   public class GetCollectionOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -8373,7 +9849,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -8402,6 +9878,12 @@ public class IBMDiscoveryV1Models {
       return new GetCollectionOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -8484,7 +9966,7 @@ public class IBMDiscoveryV1Models {
   public class GetConfigurationOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String configurationId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -8495,7 +9977,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the configurationId.
      *
@@ -8524,6 +10006,12 @@ public class IBMDiscoveryV1Models {
       return new GetConfigurationOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('configurationId', 'configuration_id');
+      return mapping;
+    }
   }
 
   /**
@@ -8606,7 +10094,7 @@ public class IBMDiscoveryV1Models {
   public class GetCredentialsOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String credentialId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -8617,7 +10105,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the credentialId.
      *
@@ -8646,6 +10134,12 @@ public class IBMDiscoveryV1Models {
       return new GetCredentialsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('credentialId', 'credential_id');
+      return mapping;
+    }
   }
 
   /**
@@ -8729,7 +10223,7 @@ public class IBMDiscoveryV1Models {
     private String environmentId;
     private String collectionId;
     private String documentId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -8740,7 +10234,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -8751,7 +10245,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the documentId.
      *
@@ -8782,6 +10276,13 @@ public class IBMDiscoveryV1Models {
       return new GetDocumentStatusOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('documentId', 'document_id');
+      return mapping;
+    }
   }
 
   /**
@@ -8878,7 +10379,7 @@ public class IBMDiscoveryV1Models {
    */
   public class GetEnvironmentOptions extends IBMWatsonOptionsModel {
     private String environmentId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -8905,6 +10406,11 @@ public class IBMDiscoveryV1Models {
       return new GetEnvironmentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      return mapping;
+    }
   }
 
   /**
@@ -8972,7 +10478,7 @@ public class IBMDiscoveryV1Models {
   public class GetGatewayOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String gatewayId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -8983,7 +10489,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the gatewayId.
      *
@@ -9012,6 +10518,12 @@ public class IBMDiscoveryV1Models {
       return new GetGatewayOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('gatewayId', 'gateway_id');
+      return mapping;
+    }
   }
 
   /**
@@ -9095,7 +10607,7 @@ public class IBMDiscoveryV1Models {
     private Datetime startTime;
     private Datetime endTime;
     private String resultType;
- 
+
     /**
      * Gets the startTime.
      *
@@ -9106,7 +10618,7 @@ public class IBMDiscoveryV1Models {
     public Datetime startTime() {
       return startTime;
     }
- 
+
     /**
      * Gets the endTime.
      *
@@ -9117,7 +10629,7 @@ public class IBMDiscoveryV1Models {
     public Datetime endTime() {
       return endTime;
     }
- 
+
     /**
      * Gets the resultType.
      *
@@ -9145,6 +10657,13 @@ public class IBMDiscoveryV1Models {
       return new GetMetricsEventRateOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('startTime', 'start_time');
+      mapping.put('endTime', 'end_time');
+      mapping.put('resultType', 'result_type');
+      return mapping;
+    }
   }
 
   /**
@@ -9230,7 +10749,7 @@ public class IBMDiscoveryV1Models {
     private Datetime startTime;
     private Datetime endTime;
     private String resultType;
- 
+
     /**
      * Gets the startTime.
      *
@@ -9241,7 +10760,7 @@ public class IBMDiscoveryV1Models {
     public Datetime startTime() {
       return startTime;
     }
- 
+
     /**
      * Gets the endTime.
      *
@@ -9252,7 +10771,7 @@ public class IBMDiscoveryV1Models {
     public Datetime endTime() {
       return endTime;
     }
- 
+
     /**
      * Gets the resultType.
      *
@@ -9280,6 +10799,13 @@ public class IBMDiscoveryV1Models {
       return new GetMetricsQueryEventOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('startTime', 'start_time');
+      mapping.put('endTime', 'end_time');
+      mapping.put('resultType', 'result_type');
+      return mapping;
+    }
   }
 
   /**
@@ -9365,7 +10891,7 @@ public class IBMDiscoveryV1Models {
     private Datetime startTime;
     private Datetime endTime;
     private String resultType;
- 
+
     /**
      * Gets the startTime.
      *
@@ -9376,7 +10902,7 @@ public class IBMDiscoveryV1Models {
     public Datetime startTime() {
       return startTime;
     }
- 
+
     /**
      * Gets the endTime.
      *
@@ -9387,7 +10913,7 @@ public class IBMDiscoveryV1Models {
     public Datetime endTime() {
       return endTime;
     }
- 
+
     /**
      * Gets the resultType.
      *
@@ -9415,6 +10941,13 @@ public class IBMDiscoveryV1Models {
       return new GetMetricsQueryNoResultsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('startTime', 'start_time');
+      mapping.put('endTime', 'end_time');
+      mapping.put('resultType', 'result_type');
+      return mapping;
+    }
   }
 
   /**
@@ -9500,7 +11033,7 @@ public class IBMDiscoveryV1Models {
     private Datetime startTime;
     private Datetime endTime;
     private String resultType;
- 
+
     /**
      * Gets the startTime.
      *
@@ -9511,7 +11044,7 @@ public class IBMDiscoveryV1Models {
     public Datetime startTime() {
       return startTime;
     }
- 
+
     /**
      * Gets the endTime.
      *
@@ -9522,7 +11055,7 @@ public class IBMDiscoveryV1Models {
     public Datetime endTime() {
       return endTime;
     }
- 
+
     /**
      * Gets the resultType.
      *
@@ -9550,6 +11083,13 @@ public class IBMDiscoveryV1Models {
       return new GetMetricsQueryOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('startTime', 'start_time');
+      mapping.put('endTime', 'end_time');
+      mapping.put('resultType', 'result_type');
+      return mapping;
+    }
   }
 
   /**
@@ -9633,7 +11173,7 @@ public class IBMDiscoveryV1Models {
    */
   public class GetMetricsQueryTokenEventOptions extends IBMWatsonOptionsModel {
     private Long count;
- 
+
     /**
      * Gets the count.
      *
@@ -9659,7 +11199,6 @@ public class IBMDiscoveryV1Models {
     public GetMetricsQueryTokenEventOptionsBuilder newBuilder() {
       return new GetMetricsQueryTokenEventOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -9718,7 +11257,7 @@ public class IBMDiscoveryV1Models {
   public class GetStopwordListStatusOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -9729,7 +11268,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -9758,6 +11297,12 @@ public class IBMDiscoveryV1Models {
       return new GetStopwordListStatusOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -9840,7 +11385,7 @@ public class IBMDiscoveryV1Models {
   public class GetTokenizationDictionaryStatusOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -9851,7 +11396,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -9880,6 +11425,12 @@ public class IBMDiscoveryV1Models {
       return new GetTokenizationDictionaryStatusOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -9963,7 +11514,7 @@ public class IBMDiscoveryV1Models {
     private String environmentId;
     private String collectionId;
     private String queryId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -9974,7 +11525,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -9985,7 +11536,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -10016,6 +11567,13 @@ public class IBMDiscoveryV1Models {
       return new GetTrainingDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('queryId', 'query_id');
+      return mapping;
+    }
   }
 
   /**
@@ -10115,7 +11673,7 @@ public class IBMDiscoveryV1Models {
     private String collectionId;
     private String queryId;
     private String exampleId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -10126,7 +11684,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -10137,7 +11695,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -10148,7 +11706,7 @@ public class IBMDiscoveryV1Models {
     public String queryId() {
       return queryId;
     }
- 
+
     /**
      * Gets the exampleId.
      *
@@ -10181,6 +11739,14 @@ public class IBMDiscoveryV1Models {
       return new GetTrainingExampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('queryId', 'query_id');
+      mapping.put('exampleId', 'example_id');
+      return mapping;
+    }
   }
 
   /**
@@ -10291,12 +11857,18 @@ public class IBMDiscoveryV1Models {
    * A list of HTML conversion settings.
    */
   public class HtmlSettings extends IBMWatsonGenericModel {
-    private List<String> exclude_tags_completely_serialized_name;
-    private List<String> exclude_tags_keep_content_serialized_name;
-    private XPathPatterns keep_content_serialized_name;
-    private XPathPatterns exclude_content_serialized_name;
-    private List<String> keep_tag_attributes_serialized_name;
-    private List<String> exclude_tag_attributes_serialized_name;
+    private List<String> excludeTagsCompletely;
+    private List<String> excludeTagsKeepContent;
+    private XPathPatterns keepContent;
+    private XPathPatterns excludeContent;
+    private List<String> keepTagAttributes;
+    private List<String> excludeTagAttributes;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public HtmlSettings() { }
  
     /**
      * Gets the excludeTagsCompletely.
@@ -10307,7 +11879,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getExcludeTagsCompletely() {
-      return exclude_tags_completely_serialized_name;
+      return excludeTagsCompletely;
     }
  
     /**
@@ -10319,7 +11891,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getExcludeTagsKeepContent() {
-      return exclude_tags_keep_content_serialized_name;
+      return excludeTagsKeepContent;
     }
  
     /**
@@ -10329,7 +11901,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public XPathPatterns getKeepContent() {
-      return keep_content_serialized_name;
+      return keepContent;
     }
  
     /**
@@ -10339,7 +11911,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public XPathPatterns getExcludeContent() {
-      return exclude_content_serialized_name;
+      return excludeContent;
     }
  
     /**
@@ -10351,7 +11923,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getKeepTagAttributes() {
-      return keep_tag_attributes_serialized_name;
+      return keepTagAttributes;
     }
  
     /**
@@ -10363,61 +11935,25 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getExcludeTagAttributes() {
-      return exclude_tag_attributes_serialized_name;
+      return excludeTagAttributes;
+    }
+  
+    private HtmlSettings(HtmlSettingsBuilder builder) {
+      this.excludeTagsCompletely = builder.excludeTagsCompletely;
+      this.excludeTagsKeepContent = builder.excludeTagsKeepContent;
+      this.keepContent = builder.keepContent;
+      this.excludeContent = builder.excludeContent;
+      this.keepTagAttributes = builder.keepTagAttributes;
+      this.excludeTagAttributes = builder.excludeTagAttributes;
     }
 
     /**
-     * Sets the excludeTagsCompletely.
+     * New builder.
      *
-     * @param excludeTagsCompletely the new excludeTagsCompletely
+     * @return a HtmlSettings builder
      */
-    public void setExcludeTagsCompletely(final List<String> excludeTagsCompletely) {
-      this.exclude_tags_completely_serialized_name = excludeTagsCompletely;
-    }
-
-    /**
-     * Sets the excludeTagsKeepContent.
-     *
-     * @param excludeTagsKeepContent the new excludeTagsKeepContent
-     */
-    public void setExcludeTagsKeepContent(final List<String> excludeTagsKeepContent) {
-      this.exclude_tags_keep_content_serialized_name = excludeTagsKeepContent;
-    }
-
-    /**
-     * Sets the keepContent.
-     *
-     * @param keepContent the new keepContent
-     */
-    public void setKeepContent(final XPathPatterns keepContent) {
-      this.keep_content_serialized_name = keepContent;
-    }
-
-    /**
-     * Sets the excludeContent.
-     *
-     * @param excludeContent the new excludeContent
-     */
-    public void setExcludeContent(final XPathPatterns excludeContent) {
-      this.exclude_content_serialized_name = excludeContent;
-    }
-
-    /**
-     * Sets the keepTagAttributes.
-     *
-     * @param keepTagAttributes the new keepTagAttributes
-     */
-    public void setKeepTagAttributes(final List<String> keepTagAttributes) {
-      this.keep_tag_attributes_serialized_name = keepTagAttributes;
-    }
-
-    /**
-     * Sets the excludeTagAttributes.
-     *
-     * @param excludeTagAttributes the new excludeTagAttributes
-     */
-    public void setExcludeTagAttributes(final List<String> excludeTagAttributes) {
-      this.exclude_tag_attributes_serialized_name = excludeTagAttributes;
+    public HtmlSettingsBuilder newBuilder() {
+      return new HtmlSettingsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -10426,16 +11962,205 @@ public class IBMDiscoveryV1Models {
       }
 
       HtmlSettings ret = (HtmlSettings) super.deserialize(jsonString, jsonMap, classType);
+      HtmlSettingsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for keepContent
-      XPathPatterns newKeepContent = (XPathPatterns) new XPathPatterns().deserialize(JSON.serialize(ret.getKeepContent()), (Map<String, Object>) jsonMap.get('keep_content_serialized_name'), XPathPatterns.class);
-      ret.setKeepContent(newKeepContent);
+      XPathPatterns newKeepContent = (XPathPatterns) new XPathPatterns().deserialize(JSON.serialize(ret.getKeepContent()), (Map<String, Object>) jsonMap.get('keepContent'), XPathPatterns.class);
+      retBuilder.setKeepContent(newKeepContent);
 
       // calling custom deserializer for excludeContent
-      XPathPatterns newExcludeContent = (XPathPatterns) new XPathPatterns().deserialize(JSON.serialize(ret.getExcludeContent()), (Map<String, Object>) jsonMap.get('exclude_content_serialized_name'), XPathPatterns.class);
-      ret.setExcludeContent(newExcludeContent);
+      XPathPatterns newExcludeContent = (XPathPatterns) new XPathPatterns().deserialize(JSON.serialize(ret.getExcludeContent()), (Map<String, Object>) jsonMap.get('excludeContent'), XPathPatterns.class);
+      retBuilder.setExcludeContent(newExcludeContent);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('excludeTagsCompletely', 'exclude_tags_completely');
+      mapping.put('excludeTagsKeepContent', 'exclude_tags_keep_content');
+      mapping.put('keepContent', 'keep_content');
+      mapping.put('excludeContent', 'exclude_content');
+      mapping.put('keepTagAttributes', 'keep_tag_attributes');
+      mapping.put('excludeTagAttributes', 'exclude_tag_attributes');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('exclude_tags_completely', 'excludeTagsCompletely');
+      mapping.put('exclude_tags_keep_content', 'excludeTagsKeepContent');
+      mapping.put('keep_content', 'keepContent');
+      mapping.put('exclude_content', 'excludeContent');
+      mapping.put('keep_tag_attributes', 'keepTagAttributes');
+      mapping.put('exclude_tag_attributes', 'excludeTagAttributes');
+      return mapping;
+    }
+  }
+
+  /**
+   * HtmlSettings Builder.
+   */
+  public class HtmlSettingsBuilder {
+    private List<String> excludeTagsCompletely;
+    private List<String> excludeTagsKeepContent;
+    private XPathPatterns keepContent;
+    private XPathPatterns excludeContent;
+    private List<String> keepTagAttributes;
+    private List<String> excludeTagAttributes;
+
+    private HtmlSettingsBuilder(HtmlSettings htmlSettings) {
+      this.excludeTagsCompletely = htmlSettings.excludeTagsCompletely;
+      this.excludeTagsKeepContent = htmlSettings.excludeTagsKeepContent;
+      this.keepContent = htmlSettings.keepContent;
+      this.excludeContent = htmlSettings.excludeContent;
+      this.keepTagAttributes = htmlSettings.keepTagAttributes;
+      this.excludeTagAttributes = htmlSettings.excludeTagAttributes;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public HtmlSettingsBuilder() {
+    }
+
+    /**
+     * Builds a HtmlSettings.
+     *
+     * @return the htmlSettings
+     */
+    public HtmlSettings build() {
+      return new HtmlSettings(this);
+    }
+
+    /**
+     * Adds an excludeTagsCompletely to excludeTagsCompletely.
+     *
+     * @param excludeTagsCompletely the new excludeTagsCompletely
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder addExcludeTagsCompletely(String excludeTagsCompletely) {
+      IBMWatsonValidator.notNull(excludeTagsCompletely, 'excludeTagsCompletely cannot be null');
+      if (this.excludeTagsCompletely == null) {
+        this.excludeTagsCompletely = new List<String>();
+      }
+      this.excludeTagsCompletely.add(excludeTagsCompletely);
+      return this;
+    }
+
+    /**
+     * Adds an excludeTagsKeepContent to excludeTagsKeepContent.
+     *
+     * @param excludeTagsKeepContent the new excludeTagsKeepContent
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder addExcludeTagsKeepContent(String excludeTagsKeepContent) {
+      IBMWatsonValidator.notNull(excludeTagsKeepContent, 'excludeTagsKeepContent cannot be null');
+      if (this.excludeTagsKeepContent == null) {
+        this.excludeTagsKeepContent = new List<String>();
+      }
+      this.excludeTagsKeepContent.add(excludeTagsKeepContent);
+      return this;
+    }
+
+    /**
+     * Adds an keepTagAttributes to keepTagAttributes.
+     *
+     * @param keepTagAttributes the new keepTagAttributes
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder addKeepTagAttributes(String keepTagAttributes) {
+      IBMWatsonValidator.notNull(keepTagAttributes, 'keepTagAttributes cannot be null');
+      if (this.keepTagAttributes == null) {
+        this.keepTagAttributes = new List<String>();
+      }
+      this.keepTagAttributes.add(keepTagAttributes);
+      return this;
+    }
+
+    /**
+     * Adds an excludeTagAttributes to excludeTagAttributes.
+     *
+     * @param excludeTagAttributes the new excludeTagAttributes
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder addExcludeTagAttributes(String excludeTagAttributes) {
+      IBMWatsonValidator.notNull(excludeTagAttributes, 'excludeTagAttributes cannot be null');
+      if (this.excludeTagAttributes == null) {
+        this.excludeTagAttributes = new List<String>();
+      }
+      this.excludeTagAttributes.add(excludeTagAttributes);
+      return this;
+    }
+
+    /**
+     * Set the excludeTagsCompletely.
+     * Existing excludeTagsCompletely will be replaced.
+     *
+     * @param excludeTagsCompletely the excludeTagsCompletely
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder setExcludeTagsCompletely(List<String> excludeTagsCompletely) {
+      this.excludeTagsCompletely = excludeTagsCompletely;
+      return this;
+    }
+
+    /**
+     * Set the excludeTagsKeepContent.
+     * Existing excludeTagsKeepContent will be replaced.
+     *
+     * @param excludeTagsKeepContent the excludeTagsKeepContent
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder setExcludeTagsKeepContent(List<String> excludeTagsKeepContent) {
+      this.excludeTagsKeepContent = excludeTagsKeepContent;
+      return this;
+    }
+
+    /**
+     * Set the keepContent.
+     *
+     * @param keepContent the keepContent
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder setKeepContent(XPathPatterns keepContent) {
+      this.keepContent = keepContent;
+      return this;
+    }
+
+    /**
+     * Set the excludeContent.
+     *
+     * @param excludeContent the excludeContent
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder setExcludeContent(XPathPatterns excludeContent) {
+      this.excludeContent = excludeContent;
+      return this;
+    }
+
+    /**
+     * Set the keepTagAttributes.
+     * Existing keepTagAttributes will be replaced.
+     *
+     * @param keepTagAttributes the keepTagAttributes
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder setKeepTagAttributes(List<String> keepTagAttributes) {
+      this.keepTagAttributes = keepTagAttributes;
+      return this;
+    }
+
+    /**
+     * Set the excludeTagAttributes.
+     * Existing excludeTagAttributes will be replaced.
+     *
+     * @param excludeTagAttributes the excludeTagAttributes
+     * @return the HtmlSettings builder
+     */
+    public HtmlSettingsBuilder setExcludeTagAttributes(List<String> excludeTagAttributes) {
+      this.excludeTagAttributes = excludeTagAttributes;
+      return this;
     }
   }
 
@@ -10443,9 +12168,9 @@ public class IBMDiscoveryV1Models {
    * Details about the resource usage and capacity of the environment.
    */
   public class IndexCapacity extends IBMWatsonGenericModel {
-    private EnvironmentDocuments documents_serialized_name;
-    private DiskUsage disk_usage_serialized_name;
-    private CollectionUsage collections_serialized_name;
+    private EnvironmentDocuments documents;
+    private DiskUsage diskUsage;
+    private CollectionUsage collections;
  
     /**
      * Gets the documents.
@@ -10456,7 +12181,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public EnvironmentDocuments getDocuments() {
-      return documents_serialized_name;
+      return documents;
     }
  
     /**
@@ -10468,7 +12193,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public DiskUsage getDiskUsage() {
-      return disk_usage_serialized_name;
+      return diskUsage;
     }
  
     /**
@@ -10480,7 +12205,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public CollectionUsage getCollections() {
-      return collections_serialized_name;
+      return collections;
     }
 
     /**
@@ -10489,7 +12214,7 @@ public class IBMDiscoveryV1Models {
      * @param documents the new documents
      */
     public void setDocuments(final EnvironmentDocuments documents) {
-      this.documents_serialized_name = documents;
+      this.documents = documents;
     }
 
     /**
@@ -10498,7 +12223,7 @@ public class IBMDiscoveryV1Models {
      * @param diskUsage the new diskUsage
      */
     public void setDiskUsage(final DiskUsage diskUsage) {
-      this.disk_usage_serialized_name = diskUsage;
+      this.diskUsage = diskUsage;
     }
 
     /**
@@ -10507,7 +12232,7 @@ public class IBMDiscoveryV1Models {
      * @param collections the new collections
      */
     public void setCollections(final CollectionUsage collections) {
-      this.collections_serialized_name = collections;
+      this.collections = collections;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -10518,18 +12243,33 @@ public class IBMDiscoveryV1Models {
       IndexCapacity ret = (IndexCapacity) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for documents
-      EnvironmentDocuments newDocuments = (EnvironmentDocuments) new EnvironmentDocuments().deserialize(JSON.serialize(ret.getDocuments()), (Map<String, Object>) jsonMap.get('documents_serialized_name'), EnvironmentDocuments.class);
+      EnvironmentDocuments newDocuments = (EnvironmentDocuments) new EnvironmentDocuments().deserialize(JSON.serialize(ret.getDocuments()), (Map<String, Object>) jsonMap.get('documents'), EnvironmentDocuments.class);
       ret.setDocuments(newDocuments);
 
       // calling custom deserializer for diskUsage
-      DiskUsage newDiskUsage = (DiskUsage) new DiskUsage().deserialize(JSON.serialize(ret.getDiskUsage()), (Map<String, Object>) jsonMap.get('disk_usage_serialized_name'), DiskUsage.class);
+      DiskUsage newDiskUsage = (DiskUsage) new DiskUsage().deserialize(JSON.serialize(ret.getDiskUsage()), (Map<String, Object>) jsonMap.get('diskUsage'), DiskUsage.class);
       ret.setDiskUsage(newDiskUsage);
 
       // calling custom deserializer for collections
-      CollectionUsage newCollections = (CollectionUsage) new CollectionUsage().deserialize(JSON.serialize(ret.getCollections()), (Map<String, Object>) jsonMap.get('collections_serialized_name'), CollectionUsage.class);
+      CollectionUsage newCollections = (CollectionUsage) new CollectionUsage().deserialize(JSON.serialize(ret.getCollections()), (Map<String, Object>) jsonMap.get('collections'), CollectionUsage.class);
       ret.setCollections(newCollections);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (documents != null) {
+        mapping.putAll(documents.getApiToSdkMapping());
+      }
+      mapping.put('disk_usage', 'diskUsage');
+      if (diskUsage != null) {
+        mapping.putAll(diskUsage.getApiToSdkMapping());
+      }
+      if (collections != null) {
+        mapping.putAll(collections.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -10539,7 +12279,7 @@ public class IBMDiscoveryV1Models {
   public class ListCollectionFieldsOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -10550,7 +12290,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -10579,6 +12319,12 @@ public class IBMDiscoveryV1Models {
       return new ListCollectionFieldsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -10670,7 +12416,7 @@ public class IBMDiscoveryV1Models {
    * `v5-fullnews-t3-2016.mappings.text.properties.author`).
    */
   public class ListCollectionFieldsResponse extends IBMWatsonResponseModel {
-    private List<Field> fields_serialized_name;
+    private List<Field> fields;
  
     /**
      * Gets the fields.
@@ -10681,7 +12427,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Field> getFields() {
-      return fields_serialized_name;
+      return fields;
     }
 
     /**
@@ -10690,7 +12436,7 @@ public class IBMDiscoveryV1Models {
      * @param fields the new fields
      */
     public void setFields(final List<Field> fields) {
-      this.fields_serialized_name = fields;
+      this.fields = fields;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -10706,14 +12452,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedFields != null) {
         for (Integer i = 0; i < deserializedFields.size(); i++) {
           Field currentItem = ret.getFields().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('fields_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('fields');
           Field newItem = (Field) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Field.class);
           newFields.add(newItem);
         }
-        ret.fields_serialized_name = newFields;
+        ret.fields = newFields;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (fields != null && fields[0] != null) {
+        mapping.putAll(fields[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -10723,7 +12477,7 @@ public class IBMDiscoveryV1Models {
   public class ListCollectionsOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String name;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -10734,7 +12488,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -10762,6 +12516,11 @@ public class IBMDiscoveryV1Models {
       return new ListCollectionsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      return mapping;
+    }
   }
 
   /**
@@ -10840,7 +12599,7 @@ public class IBMDiscoveryV1Models {
    * ListCollectionsResponse.
    */
   public class ListCollectionsResponse extends IBMWatsonResponseModel {
-    private List<Collection> collections_serialized_name;
+    private List<Collection> collections;
  
     /**
      * Gets the collections.
@@ -10851,7 +12610,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Collection> getCollections() {
-      return collections_serialized_name;
+      return collections;
     }
 
     /**
@@ -10860,7 +12619,7 @@ public class IBMDiscoveryV1Models {
      * @param collections the new collections
      */
     public void setCollections(final List<Collection> collections) {
-      this.collections_serialized_name = collections;
+      this.collections = collections;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -10876,14 +12635,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedCollections != null) {
         for (Integer i = 0; i < deserializedCollections.size(); i++) {
           Collection currentItem = ret.getCollections().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('collections_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('collections');
           Collection newItem = (Collection) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Collection.class);
           newCollections.add(newItem);
         }
-        ret.collections_serialized_name = newCollections;
+        ret.collections = newCollections;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (collections != null && collections[0] != null) {
+        mapping.putAll(collections[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -10893,7 +12660,7 @@ public class IBMDiscoveryV1Models {
   public class ListConfigurationsOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String name;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -10904,7 +12671,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -10932,6 +12699,11 @@ public class IBMDiscoveryV1Models {
       return new ListConfigurationsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      return mapping;
+    }
   }
 
   /**
@@ -11010,7 +12782,7 @@ public class IBMDiscoveryV1Models {
    * ListConfigurationsResponse.
    */
   public class ListConfigurationsResponse extends IBMWatsonResponseModel {
-    private List<Configuration> configurations_serialized_name;
+    private List<Configuration> configurations;
  
     /**
      * Gets the configurations.
@@ -11021,7 +12793,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Configuration> getConfigurations() {
-      return configurations_serialized_name;
+      return configurations;
     }
 
     /**
@@ -11030,7 +12802,7 @@ public class IBMDiscoveryV1Models {
      * @param configurations the new configurations
      */
     public void setConfigurations(final List<Configuration> configurations) {
-      this.configurations_serialized_name = configurations;
+      this.configurations = configurations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -11046,14 +12818,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedConfigurations != null) {
         for (Integer i = 0; i < deserializedConfigurations.size(); i++) {
           Configuration currentItem = ret.getConfigurations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('configurations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('configurations');
           Configuration newItem = (Configuration) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Configuration.class);
           newConfigurations.add(newItem);
         }
-        ret.configurations_serialized_name = newConfigurations;
+        ret.configurations = newConfigurations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (configurations != null && configurations[0] != null) {
+        mapping.putAll(configurations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -11062,7 +12842,7 @@ public class IBMDiscoveryV1Models {
    */
   public class ListCredentialsOptions extends IBMWatsonOptionsModel {
     private String environmentId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -11089,6 +12869,11 @@ public class IBMDiscoveryV1Models {
       return new ListCredentialsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      return mapping;
+    }
   }
 
   /**
@@ -11155,7 +12940,7 @@ public class IBMDiscoveryV1Models {
    */
   public class ListEnvironmentsOptions extends IBMWatsonOptionsModel {
     private String name;
- 
+
     /**
      * Gets the name.
      *
@@ -11180,7 +12965,6 @@ public class IBMDiscoveryV1Models {
     public ListEnvironmentsOptionsBuilder newBuilder() {
       return new ListEnvironmentsOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -11237,7 +13021,7 @@ public class IBMDiscoveryV1Models {
    * ListEnvironmentsResponse.
    */
   public class ListEnvironmentsResponse extends IBMWatsonResponseModel {
-    private List<Environment> environments_serialized_name;
+    private List<Environment> environments;
  
     /**
      * Gets the environments.
@@ -11248,7 +13032,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Environment> getEnvironments() {
-      return environments_serialized_name;
+      return environments;
     }
 
     /**
@@ -11257,7 +13041,7 @@ public class IBMDiscoveryV1Models {
      * @param environments the new environments
      */
     public void setEnvironments(final List<Environment> environments) {
-      this.environments_serialized_name = environments;
+      this.environments = environments;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -11273,14 +13057,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedEnvironments != null) {
         for (Integer i = 0; i < deserializedEnvironments.size(); i++) {
           Environment currentItem = ret.getEnvironments().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('environments_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('environments');
           Environment newItem = (Environment) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Environment.class);
           newEnvironments.add(newItem);
         }
-        ret.environments_serialized_name = newEnvironments;
+        ret.environments = newEnvironments;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (environments != null && environments[0] != null) {
+        mapping.putAll(environments[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -11290,7 +13082,7 @@ public class IBMDiscoveryV1Models {
   public class ListExpansionsOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -11301,7 +13093,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -11330,6 +13122,12 @@ public class IBMDiscoveryV1Models {
       return new ListExpansionsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -11412,7 +13210,7 @@ public class IBMDiscoveryV1Models {
   public class ListFieldsOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private List<String> collectionIds;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -11423,7 +13221,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionIds.
      *
@@ -11452,6 +13250,12 @@ public class IBMDiscoveryV1Models {
       return new ListFieldsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionIds', 'collection_ids');
+      return mapping;
+    }
   }
 
   /**
@@ -11549,7 +13353,7 @@ public class IBMDiscoveryV1Models {
    */
   public class ListGatewaysOptions extends IBMWatsonOptionsModel {
     private String environmentId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -11576,6 +13380,11 @@ public class IBMDiscoveryV1Models {
       return new ListGatewaysOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      return mapping;
+    }
   }
 
   /**
@@ -11643,7 +13452,7 @@ public class IBMDiscoveryV1Models {
   public class ListTrainingDataOptions extends IBMWatsonOptionsModel {
     private String environmentId;
     private String collectionId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -11654,7 +13463,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -11683,6 +13492,12 @@ public class IBMDiscoveryV1Models {
       return new ListTrainingDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      return mapping;
+    }
   }
 
   /**
@@ -11766,7 +13581,7 @@ public class IBMDiscoveryV1Models {
     private String environmentId;
     private String collectionId;
     private String queryId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -11777,7 +13592,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -11788,7 +13603,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -11819,6 +13634,13 @@ public class IBMDiscoveryV1Models {
       return new ListTrainingExamplesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('queryId', 'query_id');
+      return mapping;
+    }
   }
 
   /**
@@ -11914,8 +13736,8 @@ public class IBMDiscoveryV1Models {
    * Object containing results that match the requested **logs** query.
    */
   public class LogQueryResponse extends IBMWatsonResponseModel {
-    private Long matching_results_serialized_name;
-    private List<LogQueryResponseResult> results_serialized_name;
+    private Long matchingResults;
+    private List<LogQueryResponseResult> results;
  
     /**
      * Gets the matchingResults.
@@ -11926,7 +13748,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMatchingResults() {
-      return matching_results_serialized_name;
+      return matchingResults;
     }
  
     /**
@@ -11938,7 +13760,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<LogQueryResponseResult> getResults() {
-      return results_serialized_name;
+      return results;
     }
 
     /**
@@ -11947,7 +13769,7 @@ public class IBMDiscoveryV1Models {
      * @param matchingResults the new matchingResults
      */
     public void setMatchingResults(final long matchingResults) {
-      this.matching_results_serialized_name = matchingResults;
+      this.matchingResults = matchingResults;
     }
 
     /**
@@ -11956,7 +13778,7 @@ public class IBMDiscoveryV1Models {
      * @param results the new results
      */
     public void setResults(final List<LogQueryResponseResult> results) {
-      this.results_serialized_name = results;
+      this.results = results;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -11972,14 +13794,23 @@ public class IBMDiscoveryV1Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           LogQueryResponseResult currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           LogQueryResponseResult newItem = (LogQueryResponseResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), LogQueryResponseResult.class);
           newResults.add(newItem);
         }
-        ret.results_serialized_name = newResults;
+        ret.results = newResults;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('matching_results', 'matchingResults');
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -11988,20 +13819,20 @@ public class IBMDiscoveryV1Models {
    * an event that is associated with a query.
    */
   public class LogQueryResponseResult extends IBMWatsonGenericModel {
-    private String environment_id_serialized_name;
-    private String customer_id_serialized_name;
-    private String document_type_serialized_name;
-    private String natural_language_query_serialized_name;
-    private LogQueryResponseResultDocuments document_results_serialized_name;
-    private Datetime created_timestamp_serialized_name;
-    private Datetime client_timestamp_serialized_name;
-    private String query_id_serialized_name;
-    private String session_token_serialized_name;
-    private String collection_id_serialized_name;
-    private Long display_rank_serialized_name;
-    private String document_id_serialized_name;
-    private String event_type_serialized_name;
-    private String result_type_serialized_name;
+    private String environmentId;
+    private String customerId;
+    private String documentType;
+    private String naturalLanguageQuery;
+    private LogQueryResponseResultDocuments documentResults;
+    private Datetime createdTimestamp;
+    private Datetime clientTimestamp;
+    private String queryId;
+    private String sessionToken;
+    private String collectionId;
+    private Long displayRank;
+    private String documentId;
+    private String eventType;
+    private String resultType;
  
     /**
      * Gets the environmentId.
@@ -12012,7 +13843,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEnvironmentId() {
-      return environment_id_serialized_name;
+      return environmentId;
     }
  
     /**
@@ -12025,7 +13856,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCustomerId() {
-      return customer_id_serialized_name;
+      return customerId;
     }
  
     /**
@@ -12041,7 +13872,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentType() {
-      return document_type_serialized_name;
+      return documentType;
     }
  
     /**
@@ -12057,7 +13888,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getNaturalLanguageQuery() {
-      return natural_language_query_serialized_name;
+      return naturalLanguageQuery;
     }
  
     /**
@@ -12070,7 +13901,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public LogQueryResponseResultDocuments getDocumentResults() {
-      return document_results_serialized_name;
+      return documentResults;
     }
  
     /**
@@ -12082,7 +13913,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getCreatedTimestamp() {
-      return created_timestamp_serialized_name;
+      return createdTimestamp;
     }
  
     /**
@@ -12095,7 +13926,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getClientTimestamp() {
-      return client_timestamp_serialized_name;
+      return clientTimestamp;
     }
  
     /**
@@ -12110,7 +13941,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getQueryId() {
-      return query_id_serialized_name;
+      return queryId;
     }
  
     /**
@@ -12129,7 +13960,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSessionToken() {
-      return session_token_serialized_name;
+      return sessionToken;
     }
  
     /**
@@ -12141,7 +13972,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCollectionId() {
-      return collection_id_serialized_name;
+      return collectionId;
     }
  
     /**
@@ -12153,7 +13984,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getDisplayRank() {
-      return display_rank_serialized_name;
+      return displayRank;
     }
  
     /**
@@ -12165,7 +13996,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -12181,7 +14012,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEventType() {
-      return event_type_serialized_name;
+      return eventType;
     }
  
     /**
@@ -12193,7 +14024,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getResultType() {
-      return result_type_serialized_name;
+      return resultType;
     }
 
     /**
@@ -12202,7 +14033,7 @@ public class IBMDiscoveryV1Models {
      * @param environmentId the new environmentId
      */
     public void setEnvironmentId(final String environmentId) {
-      this.environment_id_serialized_name = environmentId;
+      this.environmentId = environmentId;
     }
 
     /**
@@ -12211,7 +14042,7 @@ public class IBMDiscoveryV1Models {
      * @param customerId the new customerId
      */
     public void setCustomerId(final String customerId) {
-      this.customer_id_serialized_name = customerId;
+      this.customerId = customerId;
     }
 
     /**
@@ -12220,7 +14051,7 @@ public class IBMDiscoveryV1Models {
      * @param documentType the new documentType
      */
     public void setDocumentType(final String documentType) {
-      this.document_type_serialized_name = documentType;
+      this.documentType = documentType;
     }
 
     /**
@@ -12229,7 +14060,7 @@ public class IBMDiscoveryV1Models {
      * @param naturalLanguageQuery the new naturalLanguageQuery
      */
     public void setNaturalLanguageQuery(final String naturalLanguageQuery) {
-      this.natural_language_query_serialized_name = naturalLanguageQuery;
+      this.naturalLanguageQuery = naturalLanguageQuery;
     }
 
     /**
@@ -12238,7 +14069,7 @@ public class IBMDiscoveryV1Models {
      * @param documentResults the new documentResults
      */
     public void setDocumentResults(final LogQueryResponseResultDocuments documentResults) {
-      this.document_results_serialized_name = documentResults;
+      this.documentResults = documentResults;
     }
 
     /**
@@ -12247,7 +14078,7 @@ public class IBMDiscoveryV1Models {
      * @param createdTimestamp the new createdTimestamp
      */
     public void setCreatedTimestamp(final Datetime createdTimestamp) {
-      this.created_timestamp_serialized_name = createdTimestamp;
+      this.createdTimestamp = createdTimestamp;
     }
 
     /**
@@ -12256,7 +14087,7 @@ public class IBMDiscoveryV1Models {
      * @param clientTimestamp the new clientTimestamp
      */
     public void setClientTimestamp(final Datetime clientTimestamp) {
-      this.client_timestamp_serialized_name = clientTimestamp;
+      this.clientTimestamp = clientTimestamp;
     }
 
     /**
@@ -12265,7 +14096,7 @@ public class IBMDiscoveryV1Models {
      * @param queryId the new queryId
      */
     public void setQueryId(final String queryId) {
-      this.query_id_serialized_name = queryId;
+      this.queryId = queryId;
     }
 
     /**
@@ -12274,7 +14105,7 @@ public class IBMDiscoveryV1Models {
      * @param sessionToken the new sessionToken
      */
     public void setSessionToken(final String sessionToken) {
-      this.session_token_serialized_name = sessionToken;
+      this.sessionToken = sessionToken;
     }
 
     /**
@@ -12283,7 +14114,7 @@ public class IBMDiscoveryV1Models {
      * @param collectionId the new collectionId
      */
     public void setCollectionId(final String collectionId) {
-      this.collection_id_serialized_name = collectionId;
+      this.collectionId = collectionId;
     }
 
     /**
@@ -12292,7 +14123,7 @@ public class IBMDiscoveryV1Models {
      * @param displayRank the new displayRank
      */
     public void setDisplayRank(final long displayRank) {
-      this.display_rank_serialized_name = displayRank;
+      this.displayRank = displayRank;
     }
 
     /**
@@ -12301,7 +14132,7 @@ public class IBMDiscoveryV1Models {
      * @param documentId the new documentId
      */
     public void setDocumentId(final String documentId) {
-      this.document_id_serialized_name = documentId;
+      this.documentId = documentId;
     }
 
     /**
@@ -12310,7 +14141,7 @@ public class IBMDiscoveryV1Models {
      * @param eventType the new eventType
      */
     public void setEventType(final String eventType) {
-      this.event_type_serialized_name = eventType;
+      this.eventType = eventType;
     }
 
     /**
@@ -12319,7 +14150,7 @@ public class IBMDiscoveryV1Models {
      * @param resultType the new resultType
      */
     public void setResultType(final String resultType) {
-      this.result_type_serialized_name = resultType;
+      this.resultType = resultType;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -12330,10 +14161,32 @@ public class IBMDiscoveryV1Models {
       LogQueryResponseResult ret = (LogQueryResponseResult) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for documentResults
-      LogQueryResponseResultDocuments newDocumentResults = (LogQueryResponseResultDocuments) new LogQueryResponseResultDocuments().deserialize(JSON.serialize(ret.getDocumentResults()), (Map<String, Object>) jsonMap.get('document_results_serialized_name'), LogQueryResponseResultDocuments.class);
+      LogQueryResponseResultDocuments newDocumentResults = (LogQueryResponseResultDocuments) new LogQueryResponseResultDocuments().deserialize(JSON.serialize(ret.getDocumentResults()), (Map<String, Object>) jsonMap.get('documentResults'), LogQueryResponseResultDocuments.class);
       ret.setDocumentResults(newDocumentResults);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environment_id', 'environmentId');
+      mapping.put('customer_id', 'customerId');
+      mapping.put('document_type', 'documentType');
+      mapping.put('natural_language_query', 'naturalLanguageQuery');
+      mapping.put('document_results', 'documentResults');
+      if (documentResults != null) {
+        mapping.putAll(documentResults.getApiToSdkMapping());
+      }
+      mapping.put('created_timestamp', 'createdTimestamp');
+      mapping.put('client_timestamp', 'clientTimestamp');
+      mapping.put('query_id', 'queryId');
+      mapping.put('session_token', 'sessionToken');
+      mapping.put('collection_id', 'collectionId');
+      mapping.put('display_rank', 'displayRank');
+      mapping.put('document_id', 'documentId');
+      mapping.put('event_type', 'eventType');
+      mapping.put('result_type', 'resultType');
+      return mapping;
     }
   }
 
@@ -12342,8 +14195,8 @@ public class IBMDiscoveryV1Models {
    * with logs of type `query`.
    */
   public class LogQueryResponseResultDocuments extends IBMWatsonGenericModel {
-    private List<LogQueryResponseResultDocumentsResult> results_serialized_name;
-    private Long count_serialized_name;
+    private List<LogQueryResponseResultDocumentsResult> results;
+    private Long count;
  
     /**
      * Gets the results.
@@ -12354,7 +14207,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<LogQueryResponseResultDocumentsResult> getResults() {
-      return results_serialized_name;
+      return results;
     }
  
     /**
@@ -12366,7 +14219,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getCount() {
-      return count_serialized_name;
+      return count;
     }
 
     /**
@@ -12375,7 +14228,7 @@ public class IBMDiscoveryV1Models {
      * @param results the new results
      */
     public void setResults(final List<LogQueryResponseResultDocumentsResult> results) {
-      this.results_serialized_name = results;
+      this.results = results;
     }
 
     /**
@@ -12384,7 +14237,7 @@ public class IBMDiscoveryV1Models {
      * @param count the new count
      */
     public void setCount(final long count) {
-      this.count_serialized_name = count;
+      this.count = count;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -12400,14 +14253,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           LogQueryResponseResultDocumentsResult currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           LogQueryResponseResultDocumentsResult newItem = (LogQueryResponseResultDocumentsResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), LogQueryResponseResultDocumentsResult.class);
           newResults.add(newItem);
         }
-        ret.results_serialized_name = newResults;
+        ret.results = newResults;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -12415,11 +14276,11 @@ public class IBMDiscoveryV1Models {
    * Each object in the **results** array corresponds to an individual document returned by the original query.
    */
   public class LogQueryResponseResultDocumentsResult extends IBMWatsonGenericModel {
-    private Long position_serialized_name;
-    private String document_id_serialized_name;
-    private Double score_serialized_name;
-    private Double confidence_serialized_name;
-    private String collection_id_serialized_name;
+    private Long position;
+    private String documentId;
+    private Double score;
+    private Double confidence;
+    private String collectionId;
  
     /**
      * Gets the position.
@@ -12430,7 +14291,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getPosition() {
-      return position_serialized_name;
+      return position;
     }
  
     /**
@@ -12442,7 +14303,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -12454,7 +14315,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
  
     /**
@@ -12466,7 +14327,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
  
     /**
@@ -12478,7 +14339,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCollectionId() {
-      return collection_id_serialized_name;
+      return collectionId;
     }
 
     /**
@@ -12487,7 +14348,7 @@ public class IBMDiscoveryV1Models {
      * @param position the new position
      */
     public void setPosition(final long position) {
-      this.position_serialized_name = position;
+      this.position = position;
     }
 
     /**
@@ -12496,7 +14357,7 @@ public class IBMDiscoveryV1Models {
      * @param documentId the new documentId
      */
     public void setDocumentId(final String documentId) {
-      this.document_id_serialized_name = documentId;
+      this.documentId = documentId;
     }
 
     /**
@@ -12505,7 +14366,7 @@ public class IBMDiscoveryV1Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
 
     /**
@@ -12514,7 +14375,7 @@ public class IBMDiscoveryV1Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
 
     /**
@@ -12523,18 +14384,24 @@ public class IBMDiscoveryV1Models {
      * @param collectionId the new collectionId
      */
     public void setCollectionId(final String collectionId) {
-      this.collection_id_serialized_name = collectionId;
+      this.collectionId = collectionId;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_id', 'documentId');
+      mapping.put('collection_id', 'collectionId');
+      return mapping;
+    }
   }
 
   /**
    * An aggregation analyzing log information for queries and events.
    */
   public class MetricAggregation extends IBMWatsonGenericModel {
-    private String interval_serialized_name;
-    private String event_type_serialized_name;
-    private List<MetricAggregationResult> results_serialized_name;
+    private String interval;
+    private String eventType;
+    private List<MetricAggregationResult> results;
  
     /**
      * Gets the interval.
@@ -12545,7 +14412,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getInterval() {
-      return interval_serialized_name;
+      return interval;
     }
  
     /**
@@ -12557,7 +14424,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEventType() {
-      return event_type_serialized_name;
+      return eventType;
     }
  
     /**
@@ -12569,7 +14436,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<MetricAggregationResult> getResults() {
-      return results_serialized_name;
+      return results;
     }
 
     /**
@@ -12578,7 +14445,7 @@ public class IBMDiscoveryV1Models {
      * @param interval the new interval
      */
     public void setInterval(final String interval) {
-      this.interval_serialized_name = interval;
+      this.interval = interval;
     }
 
     /**
@@ -12587,7 +14454,7 @@ public class IBMDiscoveryV1Models {
      * @param eventType the new eventType
      */
     public void setEventType(final String eventType) {
-      this.event_type_serialized_name = eventType;
+      this.eventType = eventType;
     }
 
     /**
@@ -12596,7 +14463,7 @@ public class IBMDiscoveryV1Models {
      * @param results the new results
      */
     public void setResults(final List<MetricAggregationResult> results) {
-      this.results_serialized_name = results;
+      this.results = results;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -12612,14 +14479,23 @@ public class IBMDiscoveryV1Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           MetricAggregationResult currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           MetricAggregationResult newItem = (MetricAggregationResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), MetricAggregationResult.class);
           newResults.add(newItem);
         }
-        ret.results_serialized_name = newResults;
+        ret.results = newResults;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('event_type', 'eventType');
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -12627,10 +14503,10 @@ public class IBMDiscoveryV1Models {
    * Aggregation result data for the requested metric.
    */
   public class MetricAggregationResult extends IBMWatsonGenericModel {
-    private Datetime key_as_string_serialized_name;
-    private Long key_serialized_name;
-    private Long matching_results_serialized_name;
-    private Double event_rate_serialized_name;
+    private Datetime keyAsString;
+    private Long key;
+    private Long matchingResults;
+    private Double eventRate;
  
     /**
      * Gets the keyAsString.
@@ -12641,7 +14517,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getKeyAsString() {
-      return key_as_string_serialized_name;
+      return keyAsString;
     }
  
     /**
@@ -12653,7 +14529,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getKey() {
-      return key_serialized_name;
+      return key;
     }
  
     /**
@@ -12665,7 +14541,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMatchingResults() {
-      return matching_results_serialized_name;
+      return matchingResults;
     }
  
     /**
@@ -12678,7 +14554,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Double getEventRate() {
-      return event_rate_serialized_name;
+      return eventRate;
     }
 
     /**
@@ -12687,7 +14563,7 @@ public class IBMDiscoveryV1Models {
      * @param keyAsString the new keyAsString
      */
     public void setKeyAsString(final Datetime keyAsString) {
-      this.key_as_string_serialized_name = keyAsString;
+      this.keyAsString = keyAsString;
     }
 
     /**
@@ -12696,7 +14572,7 @@ public class IBMDiscoveryV1Models {
      * @param key the new key
      */
     public void setKey(final long key) {
-      this.key_serialized_name = key;
+      this.key = key;
     }
 
     /**
@@ -12705,7 +14581,7 @@ public class IBMDiscoveryV1Models {
      * @param matchingResults the new matchingResults
      */
     public void setMatchingResults(final long matchingResults) {
-      this.matching_results_serialized_name = matchingResults;
+      this.matchingResults = matchingResults;
     }
 
     /**
@@ -12714,16 +14590,23 @@ public class IBMDiscoveryV1Models {
      * @param eventRate the new eventRate
      */
     public void setEventRate(final Double eventRate) {
-      this.event_rate_serialized_name = eventRate;
+      this.eventRate = eventRate;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('key_as_string', 'keyAsString');
+      mapping.put('matching_results', 'matchingResults');
+      mapping.put('event_rate', 'eventRate');
+      return mapping;
+    }
   }
 
   /**
    * The response generated from a call to a **metrics** method.
    */
   public class MetricResponse extends IBMWatsonResponseModel {
-    private List<MetricAggregation> aggregations_serialized_name;
+    private List<MetricAggregation> aggregations;
  
     /**
      * Gets the aggregations.
@@ -12734,7 +14617,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<MetricAggregation> getAggregations() {
-      return aggregations_serialized_name;
+      return aggregations;
     }
 
     /**
@@ -12743,7 +14626,7 @@ public class IBMDiscoveryV1Models {
      * @param aggregations the new aggregations
      */
     public void setAggregations(final List<MetricAggregation> aggregations) {
-      this.aggregations_serialized_name = aggregations;
+      this.aggregations = aggregations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -12759,14 +14642,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedAggregations != null) {
         for (Integer i = 0; i < deserializedAggregations.size(); i++) {
           MetricAggregation currentItem = ret.getAggregations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations');
           MetricAggregation newItem = (MetricAggregation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), MetricAggregation.class);
           newAggregations.add(newItem);
         }
-        ret.aggregations_serialized_name = newAggregations;
+        ret.aggregations = newAggregations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (aggregations != null && aggregations[0] != null) {
+        mapping.putAll(aggregations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -12774,8 +14665,8 @@ public class IBMDiscoveryV1Models {
    * An aggregation analyzing log information for queries and events.
    */
   public class MetricTokenAggregation extends IBMWatsonGenericModel {
-    private String event_type_serialized_name;
-    private List<MetricTokenAggregationResult> results_serialized_name;
+    private String eventType;
+    private List<MetricTokenAggregationResult> results;
  
     /**
      * Gets the eventType.
@@ -12786,7 +14677,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEventType() {
-      return event_type_serialized_name;
+      return eventType;
     }
  
     /**
@@ -12798,7 +14689,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<MetricTokenAggregationResult> getResults() {
-      return results_serialized_name;
+      return results;
     }
 
     /**
@@ -12807,7 +14698,7 @@ public class IBMDiscoveryV1Models {
      * @param eventType the new eventType
      */
     public void setEventType(final String eventType) {
-      this.event_type_serialized_name = eventType;
+      this.eventType = eventType;
     }
 
     /**
@@ -12816,7 +14707,7 @@ public class IBMDiscoveryV1Models {
      * @param results the new results
      */
     public void setResults(final List<MetricTokenAggregationResult> results) {
-      this.results_serialized_name = results;
+      this.results = results;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -12832,14 +14723,23 @@ public class IBMDiscoveryV1Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           MetricTokenAggregationResult currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           MetricTokenAggregationResult newItem = (MetricTokenAggregationResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), MetricTokenAggregationResult.class);
           newResults.add(newItem);
         }
-        ret.results_serialized_name = newResults;
+        ret.results = newResults;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('event_type', 'eventType');
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -12847,9 +14747,9 @@ public class IBMDiscoveryV1Models {
    * Aggregation result data for the requested metric.
    */
   public class MetricTokenAggregationResult extends IBMWatsonGenericModel {
-    private String key_serialized_name;
-    private Long matching_results_serialized_name;
-    private Double event_rate_serialized_name;
+    private String key;
+    private Long matchingResults;
+    private Double eventRate;
  
     /**
      * Gets the key.
@@ -12860,7 +14760,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getKey() {
-      return key_serialized_name;
+      return key;
     }
  
     /**
@@ -12872,7 +14772,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMatchingResults() {
-      return matching_results_serialized_name;
+      return matchingResults;
     }
  
     /**
@@ -12885,7 +14785,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Double getEventRate() {
-      return event_rate_serialized_name;
+      return eventRate;
     }
 
     /**
@@ -12894,7 +14794,7 @@ public class IBMDiscoveryV1Models {
      * @param key the new key
      */
     public void setKey(final String key) {
-      this.key_serialized_name = key;
+      this.key = key;
     }
 
     /**
@@ -12903,7 +14803,7 @@ public class IBMDiscoveryV1Models {
      * @param matchingResults the new matchingResults
      */
     public void setMatchingResults(final long matchingResults) {
-      this.matching_results_serialized_name = matchingResults;
+      this.matchingResults = matchingResults;
     }
 
     /**
@@ -12912,16 +14812,22 @@ public class IBMDiscoveryV1Models {
      * @param eventRate the new eventRate
      */
     public void setEventRate(final Double eventRate) {
-      this.event_rate_serialized_name = eventRate;
+      this.eventRate = eventRate;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('matching_results', 'matchingResults');
+      mapping.put('event_rate', 'eventRate');
+      return mapping;
+    }
   }
 
   /**
    * The response generated from a call to a **metrics** method that evaluates tokens.
    */
   public class MetricTokenResponse extends IBMWatsonResponseModel {
-    private List<MetricTokenAggregation> aggregations_serialized_name;
+    private List<MetricTokenAggregation> aggregations;
  
     /**
      * Gets the aggregations.
@@ -12932,7 +14838,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<MetricTokenAggregation> getAggregations() {
-      return aggregations_serialized_name;
+      return aggregations;
     }
 
     /**
@@ -12941,7 +14847,7 @@ public class IBMDiscoveryV1Models {
      * @param aggregations the new aggregations
      */
     public void setAggregations(final List<MetricTokenAggregation> aggregations) {
-      this.aggregations_serialized_name = aggregations;
+      this.aggregations = aggregations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -12957,14 +14863,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedAggregations != null) {
         for (Integer i = 0; i < deserializedAggregations.size(); i++) {
           MetricTokenAggregation currentItem = ret.getAggregations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations');
           MetricTokenAggregation newItem = (MetricTokenAggregation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), MetricTokenAggregation.class);
           newAggregations.add(newItem);
         }
-        ret.aggregations_serialized_name = newAggregations;
+        ret.aggregations = newAggregations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (aggregations != null && aggregations[0] != null) {
+        mapping.putAll(aggregations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -12973,6 +14887,12 @@ public class IBMDiscoveryV1Models {
    */
   public class NluEnrichmentCategories extends IBMWatsonDynamicModel {
     private Map<String, Object> additional_properties_serialized_name;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NluEnrichmentCategories() { }
 
     /**
      * Gets the dynamic properties attached to NluEnrichmentCategories.
@@ -12984,22 +14904,59 @@ public class IBMDiscoveryV1Models {
       return this.getDynamicProperties();
     }
 
+    private NluEnrichmentCategories(NluEnrichmentCategoriesBuilder builder) {
+    }
+
+    /**
+     * New builder.
+     *
+     * @return a NluEnrichmentCategories builder
+     */
+    public NluEnrichmentCategoriesBuilder newBuilder() {
+      return new NluEnrichmentCategoriesBuilder(this);
+    }
+
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
       if (jsonMap == null) {
         return null;
       }
 
       NluEnrichmentCategories ret = (NluEnrichmentCategories) super.deserialize(jsonString, jsonMap, classType);
+      NluEnrichmentCategoriesBuilder retBuilder = ret.newBuilder();
 
+      NluEnrichmentCategories builderResult = retBuilder.build();
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
 
       for (String key : jsonMap.keySet()) {
         if (!baseProps.contains(key)) {
-          ret.put(key, jsonMap.get(key));
+          builderResult.put(key, jsonMap.get(key));
         }
       }
 
-      return ret;
+      return builderResult;
+    }
+  }
+
+  /**
+   * NluEnrichmentCategories Builder.
+   */
+  public class NluEnrichmentCategoriesBuilder {
+
+    private NluEnrichmentCategoriesBuilder(NluEnrichmentCategories nluEnrichmentCategories) {
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public NluEnrichmentCategoriesBuilder() { }
+
+    /**
+     * Builds a NluEnrichmentCategories.
+     *
+     * @return the nluEnrichmentCategories
+     */
+    public NluEnrichmentCategories build() {
+      return new NluEnrichmentCategories(this);
     }
   }
 
@@ -13007,7 +14964,13 @@ public class IBMDiscoveryV1Models {
    * An object specifiying the concepts enrichment and related parameters.
    */
   public class NluEnrichmentConcepts extends IBMWatsonGenericModel {
-    private Long limit_serialized_name;
+    private Long xlimit;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NluEnrichmentConcepts() { }
  
     /**
      * Gets the xlimit.
@@ -13018,26 +14981,78 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getXlimit() {
-      return limit_serialized_name;
+      return xlimit;
+    }
+  
+    private NluEnrichmentConcepts(NluEnrichmentConceptsBuilder builder) {
+      this.xlimit = builder.xlimit;
     }
 
     /**
-     * Sets the xlimit.
+     * New builder.
      *
-     * @param xlimit the new xlimit
+     * @return a NluEnrichmentConcepts builder
      */
-    public void setXlimit(final long xlimit) {
-      this.limit_serialized_name = xlimit;
+    public NluEnrichmentConceptsBuilder newBuilder() {
+      return new NluEnrichmentConceptsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('limit', 'xlimit');
+      return mapping;
+    }
+  }
+
+  /**
+   * NluEnrichmentConcepts Builder.
+   */
+  public class NluEnrichmentConceptsBuilder {
+    private Long xlimit;
+
+    private NluEnrichmentConceptsBuilder(NluEnrichmentConcepts nluEnrichmentConcepts) {
+      this.xlimit = nluEnrichmentConcepts.xlimit;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public NluEnrichmentConceptsBuilder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentConcepts.
+     *
+     * @return the nluEnrichmentConcepts
+     */
+    public NluEnrichmentConcepts build() {
+      return new NluEnrichmentConcepts(this);
+    }
+
+    /**
+     * Set the xlimit.
+     *
+     * @param xlimit the xlimit
+     * @return the NluEnrichmentConcepts builder
+     */
+    public NluEnrichmentConceptsBuilder setXlimit(Long xlimit) {
+      this.xlimit = xlimit;
+      return this;
+    }
   }
 
   /**
    * An object specifying the emotion detection enrichment and related parameters.
    */
   public class NluEnrichmentEmotion extends IBMWatsonGenericModel {
-    private Boolean document_serialized_name;
-    private List<String> targets_serialized_name;
+    private Boolean document;
+    private List<String> targets;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -13054,7 +15069,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getDocument() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -13066,12 +15081,12 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getTargets() {
-      return targets_serialized_name;
+      return targets;
     }
   
     private NluEnrichmentEmotion(NluEnrichmentEmotionBuilder builder) {
-      this.document_serialized_name = builder.document;
-      this.targets_serialized_name = builder.targets;
+      this.document = builder.document;
+      this.targets = builder.targets;
     }
 
     /**
@@ -13082,7 +15097,6 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentEmotionBuilder newBuilder() {
       return new NluEnrichmentEmotionBuilder(this);
     }
-
   }
 
   /**
@@ -13093,8 +15107,8 @@ public class IBMDiscoveryV1Models {
     private List<String> targets;
 
     private NluEnrichmentEmotionBuilder(NluEnrichmentEmotion nluEnrichmentEmotion) {
-      this.document = nluEnrichmentEmotion.document_serialized_name;
-      this.targets = nluEnrichmentEmotion.targets_serialized_name;
+      this.document = nluEnrichmentEmotion.document;
+      this.targets = nluEnrichmentEmotion.targets;
     }
 
     /**
@@ -13155,13 +15169,13 @@ public class IBMDiscoveryV1Models {
    * An object speficying the Entities enrichment and related parameters.
    */
   public class NluEnrichmentEntities extends IBMWatsonGenericModel {
-    private Boolean sentiment_serialized_name;
-    private Boolean emotion_serialized_name;
-    private Long limit_serialized_name;
-    private Boolean mentions_serialized_name;
-    private Boolean mention_types_serialized_name;
-    private Boolean sentence_locations_serialized_name;
-    private String model_serialized_name;
+    private Boolean sentiment;
+    private Boolean emotion;
+    private Long xlimit;
+    private Boolean mentions;
+    private Boolean mentionTypes;
+    private Boolean sentenceLocations;
+    private String model;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -13178,7 +15192,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getSentiment() {
-      return sentiment_serialized_name;
+      return sentiment;
     }
  
     /**
@@ -13190,7 +15204,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getEmotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
  
     /**
@@ -13202,7 +15216,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getXlimit() {
-      return limit_serialized_name;
+      return xlimit;
     }
  
     /**
@@ -13214,7 +15228,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getMentions() {
-      return mentions_serialized_name;
+      return mentions;
     }
  
     /**
@@ -13226,7 +15240,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getMentionTypes() {
-      return mention_types_serialized_name;
+      return mentionTypes;
     }
  
     /**
@@ -13239,7 +15253,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getSentenceLocations() {
-      return sentence_locations_serialized_name;
+      return sentenceLocations;
     }
  
     /**
@@ -13252,17 +15266,17 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getModel() {
-      return model_serialized_name;
+      return model;
     }
   
     private NluEnrichmentEntities(NluEnrichmentEntitiesBuilder builder) {
-      this.sentiment_serialized_name = builder.sentiment;
-      this.emotion_serialized_name = builder.emotion;
-      this.limit_serialized_name = builder.xlimit;
-      this.mentions_serialized_name = builder.mentions;
-      this.mention_types_serialized_name = builder.mentionTypes;
-      this.sentence_locations_serialized_name = builder.sentenceLocations;
-      this.model_serialized_name = builder.model;
+      this.sentiment = builder.sentiment;
+      this.emotion = builder.emotion;
+      this.xlimit = builder.xlimit;
+      this.mentions = builder.mentions;
+      this.mentionTypes = builder.mentionTypes;
+      this.sentenceLocations = builder.sentenceLocations;
+      this.model = builder.model;
     }
 
     /**
@@ -13274,6 +15288,21 @@ public class IBMDiscoveryV1Models {
       return new NluEnrichmentEntitiesBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      mapping.put('mentionTypes', 'mention_types');
+      mapping.put('sentenceLocations', 'sentence_locations');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('limit', 'xlimit');
+      mapping.put('mention_types', 'mentionTypes');
+      mapping.put('sentence_locations', 'sentenceLocations');
+      return mapping;
+    }
   }
 
   /**
@@ -13289,13 +15318,13 @@ public class IBMDiscoveryV1Models {
     private String model;
 
     private NluEnrichmentEntitiesBuilder(NluEnrichmentEntities nluEnrichmentEntities) {
-      this.sentiment = nluEnrichmentEntities.sentiment_serialized_name;
-      this.emotion = nluEnrichmentEntities.emotion_serialized_name;
-      this.xlimit = nluEnrichmentEntities.limit_serialized_name;
-      this.mentions = nluEnrichmentEntities.mentions_serialized_name;
-      this.mentionTypes = nluEnrichmentEntities.mention_types_serialized_name;
-      this.sentenceLocations = nluEnrichmentEntities.sentence_locations_serialized_name;
-      this.model = nluEnrichmentEntities.model_serialized_name;
+      this.sentiment = nluEnrichmentEntities.sentiment;
+      this.emotion = nluEnrichmentEntities.emotion;
+      this.xlimit = nluEnrichmentEntities.xlimit;
+      this.mentions = nluEnrichmentEntities.mentions;
+      this.mentionTypes = nluEnrichmentEntities.mentionTypes;
+      this.sentenceLocations = nluEnrichmentEntities.sentenceLocations;
+      this.model = nluEnrichmentEntities.model;
     }
 
     /**
@@ -13395,14 +15424,14 @@ public class IBMDiscoveryV1Models {
    * NluEnrichmentFeatures.
    */
   public class NluEnrichmentFeatures extends IBMWatsonGenericModel {
-    private NluEnrichmentKeywords keywords_serialized_name;
-    private NluEnrichmentEntities entities_serialized_name;
-    private NluEnrichmentSentiment sentiment_serialized_name;
-    private NluEnrichmentEmotion emotion_serialized_name;
-    private NluEnrichmentCategories categories_serialized_name;
-    private NluEnrichmentSemanticRoles semantic_roles_serialized_name;
-    private NluEnrichmentRelations relations_serialized_name;
-    private NluEnrichmentConcepts concepts_serialized_name;
+    private NluEnrichmentKeywords keywords;
+    private NluEnrichmentEntities entities;
+    private NluEnrichmentSentiment sentiment;
+    private NluEnrichmentEmotion emotion;
+    private NluEnrichmentCategories categories;
+    private NluEnrichmentSemanticRoles semanticRoles;
+    private NluEnrichmentRelations relations;
+    private NluEnrichmentConcepts concepts;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -13419,7 +15448,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public NluEnrichmentKeywords getKeywords() {
-      return keywords_serialized_name;
+      return keywords;
     }
  
     /**
@@ -13431,7 +15460,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public NluEnrichmentEntities getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -13443,7 +15472,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public NluEnrichmentSentiment getSentiment() {
-      return sentiment_serialized_name;
+      return sentiment;
     }
  
     /**
@@ -13455,7 +15484,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public NluEnrichmentEmotion getEmotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
  
     /**
@@ -13467,7 +15496,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public NluEnrichmentCategories getCategories() {
-      return categories_serialized_name;
+      return categories;
     }
  
     /**
@@ -13479,7 +15508,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public NluEnrichmentSemanticRoles getSemanticRoles() {
-      return semantic_roles_serialized_name;
+      return semanticRoles;
     }
  
     /**
@@ -13491,7 +15520,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public NluEnrichmentRelations getRelations() {
-      return relations_serialized_name;
+      return relations;
     }
  
     /**
@@ -13503,18 +15532,18 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public NluEnrichmentConcepts getConcepts() {
-      return concepts_serialized_name;
+      return concepts;
     }
   
     private NluEnrichmentFeatures(NluEnrichmentFeaturesBuilder builder) {
-      this.keywords_serialized_name = builder.keywords;
-      this.entities_serialized_name = builder.entities;
-      this.sentiment_serialized_name = builder.sentiment;
-      this.emotion_serialized_name = builder.emotion;
-      this.categories_serialized_name = builder.categories;
-      this.semantic_roles_serialized_name = builder.semanticRoles;
-      this.relations_serialized_name = builder.relations;
-      this.concepts_serialized_name = builder.concepts;
+      this.keywords = builder.keywords;
+      this.entities = builder.entities;
+      this.sentiment = builder.sentiment;
+      this.emotion = builder.emotion;
+      this.categories = builder.categories;
+      this.semanticRoles = builder.semanticRoles;
+      this.relations = builder.relations;
+      this.concepts = builder.concepts;
     }
 
     /**
@@ -13535,38 +15564,74 @@ public class IBMDiscoveryV1Models {
       NluEnrichmentFeaturesBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for keywords
-      NluEnrichmentKeywords newKeywords = (NluEnrichmentKeywords) new NluEnrichmentKeywords().deserialize(JSON.serialize(ret.getKeywords()), (Map<String, Object>) jsonMap.get('keywords_serialized_name'), NluEnrichmentKeywords.class);
+      NluEnrichmentKeywords newKeywords = (NluEnrichmentKeywords) new NluEnrichmentKeywords().deserialize(JSON.serialize(ret.getKeywords()), (Map<String, Object>) jsonMap.get('keywords'), NluEnrichmentKeywords.class);
       retBuilder.keywords(newKeywords);
 
       // calling custom deserializer for entities
-      NluEnrichmentEntities newEntities = (NluEnrichmentEntities) new NluEnrichmentEntities().deserialize(JSON.serialize(ret.getEntities()), (Map<String, Object>) jsonMap.get('entities_serialized_name'), NluEnrichmentEntities.class);
+      NluEnrichmentEntities newEntities = (NluEnrichmentEntities) new NluEnrichmentEntities().deserialize(JSON.serialize(ret.getEntities()), (Map<String, Object>) jsonMap.get('entities'), NluEnrichmentEntities.class);
       retBuilder.entities(newEntities);
 
       // calling custom deserializer for sentiment
-      NluEnrichmentSentiment newSentiment = (NluEnrichmentSentiment) new NluEnrichmentSentiment().deserialize(JSON.serialize(ret.getSentiment()), (Map<String, Object>) jsonMap.get('sentiment_serialized_name'), NluEnrichmentSentiment.class);
+      NluEnrichmentSentiment newSentiment = (NluEnrichmentSentiment) new NluEnrichmentSentiment().deserialize(JSON.serialize(ret.getSentiment()), (Map<String, Object>) jsonMap.get('sentiment'), NluEnrichmentSentiment.class);
       retBuilder.sentiment(newSentiment);
 
       // calling custom deserializer for emotion
-      NluEnrichmentEmotion newEmotion = (NluEnrichmentEmotion) new NluEnrichmentEmotion().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion_serialized_name'), NluEnrichmentEmotion.class);
+      NluEnrichmentEmotion newEmotion = (NluEnrichmentEmotion) new NluEnrichmentEmotion().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion'), NluEnrichmentEmotion.class);
       retBuilder.emotion(newEmotion);
 
       // calling custom deserializer for categories
-      NluEnrichmentCategories newCategories = (NluEnrichmentCategories) new NluEnrichmentCategories().deserialize(JSON.serialize(ret.getCategories()), (Map<String, Object>) jsonMap.get('categories_serialized_name'), NluEnrichmentCategories.class);
+      NluEnrichmentCategories newCategories = (NluEnrichmentCategories) new NluEnrichmentCategories().deserialize(JSON.serialize(ret.getCategories()), (Map<String, Object>) jsonMap.get('categories'), NluEnrichmentCategories.class);
       retBuilder.categories(newCategories);
 
       // calling custom deserializer for semanticRoles
-      NluEnrichmentSemanticRoles newSemanticRoles = (NluEnrichmentSemanticRoles) new NluEnrichmentSemanticRoles().deserialize(JSON.serialize(ret.getSemanticRoles()), (Map<String, Object>) jsonMap.get('semantic_roles_serialized_name'), NluEnrichmentSemanticRoles.class);
+      NluEnrichmentSemanticRoles newSemanticRoles = (NluEnrichmentSemanticRoles) new NluEnrichmentSemanticRoles().deserialize(JSON.serialize(ret.getSemanticRoles()), (Map<String, Object>) jsonMap.get('semanticRoles'), NluEnrichmentSemanticRoles.class);
       retBuilder.semanticRoles(newSemanticRoles);
 
       // calling custom deserializer for relations
-      NluEnrichmentRelations newRelations = (NluEnrichmentRelations) new NluEnrichmentRelations().deserialize(JSON.serialize(ret.getRelations()), (Map<String, Object>) jsonMap.get('relations_serialized_name'), NluEnrichmentRelations.class);
+      NluEnrichmentRelations newRelations = (NluEnrichmentRelations) new NluEnrichmentRelations().deserialize(JSON.serialize(ret.getRelations()), (Map<String, Object>) jsonMap.get('relations'), NluEnrichmentRelations.class);
       retBuilder.relations(newRelations);
 
       // calling custom deserializer for concepts
-      NluEnrichmentConcepts newConcepts = (NluEnrichmentConcepts) new NluEnrichmentConcepts().deserialize(JSON.serialize(ret.getConcepts()), (Map<String, Object>) jsonMap.get('concepts_serialized_name'), NluEnrichmentConcepts.class);
+      NluEnrichmentConcepts newConcepts = (NluEnrichmentConcepts) new NluEnrichmentConcepts().deserialize(JSON.serialize(ret.getConcepts()), (Map<String, Object>) jsonMap.get('concepts'), NluEnrichmentConcepts.class);
       retBuilder.concepts(newConcepts);
 
       return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (keywords != null) {
+        mapping.putAll(keywords.getSdkToApiMapping());
+      }
+      if (entities != null) {
+        mapping.putAll(entities.getSdkToApiMapping());
+      }
+      mapping.put('semanticRoles', 'semantic_roles');
+      if (semanticRoles != null) {
+        mapping.putAll(semanticRoles.getSdkToApiMapping());
+      }
+      if (concepts != null) {
+        mapping.putAll(concepts.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (keywords != null) {
+        mapping.putAll(keywords.getApiToSdkMapping());
+      }
+      if (entities != null) {
+        mapping.putAll(entities.getApiToSdkMapping());
+      }
+      mapping.put('semantic_roles', 'semanticRoles');
+      if (semanticRoles != null) {
+        mapping.putAll(semanticRoles.getApiToSdkMapping());
+      }
+      if (concepts != null) {
+        mapping.putAll(concepts.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -13584,14 +15649,14 @@ public class IBMDiscoveryV1Models {
     private NluEnrichmentConcepts concepts;
 
     private NluEnrichmentFeaturesBuilder(NluEnrichmentFeatures nluEnrichmentFeatures) {
-      this.keywords = nluEnrichmentFeatures.keywords_serialized_name;
-      this.entities = nluEnrichmentFeatures.entities_serialized_name;
-      this.sentiment = nluEnrichmentFeatures.sentiment_serialized_name;
-      this.emotion = nluEnrichmentFeatures.emotion_serialized_name;
-      this.categories = nluEnrichmentFeatures.categories_serialized_name;
-      this.semanticRoles = nluEnrichmentFeatures.semantic_roles_serialized_name;
-      this.relations = nluEnrichmentFeatures.relations_serialized_name;
-      this.concepts = nluEnrichmentFeatures.concepts_serialized_name;
+      this.keywords = nluEnrichmentFeatures.keywords;
+      this.entities = nluEnrichmentFeatures.entities;
+      this.sentiment = nluEnrichmentFeatures.sentiment;
+      this.emotion = nluEnrichmentFeatures.emotion;
+      this.categories = nluEnrichmentFeatures.categories;
+      this.semanticRoles = nluEnrichmentFeatures.semanticRoles;
+      this.relations = nluEnrichmentFeatures.relations;
+      this.concepts = nluEnrichmentFeatures.concepts;
     }
 
     /**
@@ -13702,9 +15767,9 @@ public class IBMDiscoveryV1Models {
    * An object specifying the Keyword enrichment and related parameters.
    */
   public class NluEnrichmentKeywords extends IBMWatsonGenericModel {
-    private Boolean sentiment_serialized_name;
-    private Boolean emotion_serialized_name;
-    private Long limit_serialized_name;
+    private Boolean sentiment;
+    private Boolean emotion;
+    private Long xlimit;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -13721,7 +15786,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getSentiment() {
-      return sentiment_serialized_name;
+      return sentiment;
     }
  
     /**
@@ -13733,7 +15798,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getEmotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
  
     /**
@@ -13745,13 +15810,13 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getXlimit() {
-      return limit_serialized_name;
+      return xlimit;
     }
   
     private NluEnrichmentKeywords(NluEnrichmentKeywordsBuilder builder) {
-      this.sentiment_serialized_name = builder.sentiment;
-      this.emotion_serialized_name = builder.emotion;
-      this.limit_serialized_name = builder.xlimit;
+      this.sentiment = builder.sentiment;
+      this.emotion = builder.emotion;
+      this.xlimit = builder.xlimit;
     }
 
     /**
@@ -13763,6 +15828,17 @@ public class IBMDiscoveryV1Models {
       return new NluEnrichmentKeywordsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('limit', 'xlimit');
+      return mapping;
+    }
   }
 
   /**
@@ -13774,9 +15850,9 @@ public class IBMDiscoveryV1Models {
     private Long xlimit;
 
     private NluEnrichmentKeywordsBuilder(NluEnrichmentKeywords nluEnrichmentKeywords) {
-      this.sentiment = nluEnrichmentKeywords.sentiment_serialized_name;
-      this.emotion = nluEnrichmentKeywords.emotion_serialized_name;
-      this.xlimit = nluEnrichmentKeywords.limit_serialized_name;
+      this.sentiment = nluEnrichmentKeywords.sentiment;
+      this.emotion = nluEnrichmentKeywords.emotion;
+      this.xlimit = nluEnrichmentKeywords.xlimit;
     }
 
     /**
@@ -13832,7 +15908,13 @@ public class IBMDiscoveryV1Models {
    * An object specifying the relations enrichment and related parameters.
    */
   public class NluEnrichmentRelations extends IBMWatsonGenericModel {
-    private String model_serialized_name;
+    private String model;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NluEnrichmentRelations() { }
  
     /**
      * Gets the model.
@@ -13845,27 +15927,67 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getModel() {
-      return model_serialized_name;
+      return model;
+    }
+  
+    private NluEnrichmentRelations(NluEnrichmentRelationsBuilder builder) {
+      this.model = builder.model;
     }
 
     /**
-     * Sets the model.
+     * New builder.
      *
-     * @param model the new model
+     * @return a NluEnrichmentRelations builder
      */
-    public void setModel(final String model) {
-      this.model_serialized_name = model;
+    public NluEnrichmentRelationsBuilder newBuilder() {
+      return new NluEnrichmentRelationsBuilder(this);
+    }
+  }
+
+  /**
+   * NluEnrichmentRelations Builder.
+   */
+  public class NluEnrichmentRelationsBuilder {
+    private String model;
+
+    private NluEnrichmentRelationsBuilder(NluEnrichmentRelations nluEnrichmentRelations) {
+      this.model = nluEnrichmentRelations.model;
     }
 
+    /**
+     * Instantiates a new builder.
+     */
+    public NluEnrichmentRelationsBuilder() {
+    }
+
+    /**
+     * Builds a NluEnrichmentRelations.
+     *
+     * @return the nluEnrichmentRelations
+     */
+    public NluEnrichmentRelations build() {
+      return new NluEnrichmentRelations(this);
+    }
+
+    /**
+     * Set the model.
+     *
+     * @param model the model
+     * @return the NluEnrichmentRelations builder
+     */
+    public NluEnrichmentRelationsBuilder setModel(String model) {
+      this.model = model;
+      return this;
+    }
   }
 
   /**
    * An object specifiying the semantic roles enrichment and related parameters.
    */
   public class NluEnrichmentSemanticRoles extends IBMWatsonGenericModel {
-    private Boolean entities_serialized_name;
-    private Boolean keywords_serialized_name;
-    private Long limit_serialized_name;
+    private Boolean entities;
+    private Boolean keywords;
+    private Long xlimit;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -13882,7 +16004,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -13894,7 +16016,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getKeywords() {
-      return keywords_serialized_name;
+      return keywords;
     }
  
     /**
@@ -13906,13 +16028,13 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getXlimit() {
-      return limit_serialized_name;
+      return xlimit;
     }
   
     private NluEnrichmentSemanticRoles(NluEnrichmentSemanticRolesBuilder builder) {
-      this.entities_serialized_name = builder.entities;
-      this.keywords_serialized_name = builder.keywords;
-      this.limit_serialized_name = builder.xlimit;
+      this.entities = builder.entities;
+      this.keywords = builder.keywords;
+      this.xlimit = builder.xlimit;
     }
 
     /**
@@ -13924,6 +16046,17 @@ public class IBMDiscoveryV1Models {
       return new NluEnrichmentSemanticRolesBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('limit', 'xlimit');
+      return mapping;
+    }
   }
 
   /**
@@ -13935,9 +16068,9 @@ public class IBMDiscoveryV1Models {
     private Long xlimit;
 
     private NluEnrichmentSemanticRolesBuilder(NluEnrichmentSemanticRoles nluEnrichmentSemanticRoles) {
-      this.entities = nluEnrichmentSemanticRoles.entities_serialized_name;
-      this.keywords = nluEnrichmentSemanticRoles.keywords_serialized_name;
-      this.xlimit = nluEnrichmentSemanticRoles.limit_serialized_name;
+      this.entities = nluEnrichmentSemanticRoles.entities;
+      this.keywords = nluEnrichmentSemanticRoles.keywords;
+      this.xlimit = nluEnrichmentSemanticRoles.xlimit;
     }
 
     /**
@@ -13993,8 +16126,8 @@ public class IBMDiscoveryV1Models {
    * An object specifying the sentiment extraction enrichment and related parameters.
    */
   public class NluEnrichmentSentiment extends IBMWatsonGenericModel {
-    private Boolean document_serialized_name;
-    private List<String> targets_serialized_name;
+    private Boolean document;
+    private List<String> targets;
 
     /**
      * This constructor is strictly for internal serialization/deserialization purposes
@@ -14011,7 +16144,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getDocument() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -14023,12 +16156,12 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getTargets() {
-      return targets_serialized_name;
+      return targets;
     }
   
     private NluEnrichmentSentiment(NluEnrichmentSentimentBuilder builder) {
-      this.document_serialized_name = builder.document;
-      this.targets_serialized_name = builder.targets;
+      this.document = builder.document;
+      this.targets = builder.targets;
     }
 
     /**
@@ -14039,7 +16172,6 @@ public class IBMDiscoveryV1Models {
     public NluEnrichmentSentimentBuilder newBuilder() {
       return new NluEnrichmentSentimentBuilder(this);
     }
-
   }
 
   /**
@@ -14050,8 +16182,8 @@ public class IBMDiscoveryV1Models {
     private List<String> targets;
 
     private NluEnrichmentSentimentBuilder(NluEnrichmentSentiment nluEnrichmentSentiment) {
-      this.document = nluEnrichmentSentiment.document_serialized_name;
-      this.targets = nluEnrichmentSentiment.targets_serialized_name;
+      this.document = nluEnrichmentSentiment.document;
+      this.targets = nluEnrichmentSentiment.targets;
     }
 
     /**
@@ -14112,9 +16244,15 @@ public class IBMDiscoveryV1Models {
    * NormalizationOperation.
    */
   public class NormalizationOperation extends IBMWatsonGenericModel {
-    private String operation_serialized_name;
-    private String source_field_serialized_name;
-    private String destination_field_serialized_name;
+    private String operation;
+    private String sourceField;
+    private String destinationField;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public NormalizationOperation() { }
  
     /**
      * Gets the operation.
@@ -14148,7 +16286,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getOperation() {
-      return operation_serialized_name;
+      return operation;
     }
  
     /**
@@ -14160,7 +16298,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSourceField() {
-      return source_field_serialized_name;
+      return sourceField;
     }
  
     /**
@@ -14172,49 +16310,113 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDestinationField() {
-      return destination_field_serialized_name;
+      return destinationField;
+    }
+  
+    private NormalizationOperation(NormalizationOperationBuilder builder) {
+      this.operation = builder.operation;
+      this.sourceField = builder.sourceField;
+      this.destinationField = builder.destinationField;
     }
 
     /**
-     * Sets the operation.
+     * New builder.
      *
-     * @param operation the new operation
+     * @return a NormalizationOperation builder
      */
-    public void setOperation(final String operation) {
-      this.operation_serialized_name = operation;
+    public NormalizationOperationBuilder newBuilder() {
+      return new NormalizationOperationBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('sourceField', 'source_field');
+      mapping.put('destinationField', 'destination_field');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('source_field', 'sourceField');
+      mapping.put('destination_field', 'destinationField');
+      return mapping;
+    }
+  }
+
+  /**
+   * NormalizationOperation Builder.
+   */
+  public class NormalizationOperationBuilder {
+    private String operation;
+    private String sourceField;
+    private String destinationField;
+
+    private NormalizationOperationBuilder(NormalizationOperation normalizationOperation) {
+      this.operation = normalizationOperation.operation;
+      this.sourceField = normalizationOperation.sourceField;
+      this.destinationField = normalizationOperation.destinationField;
     }
 
     /**
-     * Sets the sourceField.
-     *
-     * @param sourceField the new sourceField
+     * Instantiates a new builder.
      */
-    public void setSourceField(final String sourceField) {
-      this.source_field_serialized_name = sourceField;
+    public NormalizationOperationBuilder() {
     }
 
     /**
-     * Sets the destinationField.
+     * Builds a NormalizationOperation.
      *
-     * @param destinationField the new destinationField
+     * @return the normalizationOperation
      */
-    public void setDestinationField(final String destinationField) {
-      this.destination_field_serialized_name = destinationField;
+    public NormalizationOperation build() {
+      return new NormalizationOperation(this);
     }
 
+    /**
+     * Set the operation.
+     *
+     * @param operation the operation
+     * @return the NormalizationOperation builder
+     */
+    public NormalizationOperationBuilder setOperation(String operation) {
+      this.operation = operation;
+      return this;
+    }
+
+    /**
+     * Set the sourceField.
+     *
+     * @param sourceField the sourceField
+     * @return the NormalizationOperation builder
+     */
+    public NormalizationOperationBuilder setSourceField(String sourceField) {
+      this.sourceField = sourceField;
+      return this;
+    }
+
+    /**
+     * Set the destinationField.
+     *
+     * @param destinationField the destinationField
+     * @return the NormalizationOperation builder
+     */
+    public NormalizationOperationBuilder setDestinationField(String destinationField) {
+      this.destinationField = destinationField;
+      return this;
+    }
   }
 
   /**
    * A notice produced for the collection.
    */
   public class Notice extends IBMWatsonGenericModel {
-    private String notice_id_serialized_name;
-    private Datetime created_serialized_name;
-    private String document_id_serialized_name;
-    private String query_id_serialized_name;
-    private String severity_serialized_name;
-    private String step_serialized_name;
-    private String description_serialized_name;
+    private String noticeId;
+    private Datetime created;
+    private String documentId;
+    private String queryId;
+    private String severity;
+    private String step;
+    private String description;
  
     /**
      * Gets the noticeId.
@@ -14233,7 +16435,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getNoticeId() {
-      return notice_id_serialized_name;
+      return noticeId;
     }
  
     /**
@@ -14245,7 +16447,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -14257,7 +16459,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -14269,7 +16471,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getQueryId() {
-      return query_id_serialized_name;
+      return queryId;
     }
  
     /**
@@ -14281,7 +16483,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSeverity() {
-      return severity_serialized_name;
+      return severity;
     }
  
     /**
@@ -14295,7 +16497,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStep() {
-      return step_serialized_name;
+      return step;
     }
  
     /**
@@ -14307,16 +16509,29 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('notice_id', 'noticeId');
+      mapping.put('document_id', 'documentId');
+      mapping.put('query_id', 'queryId');
+      return mapping;
+    }
   }
 
   /**
    * PdfHeadingDetection.
    */
   public class PdfHeadingDetection extends IBMWatsonGenericModel {
-    private List<FontSetting> fonts_serialized_name;
+    private List<FontSetting> fonts;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public PdfHeadingDetection() { }
  
     /**
      * Gets the fonts.
@@ -14325,16 +16540,20 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<FontSetting> getFonts() {
-      return fonts_serialized_name;
+      return fonts;
+    }
+  
+    private PdfHeadingDetection(PdfHeadingDetectionBuilder builder) {
+      this.fonts = builder.fonts;
     }
 
     /**
-     * Sets the fonts.
+     * New builder.
      *
-     * @param fonts the new fonts
+     * @return a PdfHeadingDetection builder
      */
-    public void setFonts(final List<FontSetting> fonts) {
-      this.fonts_serialized_name = fonts;
+    public PdfHeadingDetectionBuilder newBuilder() {
+      return new PdfHeadingDetectionBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -14343,6 +16562,7 @@ public class IBMDiscoveryV1Models {
       }
 
       PdfHeadingDetection ret = (PdfHeadingDetection) super.deserialize(jsonString, jsonMap, classType);
+      PdfHeadingDetectionBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for fonts
       List<FontSetting> newFonts = new List<FontSetting>();
@@ -14350,14 +16570,83 @@ public class IBMDiscoveryV1Models {
       if (deserializedFonts != null) {
         for (Integer i = 0; i < deserializedFonts.size(); i++) {
           FontSetting currentItem = ret.getFonts().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('fonts_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('fonts');
           FontSetting newItem = (FontSetting) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), FontSetting.class);
           newFonts.add(newItem);
         }
-        ret.fonts_serialized_name = newFonts;
+        retBuilder.setFonts(newFonts);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (fonts != null && fonts[0] != null) {
+        mapping.putAll(fonts[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (fonts != null && fonts[0] != null) {
+        mapping.putAll(fonts[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * PdfHeadingDetection Builder.
+   */
+  public class PdfHeadingDetectionBuilder {
+    private List<FontSetting> fonts;
+
+    private PdfHeadingDetectionBuilder(PdfHeadingDetection pdfHeadingDetection) {
+      this.fonts = pdfHeadingDetection.fonts;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public PdfHeadingDetectionBuilder() {
+    }
+
+    /**
+     * Builds a PdfHeadingDetection.
+     *
+     * @return the pdfHeadingDetection
+     */
+    public PdfHeadingDetection build() {
+      return new PdfHeadingDetection(this);
+    }
+
+    /**
+     * Adds an fonts to fonts.
+     *
+     * @param fonts the new fonts
+     * @return the PdfHeadingDetection builder
+     */
+    public PdfHeadingDetectionBuilder addFonts(FontSetting fonts) {
+      IBMWatsonValidator.notNull(fonts, 'fonts cannot be null');
+      if (this.fonts == null) {
+        this.fonts = new List<FontSetting>();
+      }
+      this.fonts.add(fonts);
+      return this;
+    }
+
+    /**
+     * Set the fonts.
+     * Existing fonts will be replaced.
+     *
+     * @param fonts the fonts
+     * @return the PdfHeadingDetection builder
+     */
+    public PdfHeadingDetectionBuilder setFonts(List<FontSetting> fonts) {
+      this.fonts = fonts;
+      return this;
     }
   }
 
@@ -14365,7 +16654,13 @@ public class IBMDiscoveryV1Models {
    * A list of PDF conversion settings.
    */
   public class PdfSettings extends IBMWatsonGenericModel {
-    private PdfHeadingDetection heading_serialized_name;
+    private PdfHeadingDetection heading;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public PdfSettings() { }
  
     /**
      * Gets the heading.
@@ -14374,16 +16669,20 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public PdfHeadingDetection getHeading() {
-      return heading_serialized_name;
+      return heading;
+    }
+  
+    private PdfSettings(PdfSettingsBuilder builder) {
+      this.heading = builder.heading;
     }
 
     /**
-     * Sets the heading.
+     * New builder.
      *
-     * @param heading the new heading
+     * @return a PdfSettings builder
      */
-    public void setHeading(final PdfHeadingDetection heading) {
-      this.heading_serialized_name = heading;
+    public PdfSettingsBuilder newBuilder() {
+      return new PdfSettingsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -14392,12 +16691,66 @@ public class IBMDiscoveryV1Models {
       }
 
       PdfSettings ret = (PdfSettings) super.deserialize(jsonString, jsonMap, classType);
+      PdfSettingsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for heading
-      PdfHeadingDetection newHeading = (PdfHeadingDetection) new PdfHeadingDetection().deserialize(JSON.serialize(ret.getHeading()), (Map<String, Object>) jsonMap.get('heading_serialized_name'), PdfHeadingDetection.class);
-      ret.setHeading(newHeading);
+      PdfHeadingDetection newHeading = (PdfHeadingDetection) new PdfHeadingDetection().deserialize(JSON.serialize(ret.getHeading()), (Map<String, Object>) jsonMap.get('heading'), PdfHeadingDetection.class);
+      retBuilder.setHeading(newHeading);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (heading != null) {
+        mapping.putAll(heading.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (heading != null) {
+        mapping.putAll(heading.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * PdfSettings Builder.
+   */
+  public class PdfSettingsBuilder {
+    private PdfHeadingDetection heading;
+
+    private PdfSettingsBuilder(PdfSettings pdfSettings) {
+      this.heading = pdfSettings.heading;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public PdfSettingsBuilder() {
+    }
+
+    /**
+     * Builds a PdfSettings.
+     *
+     * @return the pdfSettings
+     */
+    public PdfSettings build() {
+      return new PdfSettings(this);
+    }
+
+    /**
+     * Set the heading.
+     *
+     * @param heading the heading
+     * @return the PdfSettings builder
+     */
+    public PdfSettingsBuilder setHeading(PdfHeadingDetection heading) {
+      this.heading = heading;
+      return this;
     }
   }
 
@@ -14405,20 +16758,20 @@ public class IBMDiscoveryV1Models {
    * An aggregation produced by  Discovery to analyze the input provided.
    */
   public class QueryAggregation extends IBMWatsonGenericModel {
-    private String type_serialized_name;
-    private List<AggregationResult> results_serialized_name;
-    private Long matching_results_serialized_name;
-    private List<QueryAggregation> aggregations_serialized_name;
-    private String field_serialized_name;
-    private Long histogram_interval_serialized_name;
-    private Double value_serialized_name;
-    private Long count_serialized_name;
-    private String match_serialized_name;
-    private String path_serialized_name;
-    private String timeslice_interval_serialized_name;
-    private Boolean anomaly_serialized_name;
-    private Long size_serialized_name;
-    private TopHitsResults hits_serialized_name;
+    private String xtype;
+    private List<AggregationResult> results;
+    private Long matchingResults;
+    private List<QueryAggregation> aggregations;
+    private String field;
+    private Long histogramInterval;
+    private Double value;
+    private Long count;
+    private String match;
+    private String path;
+    private String timesliceInterval;
+    private Boolean anomaly;
+    private Long size;
+    private TopHitsResults hits;
  
     /**
      * Gets the xtype.
@@ -14429,7 +16782,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -14441,7 +16794,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<AggregationResult> getResults() {
-      return results_serialized_name;
+      return results;
     }
  
     /**
@@ -14453,7 +16806,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMatchingResults() {
-      return matching_results_serialized_name;
+      return matchingResults;
     }
  
     /**
@@ -14465,7 +16818,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryAggregation> getAggregations() {
-      return aggregations_serialized_name;
+      return aggregations;
     }
  
     /**
@@ -14477,7 +16830,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getField() {
-      return field_serialized_name;
+      return field;
     }
  
     /**
@@ -14489,7 +16842,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getHistogramInterval() {
-      return histogram_interval_serialized_name;
+      return histogramInterval;
     }
  
     /**
@@ -14501,7 +16854,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Double getValue() {
-      return value_serialized_name;
+      return value;
     }
  
     /**
@@ -14511,7 +16864,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getCount() {
-      return count_serialized_name;
+      return count;
     }
  
     /**
@@ -14523,7 +16876,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getMatch() {
-      return match_serialized_name;
+      return match;
     }
  
     /**
@@ -14535,7 +16888,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getPath() {
-      return path_serialized_name;
+      return path;
     }
  
     /**
@@ -14548,7 +16901,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getTimesliceInterval() {
-      return timeslice_interval_serialized_name;
+      return timesliceInterval;
     }
  
     /**
@@ -14561,7 +16914,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getAnomaly() {
-      return anomaly_serialized_name;
+      return anomaly;
     }
  
     /**
@@ -14573,7 +16926,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getSize() {
-      return size_serialized_name;
+      return size;
     }
  
     /**
@@ -14583,7 +16936,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public TopHitsResults getHits() {
-      return hits_serialized_name;
+      return hits;
     }
 
     /**
@@ -14592,7 +16945,7 @@ public class IBMDiscoveryV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -14601,7 +16954,7 @@ public class IBMDiscoveryV1Models {
      * @param results the new results
      */
     public void setResults(final List<AggregationResult> results) {
-      this.results_serialized_name = results;
+      this.results = results;
     }
 
     /**
@@ -14610,7 +16963,7 @@ public class IBMDiscoveryV1Models {
      * @param matchingResults the new matchingResults
      */
     public void setMatchingResults(final long matchingResults) {
-      this.matching_results_serialized_name = matchingResults;
+      this.matchingResults = matchingResults;
     }
 
     /**
@@ -14619,7 +16972,7 @@ public class IBMDiscoveryV1Models {
      * @param aggregations the new aggregations
      */
     public void setAggregations(final List<QueryAggregation> aggregations) {
-      this.aggregations_serialized_name = aggregations;
+      this.aggregations = aggregations;
     }
 
     /**
@@ -14628,7 +16981,7 @@ public class IBMDiscoveryV1Models {
      * @param field the new field
      */
     public void setField(final String field) {
-      this.field_serialized_name = field;
+      this.field = field;
     }
 
     /**
@@ -14637,7 +16990,7 @@ public class IBMDiscoveryV1Models {
      * @param histogramInterval the new histogramInterval
      */
     public void setHistogramInterval(final long histogramInterval) {
-      this.histogram_interval_serialized_name = histogramInterval;
+      this.histogramInterval = histogramInterval;
     }
 
     /**
@@ -14646,7 +16999,7 @@ public class IBMDiscoveryV1Models {
      * @param value the new value
      */
     public void setValue(final Double value) {
-      this.value_serialized_name = value;
+      this.value = value;
     }
 
     /**
@@ -14655,7 +17008,7 @@ public class IBMDiscoveryV1Models {
      * @param count the new count
      */
     public void setCount(final long count) {
-      this.count_serialized_name = count;
+      this.count = count;
     }
 
     /**
@@ -14664,7 +17017,7 @@ public class IBMDiscoveryV1Models {
      * @param match the new match
      */
     public void setMatch(final String match) {
-      this.match_serialized_name = match;
+      this.match = match;
     }
 
     /**
@@ -14673,7 +17026,7 @@ public class IBMDiscoveryV1Models {
      * @param path the new path
      */
     public void setPath(final String path) {
-      this.path_serialized_name = path;
+      this.path = path;
     }
 
     /**
@@ -14682,7 +17035,7 @@ public class IBMDiscoveryV1Models {
      * @param timesliceInterval the new timesliceInterval
      */
     public void setTimesliceInterval(final String timesliceInterval) {
-      this.timeslice_interval_serialized_name = timesliceInterval;
+      this.timesliceInterval = timesliceInterval;
     }
 
     /**
@@ -14691,7 +17044,7 @@ public class IBMDiscoveryV1Models {
      * @param anomaly the new anomaly
      */
     public void setAnomaly(final Boolean anomaly) {
-      this.anomaly_serialized_name = anomaly;
+      this.anomaly = anomaly;
     }
 
     /**
@@ -14700,7 +17053,7 @@ public class IBMDiscoveryV1Models {
      * @param size the new size
      */
     public void setSize(final long size) {
-      this.size_serialized_name = size;
+      this.size = size;
     }
 
     /**
@@ -14709,7 +17062,7 @@ public class IBMDiscoveryV1Models {
      * @param hits the new hits
      */
     public void setHits(final TopHitsResults hits) {
-      this.hits_serialized_name = hits;
+      this.hits = hits;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -14725,11 +17078,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           AggregationResult currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           AggregationResult newItem = (AggregationResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), AggregationResult.class);
           newResults.add(newItem);
         }
-        ret.results_serialized_name = newResults;
+        ret.results = newResults;
       }
 
       // calling custom deserializer for aggregations
@@ -14738,18 +17091,36 @@ public class IBMDiscoveryV1Models {
       if (deserializedAggregations != null) {
         for (Integer i = 0; i < deserializedAggregations.size(); i++) {
           QueryAggregation currentItem = ret.getAggregations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations');
           QueryAggregation newItem = (QueryAggregation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryAggregation.class);
           newAggregations.add(newItem);
         }
-        ret.aggregations_serialized_name = newAggregations;
+        ret.aggregations = newAggregations;
       }
 
       // calling custom deserializer for hits
-      TopHitsResults newHits = (TopHitsResults) new TopHitsResults().deserialize(JSON.serialize(ret.getHits()), (Map<String, Object>) jsonMap.get('hits_serialized_name'), TopHitsResults.class);
+      TopHitsResults newHits = (TopHitsResults) new TopHitsResults().deserialize(JSON.serialize(ret.getHits()), (Map<String, Object>) jsonMap.get('hits'), TopHitsResults.class);
       ret.setHits(newHits);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      mapping.put('matching_results', 'matchingResults');
+      if (aggregations != null && aggregations[0] != null) {
+        mapping.putAll(aggregations[0].getApiToSdkMapping());
+      }
+      mapping.put('histogram_interval', 'histogramInterval');
+      mapping.put('timeslice_interval', 'timesliceInterval');
+      if (hits != null) {
+        mapping.putAll(hits.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -14757,8 +17128,8 @@ public class IBMDiscoveryV1Models {
    * Entity text to provide context for the queried entity and rank based on that association. For example, if you
    * wanted to query the city of London in England your query would look for `London` with the context of `England`.
    */
-  public class QueryEntitiesContext {
-    private String text_serialized_name;
+  public class QueryEntitiesContext extends IBMWatsonGenericModel {
+    private String text;
  
     /**
      * Gets the text.
@@ -14769,26 +17140,72 @@ public class IBMDiscoveryV1Models {
      * @return the text
      */
     public String getText() {
-      return text_serialized_name;
+      return text;
+    }
+  
+    private QueryEntitiesContext(QueryEntitiesContextBuilder builder) {
+      this.text = builder.text;
     }
 
     /**
-     * Sets the text.
+     * New builder.
      *
-     * @param text the new text
+     * @return a QueryEntitiesContext builder
      */
-    public void setText(final String text) {
-      this.text_serialized_name = text;
+    public QueryEntitiesContextBuilder newBuilder() {
+      return new QueryEntitiesContextBuilder(this);
+    }
+  }
+
+  /**
+   * QueryEntitiesContext Builder.
+   */
+  public class QueryEntitiesContextBuilder {
+    private String text;
+
+    private QueryEntitiesContextBuilder(QueryEntitiesContext queryEntitiesContext) {
+      this.text = queryEntitiesContext.text;
     }
 
+    /**
+     * Instantiates a new builder.
+     */
+    public QueryEntitiesContextBuilder() {
+    }
+
+    /**
+     * Builds a QueryEntitiesContext.
+     *
+     * @return the queryEntitiesContext
+     */
+    public QueryEntitiesContext build() {
+      return new QueryEntitiesContext(this);
+    }
+
+    /**
+     * Set the text.
+     *
+     * @param text the text
+     * @return the QueryEntitiesContext builder
+     */
+    public QueryEntitiesContextBuilder setText(String text) {
+      this.text = text;
+      return this;
+    }
   }
 
   /**
    * A text string that appears within the entity text field.
    */
   public class QueryEntitiesEntity extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private String type_serialized_name;
+    private String text;
+    private String xtype;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public QueryEntitiesEntity() { }
  
     /**
      * Gets the text.
@@ -14799,7 +17216,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -14811,27 +17228,84 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
+    }
+  
+    private QueryEntitiesEntity(QueryEntitiesEntityBuilder builder) {
+      this.text = builder.text;
+      this.xtype = builder.xtype;
     }
 
     /**
-     * Sets the text.
+     * New builder.
      *
-     * @param text the new text
+     * @return a QueryEntitiesEntity builder
      */
-    public void setText(final String text) {
-      this.text_serialized_name = text;
+    public QueryEntitiesEntityBuilder newBuilder() {
+      return new QueryEntitiesEntityBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xtype', 'type');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      return mapping;
+    }
+  }
+
+  /**
+   * QueryEntitiesEntity Builder.
+   */
+  public class QueryEntitiesEntityBuilder {
+    private String text;
+    private String xtype;
+
+    private QueryEntitiesEntityBuilder(QueryEntitiesEntity queryEntitiesEntity) {
+      this.text = queryEntitiesEntity.text;
+      this.xtype = queryEntitiesEntity.xtype;
     }
 
     /**
-     * Sets the xtype.
-     *
-     * @param xtype the new xtype
+     * Instantiates a new builder.
      */
-    public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+    public QueryEntitiesEntityBuilder() {
     }
 
+    /**
+     * Builds a QueryEntitiesEntity.
+     *
+     * @return the queryEntitiesEntity
+     */
+    public QueryEntitiesEntity build() {
+      return new QueryEntitiesEntity(this);
+    }
+
+    /**
+     * Set the text.
+     *
+     * @param text the text
+     * @return the QueryEntitiesEntity builder
+     */
+    public QueryEntitiesEntityBuilder setText(String text) {
+      this.text = text;
+      return this;
+    }
+
+    /**
+     * Set the xtype.
+     *
+     * @param xtype the xtype
+     * @return the QueryEntitiesEntity builder
+     */
+    public QueryEntitiesEntityBuilder setXtype(String xtype) {
+      this.xtype = xtype;
+      return this;
+    }
   }
 
   /**
@@ -14845,7 +17319,7 @@ public class IBMDiscoveryV1Models {
     private QueryEntitiesContext context;
     private Long count;
     private Long evidenceCount;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -14856,7 +17330,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -14867,7 +17341,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the feature.
      *
@@ -14878,7 +17352,7 @@ public class IBMDiscoveryV1Models {
     public String feature() {
       return feature;
     }
- 
+
     /**
      * Gets the entity.
      *
@@ -14889,7 +17363,7 @@ public class IBMDiscoveryV1Models {
     public QueryEntitiesEntity entity() {
       return entity;
     }
- 
+
     /**
      * Gets the context.
      *
@@ -14901,7 +17375,7 @@ public class IBMDiscoveryV1Models {
     public QueryEntitiesContext context() {
       return context;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -14912,7 +17386,7 @@ public class IBMDiscoveryV1Models {
     public Long count() {
       return count;
     }
- 
+
     /**
      * Gets the evidenceCount.
      *
@@ -14947,6 +17421,16 @@ public class IBMDiscoveryV1Models {
       return new QueryEntitiesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      if (entity != null) {
+        mapping.putAll(entity.getSdkToApiMapping());
+      }
+      mapping.put('evidenceCount', 'evidence_count');
+      return mapping;
+    }
   }
 
   /**
@@ -15092,7 +17576,7 @@ public class IBMDiscoveryV1Models {
    * An object that contains an array of entities resulting from the query.
    */
   public class QueryEntitiesResponse extends IBMWatsonResponseModel {
-    private List<QueryEntitiesResponseItem> entities_serialized_name;
+    private List<QueryEntitiesResponseItem> entities;
  
     /**
      * Gets the entities.
@@ -15103,7 +17587,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryEntitiesResponseItem> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
 
     /**
@@ -15112,7 +17596,7 @@ public class IBMDiscoveryV1Models {
      * @param entities the new entities
      */
     public void setEntities(final List<QueryEntitiesResponseItem> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -15128,14 +17612,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           QueryEntitiesResponseItem currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           QueryEntitiesResponseItem newItem = (QueryEntitiesResponseItem) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryEntitiesResponseItem.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -15143,9 +17635,9 @@ public class IBMDiscoveryV1Models {
    * Object containing Entity query response information.
    */
   public class QueryEntitiesResponseItem extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private String type_serialized_name;
-    private List<QueryEvidence> evidence_serialized_name;
+    private String text;
+    private String xtype;
+    private List<QueryEvidence> evidence;
  
     /**
      * Gets the text.
@@ -15156,7 +17648,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -15168,7 +17660,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -15180,7 +17672,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryEvidence> getEvidence() {
-      return evidence_serialized_name;
+      return evidence;
     }
 
     /**
@@ -15189,7 +17681,7 @@ public class IBMDiscoveryV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -15198,7 +17690,7 @@ public class IBMDiscoveryV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -15207,7 +17699,7 @@ public class IBMDiscoveryV1Models {
      * @param evidence the new evidence
      */
     public void setEvidence(final List<QueryEvidence> evidence) {
-      this.evidence_serialized_name = evidence;
+      this.evidence = evidence;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -15223,14 +17715,23 @@ public class IBMDiscoveryV1Models {
       if (deserializedEvidence != null) {
         for (Integer i = 0; i < deserializedEvidence.size(); i++) {
           QueryEvidence currentItem = ret.getEvidence().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('evidence_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('evidence');
           QueryEvidence newItem = (QueryEvidence) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryEvidence.class);
           newEvidence.add(newItem);
         }
-        ret.evidence_serialized_name = newEvidence;
+        ret.evidence = newEvidence;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      if (evidence != null && evidence[0] != null) {
+        mapping.putAll(evidence[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -15238,11 +17739,11 @@ public class IBMDiscoveryV1Models {
    * Description of evidence location supporting Knoweldge Graph query result.
    */
   public class QueryEvidence extends IBMWatsonGenericModel {
-    private String document_id_serialized_name;
-    private String field_serialized_name;
-    private Long start_offset_serialized_name;
-    private Long end_offset_serialized_name;
-    private List<QueryEvidenceEntity> entities_serialized_name;
+    private String documentId;
+    private String field;
+    private Long startOffset;
+    private Long endOffset;
+    private List<QueryEvidenceEntity> entities;
  
     /**
      * Gets the documentId.
@@ -15253,7 +17754,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -15265,7 +17766,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getField() {
-      return field_serialized_name;
+      return field;
     }
  
     /**
@@ -15277,7 +17778,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getStartOffset() {
-      return start_offset_serialized_name;
+      return startOffset;
     }
  
     /**
@@ -15289,7 +17790,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getEndOffset() {
-      return end_offset_serialized_name;
+      return endOffset;
     }
  
     /**
@@ -15301,7 +17802,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryEvidenceEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
 
     /**
@@ -15310,7 +17811,7 @@ public class IBMDiscoveryV1Models {
      * @param documentId the new documentId
      */
     public void setDocumentId(final String documentId) {
-      this.document_id_serialized_name = documentId;
+      this.documentId = documentId;
     }
 
     /**
@@ -15319,7 +17820,7 @@ public class IBMDiscoveryV1Models {
      * @param field the new field
      */
     public void setField(final String field) {
-      this.field_serialized_name = field;
+      this.field = field;
     }
 
     /**
@@ -15328,7 +17829,7 @@ public class IBMDiscoveryV1Models {
      * @param startOffset the new startOffset
      */
     public void setStartOffset(final long startOffset) {
-      this.start_offset_serialized_name = startOffset;
+      this.startOffset = startOffset;
     }
 
     /**
@@ -15337,7 +17838,7 @@ public class IBMDiscoveryV1Models {
      * @param endOffset the new endOffset
      */
     public void setEndOffset(final long endOffset) {
-      this.end_offset_serialized_name = endOffset;
+      this.endOffset = endOffset;
     }
 
     /**
@@ -15346,7 +17847,7 @@ public class IBMDiscoveryV1Models {
      * @param entities the new entities
      */
     public void setEntities(final List<QueryEvidenceEntity> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -15362,14 +17863,25 @@ public class IBMDiscoveryV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           QueryEvidenceEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           QueryEvidenceEntity newItem = (QueryEvidenceEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryEvidenceEntity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_id', 'documentId');
+      mapping.put('start_offset', 'startOffset');
+      mapping.put('end_offset', 'endOffset');
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -15377,10 +17889,10 @@ public class IBMDiscoveryV1Models {
    * Entity description and location within evidence field.
    */
   public class QueryEvidenceEntity extends IBMWatsonGenericModel {
-    private String type_serialized_name;
-    private String text_serialized_name;
-    private Long start_offset_serialized_name;
-    private Long end_offset_serialized_name;
+    private String xtype;
+    private String text;
+    private Long startOffset;
+    private Long endOffset;
  
     /**
      * Gets the xtype.
@@ -15391,7 +17903,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -15403,7 +17915,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -15415,7 +17927,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getStartOffset() {
-      return start_offset_serialized_name;
+      return startOffset;
     }
  
     /**
@@ -15427,7 +17939,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getEndOffset() {
-      return end_offset_serialized_name;
+      return endOffset;
     }
 
     /**
@@ -15436,7 +17948,7 @@ public class IBMDiscoveryV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -15445,7 +17957,7 @@ public class IBMDiscoveryV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -15454,7 +17966,7 @@ public class IBMDiscoveryV1Models {
      * @param startOffset the new startOffset
      */
     public void setStartOffset(final long startOffset) {
-      this.start_offset_serialized_name = startOffset;
+      this.startOffset = startOffset;
     }
 
     /**
@@ -15463,17 +17975,24 @@ public class IBMDiscoveryV1Models {
      * @param endOffset the new endOffset
      */
     public void setEndOffset(final long endOffset) {
-      this.end_offset_serialized_name = endOffset;
+      this.endOffset = endOffset;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      mapping.put('start_offset', 'startOffset');
+      mapping.put('end_offset', 'endOffset');
+      return mapping;
+    }
   }
 
   /**
    * QueryFilterType.
    */
-  public class QueryFilterType {
-    private List<String> exclude_serialized_name;
-    private List<String> include_serialized_name;
+  public class QueryFilterType extends IBMWatsonGenericModel {
+    private List<String> exclude;
+    private List<String> include;
  
     /**
      * Gets the exclude.
@@ -15483,7 +18002,7 @@ public class IBMDiscoveryV1Models {
      * @return the exclude
      */
     public List<String> getExclude() {
-      return exclude_serialized_name;
+      return exclude;
     }
  
     /**
@@ -15494,27 +18013,104 @@ public class IBMDiscoveryV1Models {
      * @return the include
      */
     public List<String> getInclude() {
-      return include_serialized_name;
+      return include;
+    }
+  
+    private QueryFilterType(QueryFilterTypeBuilder builder) {
+      this.exclude = builder.exclude;
+      this.include = builder.include;
     }
 
     /**
-     * Sets the exclude.
+     * New builder.
+     *
+     * @return a QueryFilterType builder
+     */
+    public QueryFilterTypeBuilder newBuilder() {
+      return new QueryFilterTypeBuilder(this);
+    }
+  }
+
+  /**
+   * QueryFilterType Builder.
+   */
+  public class QueryFilterTypeBuilder {
+    private List<String> exclude;
+    private List<String> include;
+
+    private QueryFilterTypeBuilder(QueryFilterType queryFilterType) {
+      this.exclude = queryFilterType.exclude;
+      this.include = queryFilterType.include;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public QueryFilterTypeBuilder() {
+    }
+
+    /**
+     * Builds a QueryFilterType.
+     *
+     * @return the queryFilterType
+     */
+    public QueryFilterType build() {
+      return new QueryFilterType(this);
+    }
+
+    /**
+     * Adds an exclude to exclude.
      *
      * @param exclude the new exclude
+     * @return the QueryFilterType builder
      */
-    public void setExclude(final List<String> exclude) {
-      this.exclude_serialized_name = exclude;
+    public QueryFilterTypeBuilder addExclude(String exclude) {
+      IBMWatsonValidator.notNull(exclude, 'exclude cannot be null');
+      if (this.exclude == null) {
+        this.exclude = new List<String>();
+      }
+      this.exclude.add(exclude);
+      return this;
     }
 
     /**
-     * Sets the include.
+     * Adds an include to include.
      *
      * @param include the new include
+     * @return the QueryFilterType builder
      */
-    public void setInclude(final List<String> include) {
-      this.include_serialized_name = include;
+    public QueryFilterTypeBuilder addInclude(String include) {
+      IBMWatsonValidator.notNull(include, 'include cannot be null');
+      if (this.include == null) {
+        this.include = new List<String>();
+      }
+      this.include.add(include);
+      return this;
     }
 
+    /**
+     * Set the exclude.
+     * Existing exclude will be replaced.
+     *
+     * @param exclude the exclude
+     * @return the QueryFilterType builder
+     */
+    public QueryFilterTypeBuilder setExclude(List<String> exclude) {
+      this.exclude = exclude;
+      return this;
+    }
+
+    /**
+     * Set the include.
+     * Existing include will be replaced.
+     *
+     * @param include the include
+     * @return the QueryFilterType builder
+     */
+    public QueryFilterTypeBuilder setInclude(List<String> include) {
+      this.include = include;
+      return this;
+    }
   }
 
   /**
@@ -15526,7 +18122,7 @@ public class IBMDiscoveryV1Models {
     private Long count;
     private Long offset;
     private List<String> xsort;
- 
+
     /**
      * Gets the filter.
      *
@@ -15538,7 +18134,7 @@ public class IBMDiscoveryV1Models {
     public String filter() {
       return filter;
     }
- 
+
     /**
      * Gets the query.
      *
@@ -15550,7 +18146,7 @@ public class IBMDiscoveryV1Models {
     public String query() {
       return query;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -15562,7 +18158,7 @@ public class IBMDiscoveryV1Models {
     public Long count() {
       return count;
     }
- 
+
     /**
      * Gets the offset.
      *
@@ -15575,7 +18171,7 @@ public class IBMDiscoveryV1Models {
     public Long offset() {
       return offset;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -15607,6 +18203,11 @@ public class IBMDiscoveryV1Models {
       return new QueryLogOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xsort', 'sort');
+      return mapping;
+    }
   }
 
   /**
@@ -15750,7 +18351,7 @@ public class IBMDiscoveryV1Models {
     private Boolean similar;
     private List<String> similarDocumentIds;
     private List<String> similarFields;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -15761,7 +18362,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -15772,7 +18373,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the filter.
      *
@@ -15784,7 +18385,7 @@ public class IBMDiscoveryV1Models {
     public String filter() {
       return filter;
     }
- 
+
     /**
      * Gets the query.
      *
@@ -15796,7 +18397,7 @@ public class IBMDiscoveryV1Models {
     public String query() {
       return query;
     }
- 
+
     /**
      * Gets the naturalLanguageQuery.
      *
@@ -15808,7 +18409,7 @@ public class IBMDiscoveryV1Models {
     public String naturalLanguageQuery() {
       return naturalLanguageQuery;
     }
- 
+
     /**
      * Gets the passages.
      *
@@ -15819,7 +18420,7 @@ public class IBMDiscoveryV1Models {
     public Boolean passages() {
       return passages;
     }
- 
+
     /**
      * Gets the aggregation.
      *
@@ -15832,7 +18433,7 @@ public class IBMDiscoveryV1Models {
     public String aggregation() {
       return aggregation;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -15844,7 +18445,7 @@ public class IBMDiscoveryV1Models {
     public Long count() {
       return count;
     }
- 
+
     /**
      * Gets the returnFields.
      *
@@ -15855,7 +18456,7 @@ public class IBMDiscoveryV1Models {
     public List<String> returnFields() {
       return returnFields;
     }
- 
+
     /**
      * Gets the offset.
      *
@@ -15868,7 +18469,7 @@ public class IBMDiscoveryV1Models {
     public Long offset() {
       return offset;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -15881,7 +18482,7 @@ public class IBMDiscoveryV1Models {
     public List<String> xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the highlight.
      *
@@ -15893,7 +18494,7 @@ public class IBMDiscoveryV1Models {
     public Boolean highlight() {
       return highlight;
     }
- 
+
     /**
      * Gets the passagesFields.
      *
@@ -15905,7 +18506,7 @@ public class IBMDiscoveryV1Models {
     public List<String> passagesFields() {
       return passagesFields;
     }
- 
+
     /**
      * Gets the passagesCount.
      *
@@ -15916,7 +18517,7 @@ public class IBMDiscoveryV1Models {
     public Long passagesCount() {
       return passagesCount;
     }
- 
+
     /**
      * Gets the passagesCharacters.
      *
@@ -15927,7 +18528,7 @@ public class IBMDiscoveryV1Models {
     public Long passagesCharacters() {
       return passagesCharacters;
     }
- 
+
     /**
      * Gets the deduplicateField.
      *
@@ -15940,7 +18541,7 @@ public class IBMDiscoveryV1Models {
     public String deduplicateField() {
       return deduplicateField;
     }
- 
+
     /**
      * Gets the similar.
      *
@@ -15952,7 +18553,7 @@ public class IBMDiscoveryV1Models {
     public Boolean similar() {
       return similar;
     }
- 
+
     /**
      * Gets the similarDocumentIds.
      *
@@ -15967,7 +18568,7 @@ public class IBMDiscoveryV1Models {
     public List<String> similarDocumentIds() {
       return similarDocumentIds;
     }
- 
+
     /**
      * Gets the similarFields.
      *
@@ -16014,6 +18615,21 @@ public class IBMDiscoveryV1Models {
       return new QueryNoticesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('naturalLanguageQuery', 'natural_language_query');
+      mapping.put('returnFields', 'return');
+      mapping.put('xsort', 'sort');
+      mapping.put('passagesFields', 'passages.fields');
+      mapping.put('passagesCount', 'passages.count');
+      mapping.put('passagesCharacters', 'passages.characters');
+      mapping.put('deduplicateField', 'deduplicate.field');
+      mapping.put('similarDocumentIds', 'similar.document_ids');
+      mapping.put('similarFields', 'similar.fields');
+      return mapping;
+    }
   }
 
   /**
@@ -16395,11 +19011,11 @@ public class IBMDiscoveryV1Models {
    * QueryNoticesResponse.
    */
   public class QueryNoticesResponse extends IBMWatsonResponseModel {
-    private Long matching_results_serialized_name;
-    private List<QueryNoticesResult> results_serialized_name;
-    private List<QueryAggregation> aggregations_serialized_name;
-    private List<QueryPassages> passages_serialized_name;
-    private Long duplicates_removed_serialized_name;
+    private Long matchingResults;
+    private List<QueryNoticesResult> results;
+    private List<QueryAggregation> aggregations;
+    private List<QueryPassages> passages;
+    private Long duplicatesRemoved;
  
     /**
      * Gets the matchingResults.
@@ -16410,7 +19026,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMatchingResults() {
-      return matching_results_serialized_name;
+      return matchingResults;
     }
  
     /**
@@ -16422,7 +19038,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryNoticesResult> getResults() {
-      return results_serialized_name;
+      return results;
     }
  
     /**
@@ -16434,7 +19050,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryAggregation> getAggregations() {
-      return aggregations_serialized_name;
+      return aggregations;
     }
  
     /**
@@ -16446,7 +19062,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryPassages> getPassages() {
-      return passages_serialized_name;
+      return passages;
     }
  
     /**
@@ -16458,7 +19074,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getDuplicatesRemoved() {
-      return duplicates_removed_serialized_name;
+      return duplicatesRemoved;
     }
 
     /**
@@ -16467,7 +19083,7 @@ public class IBMDiscoveryV1Models {
      * @param matchingResults the new matchingResults
      */
     public void setMatchingResults(final long matchingResults) {
-      this.matching_results_serialized_name = matchingResults;
+      this.matchingResults = matchingResults;
     }
 
     /**
@@ -16476,7 +19092,7 @@ public class IBMDiscoveryV1Models {
      * @param results the new results
      */
     public void setResults(final List<QueryNoticesResult> results) {
-      this.results_serialized_name = results;
+      this.results = results;
     }
 
     /**
@@ -16485,7 +19101,7 @@ public class IBMDiscoveryV1Models {
      * @param aggregations the new aggregations
      */
     public void setAggregations(final List<QueryAggregation> aggregations) {
-      this.aggregations_serialized_name = aggregations;
+      this.aggregations = aggregations;
     }
 
     /**
@@ -16494,7 +19110,7 @@ public class IBMDiscoveryV1Models {
      * @param passages the new passages
      */
     public void setPassages(final List<QueryPassages> passages) {
-      this.passages_serialized_name = passages;
+      this.passages = passages;
     }
 
     /**
@@ -16503,7 +19119,7 @@ public class IBMDiscoveryV1Models {
      * @param duplicatesRemoved the new duplicatesRemoved
      */
     public void setDuplicatesRemoved(final long duplicatesRemoved) {
-      this.duplicates_removed_serialized_name = duplicatesRemoved;
+      this.duplicatesRemoved = duplicatesRemoved;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -16519,11 +19135,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           QueryNoticesResult currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           QueryNoticesResult newItem = (QueryNoticesResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryNoticesResult.class);
           newResults.add(newItem);
         }
-        ret.results_serialized_name = newResults;
+        ret.results = newResults;
       }
 
       // calling custom deserializer for aggregations
@@ -16532,11 +19148,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedAggregations != null) {
         for (Integer i = 0; i < deserializedAggregations.size(); i++) {
           QueryAggregation currentItem = ret.getAggregations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations');
           QueryAggregation newItem = (QueryAggregation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryAggregation.class);
           newAggregations.add(newItem);
         }
-        ret.aggregations_serialized_name = newAggregations;
+        ret.aggregations = newAggregations;
       }
 
       // calling custom deserializer for passages
@@ -16545,14 +19161,30 @@ public class IBMDiscoveryV1Models {
       if (deserializedPassages != null) {
         for (Integer i = 0; i < deserializedPassages.size(); i++) {
           QueryPassages currentItem = ret.getPassages().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('passages_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('passages');
           QueryPassages newItem = (QueryPassages) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryPassages.class);
           newPassages.add(newItem);
         }
-        ret.passages_serialized_name = newPassages;
+        ret.passages = newPassages;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('matching_results', 'matchingResults');
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      if (aggregations != null && aggregations[0] != null) {
+        mapping.putAll(aggregations[0].getApiToSdkMapping());
+      }
+      if (passages != null && passages[0] != null) {
+        mapping.putAll(passages[0].getApiToSdkMapping());
+      }
+      mapping.put('duplicates_removed', 'duplicatesRemoved');
+      return mapping;
     }
   }
 
@@ -16560,16 +19192,16 @@ public class IBMDiscoveryV1Models {
    * QueryNoticesResult.
    */
   public class QueryNoticesResult extends IBMWatsonDynamicModel {
-    private String id_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private String collection_id_serialized_name;
-    private QueryResultMetadata result_metadata_serialized_name;
-    private String title_serialized_name;
-    private Long code_serialized_name;
-    private String filename_serialized_name;
-    private String file_type_serialized_name;
-    private String sha1_serialized_name;
-    private List<Notice> notices_serialized_name;
+    private String id;
+    private IBMWatsonMapModel metadata;
+    private String collectionId;
+    private QueryResultMetadata resultMetadata;
+    private String title;
+    private Long code;
+    private String filename;
+    private String fileType;
+    private String sha1;
+    private List<Notice> notices;
     private Map<String, Object> additional_properties_serialized_name;
 
     /**
@@ -16579,7 +19211,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getId() {
-      return id_serialized_name;
+      return id;
     }
 
     /**
@@ -16589,7 +19221,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
 
     /**
@@ -16599,7 +19231,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCollectionId() {
-      return collection_id_serialized_name;
+      return collectionId;
     }
 
     /**
@@ -16609,7 +19241,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public QueryResultMetadata getResultMetadata() {
-      return result_metadata_serialized_name;
+      return resultMetadata;
     }
 
     /**
@@ -16619,7 +19251,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
 
     /**
@@ -16629,7 +19261,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getCode() {
-      return code_serialized_name;
+      return code;
     }
 
     /**
@@ -16639,7 +19271,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getFilename() {
-      return filename_serialized_name;
+      return filename;
     }
 
     /**
@@ -16649,7 +19281,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getFileType() {
-      return file_type_serialized_name;
+      return fileType;
     }
 
     /**
@@ -16659,7 +19291,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSha1() {
-      return sha1_serialized_name;
+      return sha1;
     }
 
     /**
@@ -16669,7 +19301,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Notice> getNotices() {
-      return notices_serialized_name;
+      return notices;
     }
 
     /**
@@ -16688,7 +19320,7 @@ public class IBMDiscoveryV1Models {
      * @param id the new id
      */
     public void setId(final String id) {
-      this.id_serialized_name = id;
+      this.id = id;
     }
 
     /**
@@ -16697,7 +19329,7 @@ public class IBMDiscoveryV1Models {
      * @param metadata the new metadata
      */
     public void setMetadata(final IBMWatsonMapModel metadata) {
-      this.metadata_serialized_name = metadata;
+      this.metadata = metadata;
     }
 
     /**
@@ -16706,7 +19338,7 @@ public class IBMDiscoveryV1Models {
      * @param collectionId the new collectionId
      */
     public void setCollectionId(final String collectionId) {
-      this.collection_id_serialized_name = collectionId;
+      this.collectionId = collectionId;
     }
 
     /**
@@ -16715,7 +19347,7 @@ public class IBMDiscoveryV1Models {
      * @param resultMetadata the new resultMetadata
      */
     public void setResultMetadata(final QueryResultMetadata resultMetadata) {
-      this.result_metadata_serialized_name = resultMetadata;
+      this.resultMetadata = resultMetadata;
     }
 
     /**
@@ -16724,7 +19356,7 @@ public class IBMDiscoveryV1Models {
      * @param title the new title
      */
     public void setTitle(final String title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     /**
@@ -16733,7 +19365,7 @@ public class IBMDiscoveryV1Models {
      * @param code the new code
      */
     public void setCode(final Long code) {
-      this.code_serialized_name = code;
+      this.code = code;
     }
 
     /**
@@ -16742,7 +19374,7 @@ public class IBMDiscoveryV1Models {
      * @param filename the new filename
      */
     public void setFilename(final String filename) {
-      this.filename_serialized_name = filename;
+      this.filename = filename;
     }
 
     /**
@@ -16751,7 +19383,7 @@ public class IBMDiscoveryV1Models {
      * @param fileType the new fileType
      */
     public void setFileType(final String fileType) {
-      this.file_type_serialized_name = fileType;
+      this.fileType = fileType;
     }
 
     /**
@@ -16760,7 +19392,7 @@ public class IBMDiscoveryV1Models {
      * @param sha1 the new sha1
      */
     public void setSha1(final String sha1) {
-      this.sha1_serialized_name = sha1;
+      this.sha1 = sha1;
     }
 
     /**
@@ -16769,7 +19401,7 @@ public class IBMDiscoveryV1Models {
      * @param notices the new notices
      */
     public void setNotices(final List<Notice> notices) {
-      this.notices_serialized_name = notices;
+      this.notices = notices;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -16780,11 +19412,11 @@ public class IBMDiscoveryV1Models {
       QueryNoticesResult ret = (QueryNoticesResult) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for metadata
-      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
       ret.setMetadata(newMetadata);
 
       // calling custom deserializer for resultMetadata
-      QueryResultMetadata newResultMetadata = (QueryResultMetadata) new QueryResultMetadata().deserialize(JSON.serialize(ret.getResultMetadata()), (Map<String, Object>) jsonMap.get('result_metadata_serialized_name'), QueryResultMetadata.class);
+      QueryResultMetadata newResultMetadata = (QueryResultMetadata) new QueryResultMetadata().deserialize(JSON.serialize(ret.getResultMetadata()), (Map<String, Object>) jsonMap.get('resultMetadata'), QueryResultMetadata.class);
       ret.setResultMetadata(newResultMetadata);
 
       // calling custom deserializer for notices
@@ -16793,7 +19425,7 @@ public class IBMDiscoveryV1Models {
       if (deserializedNotices != null) {
         for (Integer i = 0; i < deserializedNotices.size(); i++) {
           Notice currentItem = ret.getNotices().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('notices_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('notices');
           Notice newItem = (Notice) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Notice.class);
           newNotices.add(newItem);
         }
@@ -16809,6 +19441,17 @@ public class IBMDiscoveryV1Models {
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('collection_id', 'collectionId');
+      mapping.put('result_metadata', 'resultMetadata');
+      mapping.put('file_type', 'fileType');
+      if (notices != null && notices[0] != null) {
+        mapping.putAll(notices[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -16839,7 +19482,7 @@ public class IBMDiscoveryV1Models {
     private String similarFields;
     private String bias;
     private Boolean loggingOptOut;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -16850,7 +19493,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -16861,7 +19504,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the filter.
      *
@@ -16873,7 +19516,7 @@ public class IBMDiscoveryV1Models {
     public String filter() {
       return filter;
     }
- 
+
     /**
      * Gets the query.
      *
@@ -16885,7 +19528,7 @@ public class IBMDiscoveryV1Models {
     public String query() {
       return query;
     }
- 
+
     /**
      * Gets the naturalLanguageQuery.
      *
@@ -16897,7 +19540,7 @@ public class IBMDiscoveryV1Models {
     public String naturalLanguageQuery() {
       return naturalLanguageQuery;
     }
- 
+
     /**
      * Gets the passages.
      *
@@ -16908,7 +19551,7 @@ public class IBMDiscoveryV1Models {
     public Boolean passages() {
       return passages;
     }
- 
+
     /**
      * Gets the aggregation.
      *
@@ -16921,7 +19564,7 @@ public class IBMDiscoveryV1Models {
     public String aggregation() {
       return aggregation;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -16932,7 +19575,7 @@ public class IBMDiscoveryV1Models {
     public Long count() {
       return count;
     }
- 
+
     /**
      * Gets the returnFields.
      *
@@ -16943,7 +19586,7 @@ public class IBMDiscoveryV1Models {
     public String returnFields() {
       return returnFields;
     }
- 
+
     /**
      * Gets the offset.
      *
@@ -16955,7 +19598,7 @@ public class IBMDiscoveryV1Models {
     public Long offset() {
       return offset;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -16968,7 +19611,7 @@ public class IBMDiscoveryV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the highlight.
      *
@@ -16980,7 +19623,7 @@ public class IBMDiscoveryV1Models {
     public Boolean highlight() {
       return highlight;
     }
- 
+
     /**
      * Gets the passagesFields.
      *
@@ -16992,7 +19635,7 @@ public class IBMDiscoveryV1Models {
     public String passagesFields() {
       return passagesFields;
     }
- 
+
     /**
      * Gets the passagesCount.
      *
@@ -17004,7 +19647,7 @@ public class IBMDiscoveryV1Models {
     public Long passagesCount() {
       return passagesCount;
     }
- 
+
     /**
      * Gets the passagesCharacters.
      *
@@ -17015,7 +19658,7 @@ public class IBMDiscoveryV1Models {
     public Long passagesCharacters() {
       return passagesCharacters;
     }
- 
+
     /**
      * Gets the deduplicate.
      *
@@ -17028,7 +19671,7 @@ public class IBMDiscoveryV1Models {
     public Boolean deduplicate() {
       return deduplicate;
     }
- 
+
     /**
      * Gets the deduplicateField.
      *
@@ -17041,7 +19684,7 @@ public class IBMDiscoveryV1Models {
     public String deduplicateField() {
       return deduplicateField;
     }
- 
+
     /**
      * Gets the collectionIds.
      *
@@ -17053,7 +19696,7 @@ public class IBMDiscoveryV1Models {
     public String collectionIds() {
       return collectionIds;
     }
- 
+
     /**
      * Gets the similar.
      *
@@ -17065,7 +19708,7 @@ public class IBMDiscoveryV1Models {
     public Boolean similar() {
       return similar;
     }
- 
+
     /**
      * Gets the similarDocumentIds.
      *
@@ -17080,7 +19723,7 @@ public class IBMDiscoveryV1Models {
     public String similarDocumentIds() {
       return similarDocumentIds;
     }
- 
+
     /**
      * Gets the similarFields.
      *
@@ -17092,7 +19735,7 @@ public class IBMDiscoveryV1Models {
     public String similarFields() {
       return similarFields;
     }
- 
+
     /**
      * Gets the bias.
      *
@@ -17106,7 +19749,7 @@ public class IBMDiscoveryV1Models {
     public String bias() {
       return bias;
     }
- 
+
     /**
      * Gets the loggingOptOut.
      *
@@ -17156,6 +19799,23 @@ public class IBMDiscoveryV1Models {
       return new QueryOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('naturalLanguageQuery', 'natural_language_query');
+      mapping.put('returnFields', 'return');
+      mapping.put('xsort', 'sort');
+      mapping.put('passagesFields', 'passages.fields');
+      mapping.put('passagesCount', 'passages.count');
+      mapping.put('passagesCharacters', 'passages.characters');
+      mapping.put('deduplicateField', 'deduplicate.field');
+      mapping.put('collectionIds', 'collection_ids');
+      mapping.put('similarDocumentIds', 'similar.document_ids');
+      mapping.put('similarFields', 'similar.fields');
+      mapping.put('loggingOptOut', 'X-Watson-Logging-Opt-Out');
+      return mapping;
+    }
   }
 
   /**
@@ -17509,12 +20169,12 @@ public class IBMDiscoveryV1Models {
    * QueryPassages.
    */
   public class QueryPassages extends IBMWatsonGenericModel {
-    private String document_id_serialized_name;
-    private Double passage_score_serialized_name;
-    private String passage_text_serialized_name;
-    private Long start_offset_serialized_name;
-    private Long end_offset_serialized_name;
-    private String field_serialized_name;
+    private String documentId;
+    private Double passageScore;
+    private String passageText;
+    private Long startOffset;
+    private Long endOffset;
+    private String field;
  
     /**
      * Gets the documentId.
@@ -17525,7 +20185,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -17537,7 +20197,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Double getPassageScore() {
-      return passage_score_serialized_name;
+      return passageScore;
     }
  
     /**
@@ -17549,7 +20209,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getPassageText() {
-      return passage_text_serialized_name;
+      return passageText;
     }
  
     /**
@@ -17561,7 +20221,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getStartOffset() {
-      return start_offset_serialized_name;
+      return startOffset;
     }
  
     /**
@@ -17573,7 +20233,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getEndOffset() {
-      return end_offset_serialized_name;
+      return endOffset;
     }
  
     /**
@@ -17585,7 +20245,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getField() {
-      return field_serialized_name;
+      return field;
     }
 
     /**
@@ -17594,7 +20254,7 @@ public class IBMDiscoveryV1Models {
      * @param documentId the new documentId
      */
     public void setDocumentId(final String documentId) {
-      this.document_id_serialized_name = documentId;
+      this.documentId = documentId;
     }
 
     /**
@@ -17603,7 +20263,7 @@ public class IBMDiscoveryV1Models {
      * @param passageScore the new passageScore
      */
     public void setPassageScore(final Double passageScore) {
-      this.passage_score_serialized_name = passageScore;
+      this.passageScore = passageScore;
     }
 
     /**
@@ -17612,7 +20272,7 @@ public class IBMDiscoveryV1Models {
      * @param passageText the new passageText
      */
     public void setPassageText(final String passageText) {
-      this.passage_text_serialized_name = passageText;
+      this.passageText = passageText;
     }
 
     /**
@@ -17621,7 +20281,7 @@ public class IBMDiscoveryV1Models {
      * @param startOffset the new startOffset
      */
     public void setStartOffset(final long startOffset) {
-      this.start_offset_serialized_name = startOffset;
+      this.startOffset = startOffset;
     }
 
     /**
@@ -17630,7 +20290,7 @@ public class IBMDiscoveryV1Models {
      * @param endOffset the new endOffset
      */
     public void setEndOffset(final long endOffset) {
-      this.end_offset_serialized_name = endOffset;
+      this.endOffset = endOffset;
     }
 
     /**
@@ -17639,16 +20299,25 @@ public class IBMDiscoveryV1Models {
      * @param field the new field
      */
     public void setField(final String field) {
-      this.field_serialized_name = field;
+      this.field = field;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_id', 'documentId');
+      mapping.put('passage_score', 'passageScore');
+      mapping.put('passage_text', 'passageText');
+      mapping.put('start_offset', 'startOffset');
+      mapping.put('end_offset', 'endOffset');
+      return mapping;
+    }
   }
 
   /**
    * QueryRelationsArgument.
    */
   public class QueryRelationsArgument extends IBMWatsonGenericModel {
-    private List<QueryEntitiesEntity> entities_serialized_name;
+    private List<QueryEntitiesEntity> entities;
  
     /**
      * Gets the entities.
@@ -17659,7 +20328,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryEntitiesEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
 
     /**
@@ -17668,7 +20337,7 @@ public class IBMDiscoveryV1Models {
      * @param entities the new entities
      */
     public void setEntities(final List<QueryEntitiesEntity> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -17684,24 +20353,32 @@ public class IBMDiscoveryV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           QueryEntitiesEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           QueryEntitiesEntity newItem = (QueryEntitiesEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryEntitiesEntity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
   /**
    * QueryRelationsEntity.
    */
-  public class QueryRelationsEntity {
-    private String text_serialized_name;
-    private String type_serialized_name;
-    private Boolean exact_serialized_name;
+  public class QueryRelationsEntity extends IBMWatsonGenericModel {
+    private String text;
+    private String xtype;
+    private Boolean exact;
  
     /**
      * Gets the text.
@@ -17711,7 +20388,7 @@ public class IBMDiscoveryV1Models {
      * @return the text
      */
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -17722,7 +20399,7 @@ public class IBMDiscoveryV1Models {
      * @return the xtype
      */
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -17733,45 +20410,101 @@ public class IBMDiscoveryV1Models {
      * @return the exact
      */
     public Boolean getExact() {
-      return exact_serialized_name;
+      return exact;
+    }
+  
+    private QueryRelationsEntity(QueryRelationsEntityBuilder builder) {
+      this.text = builder.text;
+      this.xtype = builder.xtype;
+      this.exact = builder.exact;
     }
 
     /**
-     * Sets the text.
+     * New builder.
      *
-     * @param text the new text
+     * @return a QueryRelationsEntity builder
      */
-    public void setText(final String text) {
-      this.text_serialized_name = text;
+    public QueryRelationsEntityBuilder newBuilder() {
+      return new QueryRelationsEntityBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xtype', 'type');
+      return mapping;
+    }
+  }
+
+  /**
+   * QueryRelationsEntity Builder.
+   */
+  public class QueryRelationsEntityBuilder {
+    private String text;
+    private String xtype;
+    private Boolean exact;
+
+    private QueryRelationsEntityBuilder(QueryRelationsEntity queryRelationsEntity) {
+      this.text = queryRelationsEntity.text;
+      this.xtype = queryRelationsEntity.xtype;
+      this.exact = queryRelationsEntity.exact;
     }
 
     /**
-     * Sets the xtype.
-     *
-     * @param xtype the new xtype
+     * Instantiates a new builder.
      */
-    public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+    public QueryRelationsEntityBuilder() {
     }
 
     /**
-     * Sets the exact.
+     * Builds a QueryRelationsEntity.
      *
-     * @param exact the new exact
+     * @return the queryRelationsEntity
      */
-    public void setExact(final Boolean exact) {
-      this.exact_serialized_name = exact;
+    public QueryRelationsEntity build() {
+      return new QueryRelationsEntity(this);
     }
 
+    /**
+     * Set the text.
+     *
+     * @param text the text
+     * @return the QueryRelationsEntity builder
+     */
+    public QueryRelationsEntityBuilder setText(String text) {
+      this.text = text;
+      return this;
+    }
+
+    /**
+     * Set the xtype.
+     *
+     * @param xtype the xtype
+     * @return the QueryRelationsEntity builder
+     */
+    public QueryRelationsEntityBuilder setXtype(String xtype) {
+      this.xtype = xtype;
+      return this;
+    }
+
+    /**
+     * Set the exact.
+     *
+     * @param exact the exact
+     * @return the QueryRelationsEntity builder
+     */
+    public QueryRelationsEntityBuilder setExact(Boolean exact) {
+      this.exact = exact;
+      return this;
+    }
   }
 
   /**
    * QueryRelationsFilter.
    */
-  public class QueryRelationsFilter {
-    private QueryFilterType relation_types_serialized_name;
-    private QueryFilterType entity_types_serialized_name;
-    private List<String> document_ids_serialized_name;
+  public class QueryRelationsFilter extends IBMWatsonGenericModel {
+    private QueryFilterType relationTypes;
+    private QueryFilterType entityTypes;
+    private List<String> documentIds;
  
     /**
      * Gets the relationTypes.
@@ -17779,7 +20512,7 @@ public class IBMDiscoveryV1Models {
      * @return the relationTypes
      */
     public QueryFilterType getRelationTypes() {
-      return relation_types_serialized_name;
+      return relationTypes;
     }
  
     /**
@@ -17788,7 +20521,7 @@ public class IBMDiscoveryV1Models {
      * @return the entityTypes
      */
     public QueryFilterType getEntityTypes() {
-      return entity_types_serialized_name;
+      return entityTypes;
     }
  
     /**
@@ -17799,36 +20532,110 @@ public class IBMDiscoveryV1Models {
      * @return the documentIds
      */
     public List<String> getDocumentIds() {
-      return document_ids_serialized_name;
+      return documentIds;
+    }
+  
+    private QueryRelationsFilter(QueryRelationsFilterBuilder builder) {
+      this.relationTypes = builder.relationTypes;
+      this.entityTypes = builder.entityTypes;
+      this.documentIds = builder.documentIds;
     }
 
     /**
-     * Sets the relationTypes.
+     * New builder.
      *
-     * @param relationTypes the new relationTypes
+     * @return a QueryRelationsFilter builder
      */
-    public void setRelationTypes(final QueryFilterType relationTypes) {
-      this.relation_types_serialized_name = relationTypes;
+    public QueryRelationsFilterBuilder newBuilder() {
+      return new QueryRelationsFilterBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('relationTypes', 'relation_types');
+      mapping.put('entityTypes', 'entity_types');
+      mapping.put('documentIds', 'document_ids');
+      return mapping;
+    }
+  }
+
+  /**
+   * QueryRelationsFilter Builder.
+   */
+  public class QueryRelationsFilterBuilder {
+    private QueryFilterType relationTypes;
+    private QueryFilterType entityTypes;
+    private List<String> documentIds;
+
+    private QueryRelationsFilterBuilder(QueryRelationsFilter queryRelationsFilter) {
+      this.relationTypes = queryRelationsFilter.relationTypes;
+      this.entityTypes = queryRelationsFilter.entityTypes;
+      this.documentIds = queryRelationsFilter.documentIds;
     }
 
     /**
-     * Sets the entityTypes.
+     * Instantiates a new builder.
+     */
+    public QueryRelationsFilterBuilder() {
+    }
+
+    /**
+     * Builds a QueryRelationsFilter.
      *
-     * @param entityTypes the new entityTypes
+     * @return the queryRelationsFilter
      */
-    public void setEntityTypes(final QueryFilterType entityTypes) {
-      this.entity_types_serialized_name = entityTypes;
+    public QueryRelationsFilter build() {
+      return new QueryRelationsFilter(this);
     }
 
     /**
-     * Sets the documentIds.
+     * Adds an documentIds to documentIds.
      *
      * @param documentIds the new documentIds
+     * @return the QueryRelationsFilter builder
      */
-    public void setDocumentIds(final List<String> documentIds) {
-      this.document_ids_serialized_name = documentIds;
+    public QueryRelationsFilterBuilder addDocumentIds(String documentIds) {
+      IBMWatsonValidator.notNull(documentIds, 'documentIds cannot be null');
+      if (this.documentIds == null) {
+        this.documentIds = new List<String>();
+      }
+      this.documentIds.add(documentIds);
+      return this;
     }
 
+    /**
+     * Set the relationTypes.
+     *
+     * @param relationTypes the relationTypes
+     * @return the QueryRelationsFilter builder
+     */
+    public QueryRelationsFilterBuilder setRelationTypes(QueryFilterType relationTypes) {
+      this.relationTypes = relationTypes;
+      return this;
+    }
+
+    /**
+     * Set the entityTypes.
+     *
+     * @param entityTypes the entityTypes
+     * @return the QueryRelationsFilter builder
+     */
+    public QueryRelationsFilterBuilder setEntityTypes(QueryFilterType entityTypes) {
+      this.entityTypes = entityTypes;
+      return this;
+    }
+
+    /**
+     * Set the documentIds.
+     * Existing documentIds will be replaced.
+     *
+     * @param documentIds the documentIds
+     * @return the QueryRelationsFilter builder
+     */
+    public QueryRelationsFilterBuilder setDocumentIds(List<String> documentIds) {
+      this.documentIds = documentIds;
+      return this;
+    }
   }
 
   /**
@@ -17843,7 +20650,7 @@ public class IBMDiscoveryV1Models {
     private QueryRelationsFilter filter;
     private Long count;
     private Long evidenceCount;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -17854,7 +20661,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -17865,7 +20672,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -17876,7 +20683,7 @@ public class IBMDiscoveryV1Models {
     public List<QueryRelationsEntity> entities() {
       return entities;
     }
- 
+
     /**
      * Gets the context.
      *
@@ -17888,7 +20695,7 @@ public class IBMDiscoveryV1Models {
     public QueryEntitiesContext context() {
       return context;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -17901,7 +20708,7 @@ public class IBMDiscoveryV1Models {
     public String xsort() {
       return xsort;
     }
- 
+
     /**
      * Gets the filter.
      *
@@ -17910,7 +20717,7 @@ public class IBMDiscoveryV1Models {
     public QueryRelationsFilter filter() {
       return filter;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -17921,7 +20728,7 @@ public class IBMDiscoveryV1Models {
     public Long count() {
       return count;
     }
- 
+
     /**
      * Gets the evidenceCount.
      *
@@ -17957,6 +20764,20 @@ public class IBMDiscoveryV1Models {
       return new QueryRelationsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getSdkToApiMapping());
+      }
+      mapping.put('xsort', 'sort');
+      if (filter != null) {
+        mapping.putAll(filter.getSdkToApiMapping());
+      }
+      mapping.put('evidenceCount', 'evidence_count');
+      return mapping;
+    }
   }
 
   /**
@@ -18131,10 +20952,10 @@ public class IBMDiscoveryV1Models {
    * QueryRelationsRelationship.
    */
   public class QueryRelationsRelationship extends IBMWatsonGenericModel {
-    private String type_serialized_name;
-    private Long frequency_serialized_name;
-    private List<QueryRelationsArgument> arguments_serialized_name;
-    private List<QueryEvidence> evidence_serialized_name;
+    private String xtype;
+    private Long frequency;
+    private List<QueryRelationsArgument> arguments;
+    private List<QueryEvidence> evidence;
  
     /**
      * Gets the xtype.
@@ -18145,7 +20966,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -18157,7 +20978,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getFrequency() {
-      return frequency_serialized_name;
+      return frequency;
     }
  
     /**
@@ -18169,7 +20990,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryRelationsArgument> getArguments() {
-      return arguments_serialized_name;
+      return arguments;
     }
  
     /**
@@ -18181,7 +21002,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryEvidence> getEvidence() {
-      return evidence_serialized_name;
+      return evidence;
     }
 
     /**
@@ -18190,7 +21011,7 @@ public class IBMDiscoveryV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -18199,7 +21020,7 @@ public class IBMDiscoveryV1Models {
      * @param frequency the new frequency
      */
     public void setFrequency(final long frequency) {
-      this.frequency_serialized_name = frequency;
+      this.frequency = frequency;
     }
 
     /**
@@ -18208,7 +21029,7 @@ public class IBMDiscoveryV1Models {
      * @param arguments the new arguments
      */
     public void setArguments(final List<QueryRelationsArgument> arguments) {
-      this.arguments_serialized_name = arguments;
+      this.arguments = arguments;
     }
 
     /**
@@ -18217,7 +21038,7 @@ public class IBMDiscoveryV1Models {
      * @param evidence the new evidence
      */
     public void setEvidence(final List<QueryEvidence> evidence) {
-      this.evidence_serialized_name = evidence;
+      this.evidence = evidence;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -18233,11 +21054,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedArguments != null) {
         for (Integer i = 0; i < deserializedArguments.size(); i++) {
           QueryRelationsArgument currentItem = ret.getArguments().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('arguments_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('arguments');
           QueryRelationsArgument newItem = (QueryRelationsArgument) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryRelationsArgument.class);
           newArguments.add(newItem);
         }
-        ret.arguments_serialized_name = newArguments;
+        ret.arguments = newArguments;
       }
 
       // calling custom deserializer for evidence
@@ -18246,14 +21067,26 @@ public class IBMDiscoveryV1Models {
       if (deserializedEvidence != null) {
         for (Integer i = 0; i < deserializedEvidence.size(); i++) {
           QueryEvidence currentItem = ret.getEvidence().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('evidence_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('evidence');
           QueryEvidence newItem = (QueryEvidence) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryEvidence.class);
           newEvidence.add(newItem);
         }
-        ret.evidence_serialized_name = newEvidence;
+        ret.evidence = newEvidence;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      if (arguments != null && arguments[0] != null) {
+        mapping.putAll(arguments[0].getApiToSdkMapping());
+      }
+      if (evidence != null && evidence[0] != null) {
+        mapping.putAll(evidence[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -18261,7 +21094,7 @@ public class IBMDiscoveryV1Models {
    * QueryRelationsResponse.
    */
   public class QueryRelationsResponse extends IBMWatsonResponseModel {
-    private List<QueryRelationsRelationship> relations_serialized_name;
+    private List<QueryRelationsRelationship> relations;
  
     /**
      * Gets the relations.
@@ -18272,7 +21105,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryRelationsRelationship> getRelations() {
-      return relations_serialized_name;
+      return relations;
     }
 
     /**
@@ -18281,7 +21114,7 @@ public class IBMDiscoveryV1Models {
      * @param relations the new relations
      */
     public void setRelations(final List<QueryRelationsRelationship> relations) {
-      this.relations_serialized_name = relations;
+      this.relations = relations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -18297,14 +21130,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedRelations != null) {
         for (Integer i = 0; i < deserializedRelations.size(); i++) {
           QueryRelationsRelationship currentItem = ret.getRelations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('relations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('relations');
           QueryRelationsRelationship newItem = (QueryRelationsRelationship) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryRelationsRelationship.class);
           newRelations.add(newItem);
         }
-        ret.relations_serialized_name = newRelations;
+        ret.relations = newRelations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (relations != null && relations[0] != null) {
+        mapping.putAll(relations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -18312,13 +21153,13 @@ public class IBMDiscoveryV1Models {
    * A response containing the documents and aggregations for the query.
    */
   public class QueryResponse extends IBMWatsonResponseModel {
-    private Long matching_results_serialized_name;
-    private List<QueryResult> results_serialized_name;
-    private List<QueryAggregation> aggregations_serialized_name;
-    private List<QueryPassages> passages_serialized_name;
-    private Long duplicates_removed_serialized_name;
-    private String session_token_serialized_name;
-    private RetrievalDetails retrieval_details_serialized_name;
+    private Long matchingResults;
+    private List<QueryResult> results;
+    private List<QueryAggregation> aggregations;
+    private List<QueryPassages> passages;
+    private Long duplicatesRemoved;
+    private String sessionToken;
+    private RetrievalDetails retrievalDetails;
  
     /**
      * Gets the matchingResults.
@@ -18329,7 +21170,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMatchingResults() {
-      return matching_results_serialized_name;
+      return matchingResults;
     }
  
     /**
@@ -18341,7 +21182,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryResult> getResults() {
-      return results_serialized_name;
+      return results;
     }
  
     /**
@@ -18353,7 +21194,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryAggregation> getAggregations() {
-      return aggregations_serialized_name;
+      return aggregations;
     }
  
     /**
@@ -18365,7 +21206,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryPassages> getPassages() {
-      return passages_serialized_name;
+      return passages;
     }
  
     /**
@@ -18377,7 +21218,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getDuplicatesRemoved() {
-      return duplicates_removed_serialized_name;
+      return duplicatesRemoved;
     }
  
     /**
@@ -18392,7 +21233,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSessionToken() {
-      return session_token_serialized_name;
+      return sessionToken;
     }
  
     /**
@@ -18404,7 +21245,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public RetrievalDetails getRetrievalDetails() {
-      return retrieval_details_serialized_name;
+      return retrievalDetails;
     }
 
     /**
@@ -18413,7 +21254,7 @@ public class IBMDiscoveryV1Models {
      * @param matchingResults the new matchingResults
      */
     public void setMatchingResults(final long matchingResults) {
-      this.matching_results_serialized_name = matchingResults;
+      this.matchingResults = matchingResults;
     }
 
     /**
@@ -18422,7 +21263,7 @@ public class IBMDiscoveryV1Models {
      * @param results the new results
      */
     public void setResults(final List<QueryResult> results) {
-      this.results_serialized_name = results;
+      this.results = results;
     }
 
     /**
@@ -18431,7 +21272,7 @@ public class IBMDiscoveryV1Models {
      * @param aggregations the new aggregations
      */
     public void setAggregations(final List<QueryAggregation> aggregations) {
-      this.aggregations_serialized_name = aggregations;
+      this.aggregations = aggregations;
     }
 
     /**
@@ -18440,7 +21281,7 @@ public class IBMDiscoveryV1Models {
      * @param passages the new passages
      */
     public void setPassages(final List<QueryPassages> passages) {
-      this.passages_serialized_name = passages;
+      this.passages = passages;
     }
 
     /**
@@ -18449,7 +21290,7 @@ public class IBMDiscoveryV1Models {
      * @param duplicatesRemoved the new duplicatesRemoved
      */
     public void setDuplicatesRemoved(final long duplicatesRemoved) {
-      this.duplicates_removed_serialized_name = duplicatesRemoved;
+      this.duplicatesRemoved = duplicatesRemoved;
     }
 
     /**
@@ -18458,7 +21299,7 @@ public class IBMDiscoveryV1Models {
      * @param sessionToken the new sessionToken
      */
     public void setSessionToken(final String sessionToken) {
-      this.session_token_serialized_name = sessionToken;
+      this.sessionToken = sessionToken;
     }
 
     /**
@@ -18467,7 +21308,7 @@ public class IBMDiscoveryV1Models {
      * @param retrievalDetails the new retrievalDetails
      */
     public void setRetrievalDetails(final RetrievalDetails retrievalDetails) {
-      this.retrieval_details_serialized_name = retrievalDetails;
+      this.retrievalDetails = retrievalDetails;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -18483,11 +21324,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           QueryResult currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           QueryResult newItem = (QueryResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryResult.class);
           newResults.add(newItem);
         }
-        ret.results_serialized_name = newResults;
+        ret.results = newResults;
       }
 
       // calling custom deserializer for aggregations
@@ -18496,11 +21337,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedAggregations != null) {
         for (Integer i = 0; i < deserializedAggregations.size(); i++) {
           QueryAggregation currentItem = ret.getAggregations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('aggregations');
           QueryAggregation newItem = (QueryAggregation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryAggregation.class);
           newAggregations.add(newItem);
         }
-        ret.aggregations_serialized_name = newAggregations;
+        ret.aggregations = newAggregations;
       }
 
       // calling custom deserializer for passages
@@ -18509,18 +21350,39 @@ public class IBMDiscoveryV1Models {
       if (deserializedPassages != null) {
         for (Integer i = 0; i < deserializedPassages.size(); i++) {
           QueryPassages currentItem = ret.getPassages().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('passages_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('passages');
           QueryPassages newItem = (QueryPassages) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryPassages.class);
           newPassages.add(newItem);
         }
-        ret.passages_serialized_name = newPassages;
+        ret.passages = newPassages;
       }
 
       // calling custom deserializer for retrievalDetails
-      RetrievalDetails newRetrievalDetails = (RetrievalDetails) new RetrievalDetails().deserialize(JSON.serialize(ret.getRetrievalDetails()), (Map<String, Object>) jsonMap.get('retrieval_details_serialized_name'), RetrievalDetails.class);
+      RetrievalDetails newRetrievalDetails = (RetrievalDetails) new RetrievalDetails().deserialize(JSON.serialize(ret.getRetrievalDetails()), (Map<String, Object>) jsonMap.get('retrievalDetails'), RetrievalDetails.class);
       ret.setRetrievalDetails(newRetrievalDetails);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('matching_results', 'matchingResults');
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      if (aggregations != null && aggregations[0] != null) {
+        mapping.putAll(aggregations[0].getApiToSdkMapping());
+      }
+      if (passages != null && passages[0] != null) {
+        mapping.putAll(passages[0].getApiToSdkMapping());
+      }
+      mapping.put('duplicates_removed', 'duplicatesRemoved');
+      mapping.put('session_token', 'sessionToken');
+      mapping.put('retrieval_details', 'retrievalDetails');
+      if (retrievalDetails != null) {
+        mapping.putAll(retrievalDetails.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -18528,11 +21390,11 @@ public class IBMDiscoveryV1Models {
    * QueryResult.
    */
   public class QueryResult extends IBMWatsonDynamicModel {
-    private String id_serialized_name;
-    private IBMWatsonMapModel metadata_serialized_name;
-    private String collection_id_serialized_name;
-    private QueryResultMetadata result_metadata_serialized_name;
-    private String title_serialized_name;
+    private String id;
+    private IBMWatsonMapModel metadata;
+    private String collectionId;
+    private QueryResultMetadata resultMetadata;
+    private String title;
     private Map<String, Object> additional_properties_serialized_name;
 
     /**
@@ -18542,7 +21404,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getId() {
-      return id_serialized_name;
+      return id;
     }
 
     /**
@@ -18552,7 +21414,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public IBMWatsonMapModel getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
 
     /**
@@ -18562,7 +21424,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCollectionId() {
-      return collection_id_serialized_name;
+      return collectionId;
     }
 
     /**
@@ -18572,7 +21434,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public QueryResultMetadata getResultMetadata() {
-      return result_metadata_serialized_name;
+      return resultMetadata;
     }
 
     /**
@@ -18582,7 +21444,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
 
     /**
@@ -18601,7 +21463,7 @@ public class IBMDiscoveryV1Models {
      * @param id the new id
      */
     public void setId(final String id) {
-      this.id_serialized_name = id;
+      this.id = id;
     }
 
     /**
@@ -18610,7 +21472,7 @@ public class IBMDiscoveryV1Models {
      * @param metadata the new metadata
      */
     public void setMetadata(final IBMWatsonMapModel metadata) {
-      this.metadata_serialized_name = metadata;
+      this.metadata = metadata;
     }
 
     /**
@@ -18619,7 +21481,7 @@ public class IBMDiscoveryV1Models {
      * @param collectionId the new collectionId
      */
     public void setCollectionId(final String collectionId) {
-      this.collection_id_serialized_name = collectionId;
+      this.collectionId = collectionId;
     }
 
     /**
@@ -18628,7 +21490,7 @@ public class IBMDiscoveryV1Models {
      * @param resultMetadata the new resultMetadata
      */
     public void setResultMetadata(final QueryResultMetadata resultMetadata) {
-      this.result_metadata_serialized_name = resultMetadata;
+      this.resultMetadata = resultMetadata;
     }
 
     /**
@@ -18637,7 +21499,7 @@ public class IBMDiscoveryV1Models {
      * @param title the new title
      */
     public void setTitle(final String title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -18648,11 +21510,11 @@ public class IBMDiscoveryV1Models {
       QueryResult ret = (QueryResult) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for metadata
-      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), IBMWatsonMapModel.class);
+      IBMWatsonMapModel newMetadata = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), IBMWatsonMapModel.class);
       ret.setMetadata(newMetadata);
 
       // calling custom deserializer for resultMetadata
-      QueryResultMetadata newResultMetadata = (QueryResultMetadata) new QueryResultMetadata().deserialize(JSON.serialize(ret.getResultMetadata()), (Map<String, Object>) jsonMap.get('result_metadata_serialized_name'), QueryResultMetadata.class);
+      QueryResultMetadata newResultMetadata = (QueryResultMetadata) new QueryResultMetadata().deserialize(JSON.serialize(ret.getResultMetadata()), (Map<String, Object>) jsonMap.get('resultMetadata'), QueryResultMetadata.class);
       ret.setResultMetadata(newResultMetadata);
 
       Set<String> baseProps = ((Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this))).keySet();
@@ -18665,14 +21527,21 @@ public class IBMDiscoveryV1Models {
 
       return ret;
     }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('collection_id', 'collectionId');
+      mapping.put('result_metadata', 'resultMetadata');
+      return mapping;
+    }
   }
 
   /**
    * Metadata of a query result.
    */
   public class QueryResultMetadata extends IBMWatsonGenericModel {
-    private Double score_serialized_name;
-    private Double confidence_serialized_name;
+    private Double score;
+    private Double confidence;
  
     /**
      * Gets the score.
@@ -18684,7 +21553,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
  
     /**
@@ -18699,7 +21568,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
 
     /**
@@ -18708,7 +21577,7 @@ public class IBMDiscoveryV1Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
 
     /**
@@ -18717,16 +21586,15 @@ public class IBMDiscoveryV1Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
-
   }
 
   /**
    * An object contain retrieval type information.
    */
   public class RetrievalDetails extends IBMWatsonGenericModel {
-    private String document_retrieval_strategy_serialized_name;
+    private String documentRetrievalStrategy;
  
     /**
      * Gets the documentRetrievalStrategy.
@@ -18743,7 +21611,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentRetrievalStrategy() {
-      return document_retrieval_strategy_serialized_name;
+      return documentRetrievalStrategy;
     }
 
     /**
@@ -18752,20 +21620,25 @@ public class IBMDiscoveryV1Models {
      * @param documentRetrievalStrategy the new documentRetrievalStrategy
      */
     public void setDocumentRetrievalStrategy(final String documentRetrievalStrategy) {
-      this.document_retrieval_strategy_serialized_name = documentRetrievalStrategy;
+      this.documentRetrievalStrategy = documentRetrievalStrategy;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_retrieval_strategy', 'documentRetrievalStrategy');
+      return mapping;
+    }
   }
 
   /**
    * Object containing smart document understanding information for this collection.
    */
   public class SduStatus extends IBMWatsonGenericModel {
-    private Boolean enabled_serialized_name;
-    private Long total_annotated_pages_serialized_name;
-    private Long total_pages_serialized_name;
-    private Long total_documents_serialized_name;
-    private SduStatusCustomFields custom_fields_serialized_name;
+    private Boolean enabled;
+    private Long totalAnnotatedPages;
+    private Long totalPages;
+    private Long totalDocuments;
+    private SduStatusCustomFields customFields;
  
     /**
      * Gets the enabled.
@@ -18779,7 +21652,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getEnabled() {
-      return enabled_serialized_name;
+      return enabled;
     }
  
     /**
@@ -18791,7 +21664,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getTotalAnnotatedPages() {
-      return total_annotated_pages_serialized_name;
+      return totalAnnotatedPages;
     }
  
     /**
@@ -18804,7 +21677,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getTotalPages() {
-      return total_pages_serialized_name;
+      return totalPages;
     }
  
     /**
@@ -18820,7 +21693,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getTotalDocuments() {
-      return total_documents_serialized_name;
+      return totalDocuments;
     }
  
     /**
@@ -18832,7 +21705,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public SduStatusCustomFields getCustomFields() {
-      return custom_fields_serialized_name;
+      return customFields;
     }
 
     /**
@@ -18841,7 +21714,7 @@ public class IBMDiscoveryV1Models {
      * @param enabled the new enabled
      */
     public void setEnabled(final Boolean enabled) {
-      this.enabled_serialized_name = enabled;
+      this.enabled = enabled;
     }
 
     /**
@@ -18850,7 +21723,7 @@ public class IBMDiscoveryV1Models {
      * @param totalAnnotatedPages the new totalAnnotatedPages
      */
     public void setTotalAnnotatedPages(final long totalAnnotatedPages) {
-      this.total_annotated_pages_serialized_name = totalAnnotatedPages;
+      this.totalAnnotatedPages = totalAnnotatedPages;
     }
 
     /**
@@ -18859,7 +21732,7 @@ public class IBMDiscoveryV1Models {
      * @param totalPages the new totalPages
      */
     public void setTotalPages(final long totalPages) {
-      this.total_pages_serialized_name = totalPages;
+      this.totalPages = totalPages;
     }
 
     /**
@@ -18868,7 +21741,7 @@ public class IBMDiscoveryV1Models {
      * @param totalDocuments the new totalDocuments
      */
     public void setTotalDocuments(final long totalDocuments) {
-      this.total_documents_serialized_name = totalDocuments;
+      this.totalDocuments = totalDocuments;
     }
 
     /**
@@ -18877,7 +21750,7 @@ public class IBMDiscoveryV1Models {
      * @param customFields the new customFields
      */
     public void setCustomFields(final SduStatusCustomFields customFields) {
-      this.custom_fields_serialized_name = customFields;
+      this.customFields = customFields;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -18888,10 +21761,22 @@ public class IBMDiscoveryV1Models {
       SduStatus ret = (SduStatus) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for customFields
-      SduStatusCustomFields newCustomFields = (SduStatusCustomFields) new SduStatusCustomFields().deserialize(JSON.serialize(ret.getCustomFields()), (Map<String, Object>) jsonMap.get('custom_fields_serialized_name'), SduStatusCustomFields.class);
+      SduStatusCustomFields newCustomFields = (SduStatusCustomFields) new SduStatusCustomFields().deserialize(JSON.serialize(ret.getCustomFields()), (Map<String, Object>) jsonMap.get('customFields'), SduStatusCustomFields.class);
       ret.setCustomFields(newCustomFields);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('total_annotated_pages', 'totalAnnotatedPages');
+      mapping.put('total_pages', 'totalPages');
+      mapping.put('total_documents', 'totalDocuments');
+      mapping.put('custom_fields', 'customFields');
+      if (customFields != null) {
+        mapping.putAll(customFields.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -18899,8 +21784,8 @@ public class IBMDiscoveryV1Models {
    * Information about custom smart document understanding fields that exist in this collection.
    */
   public class SduStatusCustomFields extends IBMWatsonGenericModel {
-    private Long defined_serialized_name;
-    private Long maximum_allowed_serialized_name;
+    private Long defined;
+    private Long maximumAllowed;
  
     /**
      * Gets the defined.
@@ -18909,8 +21794,9 @@ public class IBMDiscoveryV1Models {
      *
      * @return the defined
      */
+    @AuraEnabled
     public Long getDefined() {
-      return defined_serialized_name;
+      return defined;
     }
  
     /**
@@ -18920,8 +21806,9 @@ public class IBMDiscoveryV1Models {
      *
      * @return the maximumAllowed
      */
+    @AuraEnabled
     public Long getMaximumAllowed() {
-      return maximum_allowed_serialized_name;
+      return maximumAllowed;
     }
 
     /**
@@ -18930,7 +21817,7 @@ public class IBMDiscoveryV1Models {
      * @param defined the new defined
      */
     public void setDefined(final long defined) {
-      this.defined_serialized_name = defined;
+      this.defined = defined;
     }
 
     /**
@@ -18939,19 +21826,24 @@ public class IBMDiscoveryV1Models {
      * @param maximumAllowed the new maximumAllowed
      */
     public void setMaximumAllowed(final long maximumAllowed) {
-      this.maximum_allowed_serialized_name = maximumAllowed;
+      this.maximumAllowed = maximumAllowed;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('maximum_allowed', 'maximumAllowed');
+      return mapping;
+    }
   }
 
   /**
    * Information about the Continuous Relevancy Training for this environment.
    */
   public class SearchStatus extends IBMWatsonGenericModel {
-    private String scope_serialized_name;
-    private String status_serialized_name;
-    private String status_description_serialized_name;
-    private Datetime last_trained_serialized_name;
+    private String scope;
+    private String status;
+    private String statusDescription;
+    private Datetime lastTrained;
  
     /**
      * Gets the scope.
@@ -18962,7 +21854,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getScope() {
-      return scope_serialized_name;
+      return scope;
     }
  
     /**
@@ -18974,7 +21866,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -18986,7 +21878,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatusDescription() {
-      return status_description_serialized_name;
+      return statusDescription;
     }
  
     /**
@@ -18998,7 +21890,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getLastTrained() {
-      return last_trained_serialized_name;
+      return lastTrained;
     }
 
     /**
@@ -19007,7 +21899,7 @@ public class IBMDiscoveryV1Models {
      * @param scope the new scope
      */
     public void setScope(final String scope) {
-      this.scope_serialized_name = scope;
+      this.scope = scope;
     }
 
     /**
@@ -19016,7 +21908,7 @@ public class IBMDiscoveryV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -19025,7 +21917,7 @@ public class IBMDiscoveryV1Models {
      * @param statusDescription the new statusDescription
      */
     public void setStatusDescription(final String statusDescription) {
-      this.status_description_serialized_name = statusDescription;
+      this.statusDescription = statusDescription;
     }
 
     /**
@@ -19034,18 +21926,30 @@ public class IBMDiscoveryV1Models {
      * @param lastTrained the new lastTrained
      */
     public void setLastTrained(final Datetime lastTrained) {
-      this.last_trained_serialized_name = lastTrained;
+      this.lastTrained = lastTrained;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('status_description', 'statusDescription');
+      mapping.put('last_trained', 'lastTrained');
+      return mapping;
+    }
   }
 
   /**
    * A list of Document Segmentation settings.
    */
   public class SegmentSettings extends IBMWatsonGenericModel {
-    private Boolean enabled_serialized_name;
-    private List<String> selector_tags_serialized_name;
-    private List<String> annotated_fields_serialized_name;
+    private Boolean enabled;
+    private List<String> selectorTags;
+    private List<String> annotatedFields;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public SegmentSettings() { }
  
     /**
      * Gets the enabled.
@@ -19056,7 +21960,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getEnabled() {
-      return enabled_serialized_name;
+      return enabled;
     }
  
     /**
@@ -19071,7 +21975,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getSelectorTags() {
-      return selector_tags_serialized_name;
+      return selectorTags;
     }
  
     /**
@@ -19089,46 +21993,148 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getAnnotatedFields() {
-      return annotated_fields_serialized_name;
+      return annotatedFields;
+    }
+  
+    private SegmentSettings(SegmentSettingsBuilder builder) {
+      this.enabled = builder.enabled;
+      this.selectorTags = builder.selectorTags;
+      this.annotatedFields = builder.annotatedFields;
     }
 
     /**
-     * Sets the enabled.
+     * New builder.
      *
-     * @param enabled the new enabled
+     * @return a SegmentSettings builder
      */
-    public void setEnabled(final Boolean enabled) {
-      this.enabled_serialized_name = enabled;
+    public SegmentSettingsBuilder newBuilder() {
+      return new SegmentSettingsBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('selectorTags', 'selector_tags');
+      mapping.put('annotatedFields', 'annotated_fields');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('selector_tags', 'selectorTags');
+      mapping.put('annotated_fields', 'annotatedFields');
+      return mapping;
+    }
+  }
+
+  /**
+   * SegmentSettings Builder.
+   */
+  public class SegmentSettingsBuilder {
+    private Boolean enabled;
+    private List<String> selectorTags;
+    private List<String> annotatedFields;
+
+    private SegmentSettingsBuilder(SegmentSettings segmentSettings) {
+      this.enabled = segmentSettings.enabled;
+      this.selectorTags = segmentSettings.selectorTags;
+      this.annotatedFields = segmentSettings.annotatedFields;
     }
 
     /**
-     * Sets the selectorTags.
+     * Instantiates a new builder.
+     */
+    public SegmentSettingsBuilder() {
+    }
+
+    /**
+     * Builds a SegmentSettings.
+     *
+     * @return the segmentSettings
+     */
+    public SegmentSettings build() {
+      return new SegmentSettings(this);
+    }
+
+    /**
+     * Adds an selectorTags to selectorTags.
      *
      * @param selectorTags the new selectorTags
+     * @return the SegmentSettings builder
      */
-    public void setSelectorTags(final List<String> selectorTags) {
-      this.selector_tags_serialized_name = selectorTags;
+    public SegmentSettingsBuilder addSelectorTags(String selectorTags) {
+      IBMWatsonValidator.notNull(selectorTags, 'selectorTags cannot be null');
+      if (this.selectorTags == null) {
+        this.selectorTags = new List<String>();
+      }
+      this.selectorTags.add(selectorTags);
+      return this;
     }
 
     /**
-     * Sets the annotatedFields.
+     * Adds an annotatedFields to annotatedFields.
      *
      * @param annotatedFields the new annotatedFields
+     * @return the SegmentSettings builder
      */
-    public void setAnnotatedFields(final List<String> annotatedFields) {
-      this.annotated_fields_serialized_name = annotatedFields;
+    public SegmentSettingsBuilder addAnnotatedFields(String annotatedFields) {
+      IBMWatsonValidator.notNull(annotatedFields, 'annotatedFields cannot be null');
+      if (this.annotatedFields == null) {
+        this.annotatedFields = new List<String>();
+      }
+      this.annotatedFields.add(annotatedFields);
+      return this;
     }
 
+    /**
+     * Set the enabled.
+     *
+     * @param enabled the enabled
+     * @return the SegmentSettings builder
+     */
+    public SegmentSettingsBuilder setEnabled(Boolean enabled) {
+      this.enabled = enabled;
+      return this;
+    }
+
+    /**
+     * Set the selectorTags.
+     * Existing selectorTags will be replaced.
+     *
+     * @param selectorTags the selectorTags
+     * @return the SegmentSettings builder
+     */
+    public SegmentSettingsBuilder setSelectorTags(List<String> selectorTags) {
+      this.selectorTags = selectorTags;
+      return this;
+    }
+
+    /**
+     * Set the annotatedFields.
+     * Existing annotatedFields will be replaced.
+     *
+     * @param annotatedFields the annotatedFields
+     * @return the SegmentSettings builder
+     */
+    public SegmentSettingsBuilder setAnnotatedFields(List<String> annotatedFields) {
+      this.annotatedFields = annotatedFields;
+      return this;
+    }
   }
 
   /**
    * Object containing source parameters for the configuration.
    */
   public class Source extends IBMWatsonGenericModel {
-    private String type_serialized_name;
-    private String credential_id_serialized_name;
-    private SourceSchedule schedule_serialized_name;
-    private SourceOptions options_serialized_name;
+    private String xtype;
+    private String credentialId;
+    private SourceSchedule schedule;
+    private SourceOptions options;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Source() { }
  
     /**
      * Gets the xtype.
@@ -19144,7 +22150,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -19158,7 +22164,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCredentialId() {
-      return credential_id_serialized_name;
+      return credentialId;
     }
  
     /**
@@ -19170,7 +22176,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public SourceSchedule getSchedule() {
-      return schedule_serialized_name;
+      return schedule;
     }
  
     /**
@@ -19182,43 +22188,23 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public SourceOptions getOptions() {
-      return options_serialized_name;
+      return options;
+    }
+  
+    private Source(SourceBuilder builder) {
+      this.xtype = builder.xtype;
+      this.credentialId = builder.credentialId;
+      this.schedule = builder.schedule;
+      this.options = builder.options;
     }
 
     /**
-     * Sets the xtype.
+     * New builder.
      *
-     * @param xtype the new xtype
+     * @return a Source builder
      */
-    public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
-    }
-
-    /**
-     * Sets the credentialId.
-     *
-     * @param credentialId the new credentialId
-     */
-    public void setCredentialId(final String credentialId) {
-      this.credential_id_serialized_name = credentialId;
-    }
-
-    /**
-     * Sets the schedule.
-     *
-     * @param schedule the new schedule
-     */
-    public void setSchedule(final SourceSchedule schedule) {
-      this.schedule_serialized_name = schedule;
-    }
-
-    /**
-     * Sets the options.
-     *
-     * @param options the new options
-     */
-    public void setOptions(final SourceOptions options) {
-      this.options_serialized_name = options;
+    public SourceBuilder newBuilder() {
+      return new SourceBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -19227,16 +22213,119 @@ public class IBMDiscoveryV1Models {
       }
 
       Source ret = (Source) super.deserialize(jsonString, jsonMap, classType);
+      SourceBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for schedule
-      SourceSchedule newSchedule = (SourceSchedule) new SourceSchedule().deserialize(JSON.serialize(ret.getSchedule()), (Map<String, Object>) jsonMap.get('schedule_serialized_name'), SourceSchedule.class);
-      ret.setSchedule(newSchedule);
+      SourceSchedule newSchedule = (SourceSchedule) new SourceSchedule().deserialize(JSON.serialize(ret.getSchedule()), (Map<String, Object>) jsonMap.get('schedule'), SourceSchedule.class);
+      retBuilder.setSchedule(newSchedule);
 
       // calling custom deserializer for options
-      SourceOptions newOptions = (SourceOptions) new SourceOptions().deserialize(JSON.serialize(ret.getOptions()), (Map<String, Object>) jsonMap.get('options_serialized_name'), SourceOptions.class);
-      ret.setOptions(newOptions);
+      SourceOptions newOptions = (SourceOptions) new SourceOptions().deserialize(JSON.serialize(ret.getOptions()), (Map<String, Object>) jsonMap.get('options'), SourceOptions.class);
+      retBuilder.setOptions(newOptions);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xtype', 'type');
+      mapping.put('credentialId', 'credential_id');
+      if (schedule != null) {
+        mapping.putAll(schedule.getSdkToApiMapping());
+      }
+      if (options != null) {
+        mapping.putAll(options.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      mapping.put('credential_id', 'credentialId');
+      if (schedule != null) {
+        mapping.putAll(schedule.getApiToSdkMapping());
+      }
+      if (options != null) {
+        mapping.putAll(options.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * Source Builder.
+   */
+  public class SourceBuilder {
+    private String xtype;
+    private String credentialId;
+    private SourceSchedule schedule;
+    private SourceOptions options;
+
+    private SourceBuilder(Source source) {
+      this.xtype = source.xtype;
+      this.credentialId = source.credentialId;
+      this.schedule = source.schedule;
+      this.options = source.options;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public SourceBuilder() {
+    }
+
+    /**
+     * Builds a Source.
+     *
+     * @return the source
+     */
+    public Source build() {
+      return new Source(this);
+    }
+
+    /**
+     * Set the xtype.
+     *
+     * @param xtype the xtype
+     * @return the Source builder
+     */
+    public SourceBuilder setXtype(String xtype) {
+      this.xtype = xtype;
+      return this;
+    }
+
+    /**
+     * Set the credentialId.
+     *
+     * @param credentialId the credentialId
+     * @return the Source builder
+     */
+    public SourceBuilder setCredentialId(String credentialId) {
+      this.credentialId = credentialId;
+      return this;
+    }
+
+    /**
+     * Set the schedule.
+     *
+     * @param schedule the schedule
+     * @return the Source builder
+     */
+    public SourceBuilder setSchedule(SourceSchedule schedule) {
+      this.schedule = schedule;
+      return this;
+    }
+
+    /**
+     * Set the options.
+     *
+     * @param options the options
+     * @return the Source builder
+     */
+    public SourceBuilder setOptions(SourceOptions options) {
+      this.options = options;
+      return this;
     }
   }
 
@@ -19244,12 +22333,18 @@ public class IBMDiscoveryV1Models {
    * The **options** object defines which items to crawl from the source system.
    */
   public class SourceOptions extends IBMWatsonGenericModel {
-    private List<SourceOptionsFolder> folders_serialized_name;
-    private List<SourceOptionsObject> objects_serialized_name;
-    private List<SourceOptionsSiteColl> site_collections_serialized_name;
-    private List<SourceOptionsWebCrawl> urls_serialized_name;
-    private List<SourceOptionsBuckets> buckets_serialized_name;
-    private Boolean crawl_all_buckets_serialized_name;
+    private List<SourceOptionsFolder> folders;
+    private List<SourceOptionsObject> objects;
+    private List<SourceOptionsSiteColl> siteCollections;
+    private List<SourceOptionsWebCrawl> urls;
+    private List<SourceOptionsBuckets> buckets;
+    private Boolean crawlAllBuckets;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public SourceOptions() { }
  
     /**
      * Gets the folders.
@@ -19261,7 +22356,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<SourceOptionsFolder> getFolders() {
-      return folders_serialized_name;
+      return folders;
     }
  
     /**
@@ -19274,7 +22369,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<SourceOptionsObject> getObjects() {
-      return objects_serialized_name;
+      return objects;
     }
  
     /**
@@ -19287,7 +22382,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<SourceOptionsSiteColl> getSiteCollections() {
-      return site_collections_serialized_name;
+      return siteCollections;
     }
  
     /**
@@ -19300,7 +22395,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<SourceOptionsWebCrawl> getUrls() {
-      return urls_serialized_name;
+      return urls;
     }
  
     /**
@@ -19314,7 +22409,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<SourceOptionsBuckets> getBuckets() {
-      return buckets_serialized_name;
+      return buckets;
     }
  
     /**
@@ -19327,61 +22422,25 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getCrawlAllBuckets() {
-      return crawl_all_buckets_serialized_name;
+      return crawlAllBuckets;
+    }
+  
+    private SourceOptions(SourceOptionsBuilder builder) {
+      this.folders = builder.folders;
+      this.objects = builder.objects;
+      this.siteCollections = builder.siteCollections;
+      this.urls = builder.urls;
+      this.buckets = builder.buckets;
+      this.crawlAllBuckets = builder.crawlAllBuckets;
     }
 
     /**
-     * Sets the folders.
+     * New builder.
      *
-     * @param folders the new folders
+     * @return a SourceOptions builder
      */
-    public void setFolders(final List<SourceOptionsFolder> folders) {
-      this.folders_serialized_name = folders;
-    }
-
-    /**
-     * Sets the objects.
-     *
-     * @param objects the new objects
-     */
-    public void setObjects(final List<SourceOptionsObject> objects) {
-      this.objects_serialized_name = objects;
-    }
-
-    /**
-     * Sets the siteCollections.
-     *
-     * @param siteCollections the new siteCollections
-     */
-    public void setSiteCollections(final List<SourceOptionsSiteColl> siteCollections) {
-      this.site_collections_serialized_name = siteCollections;
-    }
-
-    /**
-     * Sets the urls.
-     *
-     * @param urls the new urls
-     */
-    public void setUrls(final List<SourceOptionsWebCrawl> urls) {
-      this.urls_serialized_name = urls;
-    }
-
-    /**
-     * Sets the buckets.
-     *
-     * @param buckets the new buckets
-     */
-    public void setBuckets(final List<SourceOptionsBuckets> buckets) {
-      this.buckets_serialized_name = buckets;
-    }
-
-    /**
-     * Sets the crawlAllBuckets.
-     *
-     * @param crawlAllBuckets the new crawlAllBuckets
-     */
-    public void setCrawlAllBuckets(final Boolean crawlAllBuckets) {
-      this.crawl_all_buckets_serialized_name = crawlAllBuckets;
+    public SourceOptionsBuilder newBuilder() {
+      return new SourceOptionsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -19390,6 +22449,7 @@ public class IBMDiscoveryV1Models {
       }
 
       SourceOptions ret = (SourceOptions) super.deserialize(jsonString, jsonMap, classType);
+      SourceOptionsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for folders
       List<SourceOptionsFolder> newFolders = new List<SourceOptionsFolder>();
@@ -19397,11 +22457,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedFolders != null) {
         for (Integer i = 0; i < deserializedFolders.size(); i++) {
           SourceOptionsFolder currentItem = ret.getFolders().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('folders_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('folders');
           SourceOptionsFolder newItem = (SourceOptionsFolder) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsFolder.class);
           newFolders.add(newItem);
         }
-        ret.folders_serialized_name = newFolders;
+        retBuilder.setFolders(newFolders);
       }
 
       // calling custom deserializer for objects
@@ -19410,11 +22470,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedObjects != null) {
         for (Integer i = 0; i < deserializedObjects.size(); i++) {
           SourceOptionsObject currentItem = ret.getObjects().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('objects_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('objects');
           SourceOptionsObject newItem = (SourceOptionsObject) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsObject.class);
           newObjects.add(newItem);
         }
-        ret.objects_serialized_name = newObjects;
+        retBuilder.setObjects(newObjects);
       }
 
       // calling custom deserializer for siteCollections
@@ -19423,11 +22483,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedSiteCollections != null) {
         for (Integer i = 0; i < deserializedSiteCollections.size(); i++) {
           SourceOptionsSiteColl currentItem = ret.getSiteCollections().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('site_collections_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('siteCollections');
           SourceOptionsSiteColl newItem = (SourceOptionsSiteColl) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsSiteColl.class);
           newSiteCollections.add(newItem);
         }
-        ret.site_collections_serialized_name = newSiteCollections;
+        retBuilder.setSiteCollections(newSiteCollections);
       }
 
       // calling custom deserializer for urls
@@ -19436,11 +22496,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedUrls != null) {
         for (Integer i = 0; i < deserializedUrls.size(); i++) {
           SourceOptionsWebCrawl currentItem = ret.getUrls().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('urls_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('urls');
           SourceOptionsWebCrawl newItem = (SourceOptionsWebCrawl) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsWebCrawl.class);
           newUrls.add(newItem);
         }
-        ret.urls_serialized_name = newUrls;
+        retBuilder.setUrls(newUrls);
       }
 
       // calling custom deserializer for buckets
@@ -19449,14 +22509,240 @@ public class IBMDiscoveryV1Models {
       if (deserializedBuckets != null) {
         for (Integer i = 0; i < deserializedBuckets.size(); i++) {
           SourceOptionsBuckets currentItem = ret.getBuckets().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('buckets_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('buckets');
           SourceOptionsBuckets newItem = (SourceOptionsBuckets) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SourceOptionsBuckets.class);
           newBuckets.add(newItem);
         }
-        ret.buckets_serialized_name = newBuckets;
+        retBuilder.setBuckets(newBuckets);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (folders != null && folders[0] != null) {
+        mapping.putAll(folders[0].getSdkToApiMapping());
+      }
+      if (objects != null && objects[0] != null) {
+        mapping.putAll(objects[0].getSdkToApiMapping());
+      }
+      mapping.put('siteCollections', 'site_collections');
+      if (siteCollections != null && siteCollections[0] != null) {
+        mapping.putAll(siteCollections[0].getSdkToApiMapping());
+      }
+      if (urls != null && urls[0] != null) {
+        mapping.putAll(urls[0].getSdkToApiMapping());
+      }
+      if (buckets != null && buckets[0] != null) {
+        mapping.putAll(buckets[0].getSdkToApiMapping());
+      }
+      mapping.put('crawlAllBuckets', 'crawl_all_buckets');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (folders != null && folders[0] != null) {
+        mapping.putAll(folders[0].getApiToSdkMapping());
+      }
+      if (objects != null && objects[0] != null) {
+        mapping.putAll(objects[0].getApiToSdkMapping());
+      }
+      mapping.put('site_collections', 'siteCollections');
+      if (siteCollections != null && siteCollections[0] != null) {
+        mapping.putAll(siteCollections[0].getApiToSdkMapping());
+      }
+      if (urls != null && urls[0] != null) {
+        mapping.putAll(urls[0].getApiToSdkMapping());
+      }
+      if (buckets != null && buckets[0] != null) {
+        mapping.putAll(buckets[0].getApiToSdkMapping());
+      }
+      mapping.put('crawl_all_buckets', 'crawlAllBuckets');
+      return mapping;
+    }
+  }
+
+  /**
+   * SourceOptions Builder.
+   */
+  public class SourceOptionsBuilder {
+    private List<SourceOptionsFolder> folders;
+    private List<SourceOptionsObject> objects;
+    private List<SourceOptionsSiteColl> siteCollections;
+    private List<SourceOptionsWebCrawl> urls;
+    private List<SourceOptionsBuckets> buckets;
+    private Boolean crawlAllBuckets;
+
+    private SourceOptionsBuilder(SourceOptions sourceOptions) {
+      this.folders = sourceOptions.folders;
+      this.objects = sourceOptions.objects;
+      this.siteCollections = sourceOptions.siteCollections;
+      this.urls = sourceOptions.urls;
+      this.buckets = sourceOptions.buckets;
+      this.crawlAllBuckets = sourceOptions.crawlAllBuckets;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public SourceOptionsBuilder() {
+    }
+
+    /**
+     * Builds a SourceOptions.
+     *
+     * @return the sourceOptions
+     */
+    public SourceOptions build() {
+      return new SourceOptions(this);
+    }
+
+    /**
+     * Adds an folders to folders.
+     *
+     * @param folders the new folders
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder addFolders(SourceOptionsFolder folders) {
+      IBMWatsonValidator.notNull(folders, 'folders cannot be null');
+      if (this.folders == null) {
+        this.folders = new List<SourceOptionsFolder>();
+      }
+      this.folders.add(folders);
+      return this;
+    }
+
+    /**
+     * Adds an objects to objects.
+     *
+     * @param objects the new objects
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder addObjects(SourceOptionsObject objects) {
+      IBMWatsonValidator.notNull(objects, 'objects cannot be null');
+      if (this.objects == null) {
+        this.objects = new List<SourceOptionsObject>();
+      }
+      this.objects.add(objects);
+      return this;
+    }
+
+    /**
+     * Adds an siteCollections to siteCollections.
+     *
+     * @param siteCollections the new siteCollections
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder addSiteCollections(SourceOptionsSiteColl siteCollections) {
+      IBMWatsonValidator.notNull(siteCollections, 'siteCollections cannot be null');
+      if (this.siteCollections == null) {
+        this.siteCollections = new List<SourceOptionsSiteColl>();
+      }
+      this.siteCollections.add(siteCollections);
+      return this;
+    }
+
+    /**
+     * Adds an urls to urls.
+     *
+     * @param urls the new urls
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder addUrls(SourceOptionsWebCrawl urls) {
+      IBMWatsonValidator.notNull(urls, 'urls cannot be null');
+      if (this.urls == null) {
+        this.urls = new List<SourceOptionsWebCrawl>();
+      }
+      this.urls.add(urls);
+      return this;
+    }
+
+    /**
+     * Adds an buckets to buckets.
+     *
+     * @param buckets the new buckets
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder addBuckets(SourceOptionsBuckets buckets) {
+      IBMWatsonValidator.notNull(buckets, 'buckets cannot be null');
+      if (this.buckets == null) {
+        this.buckets = new List<SourceOptionsBuckets>();
+      }
+      this.buckets.add(buckets);
+      return this;
+    }
+
+    /**
+     * Set the folders.
+     * Existing folders will be replaced.
+     *
+     * @param folders the folders
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder setFolders(List<SourceOptionsFolder> folders) {
+      this.folders = folders;
+      return this;
+    }
+
+    /**
+     * Set the objects.
+     * Existing objects will be replaced.
+     *
+     * @param objects the objects
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder setObjects(List<SourceOptionsObject> objects) {
+      this.objects = objects;
+      return this;
+    }
+
+    /**
+     * Set the siteCollections.
+     * Existing siteCollections will be replaced.
+     *
+     * @param siteCollections the siteCollections
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder setSiteCollections(List<SourceOptionsSiteColl> siteCollections) {
+      this.siteCollections = siteCollections;
+      return this;
+    }
+
+    /**
+     * Set the urls.
+     * Existing urls will be replaced.
+     *
+     * @param urls the urls
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder setUrls(List<SourceOptionsWebCrawl> urls) {
+      this.urls = urls;
+      return this;
+    }
+
+    /**
+     * Set the buckets.
+     * Existing buckets will be replaced.
+     *
+     * @param buckets the buckets
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder setBuckets(List<SourceOptionsBuckets> buckets) {
+      this.buckets = buckets;
+      return this;
+    }
+
+    /**
+     * Set the crawlAllBuckets.
+     *
+     * @param crawlAllBuckets the crawlAllBuckets
+     * @return the SourceOptions builder
+     */
+    public SourceOptionsBuilder setCrawlAllBuckets(Boolean crawlAllBuckets) {
+      this.crawlAllBuckets = crawlAllBuckets;
+      return this;
     }
   }
 
@@ -19464,8 +22750,14 @@ public class IBMDiscoveryV1Models {
    * Object defining a cloud object store bucket to crawl.
    */
   public class SourceOptionsBuckets extends IBMWatsonGenericModel {
-    private String name_serialized_name;
-    private Long limit_serialized_name;
+    private String name;
+    private Long xlimit;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public SourceOptionsBuckets() { }
  
     /**
      * Gets the name.
@@ -19476,7 +22768,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -19489,36 +22781,109 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getXlimit() {
-      return limit_serialized_name;
+      return xlimit;
+    }
+  
+    private SourceOptionsBuckets(SourceOptionsBucketsBuilder builder) {
+      IBMWatsonValidator.notNull(builder.name, 'name cannot be null');
+      this.name = builder.name;
+      this.xlimit = builder.xlimit;
     }
 
     /**
-     * Sets the name.
+     * New builder.
      *
-     * @param name the new name
+     * @return a SourceOptionsBuckets builder
      */
-    public void setName(final String name) {
-      this.name_serialized_name = name;
+    public SourceOptionsBucketsBuilder newBuilder() {
+      return new SourceOptionsBucketsBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('limit', 'xlimit');
+      return mapping;
+    }
+  }
+
+  /**
+   * SourceOptionsBuckets Builder.
+   */
+  public class SourceOptionsBucketsBuilder {
+    private String name;
+    private Long xlimit;
+
+    private SourceOptionsBucketsBuilder(SourceOptionsBuckets sourceOptionsBuckets) {
+      this.name = sourceOptionsBuckets.name;
+      this.xlimit = sourceOptionsBuckets.xlimit;
     }
 
     /**
-     * Sets the xlimit.
-     *
-     * @param xlimit the new xlimit
+     * Instantiates a new builder.
      */
-    public void setXlimit(final long xlimit) {
-      this.limit_serialized_name = xlimit;
+    public SourceOptionsBucketsBuilder() {
     }
 
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param name the name
+     */
+    public SourceOptionsBucketsBuilder(String name) {
+      this.name = name;
+    }
+
+    /**
+     * Builds a SourceOptionsBuckets.
+     *
+     * @return the sourceOptionsBuckets
+     */
+    public SourceOptionsBuckets build() {
+      return new SourceOptionsBuckets(this);
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the SourceOptionsBuckets builder
+     */
+    public SourceOptionsBucketsBuilder setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the xlimit.
+     *
+     * @param xlimit the xlimit
+     * @return the SourceOptionsBuckets builder
+     */
+    public SourceOptionsBucketsBuilder setXlimit(Long xlimit) {
+      this.xlimit = xlimit;
+      return this;
+    }
   }
 
   /**
    * Object that defines a box folder to crawl with this configuration.
    */
   public class SourceOptionsFolder extends IBMWatsonGenericModel {
-    private String owner_user_id_serialized_name;
-    private String folder_id_serialized_name;
-    private Long limit_serialized_name;
+    private String ownerUserId;
+    private String folderId;
+    private Long xlimit;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public SourceOptionsFolder() { }
  
     /**
      * Gets the ownerUserId.
@@ -19529,7 +22894,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getOwnerUserId() {
-      return owner_user_id_serialized_name;
+      return ownerUserId;
     }
  
     /**
@@ -19541,7 +22906,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getFolderId() {
-      return folder_id_serialized_name;
+      return folderId;
     }
  
     /**
@@ -19553,44 +22918,129 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getXlimit() {
-      return limit_serialized_name;
+      return xlimit;
+    }
+  
+    private SourceOptionsFolder(SourceOptionsFolderBuilder builder) {
+      IBMWatsonValidator.notNull(builder.ownerUserId, 'ownerUserId cannot be null');
+      IBMWatsonValidator.notNull(builder.folderId, 'folderId cannot be null');
+      this.ownerUserId = builder.ownerUserId;
+      this.folderId = builder.folderId;
+      this.xlimit = builder.xlimit;
     }
 
     /**
-     * Sets the ownerUserId.
+     * New builder.
      *
-     * @param ownerUserId the new ownerUserId
+     * @return a SourceOptionsFolder builder
      */
-    public void setOwnerUserId(final String ownerUserId) {
-      this.owner_user_id_serialized_name = ownerUserId;
+    public SourceOptionsFolderBuilder newBuilder() {
+      return new SourceOptionsFolderBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('ownerUserId', 'owner_user_id');
+      mapping.put('folderId', 'folder_id');
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('owner_user_id', 'ownerUserId');
+      mapping.put('folder_id', 'folderId');
+      mapping.put('limit', 'xlimit');
+      return mapping;
+    }
+  }
+
+  /**
+   * SourceOptionsFolder Builder.
+   */
+  public class SourceOptionsFolderBuilder {
+    private String ownerUserId;
+    private String folderId;
+    private Long xlimit;
+
+    private SourceOptionsFolderBuilder(SourceOptionsFolder sourceOptionsFolder) {
+      this.ownerUserId = sourceOptionsFolder.ownerUserId;
+      this.folderId = sourceOptionsFolder.folderId;
+      this.xlimit = sourceOptionsFolder.xlimit;
     }
 
     /**
-     * Sets the folderId.
-     *
-     * @param folderId the new folderId
+     * Instantiates a new builder.
      */
-    public void setFolderId(final String folderId) {
-      this.folder_id_serialized_name = folderId;
+    public SourceOptionsFolderBuilder() {
     }
 
     /**
-     * Sets the xlimit.
+     * Instantiates a new builder with required properties.
      *
-     * @param xlimit the new xlimit
+     * @param ownerUserId the ownerUserId
+     * @param folderId the folderId
      */
-    public void setXlimit(final long xlimit) {
-      this.limit_serialized_name = xlimit;
+    public SourceOptionsFolderBuilder(String ownerUserId, String folderId) {
+      this.ownerUserId = ownerUserId;
+      this.folderId = folderId;
     }
 
+    /**
+     * Builds a SourceOptionsFolder.
+     *
+     * @return the sourceOptionsFolder
+     */
+    public SourceOptionsFolder build() {
+      return new SourceOptionsFolder(this);
+    }
+
+    /**
+     * Set the ownerUserId.
+     *
+     * @param ownerUserId the ownerUserId
+     * @return the SourceOptionsFolder builder
+     */
+    public SourceOptionsFolderBuilder setOwnerUserId(String ownerUserId) {
+      this.ownerUserId = ownerUserId;
+      return this;
+    }
+
+    /**
+     * Set the folderId.
+     *
+     * @param folderId the folderId
+     * @return the SourceOptionsFolder builder
+     */
+    public SourceOptionsFolderBuilder setFolderId(String folderId) {
+      this.folderId = folderId;
+      return this;
+    }
+
+    /**
+     * Set the xlimit.
+     *
+     * @param xlimit the xlimit
+     * @return the SourceOptionsFolder builder
+     */
+    public SourceOptionsFolderBuilder setXlimit(Long xlimit) {
+      this.xlimit = xlimit;
+      return this;
+    }
   }
 
   /**
    * Object that defines a Salesforce document object type crawl with this configuration.
    */
   public class SourceOptionsObject extends IBMWatsonGenericModel {
-    private String name_serialized_name;
-    private Long limit_serialized_name;
+    private String name;
+    private Long xlimit;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public SourceOptionsObject() { }
  
     /**
      * Gets the name.
@@ -19601,7 +23051,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -19614,35 +23064,108 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getXlimit() {
-      return limit_serialized_name;
+      return xlimit;
+    }
+  
+    private SourceOptionsObject(SourceOptionsObjectBuilder builder) {
+      IBMWatsonValidator.notNull(builder.name, 'name cannot be null');
+      this.name = builder.name;
+      this.xlimit = builder.xlimit;
     }
 
     /**
-     * Sets the name.
+     * New builder.
      *
-     * @param name the new name
+     * @return a SourceOptionsObject builder
      */
-    public void setName(final String name) {
-      this.name_serialized_name = name;
+    public SourceOptionsObjectBuilder newBuilder() {
+      return new SourceOptionsObjectBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('limit', 'xlimit');
+      return mapping;
+    }
+  }
+
+  /**
+   * SourceOptionsObject Builder.
+   */
+  public class SourceOptionsObjectBuilder {
+    private String name;
+    private Long xlimit;
+
+    private SourceOptionsObjectBuilder(SourceOptionsObject sourceOptionsObject) {
+      this.name = sourceOptionsObject.name;
+      this.xlimit = sourceOptionsObject.xlimit;
     }
 
     /**
-     * Sets the xlimit.
-     *
-     * @param xlimit the new xlimit
+     * Instantiates a new builder.
      */
-    public void setXlimit(final long xlimit) {
-      this.limit_serialized_name = xlimit;
+    public SourceOptionsObjectBuilder() {
     }
 
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param name the name
+     */
+    public SourceOptionsObjectBuilder(String name) {
+      this.name = name;
+    }
+
+    /**
+     * Builds a SourceOptionsObject.
+     *
+     * @return the sourceOptionsObject
+     */
+    public SourceOptionsObject build() {
+      return new SourceOptionsObject(this);
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name the name
+     * @return the SourceOptionsObject builder
+     */
+    public SourceOptionsObjectBuilder setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Set the xlimit.
+     *
+     * @param xlimit the xlimit
+     * @return the SourceOptionsObject builder
+     */
+    public SourceOptionsObjectBuilder setXlimit(Long xlimit) {
+      this.xlimit = xlimit;
+      return this;
+    }
   }
 
   /**
    * Object that defines a Microsoft SharePoint site collection to crawl with this configuration.
    */
   public class SourceOptionsSiteColl extends IBMWatsonGenericModel {
-    private String site_collection_path_serialized_name;
-    private Long limit_serialized_name;
+    private String siteCollectionPath;
+    private Long xlimit;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public SourceOptionsSiteColl() { }
  
     /**
      * Gets the siteCollectionPath.
@@ -19654,7 +23177,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getSiteCollectionPath() {
-      return site_collection_path_serialized_name;
+      return siteCollectionPath;
     }
  
     /**
@@ -19667,41 +23190,116 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getXlimit() {
-      return limit_serialized_name;
+      return xlimit;
+    }
+  
+    private SourceOptionsSiteColl(SourceOptionsSiteCollBuilder builder) {
+      IBMWatsonValidator.notNull(builder.siteCollectionPath, 'siteCollectionPath cannot be null');
+      this.siteCollectionPath = builder.siteCollectionPath;
+      this.xlimit = builder.xlimit;
     }
 
     /**
-     * Sets the siteCollectionPath.
+     * New builder.
      *
-     * @param siteCollectionPath the new siteCollectionPath
+     * @return a SourceOptionsSiteColl builder
      */
-    public void setSiteCollectionPath(final String siteCollectionPath) {
-      this.site_collection_path_serialized_name = siteCollectionPath;
+    public SourceOptionsSiteCollBuilder newBuilder() {
+      return new SourceOptionsSiteCollBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('siteCollectionPath', 'site_collection_path');
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('site_collection_path', 'siteCollectionPath');
+      mapping.put('limit', 'xlimit');
+      return mapping;
+    }
+  }
+
+  /**
+   * SourceOptionsSiteColl Builder.
+   */
+  public class SourceOptionsSiteCollBuilder {
+    private String siteCollectionPath;
+    private Long xlimit;
+
+    private SourceOptionsSiteCollBuilder(SourceOptionsSiteColl sourceOptionsSiteColl) {
+      this.siteCollectionPath = sourceOptionsSiteColl.siteCollectionPath;
+      this.xlimit = sourceOptionsSiteColl.xlimit;
     }
 
     /**
-     * Sets the xlimit.
-     *
-     * @param xlimit the new xlimit
+     * Instantiates a new builder.
      */
-    public void setXlimit(final long xlimit) {
-      this.limit_serialized_name = xlimit;
+    public SourceOptionsSiteCollBuilder() {
     }
 
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param siteCollectionPath the siteCollectionPath
+     */
+    public SourceOptionsSiteCollBuilder(String siteCollectionPath) {
+      this.siteCollectionPath = siteCollectionPath;
+    }
+
+    /**
+     * Builds a SourceOptionsSiteColl.
+     *
+     * @return the sourceOptionsSiteColl
+     */
+    public SourceOptionsSiteColl build() {
+      return new SourceOptionsSiteColl(this);
+    }
+
+    /**
+     * Set the siteCollectionPath.
+     *
+     * @param siteCollectionPath the siteCollectionPath
+     * @return the SourceOptionsSiteColl builder
+     */
+    public SourceOptionsSiteCollBuilder setSiteCollectionPath(String siteCollectionPath) {
+      this.siteCollectionPath = siteCollectionPath;
+      return this;
+    }
+
+    /**
+     * Set the xlimit.
+     *
+     * @param xlimit the xlimit
+     * @return the SourceOptionsSiteColl builder
+     */
+    public SourceOptionsSiteCollBuilder setXlimit(Long xlimit) {
+      this.xlimit = xlimit;
+      return this;
+    }
   }
 
   /**
    * Object defining which URL to crawl and how to crawl it.
    */
   public class SourceOptionsWebCrawl extends IBMWatsonGenericModel {
-    private String url_serialized_name;
-    private Boolean limit_to_starting_hosts_serialized_name;
-    private String crawl_speed_serialized_name;
-    private Boolean allow_untrusted_certificate_serialized_name;
-    private Long maximum_hops_serialized_name;
-    private Long request_timeout_serialized_name;
-    private Boolean override_robots_txt_serialized_name;
-    private List<String> blacklist_serialized_name;
+    private String url;
+    private Boolean limitToStartingHosts;
+    private String crawlSpeed;
+    private Boolean allowUntrustedCertificate;
+    private Long maximumHops;
+    private Long requestTimeout;
+    private Boolean overrideRobotsTxt;
+    private List<String> blacklist;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public SourceOptionsWebCrawl() { }
  
     /**
      * Gets the url.
@@ -19712,7 +23310,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
  
     /**
@@ -19724,7 +23322,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getLimitToStartingHosts() {
-      return limit_to_starting_hosts_serialized_name;
+      return limitToStartingHosts;
     }
  
     /**
@@ -19738,7 +23336,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCrawlSpeed() {
-      return crawl_speed_serialized_name;
+      return crawlSpeed;
     }
  
     /**
@@ -19750,7 +23348,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getAllowUntrustedCertificate() {
-      return allow_untrusted_certificate_serialized_name;
+      return allowUntrustedCertificate;
     }
  
     /**
@@ -19764,7 +23362,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMaximumHops() {
-      return maximum_hops_serialized_name;
+      return maximumHops;
     }
  
     /**
@@ -19776,7 +23374,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getRequestTimeout() {
-      return request_timeout_serialized_name;
+      return requestTimeout;
     }
  
     /**
@@ -19790,7 +23388,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getOverrideRobotsTxt() {
-      return override_robots_txt_serialized_name;
+      return overrideRobotsTxt;
     }
  
     /**
@@ -19803,90 +23401,219 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getBlacklist() {
-      return blacklist_serialized_name;
+      return blacklist;
+    }
+  
+    private SourceOptionsWebCrawl(SourceOptionsWebCrawlBuilder builder) {
+      IBMWatsonValidator.notNull(builder.url, 'url cannot be null');
+      this.url = builder.url;
+      this.limitToStartingHosts = builder.limitToStartingHosts;
+      this.crawlSpeed = builder.crawlSpeed;
+      this.allowUntrustedCertificate = builder.allowUntrustedCertificate;
+      this.maximumHops = builder.maximumHops;
+      this.requestTimeout = builder.requestTimeout;
+      this.overrideRobotsTxt = builder.overrideRobotsTxt;
+      this.blacklist = builder.blacklist;
     }
 
     /**
-     * Sets the url.
+     * New builder.
      *
-     * @param url the new url
+     * @return a SourceOptionsWebCrawl builder
      */
-    public void setUrl(final String url) {
-      this.url_serialized_name = url;
+    public SourceOptionsWebCrawlBuilder newBuilder() {
+      return new SourceOptionsWebCrawlBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('limitToStartingHosts', 'limit_to_starting_hosts');
+      mapping.put('crawlSpeed', 'crawl_speed');
+      mapping.put('allowUntrustedCertificate', 'allow_untrusted_certificate');
+      mapping.put('maximumHops', 'maximum_hops');
+      mapping.put('requestTimeout', 'request_timeout');
+      mapping.put('overrideRobotsTxt', 'override_robots_txt');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('limit_to_starting_hosts', 'limitToStartingHosts');
+      mapping.put('crawl_speed', 'crawlSpeed');
+      mapping.put('allow_untrusted_certificate', 'allowUntrustedCertificate');
+      mapping.put('maximum_hops', 'maximumHops');
+      mapping.put('request_timeout', 'requestTimeout');
+      mapping.put('override_robots_txt', 'overrideRobotsTxt');
+      return mapping;
+    }
+  }
+
+  /**
+   * SourceOptionsWebCrawl Builder.
+   */
+  public class SourceOptionsWebCrawlBuilder {
+    private String url;
+    private Boolean limitToStartingHosts;
+    private String crawlSpeed;
+    private Boolean allowUntrustedCertificate;
+    private Long maximumHops;
+    private Long requestTimeout;
+    private Boolean overrideRobotsTxt;
+    private List<String> blacklist;
+
+    private SourceOptionsWebCrawlBuilder(SourceOptionsWebCrawl sourceOptionsWebCrawl) {
+      this.url = sourceOptionsWebCrawl.url;
+      this.limitToStartingHosts = sourceOptionsWebCrawl.limitToStartingHosts;
+      this.crawlSpeed = sourceOptionsWebCrawl.crawlSpeed;
+      this.allowUntrustedCertificate = sourceOptionsWebCrawl.allowUntrustedCertificate;
+      this.maximumHops = sourceOptionsWebCrawl.maximumHops;
+      this.requestTimeout = sourceOptionsWebCrawl.requestTimeout;
+      this.overrideRobotsTxt = sourceOptionsWebCrawl.overrideRobotsTxt;
+      this.blacklist = sourceOptionsWebCrawl.blacklist;
     }
 
     /**
-     * Sets the limitToStartingHosts.
+     * Instantiates a new builder.
+     */
+    public SourceOptionsWebCrawlBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
      *
-     * @param limitToStartingHosts the new limitToStartingHosts
+     * @param url the url
      */
-    public void setLimitToStartingHosts(final Boolean limitToStartingHosts) {
-      this.limit_to_starting_hosts_serialized_name = limitToStartingHosts;
+    public SourceOptionsWebCrawlBuilder(String url) {
+      this.url = url;
     }
 
     /**
-     * Sets the crawlSpeed.
+     * Builds a SourceOptionsWebCrawl.
      *
-     * @param crawlSpeed the new crawlSpeed
+     * @return the sourceOptionsWebCrawl
      */
-    public void setCrawlSpeed(final String crawlSpeed) {
-      this.crawl_speed_serialized_name = crawlSpeed;
+    public SourceOptionsWebCrawl build() {
+      return new SourceOptionsWebCrawl(this);
     }
 
     /**
-     * Sets the allowUntrustedCertificate.
-     *
-     * @param allowUntrustedCertificate the new allowUntrustedCertificate
-     */
-    public void setAllowUntrustedCertificate(final Boolean allowUntrustedCertificate) {
-      this.allow_untrusted_certificate_serialized_name = allowUntrustedCertificate;
-    }
-
-    /**
-     * Sets the maximumHops.
-     *
-     * @param maximumHops the new maximumHops
-     */
-    public void setMaximumHops(final long maximumHops) {
-      this.maximum_hops_serialized_name = maximumHops;
-    }
-
-    /**
-     * Sets the requestTimeout.
-     *
-     * @param requestTimeout the new requestTimeout
-     */
-    public void setRequestTimeout(final long requestTimeout) {
-      this.request_timeout_serialized_name = requestTimeout;
-    }
-
-    /**
-     * Sets the overrideRobotsTxt.
-     *
-     * @param overrideRobotsTxt the new overrideRobotsTxt
-     */
-    public void setOverrideRobotsTxt(final Boolean overrideRobotsTxt) {
-      this.override_robots_txt_serialized_name = overrideRobotsTxt;
-    }
-
-    /**
-     * Sets the blacklist.
+     * Adds an blacklist to blacklist.
      *
      * @param blacklist the new blacklist
+     * @return the SourceOptionsWebCrawl builder
      */
-    public void setBlacklist(final List<String> blacklist) {
-      this.blacklist_serialized_name = blacklist;
+    public SourceOptionsWebCrawlBuilder addBlacklist(String blacklist) {
+      IBMWatsonValidator.notNull(blacklist, 'blacklist cannot be null');
+      if (this.blacklist == null) {
+        this.blacklist = new List<String>();
+      }
+      this.blacklist.add(blacklist);
+      return this;
     }
 
+    /**
+     * Set the url.
+     *
+     * @param url the url
+     * @return the SourceOptionsWebCrawl builder
+     */
+    public SourceOptionsWebCrawlBuilder setUrl(String url) {
+      this.url = url;
+      return this;
+    }
+
+    /**
+     * Set the limitToStartingHosts.
+     *
+     * @param limitToStartingHosts the limitToStartingHosts
+     * @return the SourceOptionsWebCrawl builder
+     */
+    public SourceOptionsWebCrawlBuilder setLimitToStartingHosts(Boolean limitToStartingHosts) {
+      this.limitToStartingHosts = limitToStartingHosts;
+      return this;
+    }
+
+    /**
+     * Set the crawlSpeed.
+     *
+     * @param crawlSpeed the crawlSpeed
+     * @return the SourceOptionsWebCrawl builder
+     */
+    public SourceOptionsWebCrawlBuilder setCrawlSpeed(String crawlSpeed) {
+      this.crawlSpeed = crawlSpeed;
+      return this;
+    }
+
+    /**
+     * Set the allowUntrustedCertificate.
+     *
+     * @param allowUntrustedCertificate the allowUntrustedCertificate
+     * @return the SourceOptionsWebCrawl builder
+     */
+    public SourceOptionsWebCrawlBuilder setAllowUntrustedCertificate(Boolean allowUntrustedCertificate) {
+      this.allowUntrustedCertificate = allowUntrustedCertificate;
+      return this;
+    }
+
+    /**
+     * Set the maximumHops.
+     *
+     * @param maximumHops the maximumHops
+     * @return the SourceOptionsWebCrawl builder
+     */
+    public SourceOptionsWebCrawlBuilder setMaximumHops(Long maximumHops) {
+      this.maximumHops = maximumHops;
+      return this;
+    }
+
+    /**
+     * Set the requestTimeout.
+     *
+     * @param requestTimeout the requestTimeout
+     * @return the SourceOptionsWebCrawl builder
+     */
+    public SourceOptionsWebCrawlBuilder setRequestTimeout(Long requestTimeout) {
+      this.requestTimeout = requestTimeout;
+      return this;
+    }
+
+    /**
+     * Set the overrideRobotsTxt.
+     *
+     * @param overrideRobotsTxt the overrideRobotsTxt
+     * @return the SourceOptionsWebCrawl builder
+     */
+    public SourceOptionsWebCrawlBuilder setOverrideRobotsTxt(Boolean overrideRobotsTxt) {
+      this.overrideRobotsTxt = overrideRobotsTxt;
+      return this;
+    }
+
+    /**
+     * Set the blacklist.
+     * Existing blacklist will be replaced.
+     *
+     * @param blacklist the blacklist
+     * @return the SourceOptionsWebCrawl builder
+     */
+    public SourceOptionsWebCrawlBuilder setBlacklist(List<String> blacklist) {
+      this.blacklist = blacklist;
+      return this;
+    }
   }
 
   /**
    * Object containing the schedule information for the source.
    */
   public class SourceSchedule extends IBMWatsonGenericModel {
-    private Boolean enabled_serialized_name;
-    private String time_zone_serialized_name;
-    private String frequency_serialized_name;
+    private Boolean enabled;
+    private String timeZone;
+    private String frequency;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public SourceSchedule() { }
  
     /**
      * Gets the enabled.
@@ -19898,7 +23625,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getEnabled() {
-      return enabled_serialized_name;
+      return enabled;
     }
  
     /**
@@ -19911,7 +23638,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getTimeZone() {
-      return time_zone_serialized_name;
+      return timeZone;
     }
  
     /**
@@ -19929,44 +23656,106 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getFrequency() {
-      return frequency_serialized_name;
+      return frequency;
+    }
+  
+    private SourceSchedule(SourceScheduleBuilder builder) {
+      this.enabled = builder.enabled;
+      this.timeZone = builder.timeZone;
+      this.frequency = builder.frequency;
     }
 
     /**
-     * Sets the enabled.
+     * New builder.
      *
-     * @param enabled the new enabled
+     * @return a SourceSchedule builder
      */
-    public void setEnabled(final Boolean enabled) {
-      this.enabled_serialized_name = enabled;
+    public SourceScheduleBuilder newBuilder() {
+      return new SourceScheduleBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('timeZone', 'time_zone');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('time_zone', 'timeZone');
+      return mapping;
+    }
+  }
+
+  /**
+   * SourceSchedule Builder.
+   */
+  public class SourceScheduleBuilder {
+    private Boolean enabled;
+    private String timeZone;
+    private String frequency;
+
+    private SourceScheduleBuilder(SourceSchedule sourceSchedule) {
+      this.enabled = sourceSchedule.enabled;
+      this.timeZone = sourceSchedule.timeZone;
+      this.frequency = sourceSchedule.frequency;
     }
 
     /**
-     * Sets the timeZone.
-     *
-     * @param timeZone the new timeZone
+     * Instantiates a new builder.
      */
-    public void setTimeZone(final String timeZone) {
-      this.time_zone_serialized_name = timeZone;
+    public SourceScheduleBuilder() {
     }
 
     /**
-     * Sets the frequency.
+     * Builds a SourceSchedule.
      *
-     * @param frequency the new frequency
+     * @return the sourceSchedule
      */
-    public void setFrequency(final String frequency) {
-      this.frequency_serialized_name = frequency;
+    public SourceSchedule build() {
+      return new SourceSchedule(this);
     }
 
+    /**
+     * Set the enabled.
+     *
+     * @param enabled the enabled
+     * @return the SourceSchedule builder
+     */
+    public SourceScheduleBuilder setEnabled(Boolean enabled) {
+      this.enabled = enabled;
+      return this;
+    }
+
+    /**
+     * Set the timeZone.
+     *
+     * @param timeZone the timeZone
+     * @return the SourceSchedule builder
+     */
+    public SourceScheduleBuilder setTimeZone(String timeZone) {
+      this.timeZone = timeZone;
+      return this;
+    }
+
+    /**
+     * Set the frequency.
+     *
+     * @param frequency the frequency
+     * @return the SourceSchedule builder
+     */
+    public SourceScheduleBuilder setFrequency(String frequency) {
+      this.frequency = frequency;
+      return this;
+    }
   }
 
   /**
    * Object containing source crawl status information.
    */
   public class SourceStatus extends IBMWatsonGenericModel {
-    private String status_serialized_name;
-    private Datetime next_crawl_serialized_name;
+    private String status;
+    private Datetime nextCrawl;
  
     /**
      * Gets the status.
@@ -19983,7 +23772,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -19995,7 +23784,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getNextCrawl() {
-      return next_crawl_serialized_name;
+      return nextCrawl;
     }
 
     /**
@@ -20004,7 +23793,7 @@ public class IBMDiscoveryV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -20013,9 +23802,14 @@ public class IBMDiscoveryV1Models {
      * @param nextCrawl the new nextCrawl
      */
     public void setNextCrawl(final Datetime nextCrawl) {
-      this.next_crawl_serialized_name = nextCrawl;
+      this.nextCrawl = nextCrawl;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('next_crawl', 'nextCrawl');
+      return mapping;
+    }
   }
 
   /**
@@ -20030,7 +23824,7 @@ public class IBMDiscoveryV1Models {
     private String metadata;
     private String step;
     private String configurationId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -20041,7 +23835,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the configuration.
      *
@@ -20056,7 +23850,7 @@ public class IBMDiscoveryV1Models {
     public String configuration() {
       return configuration;
     }
- 
+
     /**
      * Gets the file.
      *
@@ -20069,7 +23863,7 @@ public class IBMDiscoveryV1Models {
     public IBMWatsonFile file() {
       return file;
     }
- 
+
     /**
      * Gets the filename.
      *
@@ -20080,7 +23874,7 @@ public class IBMDiscoveryV1Models {
     public String filename() {
       return filename;
     }
- 
+
     /**
      * Gets the fileContentType.
      *
@@ -20091,7 +23885,7 @@ public class IBMDiscoveryV1Models {
     public String fileContentType() {
       return fileContentType;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -20106,7 +23900,7 @@ public class IBMDiscoveryV1Models {
     public String metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the step.
      *
@@ -20118,7 +23912,7 @@ public class IBMDiscoveryV1Models {
     public String step() {
       return step;
     }
- 
+
     /**
      * Gets the configurationId.
      *
@@ -20154,6 +23948,13 @@ public class IBMDiscoveryV1Models {
       return new TestConfigurationInEnvironmentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('fileContentType', 'file_content_type');
+      mapping.put('configurationId', 'configuration_id');
+      return mapping;
+    }
   }
 
   /**
@@ -20310,12 +24111,12 @@ public class IBMDiscoveryV1Models {
    * TestDocument.
    */
   public class TestDocument extends IBMWatsonResponseModel {
-    private String configuration_id_serialized_name;
-    private String status_serialized_name;
-    private Long enriched_field_units_serialized_name;
-    private String original_media_type_serialized_name;
-    private List<DocumentSnapshot> snapshots_serialized_name;
-    private List<Notice> notices_serialized_name;
+    private String configurationId;
+    private String status;
+    private Long enrichedFieldUnits;
+    private String originalMediaType;
+    private List<DocumentSnapshot> snapshots;
+    private List<Notice> notices;
  
     /**
      * Gets the configurationId.
@@ -20326,7 +24127,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getConfigurationId() {
-      return configuration_id_serialized_name;
+      return configurationId;
     }
  
     /**
@@ -20338,7 +24139,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -20351,7 +24152,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getEnrichedFieldUnits() {
-      return enriched_field_units_serialized_name;
+      return enrichedFieldUnits;
     }
  
     /**
@@ -20363,7 +24164,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getOriginalMediaType() {
-      return original_media_type_serialized_name;
+      return originalMediaType;
     }
  
     /**
@@ -20375,7 +24176,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<DocumentSnapshot> getSnapshots() {
-      return snapshots_serialized_name;
+      return snapshots;
     }
  
     /**
@@ -20387,7 +24188,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<Notice> getNotices() {
-      return notices_serialized_name;
+      return notices;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -20403,11 +24204,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedSnapshots != null) {
         for (Integer i = 0; i < deserializedSnapshots.size(); i++) {
           DocumentSnapshot currentItem = ret.getSnapshots().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('snapshots_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('snapshots');
           DocumentSnapshot newItem = (DocumentSnapshot) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DocumentSnapshot.class);
           newSnapshots.add(newItem);
         }
-        ret.snapshots_serialized_name = newSnapshots;
+        ret.snapshots = newSnapshots;
       }
 
       // calling custom deserializer for notices
@@ -20416,25 +24217,36 @@ public class IBMDiscoveryV1Models {
       if (deserializedNotices != null) {
         for (Integer i = 0; i < deserializedNotices.size(); i++) {
           Notice currentItem = ret.getNotices().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('notices_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('notices');
           Notice newItem = (Notice) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Notice.class);
           newNotices.add(newItem);
         }
-        ret.notices_serialized_name = newNotices;
+        ret.notices = newNotices;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('configuration_id', 'configurationId');
+      mapping.put('enriched_field_units', 'enrichedFieldUnits');
+      mapping.put('original_media_type', 'originalMediaType');
+      if (notices != null && notices[0] != null) {
+        mapping.putAll(notices[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
   /**
    * An object defining a single tokenizaion rule.
    */
-  public class TokenDictRule {
-    private String text_serialized_name;
-    private List<String> tokens_serialized_name;
-    private List<String> readings_serialized_name;
-    private String part_of_speech_serialized_name;
+  public class TokenDictRule extends IBMWatsonGenericModel {
+    private String text;
+    private List<String> tokens;
+    private List<String> readings;
+    private String partOfSpeech;
  
     /**
      * Gets the text.
@@ -20444,7 +24256,7 @@ public class IBMDiscoveryV1Models {
      * @return the text
      */
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -20455,7 +24267,7 @@ public class IBMDiscoveryV1Models {
      * @return the tokens
      */
     public List<String> getTokens() {
-      return tokens_serialized_name;
+      return tokens;
     }
  
     /**
@@ -20466,7 +24278,7 @@ public class IBMDiscoveryV1Models {
      * @return the readings
      */
     public List<String> getReadings() {
-      return readings_serialized_name;
+      return readings;
     }
  
     /**
@@ -20478,53 +24290,162 @@ public class IBMDiscoveryV1Models {
      * @return the partOfSpeech
      */
     public String getPartOfSpeech() {
-      return part_of_speech_serialized_name;
+      return partOfSpeech;
+    }
+  
+    private TokenDictRule(TokenDictRuleBuilder builder) {
+      IBMWatsonValidator.notNull(builder.text, 'text cannot be null');
+      IBMWatsonValidator.notNull(builder.tokens, 'tokens cannot be null');
+      IBMWatsonValidator.notNull(builder.partOfSpeech, 'partOfSpeech cannot be null');
+      this.text = builder.text;
+      this.tokens = builder.tokens;
+      this.readings = builder.readings;
+      this.partOfSpeech = builder.partOfSpeech;
     }
 
     /**
-     * Sets the text.
+     * New builder.
      *
-     * @param text the new text
+     * @return a TokenDictRule builder
      */
-    public void setText(final String text) {
-      this.text_serialized_name = text;
+    public TokenDictRuleBuilder newBuilder() {
+      return new TokenDictRuleBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('partOfSpeech', 'part_of_speech');
+      return mapping;
+    }
+  }
+
+  /**
+   * TokenDictRule Builder.
+   */
+  public class TokenDictRuleBuilder {
+    private String text;
+    private List<String> tokens;
+    private List<String> readings;
+    private String partOfSpeech;
+
+    private TokenDictRuleBuilder(TokenDictRule tokenDictRule) {
+      this.text = tokenDictRule.text;
+      this.tokens = tokenDictRule.tokens;
+      this.readings = tokenDictRule.readings;
+      this.partOfSpeech = tokenDictRule.partOfSpeech;
     }
 
     /**
-     * Sets the tokens.
+     * Instantiates a new builder.
+     */
+    public TokenDictRuleBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param text the text
+     * @param tokens the tokens
+     * @param partOfSpeech the partOfSpeech
+     */
+    public TokenDictRuleBuilder(String text, List<String> tokens, String partOfSpeech) {
+      this.text = text;
+      this.tokens = tokens;
+      this.partOfSpeech = partOfSpeech;
+    }
+
+    /**
+     * Builds a TokenDictRule.
+     *
+     * @return the tokenDictRule
+     */
+    public TokenDictRule build() {
+      return new TokenDictRule(this);
+    }
+
+    /**
+     * Adds an tokens to tokens.
      *
      * @param tokens the new tokens
+     * @return the TokenDictRule builder
      */
-    public void setTokens(final List<String> tokens) {
-      this.tokens_serialized_name = tokens;
+    public TokenDictRuleBuilder addTokens(String tokens) {
+      IBMWatsonValidator.notNull(tokens, 'tokens cannot be null');
+      if (this.tokens == null) {
+        this.tokens = new List<String>();
+      }
+      this.tokens.add(tokens);
+      return this;
     }
 
     /**
-     * Sets the readings.
+     * Adds an readings to readings.
      *
      * @param readings the new readings
+     * @return the TokenDictRule builder
      */
-    public void setReadings(final List<String> readings) {
-      this.readings_serialized_name = readings;
+    public TokenDictRuleBuilder addReadings(String readings) {
+      IBMWatsonValidator.notNull(readings, 'readings cannot be null');
+      if (this.readings == null) {
+        this.readings = new List<String>();
+      }
+      this.readings.add(readings);
+      return this;
     }
 
     /**
-     * Sets the partOfSpeech.
+     * Set the text.
      *
-     * @param partOfSpeech the new partOfSpeech
+     * @param text the text
+     * @return the TokenDictRule builder
      */
-    public void setPartOfSpeech(final String partOfSpeech) {
-      this.part_of_speech_serialized_name = partOfSpeech;
+    public TokenDictRuleBuilder setText(String text) {
+      this.text = text;
+      return this;
     }
 
+    /**
+     * Set the tokens.
+     * Existing tokens will be replaced.
+     *
+     * @param tokens the tokens
+     * @return the TokenDictRule builder
+     */
+    public TokenDictRuleBuilder setTokens(List<String> tokens) {
+      this.tokens = tokens;
+      return this;
+    }
+
+    /**
+     * Set the readings.
+     * Existing readings will be replaced.
+     *
+     * @param readings the readings
+     * @return the TokenDictRule builder
+     */
+    public TokenDictRuleBuilder setReadings(List<String> readings) {
+      this.readings = readings;
+      return this;
+    }
+
+    /**
+     * Set the partOfSpeech.
+     *
+     * @param partOfSpeech the partOfSpeech
+     * @return the TokenDictRule builder
+     */
+    public TokenDictRuleBuilder setPartOfSpeech(String partOfSpeech) {
+      this.partOfSpeech = partOfSpeech;
+      return this;
+    }
   }
 
   /**
    * Object describing the current status of the wordlist.
    */
   public class TokenDictStatusResponse extends IBMWatsonResponseModel {
-    private String status_serialized_name;
-    private String type_serialized_name;
+    private String status;
+    private String xtype;
  
     /**
      * Gets the status.
@@ -20535,7 +24456,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -20547,7 +24468,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
 
     /**
@@ -20556,7 +24477,7 @@ public class IBMDiscoveryV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -20565,17 +24486,22 @@ public class IBMDiscoveryV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      return mapping;
+    }
   }
 
   /**
    * TopHitsResults.
    */
   public class TopHitsResults extends IBMWatsonGenericModel {
-    private Long matching_results_serialized_name;
-    private List<QueryResult> hits_serialized_name;
+    private Long matchingResults;
+    private List<QueryResult> hits;
  
     /**
      * Gets the matchingResults.
@@ -20586,7 +24512,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getMatchingResults() {
-      return matching_results_serialized_name;
+      return matchingResults;
     }
  
     /**
@@ -20598,7 +24524,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<QueryResult> getHits() {
-      return hits_serialized_name;
+      return hits;
     }
 
     /**
@@ -20607,7 +24533,7 @@ public class IBMDiscoveryV1Models {
      * @param matchingResults the new matchingResults
      */
     public void setMatchingResults(final long matchingResults) {
-      this.matching_results_serialized_name = matchingResults;
+      this.matchingResults = matchingResults;
     }
 
     /**
@@ -20616,7 +24542,7 @@ public class IBMDiscoveryV1Models {
      * @param hits the new hits
      */
     public void setHits(final List<QueryResult> hits) {
-      this.hits_serialized_name = hits;
+      this.hits = hits;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -20632,14 +24558,23 @@ public class IBMDiscoveryV1Models {
       if (deserializedHits != null) {
         for (Integer i = 0; i < deserializedHits.size(); i++) {
           QueryResult currentItem = ret.getHits().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('hits_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('hits');
           QueryResult newItem = (QueryResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), QueryResult.class);
           newHits.add(newItem);
         }
-        ret.hits_serialized_name = newHits;
+        ret.hits = newHits;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('matching_results', 'matchingResults');
+      if (hits != null && hits[0] != null) {
+        mapping.putAll(hits[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -20647,9 +24582,9 @@ public class IBMDiscoveryV1Models {
    * TrainingDataSet.
    */
   public class TrainingDataSet extends IBMWatsonResponseModel {
-    private String environment_id_serialized_name;
-    private String collection_id_serialized_name;
-    private List<TrainingQuery> queries_serialized_name;
+    private String environmentId;
+    private String collectionId;
+    private List<TrainingQuery> queries;
  
     /**
      * Gets the environmentId.
@@ -20660,7 +24595,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getEnvironmentId() {
-      return environment_id_serialized_name;
+      return environmentId;
     }
  
     /**
@@ -20672,7 +24607,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCollectionId() {
-      return collection_id_serialized_name;
+      return collectionId;
     }
  
     /**
@@ -20684,7 +24619,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<TrainingQuery> getQueries() {
-      return queries_serialized_name;
+      return queries;
     }
 
     /**
@@ -20693,7 +24628,7 @@ public class IBMDiscoveryV1Models {
      * @param environmentId the new environmentId
      */
     public void setEnvironmentId(final String environmentId) {
-      this.environment_id_serialized_name = environmentId;
+      this.environmentId = environmentId;
     }
 
     /**
@@ -20702,7 +24637,7 @@ public class IBMDiscoveryV1Models {
      * @param collectionId the new collectionId
      */
     public void setCollectionId(final String collectionId) {
-      this.collection_id_serialized_name = collectionId;
+      this.collectionId = collectionId;
     }
 
     /**
@@ -20711,7 +24646,7 @@ public class IBMDiscoveryV1Models {
      * @param queries the new queries
      */
     public void setQueries(final List<TrainingQuery> queries) {
-      this.queries_serialized_name = queries;
+      this.queries = queries;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -20727,14 +24662,24 @@ public class IBMDiscoveryV1Models {
       if (deserializedQueries != null) {
         for (Integer i = 0; i < deserializedQueries.size(); i++) {
           TrainingQuery currentItem = ret.getQueries().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('queries_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('queries');
           TrainingQuery newItem = (TrainingQuery) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TrainingQuery.class);
           newQueries.add(newItem);
         }
-        ret.queries_serialized_name = newQueries;
+        ret.queries = newQueries;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environment_id', 'environmentId');
+      mapping.put('collection_id', 'collectionId');
+      if (queries != null && queries[0] != null) {
+        mapping.putAll(queries[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -20742,9 +24687,15 @@ public class IBMDiscoveryV1Models {
    * TrainingExample.
    */
   public class TrainingExample extends IBMWatsonResponseModel {
-    private String document_id_serialized_name;
-    private String cross_reference_serialized_name;
-    private Long relevance_serialized_name;
+    private String documentId;
+    private String crossReference;
+    private Long relevance;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public TrainingExample() { }
  
     /**
      * Gets the documentId.
@@ -20755,7 +24706,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -20767,7 +24718,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getCrossReference() {
-      return cross_reference_serialized_name;
+      return crossReference;
     }
  
     /**
@@ -20779,43 +24730,107 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getRelevance() {
-      return relevance_serialized_name;
+      return relevance;
+    }
+  
+    private TrainingExample(TrainingExampleBuilder builder) {
+      this.documentId = builder.documentId;
+      this.crossReference = builder.crossReference;
+      this.relevance = builder.relevance;
     }
 
     /**
-     * Sets the documentId.
+     * New builder.
      *
-     * @param documentId the new documentId
+     * @return a TrainingExample builder
      */
-    public void setDocumentId(final String documentId) {
-      this.document_id_serialized_name = documentId;
+    public TrainingExampleBuilder newBuilder() {
+      return new TrainingExampleBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('documentId', 'document_id');
+      mapping.put('crossReference', 'cross_reference');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_id', 'documentId');
+      mapping.put('cross_reference', 'crossReference');
+      return mapping;
+    }
+  }
+
+  /**
+   * TrainingExample Builder.
+   */
+  public class TrainingExampleBuilder {
+    private String documentId;
+    private String crossReference;
+    private Long relevance;
+
+    private TrainingExampleBuilder(TrainingExample trainingExample) {
+      this.documentId = trainingExample.documentId;
+      this.crossReference = trainingExample.crossReference;
+      this.relevance = trainingExample.relevance;
     }
 
     /**
-     * Sets the crossReference.
-     *
-     * @param crossReference the new crossReference
+     * Instantiates a new builder.
      */
-    public void setCrossReference(final String crossReference) {
-      this.cross_reference_serialized_name = crossReference;
+    public TrainingExampleBuilder() {
     }
 
     /**
-     * Sets the relevance.
+     * Builds a TrainingExample.
      *
-     * @param relevance the new relevance
+     * @return the trainingExample
      */
-    public void setRelevance(final long relevance) {
-      this.relevance_serialized_name = relevance;
+    public TrainingExample build() {
+      return new TrainingExample(this);
     }
 
+    /**
+     * Set the documentId.
+     *
+     * @param documentId the documentId
+     * @return the TrainingExample builder
+     */
+    public TrainingExampleBuilder setDocumentId(String documentId) {
+      this.documentId = documentId;
+      return this;
+    }
+
+    /**
+     * Set the crossReference.
+     *
+     * @param crossReference the crossReference
+     * @return the TrainingExample builder
+     */
+    public TrainingExampleBuilder setCrossReference(String crossReference) {
+      this.crossReference = crossReference;
+      return this;
+    }
+
+    /**
+     * Set the relevance.
+     *
+     * @param relevance the relevance
+     * @return the TrainingExample builder
+     */
+    public TrainingExampleBuilder setRelevance(Long relevance) {
+      this.relevance = relevance;
+      return this;
+    }
   }
 
   /**
    * TrainingExampleList.
    */
   public class TrainingExampleList extends IBMWatsonResponseModel {
-    private List<TrainingExample> examples_serialized_name;
+    private List<TrainingExample> examples;
  
     /**
      * Gets the examples.
@@ -20826,7 +24841,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<TrainingExample> getExamples() {
-      return examples_serialized_name;
+      return examples;
     }
 
     /**
@@ -20835,7 +24850,7 @@ public class IBMDiscoveryV1Models {
      * @param examples the new examples
      */
     public void setExamples(final List<TrainingExample> examples) {
-      this.examples_serialized_name = examples;
+      this.examples = examples;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -20851,14 +24866,22 @@ public class IBMDiscoveryV1Models {
       if (deserializedExamples != null) {
         for (Integer i = 0; i < deserializedExamples.size(); i++) {
           TrainingExample currentItem = ret.getExamples().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('examples_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('examples');
           TrainingExample newItem = (TrainingExample) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TrainingExample.class);
           newExamples.add(newItem);
         }
-        ret.examples_serialized_name = newExamples;
+        ret.examples = newExamples;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (examples != null && examples[0] != null) {
+        mapping.putAll(examples[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -20866,10 +24889,10 @@ public class IBMDiscoveryV1Models {
    * TrainingQuery.
    */
   public class TrainingQuery extends IBMWatsonResponseModel {
-    private String query_id_serialized_name;
-    private String natural_language_query_serialized_name;
-    private String filter_serialized_name;
-    private List<TrainingExample> examples_serialized_name;
+    private String queryId;
+    private String naturalLanguageQuery;
+    private String filter;
+    private List<TrainingExample> examples;
  
     /**
      * Gets the queryId.
@@ -20880,7 +24903,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getQueryId() {
-      return query_id_serialized_name;
+      return queryId;
     }
  
     /**
@@ -20892,7 +24915,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getNaturalLanguageQuery() {
-      return natural_language_query_serialized_name;
+      return naturalLanguageQuery;
     }
  
     /**
@@ -20904,7 +24927,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public String getFilter() {
-      return filter_serialized_name;
+      return filter;
     }
  
     /**
@@ -20916,7 +24939,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<TrainingExample> getExamples() {
-      return examples_serialized_name;
+      return examples;
     }
 
     /**
@@ -20925,7 +24948,7 @@ public class IBMDiscoveryV1Models {
      * @param queryId the new queryId
      */
     public void setQueryId(final String queryId) {
-      this.query_id_serialized_name = queryId;
+      this.queryId = queryId;
     }
 
     /**
@@ -20934,7 +24957,7 @@ public class IBMDiscoveryV1Models {
      * @param naturalLanguageQuery the new naturalLanguageQuery
      */
     public void setNaturalLanguageQuery(final String naturalLanguageQuery) {
-      this.natural_language_query_serialized_name = naturalLanguageQuery;
+      this.naturalLanguageQuery = naturalLanguageQuery;
     }
 
     /**
@@ -20943,7 +24966,7 @@ public class IBMDiscoveryV1Models {
      * @param filter the new filter
      */
     public void setFilter(final String filter) {
-      this.filter_serialized_name = filter;
+      this.filter = filter;
     }
 
     /**
@@ -20952,7 +24975,7 @@ public class IBMDiscoveryV1Models {
      * @param examples the new examples
      */
     public void setExamples(final List<TrainingExample> examples) {
-      this.examples_serialized_name = examples;
+      this.examples = examples;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -20968,14 +24991,24 @@ public class IBMDiscoveryV1Models {
       if (deserializedExamples != null) {
         for (Integer i = 0; i < deserializedExamples.size(); i++) {
           TrainingExample currentItem = ret.getExamples().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('examples_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('examples');
           TrainingExample newItem = (TrainingExample) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TrainingExample.class);
           newExamples.add(newItem);
         }
-        ret.examples_serialized_name = newExamples;
+        ret.examples = newExamples;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('query_id', 'queryId');
+      mapping.put('natural_language_query', 'naturalLanguageQuery');
+      if (examples != null && examples[0] != null) {
+        mapping.putAll(examples[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -20983,15 +25016,15 @@ public class IBMDiscoveryV1Models {
    * TrainingStatus.
    */
   public class TrainingStatus extends IBMWatsonGenericModel {
-    private Long total_examples_serialized_name;
-    private Boolean available_serialized_name;
-    private Boolean processing_serialized_name;
-    private Boolean minimum_queries_added_serialized_name;
-    private Boolean minimum_examples_added_serialized_name;
-    private Boolean sufficient_label_diversity_serialized_name;
-    private Long notices_serialized_name;
-    private Datetime successfully_trained_serialized_name;
-    private Datetime data_updated_serialized_name;
+    private Long totalExamples;
+    private Boolean available;
+    private Boolean processing;
+    private Boolean minimumQueriesAdded;
+    private Boolean minimumExamplesAdded;
+    private Boolean sufficientLabelDiversity;
+    private Long notices;
+    private Datetime successfullyTrained;
+    private Datetime dataUpdated;
  
     /**
      * Gets the totalExamples.
@@ -21002,7 +25035,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getTotalExamples() {
-      return total_examples_serialized_name;
+      return totalExamples;
     }
  
     /**
@@ -21014,7 +25047,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getAvailable() {
-      return available_serialized_name;
+      return available;
     }
  
     /**
@@ -21026,7 +25059,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getProcessing() {
-      return processing_serialized_name;
+      return processing;
     }
  
     /**
@@ -21038,7 +25071,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getMinimumQueriesAdded() {
-      return minimum_queries_added_serialized_name;
+      return minimumQueriesAdded;
     }
  
     /**
@@ -21050,7 +25083,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getMinimumExamplesAdded() {
-      return minimum_examples_added_serialized_name;
+      return minimumExamplesAdded;
     }
  
     /**
@@ -21062,7 +25095,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Boolean getSufficientLabelDiversity() {
-      return sufficient_label_diversity_serialized_name;
+      return sufficientLabelDiversity;
     }
  
     /**
@@ -21074,7 +25107,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getNotices() {
-      return notices_serialized_name;
+      return notices;
     }
  
     /**
@@ -21086,7 +25119,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getSuccessfullyTrained() {
-      return successfully_trained_serialized_name;
+      return successfullyTrained;
     }
  
     /**
@@ -21098,7 +25131,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Datetime getDataUpdated() {
-      return data_updated_serialized_name;
+      return dataUpdated;
     }
 
     /**
@@ -21107,7 +25140,7 @@ public class IBMDiscoveryV1Models {
      * @param totalExamples the new totalExamples
      */
     public void setTotalExamples(final long totalExamples) {
-      this.total_examples_serialized_name = totalExamples;
+      this.totalExamples = totalExamples;
     }
 
     /**
@@ -21116,7 +25149,7 @@ public class IBMDiscoveryV1Models {
      * @param available the new available
      */
     public void setAvailable(final Boolean available) {
-      this.available_serialized_name = available;
+      this.available = available;
     }
 
     /**
@@ -21125,7 +25158,7 @@ public class IBMDiscoveryV1Models {
      * @param processing the new processing
      */
     public void setProcessing(final Boolean processing) {
-      this.processing_serialized_name = processing;
+      this.processing = processing;
     }
 
     /**
@@ -21134,7 +25167,7 @@ public class IBMDiscoveryV1Models {
      * @param minimumQueriesAdded the new minimumQueriesAdded
      */
     public void setMinimumQueriesAdded(final Boolean minimumQueriesAdded) {
-      this.minimum_queries_added_serialized_name = minimumQueriesAdded;
+      this.minimumQueriesAdded = minimumQueriesAdded;
     }
 
     /**
@@ -21143,7 +25176,7 @@ public class IBMDiscoveryV1Models {
      * @param minimumExamplesAdded the new minimumExamplesAdded
      */
     public void setMinimumExamplesAdded(final Boolean minimumExamplesAdded) {
-      this.minimum_examples_added_serialized_name = minimumExamplesAdded;
+      this.minimumExamplesAdded = minimumExamplesAdded;
     }
 
     /**
@@ -21152,7 +25185,7 @@ public class IBMDiscoveryV1Models {
      * @param sufficientLabelDiversity the new sufficientLabelDiversity
      */
     public void setSufficientLabelDiversity(final Boolean sufficientLabelDiversity) {
-      this.sufficient_label_diversity_serialized_name = sufficientLabelDiversity;
+      this.sufficientLabelDiversity = sufficientLabelDiversity;
     }
 
     /**
@@ -21161,7 +25194,7 @@ public class IBMDiscoveryV1Models {
      * @param notices the new notices
      */
     public void setNotices(final long notices) {
-      this.notices_serialized_name = notices;
+      this.notices = notices;
     }
 
     /**
@@ -21170,7 +25203,7 @@ public class IBMDiscoveryV1Models {
      * @param successfullyTrained the new successfullyTrained
      */
     public void setSuccessfullyTrained(final Datetime successfullyTrained) {
-      this.successfully_trained_serialized_name = successfullyTrained;
+      this.successfullyTrained = successfullyTrained;
     }
 
     /**
@@ -21179,9 +25212,19 @@ public class IBMDiscoveryV1Models {
      * @param dataUpdated the new dataUpdated
      */
     public void setDataUpdated(final Datetime dataUpdated) {
-      this.data_updated_serialized_name = dataUpdated;
+      this.dataUpdated = dataUpdated;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('total_examples', 'totalExamples');
+      mapping.put('minimum_queries_added', 'minimumQueriesAdded');
+      mapping.put('minimum_examples_added', 'minimumExamplesAdded');
+      mapping.put('sufficient_label_diversity', 'sufficientLabelDiversity');
+      mapping.put('successfully_trained', 'successfullyTrained');
+      mapping.put('data_updated', 'dataUpdated');
+      return mapping;
+    }
   }
 
   /**
@@ -21193,7 +25236,7 @@ public class IBMDiscoveryV1Models {
     private String name;
     private String description;
     private String configurationId;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -21204,7 +25247,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -21215,7 +25258,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -21226,7 +25269,7 @@ public class IBMDiscoveryV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -21237,7 +25280,7 @@ public class IBMDiscoveryV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the configurationId.
      *
@@ -21269,6 +25312,13 @@ public class IBMDiscoveryV1Models {
       return new UpdateCollectionOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('configurationId', 'configuration_id');
+      return mapping;
+    }
   }
 
   /**
@@ -21396,7 +25446,7 @@ public class IBMDiscoveryV1Models {
     private List<Enrichment> enrichments;
     private List<NormalizationOperation> normalizations;
     private Source source;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -21407,7 +25457,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the configurationId.
      *
@@ -21418,7 +25468,7 @@ public class IBMDiscoveryV1Models {
     public String configurationId() {
       return configurationId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -21429,7 +25479,7 @@ public class IBMDiscoveryV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -21440,7 +25490,7 @@ public class IBMDiscoveryV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the conversions.
      *
@@ -21451,7 +25501,7 @@ public class IBMDiscoveryV1Models {
     public Conversions conversions() {
       return conversions;
     }
- 
+
     /**
      * Gets the enrichments.
      *
@@ -21462,7 +25512,7 @@ public class IBMDiscoveryV1Models {
     public List<Enrichment> enrichments() {
       return enrichments;
     }
- 
+
     /**
      * Gets the normalizations.
      *
@@ -21474,7 +25524,7 @@ public class IBMDiscoveryV1Models {
     public List<NormalizationOperation> normalizations() {
       return normalizations;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -21510,6 +25560,24 @@ public class IBMDiscoveryV1Models {
       return new UpdateConfigurationOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('configurationId', 'configuration_id');
+      if (conversions != null) {
+        mapping.putAll(conversions.getSdkToApiMapping());
+      }
+      if (enrichments != null && enrichments[0] != null) {
+        mapping.putAll(enrichments[0].getSdkToApiMapping());
+      }
+      if (normalizations != null && normalizations[0] != null) {
+        mapping.putAll(normalizations[0].getSdkToApiMapping());
+      }
+      if (source != null) {
+        mapping.putAll(source.getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -21723,7 +25791,7 @@ public class IBMDiscoveryV1Models {
     private String sourceType;
     private CredentialDetails credentialDetails;
     private String status;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -21734,7 +25802,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the credentialId.
      *
@@ -21745,7 +25813,7 @@ public class IBMDiscoveryV1Models {
     public String credentialId() {
       return credentialId;
     }
- 
+
     /**
      * Gets the sourceType.
      *
@@ -21761,7 +25829,7 @@ public class IBMDiscoveryV1Models {
     public String sourceType() {
       return sourceType;
     }
- 
+
     /**
      * Gets the credentialDetails.
      *
@@ -21774,7 +25842,7 @@ public class IBMDiscoveryV1Models {
     public CredentialDetails credentialDetails() {
       return credentialDetails;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -21808,6 +25876,17 @@ public class IBMDiscoveryV1Models {
       return new UpdateCredentialsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('credentialId', 'credential_id');
+      mapping.put('sourceType', 'source_type');
+      mapping.put('credentialDetails', 'credential_details');
+      if (credentialDetails != null) {
+        mapping.putAll(credentialDetails.getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -21947,7 +26026,7 @@ public class IBMDiscoveryV1Models {
     private String filename;
     private String fileContentType;
     private String metadata;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -21958,7 +26037,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -21969,7 +26048,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the documentId.
      *
@@ -21980,7 +26059,7 @@ public class IBMDiscoveryV1Models {
     public String documentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the file.
      *
@@ -21993,7 +26072,7 @@ public class IBMDiscoveryV1Models {
     public IBMWatsonFile file() {
       return file;
     }
- 
+
     /**
      * Gets the filename.
      *
@@ -22004,7 +26083,7 @@ public class IBMDiscoveryV1Models {
     public String filename() {
       return filename;
     }
- 
+
     /**
      * Gets the fileContentType.
      *
@@ -22015,7 +26094,7 @@ public class IBMDiscoveryV1Models {
     public String fileContentType() {
       return fileContentType;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -22055,6 +26134,14 @@ public class IBMDiscoveryV1Models {
       return new UpdateDocumentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('documentId', 'document_id');
+      mapping.put('fileContentType', 'file_content_type');
+      return mapping;
+    }
   }
 
   /**
@@ -22206,7 +26293,7 @@ public class IBMDiscoveryV1Models {
     private String name;
     private String description;
     private String size;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -22217,7 +26304,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -22228,7 +26315,7 @@ public class IBMDiscoveryV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -22239,7 +26326,7 @@ public class IBMDiscoveryV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the size.
      *
@@ -22270,6 +26357,11 @@ public class IBMDiscoveryV1Models {
       return new UpdateEnvironmentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      return mapping;
+    }
   }
 
   /**
@@ -22380,7 +26472,7 @@ public class IBMDiscoveryV1Models {
     private String exampleId;
     private String crossReference;
     private Long relevance;
- 
+
     /**
      * Gets the environmentId.
      *
@@ -22391,7 +26483,7 @@ public class IBMDiscoveryV1Models {
     public String environmentId() {
       return environmentId;
     }
- 
+
     /**
      * Gets the collectionId.
      *
@@ -22402,7 +26494,7 @@ public class IBMDiscoveryV1Models {
     public String collectionId() {
       return collectionId;
     }
- 
+
     /**
      * Gets the queryId.
      *
@@ -22413,7 +26505,7 @@ public class IBMDiscoveryV1Models {
     public String queryId() {
       return queryId;
     }
- 
+
     /**
      * Gets the exampleId.
      *
@@ -22424,7 +26516,7 @@ public class IBMDiscoveryV1Models {
     public String exampleId() {
       return exampleId;
     }
- 
+
     /**
      * Gets the crossReference.
      *
@@ -22435,7 +26527,7 @@ public class IBMDiscoveryV1Models {
     public String crossReference() {
       return crossReference;
     }
- 
+
     /**
      * Gets the relevance.
      *
@@ -22470,6 +26562,15 @@ public class IBMDiscoveryV1Models {
       return new UpdateTrainingExampleOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('environmentId', 'environment_id');
+      mapping.put('collectionId', 'collection_id');
+      mapping.put('queryId', 'query_id');
+      mapping.put('exampleId', 'example_id');
+      mapping.put('crossReference', 'cross_reference');
+      return mapping;
+    }
   }
 
   /**
@@ -22606,8 +26707,14 @@ public class IBMDiscoveryV1Models {
    * WordHeadingDetection.
    */
   public class WordHeadingDetection extends IBMWatsonGenericModel {
-    private List<FontSetting> fonts_serialized_name;
-    private List<WordStyle> styles_serialized_name;
+    private List<FontSetting> fonts;
+    private List<WordStyle> styles;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public WordHeadingDetection() { }
  
     /**
      * Gets the fonts.
@@ -22616,7 +26723,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<FontSetting> getFonts() {
-      return fonts_serialized_name;
+      return fonts;
     }
  
     /**
@@ -22626,25 +26733,21 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<WordStyle> getStyles() {
-      return styles_serialized_name;
+      return styles;
+    }
+  
+    private WordHeadingDetection(WordHeadingDetectionBuilder builder) {
+      this.fonts = builder.fonts;
+      this.styles = builder.styles;
     }
 
     /**
-     * Sets the fonts.
+     * New builder.
      *
-     * @param fonts the new fonts
+     * @return a WordHeadingDetection builder
      */
-    public void setFonts(final List<FontSetting> fonts) {
-      this.fonts_serialized_name = fonts;
-    }
-
-    /**
-     * Sets the styles.
-     *
-     * @param styles the new styles
-     */
-    public void setStyles(final List<WordStyle> styles) {
-      this.styles_serialized_name = styles;
+    public WordHeadingDetectionBuilder newBuilder() {
+      return new WordHeadingDetectionBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -22653,6 +26756,7 @@ public class IBMDiscoveryV1Models {
       }
 
       WordHeadingDetection ret = (WordHeadingDetection) super.deserialize(jsonString, jsonMap, classType);
+      WordHeadingDetectionBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for fonts
       List<FontSetting> newFonts = new List<FontSetting>();
@@ -22660,11 +26764,11 @@ public class IBMDiscoveryV1Models {
       if (deserializedFonts != null) {
         for (Integer i = 0; i < deserializedFonts.size(); i++) {
           FontSetting currentItem = ret.getFonts().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('fonts_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('fonts');
           FontSetting newItem = (FontSetting) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), FontSetting.class);
           newFonts.add(newItem);
         }
-        ret.fonts_serialized_name = newFonts;
+        retBuilder.setFonts(newFonts);
       }
 
       // calling custom deserializer for styles
@@ -22673,14 +26777,112 @@ public class IBMDiscoveryV1Models {
       if (deserializedStyles != null) {
         for (Integer i = 0; i < deserializedStyles.size(); i++) {
           WordStyle currentItem = ret.getStyles().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('styles_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('styles');
           WordStyle newItem = (WordStyle) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), WordStyle.class);
           newStyles.add(newItem);
         }
-        ret.styles_serialized_name = newStyles;
+        retBuilder.setStyles(newStyles);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (fonts != null && fonts[0] != null) {
+        mapping.putAll(fonts[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (fonts != null && fonts[0] != null) {
+        mapping.putAll(fonts[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * WordHeadingDetection Builder.
+   */
+  public class WordHeadingDetectionBuilder {
+    private List<FontSetting> fonts;
+    private List<WordStyle> styles;
+
+    private WordHeadingDetectionBuilder(WordHeadingDetection wordHeadingDetection) {
+      this.fonts = wordHeadingDetection.fonts;
+      this.styles = wordHeadingDetection.styles;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public WordHeadingDetectionBuilder() {
+    }
+
+    /**
+     * Builds a WordHeadingDetection.
+     *
+     * @return the wordHeadingDetection
+     */
+    public WordHeadingDetection build() {
+      return new WordHeadingDetection(this);
+    }
+
+    /**
+     * Adds an fonts to fonts.
+     *
+     * @param fonts the new fonts
+     * @return the WordHeadingDetection builder
+     */
+    public WordHeadingDetectionBuilder addFonts(FontSetting fonts) {
+      IBMWatsonValidator.notNull(fonts, 'fonts cannot be null');
+      if (this.fonts == null) {
+        this.fonts = new List<FontSetting>();
+      }
+      this.fonts.add(fonts);
+      return this;
+    }
+
+    /**
+     * Adds an styles to styles.
+     *
+     * @param styles the new styles
+     * @return the WordHeadingDetection builder
+     */
+    public WordHeadingDetectionBuilder addStyles(WordStyle styles) {
+      IBMWatsonValidator.notNull(styles, 'styles cannot be null');
+      if (this.styles == null) {
+        this.styles = new List<WordStyle>();
+      }
+      this.styles.add(styles);
+      return this;
+    }
+
+    /**
+     * Set the fonts.
+     * Existing fonts will be replaced.
+     *
+     * @param fonts the fonts
+     * @return the WordHeadingDetection builder
+     */
+    public WordHeadingDetectionBuilder setFonts(List<FontSetting> fonts) {
+      this.fonts = fonts;
+      return this;
+    }
+
+    /**
+     * Set the styles.
+     * Existing styles will be replaced.
+     *
+     * @param styles the styles
+     * @return the WordHeadingDetection builder
+     */
+    public WordHeadingDetectionBuilder setStyles(List<WordStyle> styles) {
+      this.styles = styles;
+      return this;
     }
   }
 
@@ -22688,7 +26890,13 @@ public class IBMDiscoveryV1Models {
    * A list of Word conversion settings.
    */
   public class WordSettings extends IBMWatsonGenericModel {
-    private WordHeadingDetection heading_serialized_name;
+    private WordHeadingDetection heading;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public WordSettings() { }
  
     /**
      * Gets the heading.
@@ -22697,16 +26905,20 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public WordHeadingDetection getHeading() {
-      return heading_serialized_name;
+      return heading;
+    }
+  
+    private WordSettings(WordSettingsBuilder builder) {
+      this.heading = builder.heading;
     }
 
     /**
-     * Sets the heading.
+     * New builder.
      *
-     * @param heading the new heading
+     * @return a WordSettings builder
      */
-    public void setHeading(final WordHeadingDetection heading) {
-      this.heading_serialized_name = heading;
+    public WordSettingsBuilder newBuilder() {
+      return new WordSettingsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -22715,12 +26927,66 @@ public class IBMDiscoveryV1Models {
       }
 
       WordSettings ret = (WordSettings) super.deserialize(jsonString, jsonMap, classType);
+      WordSettingsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for heading
-      WordHeadingDetection newHeading = (WordHeadingDetection) new WordHeadingDetection().deserialize(JSON.serialize(ret.getHeading()), (Map<String, Object>) jsonMap.get('heading_serialized_name'), WordHeadingDetection.class);
-      ret.setHeading(newHeading);
+      WordHeadingDetection newHeading = (WordHeadingDetection) new WordHeadingDetection().deserialize(JSON.serialize(ret.getHeading()), (Map<String, Object>) jsonMap.get('heading'), WordHeadingDetection.class);
+      retBuilder.setHeading(newHeading);
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (heading != null) {
+        mapping.putAll(heading.getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (heading != null) {
+        mapping.putAll(heading.getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * WordSettings Builder.
+   */
+  public class WordSettingsBuilder {
+    private WordHeadingDetection heading;
+
+    private WordSettingsBuilder(WordSettings wordSettings) {
+      this.heading = wordSettings.heading;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public WordSettingsBuilder() {
+    }
+
+    /**
+     * Builds a WordSettings.
+     *
+     * @return the wordSettings
+     */
+    public WordSettings build() {
+      return new WordSettings(this);
+    }
+
+    /**
+     * Set the heading.
+     *
+     * @param heading the heading
+     * @return the WordSettings builder
+     */
+    public WordSettingsBuilder setHeading(WordHeadingDetection heading) {
+      this.heading = heading;
+      return this;
     }
   }
 
@@ -22728,8 +26994,14 @@ public class IBMDiscoveryV1Models {
    * WordStyle.
    */
   public class WordStyle extends IBMWatsonGenericModel {
-    private Long level_serialized_name;
-    private List<String> names_serialized_name;
+    private Long level;
+    private List<String> names;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public WordStyle() { }
  
     /**
      * Gets the level.
@@ -22740,7 +27012,7 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public Long getLevel() {
-      return level_serialized_name;
+      return level;
     }
  
     /**
@@ -22752,34 +27024,101 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getNames() {
-      return names_serialized_name;
+      return names;
+    }
+  
+    private WordStyle(WordStyleBuilder builder) {
+      this.level = builder.level;
+      this.names = builder.names;
     }
 
     /**
-     * Sets the level.
+     * New builder.
      *
-     * @param level the new level
+     * @return a WordStyle builder
      */
-    public void setLevel(final long level) {
-      this.level_serialized_name = level;
+    public WordStyleBuilder newBuilder() {
+      return new WordStyleBuilder(this);
+    }
+  }
+
+  /**
+   * WordStyle Builder.
+   */
+  public class WordStyleBuilder {
+    private Long level;
+    private List<String> names;
+
+    private WordStyleBuilder(WordStyle wordStyle) {
+      this.level = wordStyle.level;
+      this.names = wordStyle.names;
     }
 
     /**
-     * Sets the names.
+     * Instantiates a new builder.
+     */
+    public WordStyleBuilder() {
+    }
+
+    /**
+     * Builds a WordStyle.
+     *
+     * @return the wordStyle
+     */
+    public WordStyle build() {
+      return new WordStyle(this);
+    }
+
+    /**
+     * Adds an names to names.
      *
      * @param names the new names
+     * @return the WordStyle builder
      */
-    public void setNames(final List<String> names) {
-      this.names_serialized_name = names;
+    public WordStyleBuilder addNames(String names) {
+      IBMWatsonValidator.notNull(names, 'names cannot be null');
+      if (this.names == null) {
+        this.names = new List<String>();
+      }
+      this.names.add(names);
+      return this;
     }
 
+    /**
+     * Set the level.
+     *
+     * @param level the level
+     * @return the WordStyle builder
+     */
+    public WordStyleBuilder setLevel(Long level) {
+      this.level = level;
+      return this;
+    }
+
+    /**
+     * Set the names.
+     * Existing names will be replaced.
+     *
+     * @param names the names
+     * @return the WordStyle builder
+     */
+    public WordStyleBuilder setNames(List<String> names) {
+      this.names = names;
+      return this;
+    }
   }
 
   /**
    * XPathPatterns.
    */
   public class XPathPatterns extends IBMWatsonGenericModel {
-    private List<String> xpaths_serialized_name;
+    private List<String> xpaths;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public XPathPatterns() { }
  
     /**
      * Gets the xpaths.
@@ -22790,18 +27129,74 @@ public class IBMDiscoveryV1Models {
      */
     @AuraEnabled
     public List<String> getXpaths() {
-      return xpaths_serialized_name;
+      return xpaths;
+    }
+  
+    private XPathPatterns(XPathPatternsBuilder builder) {
+      this.xpaths = builder.xpaths;
     }
 
     /**
-     * Sets the xpaths.
+     * New builder.
      *
-     * @param xpaths the new xpaths
+     * @return a XPathPatterns builder
      */
-    public void setXpaths(final List<String> xpaths) {
-      this.xpaths_serialized_name = xpaths;
+    public XPathPatternsBuilder newBuilder() {
+      return new XPathPatternsBuilder(this);
+    }
+  }
+
+  /**
+   * XPathPatterns Builder.
+   */
+  public class XPathPatternsBuilder {
+    private List<String> xpaths;
+
+    private XPathPatternsBuilder(XPathPatterns xPathPatterns) {
+      this.xpaths = xPathPatterns.xpaths;
     }
 
+    /**
+     * Instantiates a new builder.
+     */
+    public XPathPatternsBuilder() {
+    }
+
+    /**
+     * Builds a XPathPatterns.
+     *
+     * @return the xPathPatterns
+     */
+    public XPathPatterns build() {
+      return new XPathPatterns(this);
+    }
+
+    /**
+     * Adds an xpaths to xpaths.
+     *
+     * @param xpaths the new xpaths
+     * @return the XPathPatterns builder
+     */
+    public XPathPatternsBuilder addXpaths(String xpaths) {
+      IBMWatsonValidator.notNull(xpaths, 'xpaths cannot be null');
+      if (this.xpaths == null) {
+        this.xpaths = new List<String>();
+      }
+      this.xpaths.add(xpaths);
+      return this;
+    }
+
+    /**
+     * Set the xpaths.
+     * Existing xpaths will be replaced.
+     *
+     * @param xpaths the xpaths
+     * @return the XPathPatterns builder
+     */
+    public XPathPatternsBuilder setXpaths(List<String> xpaths) {
+      this.xpaths = xpaths;
+      return this;
+    }
   }
 
 }

--- a/force-app/main/default/classes/IBMDiscoveryV1Test.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Test.cls
@@ -5,11 +5,32 @@ private class IBMDiscoveryV1Test {
   private static final String ENVIRONMENT_ID = '5ae96bb9-80e5-43ea-916e-1f3412fbc283';
   private static final String CONFIGURATION_ID = 'configuration_id';
 
+  private static String DESTINATION_FIELD;
+  private static String SOURCE_FIELD;
+  private static String ENRICHMENT_NAME;
+  private static String TEXT;
+  private static String TOKEN;
+  private static String PART_OF_SPEECH;
+
+  private static List<String> TOKENS;
+
+  static {
+    DESTINATION_FIELD = 'destination_field';
+    SOURCE_FIELD = 'source_field';
+    ENRICHMENT_NAME = 'enrichment_name';
+    TEXT = 'text';
+    TOKEN = 'token';
+    PART_OF_SPEECH = 'noun';
+
+    TOKENS = new List<String> { TOKEN };
+  }
+
   static testMethod void testNluEnrichmentConcepts() {
     Long lim = 5L;
 
-    IBMDiscoveryV1Models.NluEnrichmentConcepts concepts = new IBMDiscoveryV1Models.NluEnrichmentConcepts();
-    concepts.setXlimit(lim);
+    IBMDiscoveryV1Models.NluEnrichmentConcepts concepts = new IBMDiscoveryV1Models.NluEnrichmentConceptsBuilder()
+      .xlimit(lim)
+      .build();
 
     System.assertEquals(lim, concepts.getXlimit());
   }
@@ -320,56 +341,71 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1 discovery = new IBMDiscoveryV1(VERSION);
     discovery.setEndPoint('https://gateway.watsonplatform.net/discovery/api');
     discovery.setUsernameAndPassword('username', 'password');
-    IBMDiscoveryV1Models.Enrichment enrichment = new IBMDiscoveryV1Models.Enrichment();
-    enrichment.setDescription('test Description');
-    IBMDiscoveryV1Models.Conversions conversions = new IBMDiscoveryV1Models.Conversions();
-    IBMDiscoveryV1Models.HtmlSettings html = new IBMDiscoveryV1Models.HtmlSettings();
-    IBMDiscoveryV1Models.XPathPatterns patterns = new IBMDiscoveryV1Models.XPathPatterns();
-    patterns.setXpaths(new List<String>{ 'xpath' });
-    html.setExcludeContent(patterns);
-    html.setExcludeTagAttributes(new List<String>{ 'attribute' });
-    html.setExcludeTagsCompletely(new List<String>{ 'tag' });
-    html.setExcludeTagsKeepContent(new List<String>{ 'tag' });
-    html.setKeepContent(patterns);
-    html.setKeepTagAttributes(new List<String>{ 'tag' });
-    conversions.setHtml(html);
-    IBMDiscoveryV1Models.NormalizationOperation normalizationOperation = new IBMDiscoveryV1Models.NormalizationOperation();
-    normalizationOperation.setDestinationField('field');
-    normalizationOperation.setOperation('operation');
-    normalizationOperation.setSourceField('field');
-    conversions.setJsonNormalizations(new List<IBMDiscoveryV1Models.NormalizationOperation>{ normalizationOperation });
-    IBMDiscoveryV1Models.PdfSettings pdfSettings = new IBMDiscoveryV1Models.PdfSettings();
-    IBMDiscoveryV1Models.PdfHeadingDetection pdfHeadingDetection = new IBMDiscoveryV1Models.PdfHeadingDetection();
-    IBMDiscoveryV1Models.FontSetting fontSetting = new IBMDiscoveryV1Models.FontSetting();
-    fontSetting.setBold(true);
-    fontSetting.setItalic(true);
-    fontSetting.setLevel(10);
-    fontSetting.setMaxSize(10);
-    fontSetting.setMinSize(10);
-    fontSetting.setName('name');
-    pdfHeadingDetection.setFonts(new List<IBMDiscoveryV1Models.FontSetting>{ fontSetting });
-    pdfSettings.setHeading(pdfHeadingDetection);
-    conversions.setPdf(pdfSettings);
-    IBMDiscoveryV1Models.SegmentSettings segment = new IBMDiscoveryV1Models.SegmentSettings();
-    segment.setEnabled(true);
-    segment.setSelectorTags(new List<String>{ 'tag' });
-    segment.setAnnotatedFields(new List<String>{ 'field' });
-    conversions.setSegment(segment);
-    IBMDiscoveryV1Models.WordSettings word = new IBMDiscoveryV1Models.WordSettings();
-    IBMDiscoveryV1Models.WordHeadingDetection wordHeading = new IBMDiscoveryV1Models.WordHeadingDetection();
-    wordHeading.setFonts(new List<IBMDiscoveryV1Models.FontSetting>{ fontSetting });
-    IBMDiscoveryV1Models.WordStyle style = new IBMDiscoveryV1Models.WordStyle();
-    style.setLevel(10);
-    style.setNames(new List<String>{ 'name' });
-    wordHeading.setStyles(new List<IBMDiscoveryV1Models.WordStyle>{ style });
-    word.setHeading(wordHeading);
-    conversions.setWord(word);
+    IBMDiscoveryV1Models.XPathPatterns patterns = new IBMDiscoveryV1Models.XPathPatternsBuilder()
+      .xpaths(new List<String>{ 'xpath' })
+      .build();
+    IBMDiscoveryV1Models.HtmlSettings html = new IBMDiscoveryV1Models.HtmlSettingsBuilder()
+      .excludeContent(patterns)
+      .excludeTagAttributes(new List<String>{ 'attribute' })
+      .excludeTagsCompletely(new List<String>{ 'tag' })
+      .excludeTagsKeepContent(new List<String>{ 'tag' })
+      .keepContent(patterns)
+      .keepTagAttributes(new List<String>{ 'tag' })
+      .build();
+    IBMDiscoveryV1Models.NormalizationOperation normalizationOperation = new IBMDiscoveryV1Models.NormalizationOperationBuilder()
+      .destinationField('field')
+      .operation('operation')
+      .sourceField('field')
+      .build();
+    IBMDiscoveryV1Models.FontSetting fontSetting = new IBMDiscoveryV1Models.FontSettingBuilder()
+      .bold(true)
+      .italic(true)
+      .level(10)
+      .maxSize(10)
+      .minSize(10)
+      .name('name')
+      .build();
+    IBMDiscoveryV1Models.PdfHeadingDetection pdfHeadingDetection = new IBMDiscoveryV1Models.PdfHeadingDetectionBuilder()
+      .fonts(new List<IBMDiscoveryV1Models.FontSetting>{ fontSetting })
+      .build();
+    IBMDiscoveryV1Models.PdfSettings pdfSettings = new IBMDiscoveryV1Models.PdfSettingsBuilder()
+      .heading(pdfHeadingDetection)
+      .build();
+    IBMDiscoveryV1Models.SegmentSettings segment = new IBMDiscoveryV1Models.SegmentSettingsBuilder()
+      .enabled(true)
+      .selectorTags(new List<String>{ 'tag' })
+      .annotatedFields(new List<String>{ 'field' })
+      .build();
+    IBMDiscoveryV1Models.WordStyle style = new IBMDiscoveryV1Models.WordStyleBuilder()
+      .level(10)
+      .names(new List<String>{ 'name' })
+      .build();
+    IBMDiscoveryV1Models.WordHeadingDetection wordHeading = new IBMDiscoveryV1Models.WordHeadingDetectionBuilder()
+      .fonts(new List<IBMDiscoveryV1Models.FontSetting>{ fontSetting })
+      .styles(new List<IBMDiscoveryV1Models.WordStyle>{ style })
+      .build();
+    IBMDiscoveryV1Models.WordSettings word = new IBMDiscoveryV1Models.WordSettingsBuilder()
+      .heading(wordHeading)
+      .build();
+    IBMDiscoveryV1Models.Conversions conversions = new IBMDiscoveryV1Models.ConversionsBuilder()
+      .html(html)
+      .jsonNormalizations(new List<IBMDiscoveryV1Models.NormalizationOperation>{ normalizationOperation })
+      .pdf(pdfSettings)
+      .segment(segment)
+      .word(word)
+      .build();
+    IBMDiscoveryV1Models.Enrichment enrichment = new IBMDiscoveryV1Models.EnrichmentBuilder()
+      .description('test description')
+      .destinationField(DESTINATION_FIELD)
+      .sourceField(SOURCE_FIELD)
+      .enrichmentName(ENRICHMENT_NAME)
+      .build();
     IBMDiscoveryV1Models.CreateConfigurationOptions options = new IBMDiscoveryV1Models.CreateConfigurationOptionsBuilder(ENVIRONMENT_ID, 'test_environment')
       .environmentId(ENVIRONMENT_ID)
       .name('test_environment')
       .description('test_environment description')
       .addEnrichments(enrichment)
-      .enrichments(new List<IBMDiscoveryV1Models.Enrichment>{enrichment})
+      .enrichments(new List<IBMDiscoveryV1Models.Enrichment> { enrichment })
       .addNormalizations(normalizationOperation)
       .normalizations(new List<IBMDiscoveryV1Models.NormalizationOperation>{normalizationOperation})
       .conversions(conversions)
@@ -1082,18 +1118,19 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1 discovery = new IBMDiscoveryV1(VERSION);
     discovery.setEndPoint('https://gateway.watsonplatform.net/discovery/api');
     discovery.setUsernameAndPassword('username', 'password');
-    List<String> collectionIds= new List<String>{'Collection1', 'Collection2'};
-    IBMDiscoveryV1Models.TrainingExample te= new IBMDiscoveryV1Models.TrainingExample();
-    te.setDocumentId('string');
-    te.setCrossReference('string');
-    te.setRelevance(0);
+    List<String> collectionIds = new List<String> { 'Collection1', 'Collection2' };
+    IBMDiscoveryV1Models.TrainingExample trainingExample = new IBMDiscoveryV1Models.TrainingExampleBuilder()
+      .documentId('string')
+      .crossReference('string')
+      .relevance(0)
+      .build();
     IBMDiscoveryV1Models.AddTrainingDataOptions options = new IBMDiscoveryV1Models.AddTrainingDataOptionsBuilder(ENVIRONMENT_ID, '5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .naturalLanguageQuery('en')
       .filter('test')
-      .addExamples(te)
-      .examples(new List<IBMDiscoveryV1Models.TrainingExample>{te})
+      .addExamples(trainingExample)
+      .examples(new List<IBMDiscoveryV1Models.TrainingExample> { trainingExample })
       .addHeader('Test-Header', 'test_value')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
@@ -1120,16 +1157,17 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1 discovery = new IBMDiscoveryV1(VERSION);
     discovery.setEndPoint('https://gateway.watsonplatform.net/discovery/api');
     discovery.setUsernameAndPassword('username', 'password');
-    List<String> collectionIds= new List<String>{'Collection1', 'Collection2'};
-    IBMDiscoveryV1Models.TrainingExample te= new IBMDiscoveryV1Models.TrainingExample();
-    te.setDocumentId('string');
-    te.setCrossReference('string');
-    te.setRelevance(0);
+    List<String> collectionIds= new List<String> { 'Collection1', 'Collection2' };
+    IBMDiscoveryV1Models.TrainingExample trainingExample = new IBMDiscoveryV1Models.TrainingExampleBuilder()
+      .documentId('string')
+      .crossReference('string')
+      .relevance(0)
+      .build();
     IBMDiscoveryV1Models.CreateTrainingExampleOptions options = new IBMDiscoveryV1Models.CreateTrainingExampleOptionsBuilder(ENVIRONMENT_ID, '5ae96bb9-80e5-43ea-916e-1f3412fbc283', '5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .queryId('en')
-      .trainingExample(te)
+      .trainingExample(trainingExample)
       .documentId('test')
       .relevance(2)
       .crossReference('test')
@@ -1348,7 +1386,7 @@ private class IBMDiscoveryV1Test {
   }
 
    /**
-   *  Test  configuration model
+   *  Test configuration model
    *
    */
   static testMethod void testConfigurationModel() {
@@ -1356,60 +1394,56 @@ private class IBMDiscoveryV1Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMDiscoveryV1Models.Configuration configuration = new IBMDiscoveryV1Models.Configuration();
-    //set the value
-    configuration.setName('test-collection');
-    configuration.setDescription('A test collection to show as an example');
-    IBMDiscoveryV1Models.Conversions conversions = new IBMDiscoveryV1Models.Conversions();
-    IBMDiscoveryV1Models.PdfSettings pdfSettings = new IBMDiscoveryV1Models.PdfSettings();
-    IBMDiscoveryV1Models.PdfHeadingDetection pdfHeadingDetection = new IBMDiscoveryV1Models.PdfHeadingDetection();
-    IBMDiscoveryV1Models.FontSetting fontSetting = new IBMDiscoveryV1Models.FontSetting();
-    fontSetting.setLevel(1);
-    fontSetting.setMinSize(4);
-    fontSetting.setMaxSize(10);
-    fontSetting.setBold(true);
-    fontSetting.setItalic(true);
-    fontSetting.setName('ariel');
-    List<IBMDiscoveryV1Models.FontSetting> fontSettings= new List<IBMDiscoveryV1Models.FontSetting>{fontSetting};
-    pdfHeadingDetection.setFonts(fontSettings);
-    pdfSettings.setHeading(pdfHeadingDetection);
-    conversions.setPdf(pdfSettings);
-    IBMDiscoveryV1Models.WordSettings wordSettings = new IBMDiscoveryV1Models.WordSettings();
-    IBMDiscoveryV1Models.WordHeadingDetection wordHeadingDetection = new IBMDiscoveryV1Models.WordHeadingDetection();
-    IBMDiscoveryV1Models.WordStyle wordStyle = new IBMDiscoveryV1Models.WordStyle();
-    wordStyle.setLevel(1);
-    wordStyle.setNames(new List<String>{'Style1', 'Style2'});
-    List<IBMDiscoveryV1Models.WordStyle> wordStyles= new List<IBMDiscoveryV1Models.WordStyle>{wordStyle};
-    wordHeadingDetection.setFonts(fontSettings);
-    wordHeadingDetection.setStyles(wordStyles);
-    wordSettings.setHeading(wordHeadingDetection);
-    conversions.setWord(wordSettings);
-    IBMDiscoveryV1Models.HtmlSettings htmlSettings = new IBMDiscoveryV1Models.HtmlSettings();
-    htmlSettings.setExcludeTagsCompletely(new List<String>{'Tag1', 'Tag2'});
-    htmlSettings.setExcludeTagsKeepContent(new List<String>{'KeepCntent1', 'KeepCntent2'});
-    htmlSettings.setKeepTagAttributes(new List<String>{'ExAtt1'});
-    htmlSettings.setExcludeTagAttributes(new List<String>{'KeepAtt'});
-    IBMDiscoveryV1Models.XPathPatterns xPathPatterns = new IBMDiscoveryV1Models.XPathPatterns();
-    xPathPatterns.setXpaths(new List<String>{'xpath1'});
-    htmlSettings.setKeepContent(xPathPatterns);
-    htmlSettings.setExcludeContent(xPathPatterns);
-    conversions.setHtml(htmlSettings);
-    IBMDiscoveryV1Models.NormalizationOperation normalizationOperation = new IBMDiscoveryV1Models.NormalizationOperation();
-    normalizationOperation.setOperation('test operation');
-    normalizationOperation.setSourceField('test source');
-    normalizationOperation.setDestinationField('test destination');
-    conversions.setJsonNormalizations(new List<IBMDiscoveryV1Models.NormalizationOperation>{normalizationOperation});
-    configuration.setConversions(conversions);
-    IBMDiscoveryV1Models.Enrichment enrichment = new IBMDiscoveryV1Models.Enrichment();
-    enrichment.setDescription('test Description');
-    enrichment.setDestinationField('test Description');
-    enrichment.setSourceField('test Description');
-    enrichment.setOverwrite(true);
-    enrichment.setEnrichmentName('test Description');
-    enrichment.setIgnoreDownstreamErrors(true);
+    IBMDiscoveryV1Models.XPathPatterns xPathPatterns = new IBMDiscoveryV1Models.XPathPatternsBuilder()
+      .xpaths(new List<String>{ 'xpath1' })
+      .build();
+    IBMDiscoveryV1Models.HtmlSettings html = new IBMDiscoveryV1Models.HtmlSettingsBuilder()
+      .excludeContent(xPathPatterns)
+      .excludeTagAttributes(new List<String> { 'ExAtt1' })
+      .excludeTagsCompletely(new List<String> { 'Tag1', 'Tag2' })
+      .excludeTagsKeepContent(new List<String> { 'KeepCntent1', 'KeepCntent2' })
+      .keepContent(xPathPatterns)
+      .keepTagAttributes(new List<String> { 'tag' })
+      .build();
+    IBMDiscoveryV1Models.NormalizationOperation normalizationOperation = new IBMDiscoveryV1Models.NormalizationOperationBuilder()
+      .destinationField('test destination')
+      .operation('test operation')
+      .sourceField('test source')
+      .build();
+    IBMDiscoveryV1Models.FontSetting fontSetting = new IBMDiscoveryV1Models.FontSettingBuilder()
+      .bold(true)
+      .italic(true)
+      .level(1)
+      .maxSize(10)
+      .minSize(4)
+      .name('ariel')
+      .build();
+    IBMDiscoveryV1Models.PdfHeadingDetection pdfHeadingDetection = new IBMDiscoveryV1Models.PdfHeadingDetectionBuilder()
+      .fonts(new List<IBMDiscoveryV1Models.FontSetting> { fontSetting })
+      .build();
+    IBMDiscoveryV1Models.PdfSettings pdfSettings = new IBMDiscoveryV1Models.PdfSettingsBuilder()
+      .heading(pdfHeadingDetection)
+      .build();
+    IBMDiscoveryV1Models.WordStyle style = new IBMDiscoveryV1Models.WordStyleBuilder()
+      .level(1)
+      .names(new List<String> { 'Style1', 'Style2' })
+      .build();
+    IBMDiscoveryV1Models.WordHeadingDetection wordHeading = new IBMDiscoveryV1Models.WordHeadingDetectionBuilder()
+      .fonts(new List<IBMDiscoveryV1Models.FontSetting> { fontSetting })
+      .styles(new List<IBMDiscoveryV1Models.WordStyle> { style })
+      .build();
+    IBMDiscoveryV1Models.WordSettings word = new IBMDiscoveryV1Models.WordSettingsBuilder()
+      .heading(wordHeading)
+      .build();
+    IBMDiscoveryV1Models.Conversions conversions = new IBMDiscoveryV1Models.ConversionsBuilder()
+      .html(html)
+      .jsonNormalizations(new List<IBMDiscoveryV1Models.NormalizationOperation>{ normalizationOperation })
+      .pdf(pdfSettings)
+      .word(word)
+      .build();
     IBMDiscoveryV1Models.NluEnrichmentEmotion enrichmentEmotion = new IBMDiscoveryV1Models.NluEnrichmentEmotionBuilder()
       .document(true)
-      .targets(new List<String>{'Target1', 'Target2'})
+      .targets(new List<String> { 'Target1', 'Target2' })
       .build();
     IBMDiscoveryV1Models.NluEnrichmentEntities enrichmentEntities = new IBMDiscoveryV1Models.NluEnrichmentEntitiesBuilder()
       .emotion(true)
@@ -1425,8 +1459,9 @@ private class IBMDiscoveryV1Test {
       .xlimit(5)
       .sentiment(true)
       .build();
-    IBMDiscoveryV1Models.NluEnrichmentRelations enrichmentRelations = new IBMDiscoveryV1Models.NluEnrichmentRelations();
-    enrichmentRelations.setModel('test');
+    IBMDiscoveryV1Models.NluEnrichmentRelations enrichmentRelations = new IBMDiscoveryV1Models.NluEnrichmentRelationsBuilder()
+      .model('test')
+      .build();
     IBMDiscoveryV1Models.NluEnrichmentSemanticRoles enrichmentSemanticRoles = new IBMDiscoveryV1Models.NluEnrichmentSemanticRolesBuilder()
       .entities(true)
       .keywords(true)
@@ -1449,9 +1484,22 @@ private class IBMDiscoveryV1Test {
       .model('test')
       .language('en')
       .build();
-    enrichment.setOptions(enrichmentOptions);
-    configuration.setEnrichments(new List<IBMDiscoveryV1Models.Enrichment>{enrichment});
-    configuration.setNormalizations(new List<IBMDiscoveryV1Models.NormalizationOperation>{normalizationOperation});
+    IBMDiscoveryV1Models.Enrichment enrichment = new IBMDiscoveryV1Models.EnrichmentBuilder()
+      .description('test Description')
+      .destinationField('test Description')
+      .sourceField('test Description')
+      .overwrite(true)
+      .enrichmentName('test Description')
+      .ignoreDownstreamErrors(true)
+      .options(enrichmentOptions)
+      .build();
+    IBMDiscoveryV1Models.Configuration configuration = new IBMDiscoveryV1Models.ConfigurationBuilder()
+      .name('test-collection')
+      .description('A test collection to show as an example')
+      .enrichments(new List<IBMDiscoveryV1Models.Enrichment> { enrichment })
+      .normalizations(new List<IBMDiscoveryV1Models.NormalizationOperation> { normalizationOperation })
+      .conversions(conversions)
+      .build();
     IBMDiscoveryV1 discovery = new IBMDiscoveryV1(VERSION);
     discovery.setEndPoint('https://gateway.watsonplatform.net/discovery/api');
     discovery.setUsernameAndPassword('username', 'password');
@@ -1478,8 +1526,8 @@ private class IBMDiscoveryV1Test {
     System.assertEquals(configuration.getConversions().getWord().getHeading().getStyles()[0].getNames()[0], 'Style1');
     System.assertEquals(configuration.getConversions().getHtml().getExcludeTagsCompletely()[0], 'Tag1');
     System.assertEquals(configuration.getConversions().getHtml().getExcludeTagsKeepContent()[0], 'KeepCntent1');
-    System.assertEquals(configuration.getConversions().getHtml().getKeepTagAttributes()[0], 'ExAtt1');
-    System.assertEquals(configuration.getConversions().getHtml().getExcludeTagAttributes()[0], 'KeepAtt');
+    System.assertEquals(configuration.getConversions().getHtml().getKeepTagAttributes()[0], 'tag');
+    System.assertEquals(configuration.getConversions().getHtml().getExcludeTagAttributes()[0], 'ExAtt1');
     System.assertEquals(configuration.getConversions().getHtml().getKeepContent().getXpaths()[0], 'xpath1');
     System.assertEquals(configuration.getConversions().getHtml().getExcludeContent().getXpaths()[0], 'xpath1');
     System.assertEquals(configuration.getConversions().getJsonNormalizations()[0].getOperation(), 'test operation');
@@ -1658,14 +1706,17 @@ private class IBMDiscoveryV1Test {
     List<String> expansion1ExpandedTerms = new List<String> { 'monday', 'tuesday', 'wednesday', 'thursday', 'friday' };
     List<String> expansion2InputTerms = new List<String> { 'weekend', 'week end' };
     List<String> expansion2ExpandedTerms = new List<String> { 'saturday', 'sunday' };
-    IBMDiscoveryV1Models.Expansion expansion1 = new IBMDiscoveryV1Models.Expansion();
-    expansion1.setInputTerms(expansion1InputTerms);
-    expansion1.setExpandedTerms(expansion1ExpandedTerms);
-    IBMDiscoveryV1Models.Expansion expansion2 = new IBMDiscoveryV1Models.Expansion();
-    expansion2.setInputTerms(expansion2InputTerms);
-    expansion2.setExpandedTerms(expansion2ExpandedTerms);
-    IBMDiscoveryV1Models.Expansions expansions = new IBMDiscoveryV1Models.Expansions();
-    expansions.setExpansions(new List<IBMDiscoveryV1Models.Expansion> { expansion1, expansion2 });
+    IBMDiscoveryV1Models.Expansion expansion1 = new IBMDiscoveryV1Models.ExpansionBuilder()
+      .inputTerms(expansion1InputTerms)
+      .expandedTerms(expansion1ExpandedTerms)
+      .build();
+    IBMDiscoveryV1Models.Expansion expansion2 = new IBMDiscoveryV1Models.ExpansionBuilder()
+      .inputTerms(expansion2InputTerms)
+      .expandedTerms(expansion2ExpandedTerms)
+      .build();
+    IBMDiscoveryV1Models.Expansions expansions = new IBMDiscoveryV1Models.ExpansionsBuilder()
+      .expansions(new List<IBMDiscoveryV1Models.Expansion> { expansion1, expansion2 })
+      .build();
 
     IBMDiscoveryV1Models.CreateExpansionsOptions createOptions = new IBMDiscoveryV1Models.CreateExpansionsOptionsBuilder()
         .environmentId('environment_id')
@@ -1693,14 +1744,17 @@ private class IBMDiscoveryV1Test {
     List<String> expansion1ExpandedTerms = new List<String> { 'monday', 'tuesday', 'wednesday', 'thursday', 'friday' };
     List<String> expansion2InputTerms = new List<String> { 'weekend', 'week end' };
     List<String> expansion2ExpandedTerms = new List<String> { 'saturday', 'sunday' };
-    IBMDiscoveryV1Models.Expansion expansion1 = new IBMDiscoveryV1Models.Expansion();
-    expansion1.setInputTerms(expansion1InputTerms);
-    expansion1.setExpandedTerms(expansion1ExpandedTerms);
-    IBMDiscoveryV1Models.Expansion expansion2 = new IBMDiscoveryV1Models.Expansion();
-    expansion2.setInputTerms(expansion2InputTerms);
-    expansion2.setExpandedTerms(expansion2ExpandedTerms);
-    IBMDiscoveryV1Models.Expansions expansions = new IBMDiscoveryV1Models.Expansions();
-    expansions.setExpansions(new List<IBMDiscoveryV1Models.Expansion> { expansion1, expansion2 });
+    IBMDiscoveryV1Models.Expansion expansion1 = new IBMDiscoveryV1Models.ExpansionBuilder()
+      .inputTerms(expansion1InputTerms)
+      .expandedTerms(expansion1ExpandedTerms)
+      .build();
+    IBMDiscoveryV1Models.Expansion expansion2 = new IBMDiscoveryV1Models.ExpansionBuilder()
+      .inputTerms(expansion2InputTerms)
+      .expandedTerms(expansion2ExpandedTerms)
+      .build();
+    IBMDiscoveryV1Models.Expansions expansions = new IBMDiscoveryV1Models.ExpansionsBuilder()
+      .expansions(new List<IBMDiscoveryV1Models.Expansion> { expansion1, expansion2 })
+      .build();
 
     IBMDiscoveryV1Models.ListExpansionsOptions listOptions = new IBMDiscoveryV1Models.ListExpansionsOptionsBuilder()
         .environmentId('environment_id')
@@ -1742,11 +1796,13 @@ private class IBMDiscoveryV1Test {
     discovery.setEndPoint('https://gateway.watsonplatform.net/discovery/api');
     discovery.setUsernameAndPassword('username', 'password');
 
-    IBMDiscoveryV1Models.QueryEntitiesContext context = new IBMDiscoveryV1Models.QueryEntitiesContext();
-    context.setText('text');
-    IBMDiscoveryV1Models.QueryEntitiesEntity entity = new IBMDiscoveryV1Models.QueryEntitiesEntity();
-    entity.setXtype('type');
-    entity.setText('text');
+    IBMDiscoveryV1Models.QueryEntitiesContext context = new IBMDiscoveryV1Models.QueryEntitiesContextBuilder()
+      .text('text')
+      .build();
+    IBMDiscoveryV1Models.QueryEntitiesEntity entity = new IBMDiscoveryV1Models.QueryEntitiesEntityBuilder()
+      .xtype('type')
+      .text('text')
+      .build();
     IBMDiscoveryV1Models.QueryEntitiesOptions options = new IBMDiscoveryV1Models.QueryEntitiesOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
@@ -1783,19 +1839,23 @@ private class IBMDiscoveryV1Test {
     discovery.setEndPoint('https://gateway.watsonplatform.net/discovery/api');
     discovery.setUsernameAndPassword('username', 'password');
 
-    IBMDiscoveryV1Models.QueryEntitiesContext context = new IBMDiscoveryV1Models.QueryEntitiesContext();
-    context.setText('text');
-    IBMDiscoveryV1Models.QueryRelationsEntity entity = new IBMDiscoveryV1Models.QueryRelationsEntity();
-    entity.setXtype('text');
-    entity.setExact(true);
-    entity.setText('text');
-    IBMDiscoveryV1Models.QueryFilterType filterType = new IBMDiscoveryV1Models.QueryFilterType();
-    filterType.setInclude(new List<String>{ 'include' });
-    filterType.setExclude(new List<String>{ 'exclude' });
-    IBMDiscoveryV1Models.QueryRelationsFilter filter = new IBMDiscoveryV1Models.QueryRelationsFilter();
-    filter.setDocumentIds(new List<String>{ 'id' });
-    filter.setEntityTypes(filterType);
-    filter.setRelationTypes(filterType);
+    IBMDiscoveryV1Models.QueryEntitiesContext context = new IBMDiscoveryV1Models.QueryEntitiesContextBuilder()
+      .text('text')
+      .build();
+    IBMDiscoveryV1Models.QueryRelationsEntity entity = new IBMDiscoveryV1Models.QueryRelationsEntityBuilder()
+      .xtype('text')
+      .exact(true)
+      .text('text')
+      .build();
+    IBMDiscoveryV1Models.QueryFilterType filterType = new IBMDiscoveryV1Models.QueryFilterTypeBuilder()
+      .include(new List<String>{ 'include' })
+      .exclude(new List<String>{ 'exclude' })
+      .build();
+    IBMDiscoveryV1Models.QueryRelationsFilter filter = new IBMDiscoveryV1Models.QueryRelationsFilterBuilder()
+      .documentIds(new List<String> { 'id' })
+      .entityTypes(filterType)
+      .relationTypes(filterType)
+      .build();
     IBMDiscoveryV1Models.QueryRelationsOptions options = new IBMDiscoveryV1Models.QueryRelationsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
@@ -1871,26 +1931,27 @@ private class IBMDiscoveryV1Test {
     String endpoint = 'endpoint';
     String secretAccessKey = 'secret_access_key';
 
-    IBMDiscoveryV1Models.CredentialDetails details = new IBMDiscoveryV1Models.CredentialDetails();
-    details.setClientId(clientId);
-    details.setClientSecret(clientSecret);
-    details.setCredentialType(credentialType);
-    details.setEnterpriseId(enterpriseId);
-    details.setOrganizationUrl(organizationUrl);
-    details.setPassphrase(passphrase);
-    details.setPassword(password);
-    details.setPrivateKey(privateKey);
-    details.setPublicKeyId(publicKeyId);
-    details.setSiteCollectionPath(siteCollectionPath);
-    details.setUrl(url);
-    details.setUsername(username);
-    details.setGatewayId(gatewayId);
-    details.setSourceVersion(sourceVersion);
-    details.setWebApplicationUrl(webApplicationUrl);
-    details.setDomain(domain);
-    details.setAccessKeyId(accessKeyId);
-    details.setEndpoint(endpoint);
-    details.setSecretAccessKey(secretAccessKey);
+    IBMDiscoveryV1Models.CredentialDetails details = new IBMDiscoveryV1Models.CredentialDetailsBuilder()
+      .clientId(clientId)
+      .clientSecret(clientSecret)
+      .credentialType(credentialType)
+      .enterpriseId(enterpriseId)
+      .organizationUrl(organizationUrl)
+      .passphrase(passphrase)
+      .password(password)
+      .privateKey(privateKey)
+      .publicKeyId(publicKeyId)
+      .siteCollectionPath(siteCollectionPath)
+      .url(url)
+      .username(username)
+      .gatewayId(gatewayId)
+      .sourceVersion(sourceVersion)
+      .webApplicationUrl(webApplicationUrl)
+      .domain(domain)
+      .accessKeyId(accessKeyId)
+      .endpoint(endpoint)
+      .secretAccessKey(secretAccessKey)
+      .build();
 
     System.assertEquals(clientId, details.getClientId());
     System.assertEquals(clientSecret, details.getClientSecret());
@@ -1928,28 +1989,29 @@ private class IBMDiscoveryV1Test {
     String url = 'login.salesforce.com';
     String username = 'user@email.address';
     String status = 'connected';
-
-    IBMDiscoveryV1Models.CredentialDetails details = new IBMDiscoveryV1Models.CredentialDetails();
-    details.setClientId('client_id');
-    details.setClientSecret('client_secret');
-    details.setCredentialType(credentialType);
-    details.setEnterpriseId('enterprise_id');
-    details.setOrganizationUrl('organization_url');
-    details.setPassphrase('passphrase');
-    details.setPassword('password');
-    details.setPrivateKey('private_key');
-    details.setPublicKeyId('public_key_id');
-    details.setSiteCollectionPath('site_collection_path');
-    details.setUrl(url);
-    details.setUsername(username);
-    details.setGatewayId('gateway_id');
-    details.setSourceVersion('source_version');
-    details.setWebApplicationUrl('web_application_url');
-    details.setDomain('domain');
-    IBMDiscoveryV1Models.Credentials credentials = new IBMDiscoveryV1Models.Credentials();
-    credentials.setSourceType(sourceType);
-    credentials.setCredentialDetails(details);
-    credentials.setStatus(status);
+    IBMDiscoveryV1Models.CredentialDetails details = new IBMDiscoveryV1Models.CredentialDetailsBuilder()
+      .clientId('client_id')
+      .clientSecret('client_secret')
+      .credentialType(credentialType)
+      .enterpriseId('enterprise_id')
+      .organizationUrl('organization_url')
+      .passphrase('passphrase')
+      .password('password')
+      .privateKey('private_key')
+      .publicKeyId('public_key_id')
+      .siteCollectionPath('site_collection_path')
+      .url(url)
+      .username(username)
+      .gatewayId('gateway_id')
+      .sourceVersion('source_version')
+      .webApplicationUrl('web_application_url')
+      .domain('domain')
+      .build();
+    IBMDiscoveryV1Models.Credentials credentials = new IBMDiscoveryV1Models.CredentialsBuilder()
+      .sourceType(sourceType)
+      .credentialDetails(details)
+      .status(status)
+      .build();
 
     IBMDiscoveryV1Models.CreateCredentialsOptions options = new IBMDiscoveryV1Models.CreateCredentialsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
@@ -2049,22 +2111,24 @@ private class IBMDiscoveryV1Test {
     String username = 'user@email.address';
     String status = 'connected';
 
-    IBMDiscoveryV1Models.CredentialDetails newDetails = new IBMDiscoveryV1Models.CredentialDetails();
-    newDetails.setClientId('client_id');
-    newDetails.setClientSecret('client_secret');
-    newDetails.setCredentialType(credentialType);
-    newDetails.setEnterpriseId('enterprise_id');
-    newDetails.setOrganizationUrl('organization_url');
-    newDetails.setPassphrase('passphrase');
-    newDetails.setPassword('password');
-    newDetails.setPrivateKey('private_key');
-    newDetails.setPublicKeyId('public_key_id');
-    newDetails.setSiteCollectionPath('site_collection_path');
-    newDetails.setUrl(url);
-    newDetails.setUsername(username);
-    IBMDiscoveryV1Models.Credentials newCredentials = new IBMDiscoveryV1Models.Credentials();
-    newCredentials.setSourceType(sourceType);
-    newCredentials.setCredentialDetails(newDetails);
+    IBMDiscoveryV1Models.CredentialDetails newDetails = new IBMDiscoveryV1Models.CredentialDetailsBuilder()
+      .clientId('client_id')
+      .clientSecret('client_secret')
+      .credentialType(credentialType)
+      .enterpriseId('enterprise_id')
+      .organizationUrl('organization_url')
+      .passphrase('passphrase')
+      .password('password')
+      .privateKey('private_key')
+      .publicKeyId('public_key_id')
+      .siteCollectionPath('site_collection_path')
+      .url(url)
+      .username(username)
+      .build();
+    IBMDiscoveryV1Models.Credentials newCredentials = new IBMDiscoveryV1Models.CredentialsBuilder()
+      .sourceType(sourceType)
+      .credentialDetails(newDetails)
+      .build();
 
     IBMDiscoveryV1Models.UpdateCredentialsOptions options = new IBMDiscoveryV1Models.UpdateCredentialsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
@@ -2103,13 +2167,14 @@ private class IBMDiscoveryV1Test {
     String documentId = 'mock_docid';
     String queryId = 'mock_queryid';
 
-    IBMDiscoveryV1Models.EventData eventData = new IBMDiscoveryV1Models.EventData();
-    eventData.setEnvironmentId(ENVIRONMENT_ID);
-    eventData.setCollectionId(collectionId);
-    eventData.setDocumentId(documentId);
-    eventData.setDisplayRank(displayRank);
-    eventData.setSessionToken(sessionToken);
-    eventData.setClientTimestamp(dateValue);
+    IBMDiscoveryV1Models.EventData eventData = new IBMDiscoveryV1Models.EventDataBuilder()
+      .environmentId(ENVIRONMENT_ID)
+      .collectionId(collectionId)
+      .documentId(documentId)
+      .displayRank(displayRank)
+      .sessionToken(sessionToken)
+      .clientTimestamp(dateValue)
+      .build();
     IBMDiscoveryV1Models.CreateEventOptions createEventOptions = new IBMDiscoveryV1Models.CreateEventOptionsBuilder()
         .xtype(eventType)
         .data(eventData)
@@ -2368,11 +2433,12 @@ private class IBMDiscoveryV1Test {
     List<String> readings = new List<String> { 'reading 1', 'reading 2' };
     List<String> tokens = new List<String> { 'token 1', 'token 2' };
 
-    IBMDiscoveryV1Models.TokenDictRule tokenDictRule = new IBMDiscoveryV1Models.TokenDictRule();
-    tokenDictRule.setText(text);
-    tokenDictRule.setPartOfSpeech(partOfSpeech);
-    tokenDictRule.setReadings(readings);
-    tokenDictRule.setTokens(tokens);
+    IBMDiscoveryV1Models.TokenDictRule tokenDictRule = new IBMDiscoveryV1Models.TokenDictRuleBuilder()
+      .text(text)
+      .partOfSpeech(partOfSpeech)
+      .readings(readings)
+      .tokens(tokens)
+      .build();
 
     System.assertEquals(text, tokenDictRule.getText());
     System.assertEquals(partOfSpeech, tokenDictRule.getPartOfSpeech());
@@ -2389,8 +2455,16 @@ private class IBMDiscoveryV1Test {
     String collectionId = 'collection_id';
     String headerKey = 'Test-Header';
     String headerValue = 'test_value';
-    IBMDiscoveryV1Models.TokenDictRule firstTokenDictRule = new IBMDiscoveryV1Models.TokenDictRule();
-    IBMDiscoveryV1Models.TokenDictRule secondTokenDictRule = new IBMDiscoveryV1Models.TokenDictRule();
+    IBMDiscoveryV1Models.TokenDictRule firstTokenDictRule = new IBMDiscoveryV1Models.TokenDictRuleBuilder()
+      .text(TEXT)
+      .tokens(TOKENS)
+      .partOfSpeech(PART_OF_SPEECH)
+      .build();
+    IBMDiscoveryV1Models.TokenDictRule secondTokenDictRule = new IBMDiscoveryV1Models.TokenDictRuleBuilder()
+      .text(TEXT)
+      .tokens(TOKENS)
+      .partOfSpeech(PART_OF_SPEECH)
+      .build();
     List<IBMDiscoveryV1Models.TokenDictRule> tokenDictRuleList = new List<IBMDiscoveryV1Models.TokenDictRule>();
     tokenDictRuleList.add(firstTokenDictRule);
 
@@ -2464,10 +2538,16 @@ private class IBMDiscoveryV1Test {
 
     String environmentId = 'environment_id';
     String collectionId = 'collection_id';
+    IBMDiscoveryV1Models.TokenDictRule tokenDictRule = new IBMDiscoveryV1Models.TokenDictRuleBuilder()
+      .text(TEXT)
+      .tokens(TOKENS)
+      .partOfSpeech(PART_OF_SPEECH)
+      .build();
+
     IBMDiscoveryV1Models.CreateTokenizationDictionaryOptions createOptions = new IBMDiscoveryV1Models.CreateTokenizationDictionaryOptionsBuilder()
         .environmentId(environmentId)
         .collectionId(collectionId)
-        .tokenizationRules(new List<IBMDiscoveryV1Models.TokenDictRule> { new IBMDiscoveryV1Models.TokenDictRule() })
+        .tokenizationRules(new List<IBMDiscoveryV1Models.TokenDictRule> { tokenDictRule })
         .build();
     IBMDiscoveryV1Models.TokenDictStatusResponse response = discovery.createTokenizationDictionary(createOptions);
 
@@ -2860,15 +2940,16 @@ private class IBMDiscoveryV1Test {
     Long requestTimeout = 2000L;
     List<String> blacklist = new List<String>{ 'badsite.com' };
 
-    IBMDiscoveryV1Models.SourceOptionsWebCrawl sourceOptionsWebCrawl = new IBMDiscoveryV1Models.SourceOptionsWebCrawl();
-    sourceOptionsWebCrawl.setUrl(url);
-    sourceOptionsWebCrawl.setLimitToStartingHosts(true);
-    sourceOptionsWebCrawl.setCrawlSpeed(crawlSpeed);
-    sourceOptionsWebCrawl.setAllowUntrustedCertificate(true);
-    sourceOptionsWebCrawl.setMaximumHops(maximumHops);
-    sourceOptionsWebCrawl.setRequestTimeout(requestTimeout);
-    sourceOptionsWebCrawl.setOverrideRobotsTxt(true);
-    sourceOptionsWebCrawl.setBlacklist(blacklist);
+    IBMDiscoveryV1Models.SourceOptionsWebCrawl sourceOptionsWebCrawl = new IBMDiscoveryV1Models.SourceOptionsWebCrawlBuilder()
+      .url(url)
+      .limitToStartingHosts(true)
+      .crawlSpeed(crawlSpeed)
+      .allowUntrustedCertificate(true)
+      .maximumHops(maximumHops)
+      .requestTimeout(requestTimeout)
+      .overrideRobotsTxt(true)
+      .blacklist(blacklist)
+      .build();
 
     System.assertEquals(url, sourceOptionsWebCrawl.getUrl());
     System.assert(sourceOptionsWebCrawl.getLimitToStartingHosts());
@@ -2884,9 +2965,10 @@ private class IBMDiscoveryV1Test {
     String name = 'name';
     Long testLimit = 9000L;
 
-    IBMDiscoveryV1Models.SourceOptionsBuckets sourceOptionsBuckets = new IBMDiscoveryV1Models.SourceOptionsBuckets();
-    sourceOptionsBuckets.setName(name);
-    sourceOptionsBuckets.setXlimit(testLimit);
+    IBMDiscoveryV1Models.SourceOptionsBuckets sourceOptionsBuckets = new IBMDiscoveryV1Models.SourceOptionsBucketsBuilder()
+      .name(name)
+      .xlimit(testLimit)
+      .build();
 
     System.assertEquals(name, sourceOptionsBuckets.getName());
     System.assertEquals(testLimit, sourceOptionsBuckets.getXlimit());
@@ -2904,34 +2986,40 @@ private class IBMDiscoveryV1Test {
     String bucketName = 'bucket_name';
     String crawlSpeed = 'aggressive';
 
-    IBMDiscoveryV1Models.SourceOptions sourceOptions = new IBMDiscoveryV1Models.SourceOptions();
-    IBMDiscoveryV1Models.SourceOptionsFolder folder = new IBMDiscoveryV1Models.SourceOptionsFolder();
-    folder.setOwnerUserId(folderOwnerUserId);
-    folder.setFolderId(folderId);
-    folder.setXlimit(testLimit);
-    sourceOptions.setFolders(new List<IBMDiscoveryV1Models.SourceOptionsFolder> { folder });
-    IBMDiscoveryV1Models.SourceOptionsObject sourceObject = new IBMDiscoveryV1Models.SourceOptionsObject();
-    sourceObject.setName(objectName);
-    sourceObject.setXlimit(testLimit);
-    sourceOptions.setObjects(new List<IBMDiscoveryV1Models.SourceOptionsObject> { sourceObject });
-    IBMDiscoveryV1Models.SourceOptionsSiteColl siteColl = new IBMDiscoveryV1Models.SourceOptionsSiteColl();
-    siteColl.setSiteCollectionPath(siteCollectionPath);
-    siteColl.setXlimit(testLimit);
-    sourceOptions.setSiteCollections(new List<IBMDiscoveryV1Models.SourceOptionsSiteColl> { siteColl });
-    IBMDiscoveryV1Models.SourceOptionsWebCrawl webCrawl = new IBMDiscoveryV1Models.SourceOptionsWebCrawl();
-    webCrawl.setUrl(url);
-    webCrawl.setLimitToStartingHosts(true);
-    webCrawl.setCrawlSpeed(crawlSpeed);
-    webCrawl.setAllowUntrustedCertificate(true);
-    webCrawl.setMaximumHops(maximumHops);
-    webCrawl.setRequestTimeout(requestTimeout);
-    webCrawl.setOverrideRobotsTxt(true);
-    sourceOptions.setUrls(new List<IBMDiscoveryV1Models.SourceOptionsWebCrawl> { webCrawl });
-    IBMDiscoveryV1Models.SourceOptionsBuckets buckets = new IBMDiscoveryV1Models.SourceOptionsBuckets();
-    buckets.setName(bucketName);
-    buckets.setXlimit(testLimit);
-    sourceOptions.setBuckets(new List<IBMDiscoveryV1Models.SourceOptionsBuckets> { buckets });
-    sourceOptions.setCrawlAllBuckets(true);
+    IBMDiscoveryV1Models.SourceOptionsFolder folder = new IBMDiscoveryV1Models.SourceOptionsFolderBuilder()
+      .ownerUserId(folderOwnerUserId)
+      .folderId(folderId)
+      .xlimit(testLimit)
+      .build();
+    IBMDiscoveryV1Models.SourceOptionsObject sourceObject = new IBMDiscoveryV1Models.SourceOptionsObjectBuilder()
+      .name(objectName)
+      .xlimit(testLimit)
+      .build();
+    IBMDiscoveryV1Models.SourceOptionsSiteColl siteColl = new IBMDiscoveryV1Models.SourceOptionsSiteCollBuilder()
+      .siteCollectionPath(siteCollectionPath)
+      .xlimit(testLimit)
+      .build();
+    IBMDiscoveryV1Models.SourceOptionsWebCrawl webCrawl = new IBMDiscoveryV1Models.SourceOptionsWebCrawlBuilder()
+      .url(url)
+      .limitToStartingHosts(true)
+      .crawlSpeed(crawlSpeed)
+      .allowUntrustedCertificate(true)
+      .maximumHops(maximumHops)
+      .requestTimeout(requestTimeout)
+      .overrideRobotsTxt(true)
+      .build();
+    IBMDiscoveryV1Models.SourceOptionsBuckets buckets = new IBMDiscoveryV1Models.SourceOptionsBucketsBuilder()
+      .name(bucketName)
+      .xlimit(testLimit)
+      .build();
+    IBMDiscoveryV1Models.SourceOptions sourceOptions = new IBMDiscoveryV1Models.SourceOptionsBuilder()
+      .folders(new List<IBMDiscoveryV1Models.SourceOptionsFolder> { folder })
+      .siteCollections(new List<IBMDiscoveryV1Models.SourceOptionsSiteColl> { siteColl })
+      .urls(new List<IBMDiscoveryV1Models.SourceOptionsWebCrawl> { webCrawl })
+      .buckets(new List<IBMDiscoveryV1Models.SourceOptionsBuckets> { buckets })
+      .objects(new List<IBMDiscoveryV1Models.SourceOptionsObject> { sourceObject })
+      .crawlAllBuckets(true)
+      .build();
 
     System.assertEquals(folderOwnerUserId, sourceOptions.getFolders().get(0).getOwnerUserId());
     System.assertEquals(folderId, sourceOptions.getFolders().get(0).getFolderId());

--- a/force-app/main/default/classes/IBMLanguageTranslatorV3.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV3.cls
@@ -85,7 +85,7 @@ public class IBMLanguageTranslatorV3 extends IBMWatsonService {
     if (translateOptions.target() != null) {
       contentJson.put('target', translateOptions.target());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, translateOptions.getSdkToApiMapping()));
 
     return (IBMLanguageTranslatorV3Models.TranslationResult) createServiceCall(builder.build(), IBMLanguageTranslatorV3Models.TranslationResult.class);
   }
@@ -185,7 +185,7 @@ public class IBMLanguageTranslatorV3 extends IBMWatsonService {
    * files is limited to <b>250 MB</b>. To successfully train with a parallel corpus you must have at least <b>5,000
    * parallel sentences</b> in your corpus.
    *
-   * You can have a <b>maxium of 10 custom models per language pair</b>.
+   * You can have a <b>maximum of 10 custom models per language pair</b>.
    *
    * @param createModelOptions the {@link IBMLanguageTranslatorV3Models.CreateModelOptions} containing the options for the call
    * @return the {@link IBMLanguageTranslatorV3Models.TranslationModel} with the response

--- a/force-app/main/default/classes/IBMLanguageTranslatorV3Models.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV3Models.cls
@@ -7,7 +7,7 @@ public class IBMLanguageTranslatorV3Models {
     private IBMWatsonFile forcedGlossary;
     private IBMWatsonFile parallelCorpus;
     private String name;
- 
+
     /**
      * Gets the baseModelId.
      *
@@ -20,7 +20,7 @@ public class IBMLanguageTranslatorV3Models {
     public String baseModelId() {
       return baseModelId;
     }
- 
+
     /**
      * Gets the forcedGlossary.
      *
@@ -33,7 +33,7 @@ public class IBMLanguageTranslatorV3Models {
     public IBMWatsonFile forcedGlossary() {
       return forcedGlossary;
     }
- 
+
     /**
      * Gets the parallelCorpus.
      *
@@ -46,7 +46,7 @@ public class IBMLanguageTranslatorV3Models {
     public IBMWatsonFile parallelCorpus() {
       return parallelCorpus;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -77,6 +77,13 @@ public class IBMLanguageTranslatorV3Models {
       return new CreateModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('baseModelId', 'base_model_id');
+      mapping.put('forcedGlossary', 'forced_glossary');
+      mapping.put('parallelCorpus', 'parallel_corpus');
+      return mapping;
+    }
   }
 
   /**
@@ -182,7 +189,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class DeleteDocumentOptions extends IBMWatsonOptionsModel {
     private String documentId;
- 
+
     /**
      * Gets the documentId.
      *
@@ -209,6 +216,11 @@ public class IBMLanguageTranslatorV3Models {
       return new DeleteDocumentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('documentId', 'document_id');
+      return mapping;
+    }
   }
 
   /**
@@ -275,7 +287,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class DeleteModelOptions extends IBMWatsonOptionsModel {
     private String modelId;
- 
+
     /**
      * Gets the modelId.
      *
@@ -302,6 +314,11 @@ public class IBMLanguageTranslatorV3Models {
       return new DeleteModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('modelId', 'model_id');
+      return mapping;
+    }
   }
 
   /**
@@ -367,7 +384,7 @@ public class IBMLanguageTranslatorV3Models {
    * DocumentList.
    */
   public class DocumentList extends IBMWatsonResponseModel {
-    private List<DocumentStatus> documents_serialized_name;
+    private List<DocumentStatus> documents;
  
     /**
      * Gets the documents.
@@ -378,7 +395,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public List<DocumentStatus> getDocuments() {
-      return documents_serialized_name;
+      return documents;
     }
 
     /**
@@ -387,7 +404,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param documents the new documents
      */
     public void setDocuments(final List<DocumentStatus> documents) {
-      this.documents_serialized_name = documents;
+      this.documents = documents;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -403,14 +420,22 @@ public class IBMLanguageTranslatorV3Models {
       if (deserializedDocuments != null) {
         for (Integer i = 0; i < deserializedDocuments.size(); i++) {
           DocumentStatus currentItem = ret.getDocuments().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('documents_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('documents');
           DocumentStatus newItem = (DocumentStatus) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), DocumentStatus.class);
           newDocuments.add(newItem);
         }
-        ret.documents_serialized_name = newDocuments;
+        ret.documents = newDocuments;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (documents != null && documents[0] != null) {
+        mapping.putAll(documents[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -418,17 +443,17 @@ public class IBMLanguageTranslatorV3Models {
    * Document information, including translation status.
    */
   public class DocumentStatus extends IBMWatsonResponseModel {
-    private String document_id_serialized_name;
-    private String filename_serialized_name;
-    private String status_serialized_name;
-    private String model_id_serialized_name;
-    private String base_model_id_serialized_name;
-    private String source_serialized_name;
-    private String target_serialized_name;
-    private Datetime created_serialized_name;
-    private Datetime completed_serialized_name;
-    private Long word_count_serialized_name;
-    private Long character_count_serialized_name;
+    private String documentId;
+    private String filename;
+    private String status;
+    private String modelId;
+    private String baseModelId;
+    private String source;
+    private String target;
+    private Datetime created;
+    private Datetime completed;
+    private Long wordCount;
+    private Long characterCount;
  
     /**
      * Gets the documentId.
@@ -439,7 +464,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getDocumentId() {
-      return document_id_serialized_name;
+      return documentId;
     }
  
     /**
@@ -452,7 +477,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getFilename() {
-      return filename_serialized_name;
+      return filename;
     }
  
     /**
@@ -464,7 +489,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -476,7 +501,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getModelId() {
-      return model_id_serialized_name;
+      return modelId;
     }
  
     /**
@@ -489,7 +514,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getBaseModelId() {
-      return base_model_id_serialized_name;
+      return baseModelId;
     }
  
     /**
@@ -501,7 +526,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getSource() {
-      return source_serialized_name;
+      return source;
     }
  
     /**
@@ -513,7 +538,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getTarget() {
-      return target_serialized_name;
+      return target;
     }
  
     /**
@@ -525,7 +550,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -537,7 +562,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public Datetime getCompleted() {
-      return completed_serialized_name;
+      return completed;
     }
  
     /**
@@ -549,7 +574,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public Long getWordCount() {
-      return word_count_serialized_name;
+      return wordCount;
     }
  
     /**
@@ -561,7 +586,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public Long getCharacterCount() {
-      return character_count_serialized_name;
+      return characterCount;
     }
 
     /**
@@ -570,7 +595,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param documentId the new documentId
      */
     public void setDocumentId(final String documentId) {
-      this.document_id_serialized_name = documentId;
+      this.documentId = documentId;
     }
 
     /**
@@ -579,7 +604,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param filename the new filename
      */
     public void setFilename(final String filename) {
-      this.filename_serialized_name = filename;
+      this.filename = filename;
     }
 
     /**
@@ -588,7 +613,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -597,7 +622,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param modelId the new modelId
      */
     public void setModelId(final String modelId) {
-      this.model_id_serialized_name = modelId;
+      this.modelId = modelId;
     }
 
     /**
@@ -606,7 +631,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param baseModelId the new baseModelId
      */
     public void setBaseModelId(final String baseModelId) {
-      this.base_model_id_serialized_name = baseModelId;
+      this.baseModelId = baseModelId;
     }
 
     /**
@@ -615,7 +640,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param source the new source
      */
     public void setSource(final String source) {
-      this.source_serialized_name = source;
+      this.source = source;
     }
 
     /**
@@ -624,7 +649,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param target the new target
      */
     public void setTarget(final String target) {
-      this.target_serialized_name = target;
+      this.target = target;
     }
 
     /**
@@ -633,7 +658,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param created the new created
      */
     public void setCreated(final Datetime created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
     /**
@@ -642,7 +667,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param completed the new completed
      */
     public void setCompleted(final Datetime completed) {
-      this.completed_serialized_name = completed;
+      this.completed = completed;
     }
 
     /**
@@ -651,7 +676,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param wordCount the new wordCount
      */
     public void setWordCount(final long wordCount) {
-      this.word_count_serialized_name = wordCount;
+      this.wordCount = wordCount;
     }
 
     /**
@@ -660,9 +685,18 @@ public class IBMLanguageTranslatorV3Models {
      * @param characterCount the new characterCount
      */
     public void setCharacterCount(final long characterCount) {
-      this.character_count_serialized_name = characterCount;
+      this.characterCount = characterCount;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_id', 'documentId');
+      mapping.put('model_id', 'modelId');
+      mapping.put('base_model_id', 'baseModelId');
+      mapping.put('word_count', 'wordCount');
+      mapping.put('character_count', 'characterCount');
+      return mapping;
+    }
   }
 
   /**
@@ -670,7 +704,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class GetDocumentStatusOptions extends IBMWatsonOptionsModel {
     private String documentId;
- 
+
     /**
      * Gets the documentId.
      *
@@ -697,6 +731,11 @@ public class IBMLanguageTranslatorV3Models {
       return new GetDocumentStatusOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('documentId', 'document_id');
+      return mapping;
+    }
   }
 
   /**
@@ -763,7 +802,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class GetModelOptions extends IBMWatsonOptionsModel {
     private String modelId;
- 
+
     /**
      * Gets the modelId.
      *
@@ -790,6 +829,11 @@ public class IBMLanguageTranslatorV3Models {
       return new GetModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('modelId', 'model_id');
+      return mapping;
+    }
   }
 
   /**
@@ -857,7 +901,7 @@ public class IBMLanguageTranslatorV3Models {
   public class GetTranslatedDocumentOptions extends IBMWatsonOptionsModel {
     private String documentId;
     private String accept;
- 
+
     /**
      * Gets the documentId.
      *
@@ -868,7 +912,7 @@ public class IBMLanguageTranslatorV3Models {
     public String documentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the accept.
      *
@@ -903,6 +947,12 @@ public class IBMLanguageTranslatorV3Models {
       return new GetTranslatedDocumentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('documentId', 'document_id');
+      mapping.put('accept', 'Accept');
+      return mapping;
+    }
   }
 
   /**
@@ -981,8 +1031,8 @@ public class IBMLanguageTranslatorV3Models {
    * IdentifiableLanguage.
    */
   public class IdentifiableLanguage extends IBMWatsonGenericModel {
-    private String language_serialized_name;
-    private String name_serialized_name;
+    private String language;
+    private String name;
  
     /**
      * Gets the language.
@@ -993,7 +1043,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -1005,7 +1055,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
 
     /**
@@ -1014,7 +1064,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -1023,16 +1073,15 @@ public class IBMLanguageTranslatorV3Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
-
   }
 
   /**
    * IdentifiableLanguages.
    */
   public class IdentifiableLanguages extends IBMWatsonResponseModel {
-    private List<IdentifiableLanguage> languages_serialized_name;
+    private List<IdentifiableLanguage> languages;
  
     /**
      * Gets the languages.
@@ -1043,7 +1092,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public List<IdentifiableLanguage> getLanguages() {
-      return languages_serialized_name;
+      return languages;
     }
 
     /**
@@ -1052,7 +1101,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param languages the new languages
      */
     public void setLanguages(final List<IdentifiableLanguage> languages) {
-      this.languages_serialized_name = languages;
+      this.languages = languages;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1068,11 +1117,11 @@ public class IBMLanguageTranslatorV3Models {
       if (deserializedLanguages != null) {
         for (Integer i = 0; i < deserializedLanguages.size(); i++) {
           IdentifiableLanguage currentItem = ret.getLanguages().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('languages_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('languages');
           IdentifiableLanguage newItem = (IdentifiableLanguage) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), IdentifiableLanguage.class);
           newLanguages.add(newItem);
         }
-        ret.languages_serialized_name = newLanguages;
+        ret.languages = newLanguages;
       }
 
       return ret;
@@ -1083,8 +1132,8 @@ public class IBMLanguageTranslatorV3Models {
    * IdentifiedLanguage.
    */
   public class IdentifiedLanguage extends IBMWatsonGenericModel {
-    private String language_serialized_name;
-    private Double confidence_serialized_name;
+    private String language;
+    private Double confidence;
  
     /**
      * Gets the language.
@@ -1095,7 +1144,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -1107,7 +1156,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
 
     /**
@@ -1116,7 +1165,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -1125,16 +1174,15 @@ public class IBMLanguageTranslatorV3Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
-
   }
 
   /**
    * IdentifiedLanguages.
    */
   public class IdentifiedLanguages extends IBMWatsonResponseModel {
-    private List<IdentifiedLanguage> languages_serialized_name;
+    private List<IdentifiedLanguage> languages;
  
     /**
      * Gets the languages.
@@ -1145,7 +1193,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public List<IdentifiedLanguage> getLanguages() {
-      return languages_serialized_name;
+      return languages;
     }
 
     /**
@@ -1154,7 +1202,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param languages the new languages
      */
     public void setLanguages(final List<IdentifiedLanguage> languages) {
-      this.languages_serialized_name = languages;
+      this.languages = languages;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1170,11 +1218,11 @@ public class IBMLanguageTranslatorV3Models {
       if (deserializedLanguages != null) {
         for (Integer i = 0; i < deserializedLanguages.size(); i++) {
           IdentifiedLanguage currentItem = ret.getLanguages().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('languages_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('languages');
           IdentifiedLanguage newItem = (IdentifiedLanguage) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), IdentifiedLanguage.class);
           newLanguages.add(newItem);
         }
-        ret.languages_serialized_name = newLanguages;
+        ret.languages = newLanguages;
       }
 
       return ret;
@@ -1186,7 +1234,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class IdentifyOptions extends IBMWatsonOptionsModel {
     private String text;
- 
+
     /**
      * Gets the text.
      *
@@ -1212,7 +1260,6 @@ public class IBMLanguageTranslatorV3Models {
     public IdentifyOptionsBuilder newBuilder() {
       return new IdentifyOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -1291,7 +1338,6 @@ public class IBMLanguageTranslatorV3Models {
     public ListDocumentsOptionsBuilder newBuilder() {
       return new ListDocumentsOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -1348,7 +1394,6 @@ public class IBMLanguageTranslatorV3Models {
     public ListIdentifiableLanguagesOptionsBuilder newBuilder() {
       return new ListIdentifiableLanguagesOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -1395,7 +1440,7 @@ public class IBMLanguageTranslatorV3Models {
     private String source;
     private String target;
     private Boolean defaultModels;
- 
+
     /**
      * Gets the source.
      *
@@ -1406,7 +1451,7 @@ public class IBMLanguageTranslatorV3Models {
     public String source() {
       return source;
     }
- 
+
     /**
      * Gets the target.
      *
@@ -1417,7 +1462,7 @@ public class IBMLanguageTranslatorV3Models {
     public String target() {
       return target;
     }
- 
+
     /**
      * Gets the defaultModels.
      *
@@ -1447,6 +1492,11 @@ public class IBMLanguageTranslatorV3Models {
       return new ListModelsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('defaultModels', 'default');
+      return mapping;
+    }
   }
 
   /**
@@ -1536,7 +1586,7 @@ public class IBMLanguageTranslatorV3Models {
     private String source;
     private String target;
     private String documentId;
- 
+
     /**
      * Gets the file.
      *
@@ -1556,12 +1606,14 @@ public class IBMLanguageTranslatorV3Models {
     /**
      * Gets the filename.
      *
+     * The filename for file.
+     *
      * @return the filename
      */
     public String filename() {
       return filename;
     }
- 
+
     /**
      * Gets the fileContentType.
      *
@@ -1572,7 +1624,7 @@ public class IBMLanguageTranslatorV3Models {
     public String fileContentType() {
       return fileContentType;
     }
- 
+
     /**
      * Gets the modelId.
      *
@@ -1583,7 +1635,7 @@ public class IBMLanguageTranslatorV3Models {
     public String modelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -1594,7 +1646,7 @@ public class IBMLanguageTranslatorV3Models {
     public String source() {
       return source;
     }
- 
+
     /**
      * Gets the target.
      *
@@ -1605,7 +1657,7 @@ public class IBMLanguageTranslatorV3Models {
     public String target() {
       return target;
     }
- 
+
     /**
      * Gets the documentId.
      *
@@ -1640,6 +1692,13 @@ public class IBMLanguageTranslatorV3Models {
       return new TranslateDocumentOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('fileContentType', 'file_content_type');
+      mapping.put('modelId', 'model_id');
+      mapping.put('documentId', 'document_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1675,9 +1734,11 @@ public class IBMLanguageTranslatorV3Models {
      * Instantiates a new builder with required properties.
      *
      * @param file the file
+     * @param filename the filename
      */
-    public TranslateDocumentOptionsBuilder(IBMWatsonFile file) {
+    public TranslateDocumentOptionsBuilder(IBMWatsonFile file, String filename) {
       this.file = file;
+      this.filename = filename;
     }
 
     /**
@@ -1787,7 +1848,7 @@ public class IBMLanguageTranslatorV3Models {
     private String modelId;
     private String source;
     private String target;
- 
+
     /**
      * Gets the text.
      *
@@ -1798,7 +1859,7 @@ public class IBMLanguageTranslatorV3Models {
     public List<String> text() {
       return text;
     }
- 
+
     /**
      * Gets the modelId.
      *
@@ -1809,7 +1870,7 @@ public class IBMLanguageTranslatorV3Models {
     public String modelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -1820,7 +1881,7 @@ public class IBMLanguageTranslatorV3Models {
     public String source() {
       return source;
     }
- 
+
     /**
      * Gets the target.
      *
@@ -1850,6 +1911,11 @@ public class IBMLanguageTranslatorV3Models {
       return new TranslateOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('modelId', 'model_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1970,7 +2036,7 @@ public class IBMLanguageTranslatorV3Models {
    * Translation.
    */
   public class Translation extends IBMWatsonGenericModel {
-    private String translation_serialized_name;
+    private String translationOutput;
  
     /**
      * Gets the translationOutput.
@@ -1981,7 +2047,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getTranslationOutput() {
-      return translation_serialized_name;
+      return translationOutput;
     }
 
     /**
@@ -1990,25 +2056,30 @@ public class IBMLanguageTranslatorV3Models {
      * @param translationOutput the new translationOutput
      */
     public void setTranslationOutput(final String translationOutput) {
-      this.translation_serialized_name = translationOutput;
+      this.translationOutput = translationOutput;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('translation', 'translationOutput');
+      return mapping;
+    }
   }
 
   /**
    * Response payload for models.
    */
   public class TranslationModel extends IBMWatsonResponseModel {
-    private String model_id_serialized_name;
-    private String name_serialized_name;
-    private String source_serialized_name;
-    private String target_serialized_name;
-    private String base_model_id_serialized_name;
-    private String domain_serialized_name;
-    private Boolean customizable_serialized_name;
-    private Boolean default_model_serialized_name;
-    private String owner_serialized_name;
-    private String status_serialized_name;
+    private String modelId;
+    private String name;
+    private String source;
+    private String target;
+    private String baseModelId;
+    private String domain;
+    private Boolean customizable;
+    private Boolean defaultModel;
+    private String owner;
+    private String status;
  
     /**
      * Gets the modelId.
@@ -2019,7 +2090,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getModelId() {
-      return model_id_serialized_name;
+      return modelId;
     }
  
     /**
@@ -2031,7 +2102,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -2043,7 +2114,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getSource() {
-      return source_serialized_name;
+      return source;
     }
  
     /**
@@ -2055,7 +2126,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getTarget() {
-      return target_serialized_name;
+      return target;
     }
  
     /**
@@ -2068,7 +2139,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getBaseModelId() {
-      return base_model_id_serialized_name;
+      return baseModelId;
     }
  
     /**
@@ -2080,7 +2151,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getDomain() {
-      return domain_serialized_name;
+      return domain;
     }
  
     /**
@@ -2093,7 +2164,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public Boolean getCustomizable() {
-      return customizable_serialized_name;
+      return customizable;
     }
  
     /**
@@ -2106,7 +2177,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public Boolean getDefaultModel() {
-      return default_model_serialized_name;
+      return defaultModel;
     }
  
     /**
@@ -2119,7 +2190,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getOwner() {
-      return owner_serialized_name;
+      return owner;
     }
  
     /**
@@ -2131,7 +2202,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
 
     /**
@@ -2140,7 +2211,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param modelId the new modelId
      */
     public void setModelId(final String modelId) {
-      this.model_id_serialized_name = modelId;
+      this.modelId = modelId;
     }
 
     /**
@@ -2149,7 +2220,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -2158,7 +2229,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param source the new source
      */
     public void setSource(final String source) {
-      this.source_serialized_name = source;
+      this.source = source;
     }
 
     /**
@@ -2167,7 +2238,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param target the new target
      */
     public void setTarget(final String target) {
-      this.target_serialized_name = target;
+      this.target = target;
     }
 
     /**
@@ -2176,7 +2247,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param baseModelId the new baseModelId
      */
     public void setBaseModelId(final String baseModelId) {
-      this.base_model_id_serialized_name = baseModelId;
+      this.baseModelId = baseModelId;
     }
 
     /**
@@ -2185,7 +2256,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param domain the new domain
      */
     public void setDomain(final String domain) {
-      this.domain_serialized_name = domain;
+      this.domain = domain;
     }
 
     /**
@@ -2194,7 +2265,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param customizable the new customizable
      */
     public void setCustomizable(final Boolean customizable) {
-      this.customizable_serialized_name = customizable;
+      this.customizable = customizable;
     }
 
     /**
@@ -2203,7 +2274,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param defaultModel the new defaultModel
      */
     public void setDefaultModel(final Boolean defaultModel) {
-      this.default_model_serialized_name = defaultModel;
+      this.defaultModel = defaultModel;
     }
 
     /**
@@ -2212,7 +2283,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param owner the new owner
      */
     public void setOwner(final String owner) {
-      this.owner_serialized_name = owner;
+      this.owner = owner;
     }
 
     /**
@@ -2221,16 +2292,23 @@ public class IBMLanguageTranslatorV3Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('model_id', 'modelId');
+      mapping.put('base_model_id', 'baseModelId');
+      mapping.put('default_model', 'defaultModel');
+      return mapping;
+    }
   }
 
   /**
    * The response type for listing existing translation models.
    */
   public class TranslationModels extends IBMWatsonResponseModel {
-    private List<TranslationModel> models_serialized_name;
+    private List<TranslationModel> models;
  
     /**
      * Gets the models.
@@ -2241,7 +2319,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public List<TranslationModel> getModels() {
-      return models_serialized_name;
+      return models;
     }
 
     /**
@@ -2250,7 +2328,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param models the new models
      */
     public void setModels(final List<TranslationModel> models) {
-      this.models_serialized_name = models;
+      this.models = models;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2266,14 +2344,22 @@ public class IBMLanguageTranslatorV3Models {
       if (deserializedModels != null) {
         for (Integer i = 0; i < deserializedModels.size(); i++) {
           TranslationModel currentItem = ret.getModels().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('models_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('models');
           TranslationModel newItem = (TranslationModel) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TranslationModel.class);
           newModels.add(newItem);
         }
-        ret.models_serialized_name = newModels;
+        ret.models = newModels;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (models != null && models[0] != null) {
+        mapping.putAll(models[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2281,9 +2367,9 @@ public class IBMLanguageTranslatorV3Models {
    * TranslationResult.
    */
   public class TranslationResult extends IBMWatsonResponseModel {
-    private Long word_count_serialized_name;
-    private Long character_count_serialized_name;
-    private List<Translation> translations_serialized_name;
+    private Long wordCount;
+    private Long characterCount;
+    private List<Translation> translations;
  
     /**
      * Gets the wordCount.
@@ -2294,7 +2380,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public Long getWordCount() {
-      return word_count_serialized_name;
+      return wordCount;
     }
  
     /**
@@ -2306,7 +2392,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public Long getCharacterCount() {
-      return character_count_serialized_name;
+      return characterCount;
     }
  
     /**
@@ -2318,7 +2404,7 @@ public class IBMLanguageTranslatorV3Models {
      */
     @AuraEnabled
     public List<Translation> getTranslations() {
-      return translations_serialized_name;
+      return translations;
     }
 
     /**
@@ -2327,7 +2413,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param wordCount the new wordCount
      */
     public void setWordCount(final long wordCount) {
-      this.word_count_serialized_name = wordCount;
+      this.wordCount = wordCount;
     }
 
     /**
@@ -2336,7 +2422,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param characterCount the new characterCount
      */
     public void setCharacterCount(final long characterCount) {
-      this.character_count_serialized_name = characterCount;
+      this.characterCount = characterCount;
     }
 
     /**
@@ -2345,7 +2431,7 @@ public class IBMLanguageTranslatorV3Models {
      * @param translations the new translations
      */
     public void setTranslations(final List<Translation> translations) {
-      this.translations_serialized_name = translations;
+      this.translations = translations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2361,14 +2447,24 @@ public class IBMLanguageTranslatorV3Models {
       if (deserializedTranslations != null) {
         for (Integer i = 0; i < deserializedTranslations.size(); i++) {
           Translation currentItem = ret.getTranslations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('translations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('translations');
           Translation newItem = (Translation) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Translation.class);
           newTranslations.add(newItem);
         }
-        ret.translations_serialized_name = newTranslations;
+        ret.translations = newTranslations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('word_count', 'wordCount');
+      mapping.put('character_count', 'characterCount');
+      if (translations != null && translations[0] != null) {
+        mapping.putAll(translations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 

--- a/force-app/main/default/classes/IBMLanguageTranslatorV3Models.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV3Models.cls
@@ -385,7 +385,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class DocumentList extends IBMWatsonResponseModel {
     private List<DocumentStatus> documents;
- 
+
     /**
      * Gets the documents.
      *
@@ -430,11 +430,8 @@ public class IBMLanguageTranslatorV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (documents != null && documents[0] != null) {
-        mapping.putAll(documents[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) DocumentStatus.class.newInstance()).addToApiToSdkMapping(parentLabel + 'documents/', mapping));
       return mapping;
     }
   }
@@ -454,7 +451,7 @@ public class IBMLanguageTranslatorV3Models {
     private Datetime completed;
     private Long wordCount;
     private Long characterCount;
- 
+
     /**
      * Gets the documentId.
      *
@@ -466,7 +463,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getDocumentId() {
       return documentId;
     }
- 
+
     /**
      * Gets the filename.
      *
@@ -479,7 +476,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getFilename() {
       return filename;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -491,7 +488,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the modelId.
      *
@@ -503,7 +500,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getModelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the baseModelId.
      *
@@ -516,7 +513,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getBaseModelId() {
       return baseModelId;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -528,7 +525,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getSource() {
       return source;
     }
- 
+
     /**
      * Gets the target.
      *
@@ -540,7 +537,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getTarget() {
       return target;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -552,7 +549,7 @@ public class IBMLanguageTranslatorV3Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the completed.
      *
@@ -564,7 +561,7 @@ public class IBMLanguageTranslatorV3Models {
     public Datetime getCompleted() {
       return completed;
     }
- 
+
     /**
      * Gets the wordCount.
      *
@@ -576,7 +573,7 @@ public class IBMLanguageTranslatorV3Models {
     public Long getWordCount() {
       return wordCount;
     }
- 
+
     /**
      * Gets the characterCount.
      *
@@ -688,13 +685,16 @@ public class IBMLanguageTranslatorV3Models {
       this.characterCount = characterCount;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_id', 'documentId');
-      mapping.put('model_id', 'modelId');
-      mapping.put('base_model_id', 'baseModelId');
-      mapping.put('word_count', 'wordCount');
-      mapping.put('character_count', 'characterCount');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'document_id', 'documentId');
+      mapping.put(parentLabel + 'model_id', 'modelId');
+      mapping.put(parentLabel + 'base_model_id', 'baseModelId');
+      mapping.put(parentLabel + 'word_count', 'wordCount');
+      mapping.put(parentLabel + 'character_count', 'characterCount');
       return mapping;
     }
   }
@@ -1033,7 +1033,7 @@ public class IBMLanguageTranslatorV3Models {
   public class IdentifiableLanguage extends IBMWatsonGenericModel {
     private String language;
     private String name;
- 
+
     /**
      * Gets the language.
      *
@@ -1045,7 +1045,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -1082,7 +1082,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class IdentifiableLanguages extends IBMWatsonResponseModel {
     private List<IdentifiableLanguage> languages;
- 
+
     /**
      * Gets the languages.
      *
@@ -1134,7 +1134,7 @@ public class IBMLanguageTranslatorV3Models {
   public class IdentifiedLanguage extends IBMWatsonGenericModel {
     private String language;
     private Double confidence;
- 
+
     /**
      * Gets the language.
      *
@@ -1146,7 +1146,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -1183,7 +1183,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class IdentifiedLanguages extends IBMWatsonResponseModel {
     private List<IdentifiedLanguage> languages;
- 
+
     /**
      * Gets the languages.
      *
@@ -2037,7 +2037,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class Translation extends IBMWatsonGenericModel {
     private String translationOutput;
- 
+
     /**
      * Gets the translationOutput.
      *
@@ -2059,9 +2059,12 @@ public class IBMLanguageTranslatorV3Models {
       this.translationOutput = translationOutput;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('translation', 'translationOutput');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'translation', 'translationOutput');
       return mapping;
     }
   }
@@ -2080,7 +2083,7 @@ public class IBMLanguageTranslatorV3Models {
     private Boolean defaultModel;
     private String owner;
     private String status;
- 
+
     /**
      * Gets the modelId.
      *
@@ -2092,7 +2095,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getModelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -2104,7 +2107,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -2116,7 +2119,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getSource() {
       return source;
     }
- 
+
     /**
      * Gets the target.
      *
@@ -2128,7 +2131,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getTarget() {
       return target;
     }
- 
+
     /**
      * Gets the baseModelId.
      *
@@ -2141,7 +2144,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getBaseModelId() {
       return baseModelId;
     }
- 
+
     /**
      * Gets the domain.
      *
@@ -2153,7 +2156,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getDomain() {
       return domain;
     }
- 
+
     /**
      * Gets the customizable.
      *
@@ -2166,7 +2169,7 @@ public class IBMLanguageTranslatorV3Models {
     public Boolean getCustomizable() {
       return customizable;
     }
- 
+
     /**
      * Gets the defaultModel.
      *
@@ -2179,7 +2182,7 @@ public class IBMLanguageTranslatorV3Models {
     public Boolean getDefaultModel() {
       return defaultModel;
     }
- 
+
     /**
      * Gets the owner.
      *
@@ -2192,7 +2195,7 @@ public class IBMLanguageTranslatorV3Models {
     public String getOwner() {
       return owner;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -2295,11 +2298,14 @@ public class IBMLanguageTranslatorV3Models {
       this.status = status;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('model_id', 'modelId');
-      mapping.put('base_model_id', 'baseModelId');
-      mapping.put('default_model', 'defaultModel');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'model_id', 'modelId');
+      mapping.put(parentLabel + 'base_model_id', 'baseModelId');
+      mapping.put(parentLabel + 'default_model', 'defaultModel');
       return mapping;
     }
   }
@@ -2309,7 +2315,7 @@ public class IBMLanguageTranslatorV3Models {
    */
   public class TranslationModels extends IBMWatsonResponseModel {
     private List<TranslationModel> models;
- 
+
     /**
      * Gets the models.
      *
@@ -2354,11 +2360,8 @@ public class IBMLanguageTranslatorV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (models != null && models[0] != null) {
-        mapping.putAll(models[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) TranslationModel.class.newInstance()).addToApiToSdkMapping(parentLabel + 'models/', mapping));
       return mapping;
     }
   }
@@ -2370,7 +2373,7 @@ public class IBMLanguageTranslatorV3Models {
     private Long wordCount;
     private Long characterCount;
     private List<Translation> translations;
- 
+
     /**
      * Gets the wordCount.
      *
@@ -2382,7 +2385,7 @@ public class IBMLanguageTranslatorV3Models {
     public Long getWordCount() {
       return wordCount;
     }
- 
+
     /**
      * Gets the characterCount.
      *
@@ -2394,7 +2397,7 @@ public class IBMLanguageTranslatorV3Models {
     public Long getCharacterCount() {
       return characterCount;
     }
- 
+
     /**
      * Gets the translations.
      *
@@ -2457,13 +2460,14 @@ public class IBMLanguageTranslatorV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('word_count', 'wordCount');
-      mapping.put('character_count', 'characterCount');
-      if (translations != null && translations[0] != null) {
-        mapping.putAll(translations[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'word_count', 'wordCount');
+      mapping.put(parentLabel + 'character_count', 'characterCount');
+      mapping.putAll(((IBMWatsonGenericModel) Translation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'translations/', mapping));
       return mapping;
     }
   }

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1.cls
@@ -62,7 +62,7 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
     }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('text', classifyOptions.text());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, classifyOptions.getSdkToApiMapping()));
 
     return (IBMNaturalLanguageClassifierV1Models.Classification) createServiceCall(builder.build(), IBMNaturalLanguageClassifierV1Models.Classification.class);
   }
@@ -91,7 +91,7 @@ public class IBMNaturalLanguageClassifierV1 extends IBMWatsonService {
     }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('collection', classifyCollectionOptions.collection());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, classifyCollectionOptions.getSdkToApiMapping()));
 
     return (IBMNaturalLanguageClassifierV1Models.ClassificationCollection) createServiceCall(builder.build(), IBMNaturalLanguageClassifierV1Models.ClassificationCollection.class);
   }

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
@@ -3,11 +3,11 @@ public class IBMNaturalLanguageClassifierV1Models {
    * Response from the classifier for a phrase.
    */
   public class Classification extends IBMWatsonResponseModel {
-    private String classifier_id_serialized_name;
-    private String url_serialized_name;
-    private String text_serialized_name;
-    private String top_class_serialized_name;
-    private List<ClassifiedClass> classes_serialized_name;
+    private String classifierId;
+    private String url;
+    private String text;
+    private String topClass;
+    private List<ClassifiedClass> classes;
  
     /**
      * Gets the classifierId.
@@ -18,7 +18,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getClassifierId() {
-      return classifier_id_serialized_name;
+      return classifierId;
     }
  
     /**
@@ -30,7 +30,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
  
     /**
@@ -42,7 +42,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -54,7 +54,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getTopClass() {
-      return top_class_serialized_name;
+      return topClass;
     }
  
     /**
@@ -66,7 +66,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public List<ClassifiedClass> getClasses() {
-      return classes_serialized_name;
+      return classes;
     }
 
     /**
@@ -75,7 +75,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param classifierId the new classifierId
      */
     public void setClassifierId(final String classifierId) {
-      this.classifier_id_serialized_name = classifierId;
+      this.classifierId = classifierId;
     }
 
     /**
@@ -84,7 +84,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param url the new url
      */
     public void setUrl(final String url) {
-      this.url_serialized_name = url;
+      this.url = url;
     }
 
     /**
@@ -93,7 +93,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -102,7 +102,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param topClass the new topClass
      */
     public void setTopClass(final String topClass) {
-      this.top_class_serialized_name = topClass;
+      this.topClass = topClass;
     }
 
     /**
@@ -111,7 +111,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param classes the new classes
      */
     public void setClasses(final List<ClassifiedClass> classes) {
-      this.classes_serialized_name = classes;
+      this.classes = classes;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -127,14 +127,24 @@ public class IBMNaturalLanguageClassifierV1Models {
       if (deserializedClasses != null) {
         for (Integer i = 0; i < deserializedClasses.size(); i++) {
           ClassifiedClass currentItem = ret.getClasses().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('classes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('classes');
           ClassifiedClass newItem = (ClassifiedClass) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ClassifiedClass.class);
           newClasses.add(newItem);
         }
-        ret.classes_serialized_name = newClasses;
+        ret.classes = newClasses;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifier_id', 'classifierId');
+      mapping.put('top_class', 'topClass');
+      if (classes != null && classes[0] != null) {
+        mapping.putAll(classes[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -142,9 +152,9 @@ public class IBMNaturalLanguageClassifierV1Models {
    * Response from the classifier for multiple phrases.
    */
   public class ClassificationCollection extends IBMWatsonResponseModel {
-    private String classifier_id_serialized_name;
-    private String url_serialized_name;
-    private List<CollectionItem> collection_serialized_name;
+    private String classifierId;
+    private String url;
+    private List<CollectionItem> collection;
  
     /**
      * Gets the classifierId.
@@ -155,7 +165,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getClassifierId() {
-      return classifier_id_serialized_name;
+      return classifierId;
     }
  
     /**
@@ -167,7 +177,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
  
     /**
@@ -179,7 +189,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public List<CollectionItem> getCollection() {
-      return collection_serialized_name;
+      return collection;
     }
 
     /**
@@ -188,7 +198,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param classifierId the new classifierId
      */
     public void setClassifierId(final String classifierId) {
-      this.classifier_id_serialized_name = classifierId;
+      this.classifierId = classifierId;
     }
 
     /**
@@ -197,7 +207,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param url the new url
      */
     public void setUrl(final String url) {
-      this.url_serialized_name = url;
+      this.url = url;
     }
 
     /**
@@ -206,7 +216,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param collection the new collection
      */
     public void setCollection(final List<CollectionItem> collection) {
-      this.collection_serialized_name = collection;
+      this.collection = collection;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -222,14 +232,23 @@ public class IBMNaturalLanguageClassifierV1Models {
       if (deserializedCollection != null) {
         for (Integer i = 0; i < deserializedCollection.size(); i++) {
           CollectionItem currentItem = ret.getCollection().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('collection_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('collection');
           CollectionItem newItem = (CollectionItem) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CollectionItem.class);
           newCollection.add(newItem);
         }
-        ret.collection_serialized_name = newCollection;
+        ret.collection = newCollection;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifier_id', 'classifierId');
+      if (collection != null && collection[0] != null) {
+        mapping.putAll(collection[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -237,8 +256,8 @@ public class IBMNaturalLanguageClassifierV1Models {
    * Class and confidence.
    */
   public class ClassifiedClass extends IBMWatsonGenericModel {
-    private Double confidence_serialized_name;
-    private String class_name_serialized_name;
+    private Double confidence;
+    private String className;
  
     /**
      * Gets the confidence.
@@ -250,7 +269,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
  
     /**
@@ -262,7 +281,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getClassName() {
-      return class_name_serialized_name;
+      return className;
     }
 
     /**
@@ -271,7 +290,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
 
     /**
@@ -280,22 +299,27 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param className the new className
      */
     public void setClassName(final String className) {
-      this.class_name_serialized_name = className;
+      this.className = className;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('class_name', 'className');
+      return mapping;
+    }
   }
 
   /**
    * A classifier for natural language phrases.
    */
   public class Classifier extends IBMWatsonResponseModel {
-    private String name_serialized_name;
-    private String url_serialized_name;
-    private String status_serialized_name;
-    private String classifier_id_serialized_name;
-    private Datetime created_serialized_name;
-    private String status_description_serialized_name;
-    private String language_serialized_name;
+    private String name;
+    private String url;
+    private String status;
+    private String classifierId;
+    private Datetime created;
+    private String statusDescription;
+    private String language;
  
     /**
      * Gets the name.
@@ -306,7 +330,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -318,7 +342,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
  
     /**
@@ -330,7 +354,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -342,7 +366,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getClassifierId() {
-      return classifier_id_serialized_name;
+      return classifierId;
     }
  
     /**
@@ -354,7 +378,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -366,7 +390,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getStatusDescription() {
-      return status_description_serialized_name;
+      return statusDescription;
     }
  
     /**
@@ -378,7 +402,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
 
     /**
@@ -387,7 +411,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -396,7 +420,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param url the new url
      */
     public void setUrl(final String url) {
-      this.url_serialized_name = url;
+      this.url = url;
     }
 
     /**
@@ -405,7 +429,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param classifierId the new classifierId
      */
     public void setClassifierId(final String classifierId) {
-      this.classifier_id_serialized_name = classifierId;
+      this.classifierId = classifierId;
     }
 
     /**
@@ -414,16 +438,22 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifier_id', 'classifierId');
+      mapping.put('status_description', 'statusDescription');
+      return mapping;
+    }
   }
 
   /**
    * List of available classifiers.
    */
   public class ClassifierList extends IBMWatsonResponseModel {
-    private List<Classifier> classifiers_serialized_name;
+    private List<Classifier> classifiers;
  
     /**
      * Gets the classifiers.
@@ -434,7 +464,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public List<Classifier> getClassifiers() {
-      return classifiers_serialized_name;
+      return classifiers;
     }
 
     /**
@@ -443,7 +473,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param classifiers the new classifiers
      */
     public void setClassifiers(final List<Classifier> classifiers) {
-      this.classifiers_serialized_name = classifiers;
+      this.classifiers = classifiers;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -459,14 +489,22 @@ public class IBMNaturalLanguageClassifierV1Models {
       if (deserializedClassifiers != null) {
         for (Integer i = 0; i < deserializedClassifiers.size(); i++) {
           Classifier currentItem = ret.getClassifiers().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('classifiers_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('classifiers');
           Classifier newItem = (Classifier) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Classifier.class);
           newClassifiers.add(newItem);
         }
-        ret.classifiers_serialized_name = newClassifiers;
+        ret.classifiers = newClassifiers;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (classifiers != null && classifiers[0] != null) {
+        mapping.putAll(classifiers[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -476,7 +514,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   public class ClassifyCollectionOptions extends IBMWatsonOptionsModel {
     private String classifierId;
     private List<ClassifyInput> collection;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -487,7 +525,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String classifierId() {
       return classifierId;
     }
- 
+
     /**
      * Gets the collection.
      *
@@ -516,6 +554,11 @@ public class IBMNaturalLanguageClassifierV1Models {
       return new ClassifyCollectionOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifierId', 'classifier_id');
+      return mapping;
+    }
   }
 
   /**
@@ -611,8 +654,8 @@ public class IBMNaturalLanguageClassifierV1Models {
   /**
    * Request payload to classify.
    */
-  public class ClassifyInput {
-    private String text_serialized_name;
+  public class ClassifyInput extends IBMWatsonGenericModel {
+    private String text;
  
     /**
      * Gets the text.
@@ -622,18 +665,68 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @return the text
      */
     public String getText() {
-      return text_serialized_name;
+      return text;
+    }
+  
+    private ClassifyInput(ClassifyInputBuilder builder) {
+      IBMWatsonValidator.notNull(builder.text, 'text cannot be null');
+      this.text = builder.text;
     }
 
     /**
-     * Sets the text.
+     * New builder.
      *
-     * @param text the new text
+     * @return a ClassifyInput builder
      */
-    public void setText(final String text) {
-      this.text_serialized_name = text;
+    public ClassifyInputBuilder newBuilder() {
+      return new ClassifyInputBuilder(this);
+    }
+  }
+
+  /**
+   * ClassifyInput Builder.
+   */
+  public class ClassifyInputBuilder {
+    private String text;
+
+    private ClassifyInputBuilder(ClassifyInput classifyInput) {
+      this.text = classifyInput.text;
     }
 
+    /**
+     * Instantiates a new builder.
+     */
+    public ClassifyInputBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param text the text
+     */
+    public ClassifyInputBuilder(String text) {
+      this.text = text;
+    }
+
+    /**
+     * Builds a ClassifyInput.
+     *
+     * @return the classifyInput
+     */
+    public ClassifyInput build() {
+      return new ClassifyInput(this);
+    }
+
+    /**
+     * Set the text.
+     *
+     * @param text the text
+     * @return the ClassifyInput builder
+     */
+    public ClassifyInputBuilder setText(String text) {
+      this.text = text;
+      return this;
+    }
   }
 
   /**
@@ -642,7 +735,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   public class ClassifyOptions extends IBMWatsonOptionsModel {
     private String classifierId;
     private String text;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -653,7 +746,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String classifierId() {
       return classifierId;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -682,6 +775,11 @@ public class IBMNaturalLanguageClassifierV1Models {
       return new ClassifyOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifierId', 'classifier_id');
+      return mapping;
+    }
   }
 
   /**
@@ -762,9 +860,9 @@ public class IBMNaturalLanguageClassifierV1Models {
    * Response from the classifier for a phrase in a collection.
    */
   public class CollectionItem extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private String top_class_serialized_name;
-    private List<ClassifiedClass> classes_serialized_name;
+    private String text;
+    private String topClass;
+    private List<ClassifiedClass> classes;
  
     /**
      * Gets the text.
@@ -775,7 +873,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -787,7 +885,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public String getTopClass() {
-      return top_class_serialized_name;
+      return topClass;
     }
  
     /**
@@ -799,7 +897,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      */
     @AuraEnabled
     public List<ClassifiedClass> getClasses() {
-      return classes_serialized_name;
+      return classes;
     }
 
     /**
@@ -808,7 +906,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -817,7 +915,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param topClass the new topClass
      */
     public void setTopClass(final String topClass) {
-      this.top_class_serialized_name = topClass;
+      this.topClass = topClass;
     }
 
     /**
@@ -826,7 +924,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param classes the new classes
      */
     public void setClasses(final List<ClassifiedClass> classes) {
-      this.classes_serialized_name = classes;
+      this.classes = classes;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -842,14 +940,23 @@ public class IBMNaturalLanguageClassifierV1Models {
       if (deserializedClasses != null) {
         for (Integer i = 0; i < deserializedClasses.size(); i++) {
           ClassifiedClass currentItem = ret.getClasses().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('classes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('classes');
           ClassifiedClass newItem = (ClassifiedClass) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ClassifiedClass.class);
           newClasses.add(newItem);
         }
-        ret.classes_serialized_name = newClasses;
+        ret.classes = newClasses;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('top_class', 'topClass');
+      if (classes != null && classes[0] != null) {
+        mapping.putAll(classes[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -859,7 +966,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   public class CreateClassifierOptions extends IBMWatsonOptionsModel {
     private IBMWatsonFile metadata;
     private IBMWatsonFile trainingData;
- 
+
     /**
      * Gets the metadata.
      *
@@ -874,7 +981,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public IBMWatsonFile metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the trainingData.
      *
@@ -905,6 +1012,12 @@ public class IBMNaturalLanguageClassifierV1Models {
       return new CreateClassifierOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('metadata', 'training_metadata');
+      mapping.put('trainingData', 'training_data');
+      return mapping;
+    }
   }
 
   /**
@@ -986,7 +1099,7 @@ public class IBMNaturalLanguageClassifierV1Models {
    */
   public class DeleteClassifierOptions extends IBMWatsonOptionsModel {
     private String classifierId;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -1013,6 +1126,11 @@ public class IBMNaturalLanguageClassifierV1Models {
       return new DeleteClassifierOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifierId', 'classifier_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1079,7 +1197,7 @@ public class IBMNaturalLanguageClassifierV1Models {
    */
   public class GetClassifierOptions extends IBMWatsonOptionsModel {
     private String classifierId;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -1106,6 +1224,11 @@ public class IBMNaturalLanguageClassifierV1Models {
       return new GetClassifierOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifierId', 'classifier_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1184,7 +1307,6 @@ public class IBMNaturalLanguageClassifierV1Models {
     public ListClassifiersOptionsBuilder newBuilder() {
       return new ListClassifiersOptionsBuilder(this);
     }
-
   }
 
   /**

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Models.cls
@@ -8,7 +8,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     private String text;
     private String topClass;
     private List<ClassifiedClass> classes;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -20,7 +20,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getClassifierId() {
       return classifierId;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -32,7 +32,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getUrl() {
       return url;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -44,7 +44,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the topClass.
      *
@@ -56,7 +56,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getTopClass() {
       return topClass;
     }
- 
+
     /**
      * Gets the classes.
      *
@@ -137,13 +137,14 @@ public class IBMNaturalLanguageClassifierV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('classifier_id', 'classifierId');
-      mapping.put('top_class', 'topClass');
-      if (classes != null && classes[0] != null) {
-        mapping.putAll(classes[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'classifier_id', 'classifierId');
+      mapping.put(parentLabel + 'top_class', 'topClass');
+      mapping.putAll(((IBMWatsonGenericModel) ClassifiedClass.class.newInstance()).addToApiToSdkMapping(parentLabel + 'classes/', mapping));
       return mapping;
     }
   }
@@ -155,7 +156,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     private String classifierId;
     private String url;
     private List<CollectionItem> collection;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -167,7 +168,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getClassifierId() {
       return classifierId;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -179,7 +180,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getUrl() {
       return url;
     }
- 
+
     /**
      * Gets the collection.
      *
@@ -242,12 +243,13 @@ public class IBMNaturalLanguageClassifierV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('classifier_id', 'classifierId');
-      if (collection != null && collection[0] != null) {
-        mapping.putAll(collection[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'classifier_id', 'classifierId');
+      mapping.putAll(((IBMWatsonGenericModel) CollectionItem.class.newInstance()).addToApiToSdkMapping(parentLabel + 'collection/', mapping));
       return mapping;
     }
   }
@@ -258,7 +260,7 @@ public class IBMNaturalLanguageClassifierV1Models {
   public class ClassifiedClass extends IBMWatsonGenericModel {
     private Double confidence;
     private String className;
- 
+
     /**
      * Gets the confidence.
      *
@@ -271,7 +273,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public Double getConfidence() {
       return confidence;
     }
- 
+
     /**
      * Gets the className.
      *
@@ -302,9 +304,8 @@ public class IBMNaturalLanguageClassifierV1Models {
       this.className = className;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('class_name', 'className');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'class_name', 'className');
       return mapping;
     }
   }
@@ -320,7 +321,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     private Datetime created;
     private String statusDescription;
     private String language;
- 
+
     /**
      * Gets the name.
      *
@@ -332,7 +333,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -344,7 +345,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getUrl() {
       return url;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -356,7 +357,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the classifierId.
      *
@@ -368,7 +369,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getClassifierId() {
       return classifierId;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -380,7 +381,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the statusDescription.
      *
@@ -392,7 +393,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getStatusDescription() {
       return statusDescription;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -441,10 +442,9 @@ public class IBMNaturalLanguageClassifierV1Models {
       this.language = language;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('classifier_id', 'classifierId');
-      mapping.put('status_description', 'statusDescription');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'classifier_id', 'classifierId');
+      mapping.put(parentLabel + 'status_description', 'statusDescription');
       return mapping;
     }
   }
@@ -454,7 +454,7 @@ public class IBMNaturalLanguageClassifierV1Models {
    */
   public class ClassifierList extends IBMWatsonResponseModel {
     private List<Classifier> classifiers;
- 
+
     /**
      * Gets the classifiers.
      *
@@ -499,11 +499,8 @@ public class IBMNaturalLanguageClassifierV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (classifiers != null && classifiers[0] != null) {
-        mapping.putAll(classifiers[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Classifier.class.newInstance()).addToApiToSdkMapping(parentLabel + 'classifiers/', mapping));
       return mapping;
     }
   }
@@ -656,7 +653,7 @@ public class IBMNaturalLanguageClassifierV1Models {
    */
   public class ClassifyInput extends IBMWatsonGenericModel {
     private String text;
- 
+
     /**
      * Gets the text.
      *
@@ -723,7 +720,7 @@ public class IBMNaturalLanguageClassifierV1Models {
      * @param text the text
      * @return the ClassifyInput builder
      */
-    public ClassifyInputBuilder setText(String text) {
+    public ClassifyInputBuilder text(String text) {
       this.text = text;
       return this;
     }
@@ -863,7 +860,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     private String text;
     private String topClass;
     private List<ClassifiedClass> classes;
- 
+
     /**
      * Gets the text.
      *
@@ -875,7 +872,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the topClass.
      *
@@ -887,7 +884,7 @@ public class IBMNaturalLanguageClassifierV1Models {
     public String getTopClass() {
       return topClass;
     }
- 
+
     /**
      * Gets the classes.
      *
@@ -950,12 +947,9 @@ public class IBMNaturalLanguageClassifierV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('top_class', 'topClass');
-      if (classes != null && classes[0] != null) {
-        mapping.putAll(classes[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'top_class', 'topClass');
+      mapping.putAll(((IBMWatsonGenericModel) ClassifiedClass.class.newInstance()).addToApiToSdkMapping(parentLabel + 'classes/', mapping));
       return mapping;
     }
   }

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
@@ -15,32 +15,32 @@ private class IBMNaturalLanguageClassifierV1Test {
       .build();
     IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1(iamOptions);
     service.setEndPoint('https://gateway.watsonplatform.net/natural-language-classifier/api');
-    String classifier_id_serialized_name = '10D41B-nlc-1';
-    String text_serialized_name = 'How hot will it be today?';
+    String classifier_id = '10D41B-nlc-1';
+    String text = 'How hot will it be today?';
     // this would be the expected top class as defined on the mock response
-    String top_class_serialized_name = 'temperature';
+    String top_class = 'temperature';
     IBMNaturalLanguageClassifierV1Models.ClassifyOptions classifyOptions = new IBMNaturalLanguageClassifierV1Models.ClassifyOptionsBuilder()
-      .classifierId(classifier_id_serialized_name)
-      .text(text_serialized_name)
+      .classifierId(classifier_id)
+      .text(text)
       .addHeader('Test-Header', 'test_value')
       .build();
     IBMNaturalLanguageClassifierV1Models.Classification classification = service.classify(classifyOptions);
-    System.assertEquals(classification.getClassifierId(), classifier_id_serialized_name);
+    System.assertEquals(classification.getClassifierId(), classifier_id);
     System.assertEquals(classification.getUrl(), IBMWatsonMockResponses.IBMNaturalLanguageClassifierClassifyURL);
-    System.assertEquals(classification.getText(), text_serialized_name);
-    System.assertEquals(classification.getTopClass(), top_class_serialized_name);
+    System.assertEquals(classification.getText(), text);
+    System.assertEquals(classification.getTopClass(), top_class);
     List<IBMNaturalLanguageClassifierV1Models.ClassifiedClass> ClassifiedClassList = classification.getClasses();
     System.assertNotEquals(ClassifiedClassList, null);
     System.assertEquals(ClassifiedClassList.size(), 2);
     IBMNaturalLanguageClassifierV1Models.ClassifiedClass ClassifiedClass = ClassifiedClassList[0];
-    String class_name_serialized_name = ClassifiedClass.getClassName();
+    String class_name = ClassifiedClass.getClassName();
     Set<String> class_name_set = new Set<String>{'temperature', 'conditions'};
-    System.assert(class_name_set.contains(class_name_serialized_name), 'Invalid class name for classifier.');
-    Double confidence_serialized_name = ClassifiedClass.getConfidence();
-    System.assertNotEquals(confidence_serialized_name, null);
-    System.assert(confidence_serialized_name > 0, 'Invalid confidence for classifier.');
+    System.assert(class_name_set.contains(class_name), 'Invalid class name for classifier.');
+    Double confidence = ClassifiedClass.getConfidence();
+    System.assertNotEquals(confidence, null);
+    System.assert(confidence > 0, 'Invalid confidence for classifier.');
     IBMNaturalLanguageClassifierV1Models.ClassifyOptionsBuilder ClassifyOptionsBuilder = classifyOptions.newBuilder();
-    ClassifyOptionsBuilder = new IBMNaturalLanguageClassifierV1Models.ClassifyOptionsBuilder(classifier_id_serialized_name, text_serialized_name);
+    ClassifyOptionsBuilder = new IBMNaturalLanguageClassifierV1Models.ClassifyOptionsBuilder(classifier_id, text);
     Test.stopTest();
   }
 
@@ -97,22 +97,22 @@ private class IBMNaturalLanguageClassifierV1Test {
       Name='test.txt',
       Description='test description',
       ContentType='text/plain');
-    IBMWatsonFile training_metadata_serialized_name = new IBMWatsonFile.FileBuilder()
+    IBMWatsonFile training_metadata = new IBMWatsonFile.FileBuilder()
       .attachment(TrainingMetadata)
       .build();
     Attachment TrainingData = new Attachment(Body = Blob.valueOf('test string'),
       Name='test.txt',
       Description='test description',
       ContentType='text/plain');
-    String training_metadata_filename_serialized_name = 'My Classifier Metadata';
-    IBMWatsonFile training_data_serialized_name = new IBMWatsonFile.FileBuilder()
+    String training_metadata_filename = 'My Classifier Metadata';
+    IBMWatsonFile training_data = new IBMWatsonFile.FileBuilder()
       .attachment(TrainingData)
       .build();
-    String training_data_filename_serialized_name = 'My Classifier Data';
+    String training_data_filename = 'My Classifier Data';
     IBMNaturalLanguageClassifierV1Models.CreateClassifierOptions createClassifierOptions =
       new IBMNaturalLanguageClassifierV1Models.CreateClassifierOptionsBuilder()
-      .metadata(training_metadata_serialized_name)
-      .trainingData(training_data_serialized_name)
+      .metadata(training_metadata)
+      .trainingData(training_data)
       .addHeader('Test-Header', 'test_value')
       .build();
     IBMNaturalLanguageClassifierV1Models.Classifier Classifier = service.createClassifier(createClassifierOptions);
@@ -125,8 +125,8 @@ private class IBMNaturalLanguageClassifierV1Test {
     System.assertEquals(Classifier.getLanguage(), 'en');
     IBMNaturalLanguageClassifierV1Models.CreateClassifierOptionsBuilder
       CreateClassifierOptionsBuilder = createClassifierOptions.newBuilder();
-    CreateClassifierOptionsBuilder = new IBMNaturalLanguageClassifierV1Models.CreateClassifierOptionsBuilder(training_metadata_serialized_name,
-     training_data_serialized_name);
+    CreateClassifierOptionsBuilder = new IBMNaturalLanguageClassifierV1Models.CreateClassifierOptionsBuilder(training_metadata,
+     training_data);
     Test.stopTest();
   }
 
@@ -142,16 +142,16 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1();
     service.setEndPoint('https://gateway.watsonplatform.net/natural-language-classifier/api');
     service.setUsernameAndPassword('username', 'password');
-    String classifier_id_serialized_name = '10D41B-nlc-1';
+    String classifier_id = '10D41B-nlc-1';
     IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptions deleteClassifierOptions =
       new IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptionsBuilder()
-      .classifierId(classifier_id_serialized_name)
+      .classifierId(classifier_id)
       .addHeader('Test-Header', 'test_value')
       .build();
     service.deleteClassifier(deleteClassifierOptions);
     IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptionsBuilder DeleteClassifierOptionsBuilder =
       deleteClassifierOptions.newBuilder();
-    DeleteClassifierOptionsBuilder = new IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptionsBuilder(classifier_id_serialized_name);
+    DeleteClassifierOptionsBuilder = new IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptionsBuilder(classifier_id);
     Test.stopTest();
   }
 
@@ -162,11 +162,11 @@ private class IBMNaturalLanguageClassifierV1Test {
     Test.startTest();
     IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1();
     service = new IBMNaturalLanguageClassifierV1('username', 'password');
-    String classifier_id_serialized_name = '10D41B-nlc-1';
+    String classifier_id = '10D41B-nlc-1';
     service.setEndPoint('https://gateway.watsonplatform.net/natural-language-classifier/api');
     IBMNaturalLanguageClassifierV1Models.GetClassifierOptions getClassifierOption =
       new IBMNaturalLanguageClassifierV1Models.GetClassifierOptionsBuilder()
-      .classifierId(classifier_id_serialized_name)
+      .classifierId(classifier_id)
       .addHeader('Test-Header', 'test_value')
       .build();
     IBMNaturalLanguageClassifierV1Models.Classifier Classifier = service.getClassifier(getClassifierOption);
@@ -179,7 +179,7 @@ private class IBMNaturalLanguageClassifierV1Test {
     System.assertEquals(Classifier.getLanguage(), 'en');
     IBMNaturalLanguageClassifierV1Models.GetClassifierOptionsBuilder GetClassifierOptionsBuilder =
       getClassifierOption.newBuilder();
-    GetClassifierOptionsBuilder = new IBMNaturalLanguageClassifierV1Models.GetClassifierOptionsBuilder(classifier_id_serialized_name);
+    GetClassifierOptionsBuilder = new IBMNaturalLanguageClassifierV1Models.GetClassifierOptionsBuilder(classifier_id);
     Test.stopTest();
   }
 

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
@@ -56,12 +56,14 @@ private class IBMNaturalLanguageClassifierV1Test {
     service.setEndPoint('https://gateway.watsonplatform.net/natural-language-classifier/api');
     service.setUsernameAndPassword('username', 'password');
     String classifierId = '10D41B-nlc-1';
-    IBMNaturalLanguageClassifierV1Models.ClassifyInput input1 = new IBMNaturalLanguageClassifierV1Models.ClassifyInput();
     String text1 = 'How hot will it be today?';
-    input1.setText(text1);
-    IBMNaturalLanguageClassifierV1Models.ClassifyInput input2 = new IBMNaturalLanguageClassifierV1Models.ClassifyInput();
     String text2 = 'Is it hot outside?';
-    input2.setText(text2);
+    IBMNaturalLanguageClassifierV1Models.ClassifyInput input1 = new IBMNaturalLanguageClassifierV1Models.ClassifyInputBuilder()
+      .text(text1)
+      .build();
+    IBMNaturalLanguageClassifierV1Models.ClassifyInput input2 = new IBMNaturalLanguageClassifierV1Models.ClassifyInputBuilder()
+      .text(text2)
+      .build();
     List<IBMNaturalLanguageClassifierV1Models.ClassifyInput> inputCollection = new List<IBMNaturalLanguageClassifierV1Models.ClassifyInput> {
       input1,
       input2

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1.cls
@@ -116,7 +116,7 @@ public class IBMNaturalLanguageUnderstandingV1 extends IBMWatsonService {
     if (analyzeOptions.limitTextCharacters() != null) {
       contentJson.put('limit_text_characters', analyzeOptions.limitTextCharacters());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, analyzeOptions.getSdkToApiMapping()));
 
     return (IBMNaturalLanguageUnderstandingV1Models.AnalysisResults) createServiceCall(builder.build(), IBMNaturalLanguageUnderstandingV1Models.AnalysisResults.class);
   }

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
@@ -3,20 +3,20 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Results of the analysis, organized by feature.
    */
   public class AnalysisResults extends IBMWatsonResponseModel {
-    private String language_serialized_name;
-    private String analyzed_text_serialized_name;
-    private String retrieved_url_serialized_name;
-    private AnalysisResultsUsage usage_serialized_name;
-    private List<ConceptsResult> concepts_serialized_name;
-    private List<EntitiesResult> entities_serialized_name;
-    private List<KeywordsResult> keywords_serialized_name;
-    private List<CategoriesResult> categories_serialized_name;
-    private EmotionResult emotion_serialized_name;
-    private AnalysisResultsMetadata metadata_serialized_name;
-    private List<RelationsResult> relations_serialized_name;
-    private List<SemanticRolesResult> semantic_roles_serialized_name;
-    private SentimentResult sentiment_serialized_name;
-    private SyntaxResult syntax_serialized_name;
+    private String language;
+    private String analyzedText;
+    private String retrievedUrl;
+    private AnalysisResultsUsage usage;
+    private List<ConceptsResult> concepts;
+    private List<EntitiesResult> entities;
+    private List<KeywordsResult> keywords;
+    private List<CategoriesResult> categories;
+    private EmotionResult emotion;
+    private AnalysisResultsMetadata metadata;
+    private List<RelationsResult> relations;
+    private List<SemanticRolesResult> semanticRoles;
+    private SentimentResult sentiment;
+    private SyntaxResult syntax;
  
     /**
      * Gets the language.
@@ -27,7 +27,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -39,7 +39,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getAnalyzedText() {
-      return analyzed_text_serialized_name;
+      return analyzedText;
     }
  
     /**
@@ -51,7 +51,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getRetrievedUrl() {
-      return retrieved_url_serialized_name;
+      return retrievedUrl;
     }
  
     /**
@@ -63,7 +63,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public AnalysisResultsUsage getUsage() {
-      return usage_serialized_name;
+      return usage;
     }
  
     /**
@@ -75,7 +75,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<ConceptsResult> getConcepts() {
-      return concepts_serialized_name;
+      return concepts;
     }
  
     /**
@@ -87,7 +87,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<EntitiesResult> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -99,7 +99,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<KeywordsResult> getKeywords() {
-      return keywords_serialized_name;
+      return keywords;
     }
  
     /**
@@ -111,7 +111,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<CategoriesResult> getCategories() {
-      return categories_serialized_name;
+      return categories;
     }
  
     /**
@@ -123,7 +123,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public EmotionResult getEmotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
  
     /**
@@ -135,7 +135,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public AnalysisResultsMetadata getMetadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
  
     /**
@@ -147,7 +147,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<RelationsResult> getRelations() {
-      return relations_serialized_name;
+      return relations;
     }
  
     /**
@@ -159,7 +159,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<SemanticRolesResult> getSemanticRoles() {
-      return semantic_roles_serialized_name;
+      return semanticRoles;
     }
  
     /**
@@ -171,7 +171,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public SentimentResult getSentiment() {
-      return sentiment_serialized_name;
+      return sentiment;
     }
  
     /**
@@ -183,7 +183,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public SyntaxResult getSyntax() {
-      return syntax_serialized_name;
+      return syntax;
     }
 
     /**
@@ -192,7 +192,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -201,7 +201,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param analyzedText the new analyzedText
      */
     public void setAnalyzedText(final String analyzedText) {
-      this.analyzed_text_serialized_name = analyzedText;
+      this.analyzedText = analyzedText;
     }
 
     /**
@@ -210,7 +210,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param retrievedUrl the new retrievedUrl
      */
     public void setRetrievedUrl(final String retrievedUrl) {
-      this.retrieved_url_serialized_name = retrievedUrl;
+      this.retrievedUrl = retrievedUrl;
     }
 
     /**
@@ -219,7 +219,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param usage the new usage
      */
     public void setUsage(final AnalysisResultsUsage usage) {
-      this.usage_serialized_name = usage;
+      this.usage = usage;
     }
 
     /**
@@ -228,7 +228,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param concepts the new concepts
      */
     public void setConcepts(final List<ConceptsResult> concepts) {
-      this.concepts_serialized_name = concepts;
+      this.concepts = concepts;
     }
 
     /**
@@ -237,7 +237,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param entities the new entities
      */
     public void setEntities(final List<EntitiesResult> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     /**
@@ -246,7 +246,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param keywords the new keywords
      */
     public void setKeywords(final List<KeywordsResult> keywords) {
-      this.keywords_serialized_name = keywords;
+      this.keywords = keywords;
     }
 
     /**
@@ -255,7 +255,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param categories the new categories
      */
     public void setCategories(final List<CategoriesResult> categories) {
-      this.categories_serialized_name = categories;
+      this.categories = categories;
     }
 
     /**
@@ -264,7 +264,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param emotion the new emotion
      */
     public void setEmotion(final EmotionResult emotion) {
-      this.emotion_serialized_name = emotion;
+      this.emotion = emotion;
     }
 
     /**
@@ -273,7 +273,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param metadata the new metadata
      */
     public void setMetadata(final AnalysisResultsMetadata metadata) {
-      this.metadata_serialized_name = metadata;
+      this.metadata = metadata;
     }
 
     /**
@@ -282,7 +282,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param relations the new relations
      */
     public void setRelations(final List<RelationsResult> relations) {
-      this.relations_serialized_name = relations;
+      this.relations = relations;
     }
 
     /**
@@ -291,7 +291,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param semanticRoles the new semanticRoles
      */
     public void setSemanticRoles(final List<SemanticRolesResult> semanticRoles) {
-      this.semantic_roles_serialized_name = semanticRoles;
+      this.semanticRoles = semanticRoles;
     }
 
     /**
@@ -300,7 +300,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param sentiment the new sentiment
      */
     public void setSentiment(final SentimentResult sentiment) {
-      this.sentiment_serialized_name = sentiment;
+      this.sentiment = sentiment;
     }
 
     /**
@@ -309,7 +309,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param syntax the new syntax
      */
     public void setSyntax(final SyntaxResult syntax) {
-      this.syntax_serialized_name = syntax;
+      this.syntax = syntax;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -320,7 +320,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       AnalysisResults ret = (AnalysisResults) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for usage
-      AnalysisResultsUsage newUsage = (AnalysisResultsUsage) new AnalysisResultsUsage().deserialize(JSON.serialize(ret.getUsage()), (Map<String, Object>) jsonMap.get('usage_serialized_name'), AnalysisResultsUsage.class);
+      AnalysisResultsUsage newUsage = (AnalysisResultsUsage) new AnalysisResultsUsage().deserialize(JSON.serialize(ret.getUsage()), (Map<String, Object>) jsonMap.get('usage'), AnalysisResultsUsage.class);
       ret.setUsage(newUsage);
 
       // calling custom deserializer for concepts
@@ -329,11 +329,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedConcepts != null) {
         for (Integer i = 0; i < deserializedConcepts.size(); i++) {
           ConceptsResult currentItem = ret.getConcepts().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('concepts_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('concepts');
           ConceptsResult newItem = (ConceptsResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ConceptsResult.class);
           newConcepts.add(newItem);
         }
-        ret.concepts_serialized_name = newConcepts;
+        ret.concepts = newConcepts;
       }
 
       // calling custom deserializer for entities
@@ -342,11 +342,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           EntitiesResult currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           EntitiesResult newItem = (EntitiesResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), EntitiesResult.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       // calling custom deserializer for keywords
@@ -355,11 +355,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedKeywords != null) {
         for (Integer i = 0; i < deserializedKeywords.size(); i++) {
           KeywordsResult currentItem = ret.getKeywords().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('keywords_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('keywords');
           KeywordsResult newItem = (KeywordsResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), KeywordsResult.class);
           newKeywords.add(newItem);
         }
-        ret.keywords_serialized_name = newKeywords;
+        ret.keywords = newKeywords;
       }
 
       // calling custom deserializer for categories
@@ -368,19 +368,19 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedCategories != null) {
         for (Integer i = 0; i < deserializedCategories.size(); i++) {
           CategoriesResult currentItem = ret.getCategories().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('categories_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('categories');
           CategoriesResult newItem = (CategoriesResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CategoriesResult.class);
           newCategories.add(newItem);
         }
-        ret.categories_serialized_name = newCategories;
+        ret.categories = newCategories;
       }
 
       // calling custom deserializer for emotion
-      EmotionResult newEmotion = (EmotionResult) new EmotionResult().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion_serialized_name'), EmotionResult.class);
+      EmotionResult newEmotion = (EmotionResult) new EmotionResult().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion'), EmotionResult.class);
       ret.setEmotion(newEmotion);
 
       // calling custom deserializer for metadata
-      AnalysisResultsMetadata newMetadata = (AnalysisResultsMetadata) new AnalysisResultsMetadata().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata_serialized_name'), AnalysisResultsMetadata.class);
+      AnalysisResultsMetadata newMetadata = (AnalysisResultsMetadata) new AnalysisResultsMetadata().deserialize(JSON.serialize(ret.getMetadata()), (Map<String, Object>) jsonMap.get('metadata'), AnalysisResultsMetadata.class);
       ret.setMetadata(newMetadata);
 
       // calling custom deserializer for relations
@@ -389,11 +389,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedRelations != null) {
         for (Integer i = 0; i < deserializedRelations.size(); i++) {
           RelationsResult currentItem = ret.getRelations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('relations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('relations');
           RelationsResult newItem = (RelationsResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RelationsResult.class);
           newRelations.add(newItem);
         }
-        ret.relations_serialized_name = newRelations;
+        ret.relations = newRelations;
       }
 
       // calling custom deserializer for semanticRoles
@@ -402,22 +402,54 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedSemanticRoles != null) {
         for (Integer i = 0; i < deserializedSemanticRoles.size(); i++) {
           SemanticRolesResult currentItem = ret.getSemanticRoles().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('semantic_roles_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('semanticRoles');
           SemanticRolesResult newItem = (SemanticRolesResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SemanticRolesResult.class);
           newSemanticRoles.add(newItem);
         }
-        ret.semantic_roles_serialized_name = newSemanticRoles;
+        ret.semanticRoles = newSemanticRoles;
       }
 
       // calling custom deserializer for sentiment
-      SentimentResult newSentiment = (SentimentResult) new SentimentResult().deserialize(JSON.serialize(ret.getSentiment()), (Map<String, Object>) jsonMap.get('sentiment_serialized_name'), SentimentResult.class);
+      SentimentResult newSentiment = (SentimentResult) new SentimentResult().deserialize(JSON.serialize(ret.getSentiment()), (Map<String, Object>) jsonMap.get('sentiment'), SentimentResult.class);
       ret.setSentiment(newSentiment);
 
       // calling custom deserializer for syntax
-      SyntaxResult newSyntax = (SyntaxResult) new SyntaxResult().deserialize(JSON.serialize(ret.getSyntax()), (Map<String, Object>) jsonMap.get('syntax_serialized_name'), SyntaxResult.class);
+      SyntaxResult newSyntax = (SyntaxResult) new SyntaxResult().deserialize(JSON.serialize(ret.getSyntax()), (Map<String, Object>) jsonMap.get('syntax'), SyntaxResult.class);
       ret.setSyntax(newSyntax);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('analyzed_text', 'analyzedText');
+      mapping.put('retrieved_url', 'retrievedUrl');
+      if (usage != null) {
+        mapping.putAll(usage.getApiToSdkMapping());
+      }
+      if (concepts != null && concepts[0] != null) {
+        mapping.putAll(concepts[0].getApiToSdkMapping());
+      }
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      if (categories != null && categories[0] != null) {
+        mapping.putAll(categories[0].getApiToSdkMapping());
+      }
+      if (metadata != null) {
+        mapping.putAll(metadata.getApiToSdkMapping());
+      }
+      if (relations != null && relations[0] != null) {
+        mapping.putAll(relations[0].getApiToSdkMapping());
+      }
+      mapping.put('semantic_roles', 'semanticRoles');
+      if (semanticRoles != null && semanticRoles[0] != null) {
+        mapping.putAll(semanticRoles[0].getApiToSdkMapping());
+      }
+      if (syntax != null) {
+        mapping.putAll(syntax.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -425,11 +457,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Webpage metadata, such as the author and the title of the page.
    */
   public class AnalysisResultsMetadata extends IBMWatsonGenericModel {
-    private List<Author> authors_serialized_name;
-    private String publication_date_serialized_name;
-    private String title_serialized_name;
-    private String image_serialized_name;
-    private List<Feed> feeds_serialized_name;
+    private List<Author> authors;
+    private String publicationDate;
+    private String title;
+    private String image;
+    private List<Feed> feeds;
  
     /**
      * Gets the authors.
@@ -438,8 +470,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the authors
      */
+    @AuraEnabled
     public List<Author> getAuthors() {
-      return authors_serialized_name;
+      return authors;
     }
  
     /**
@@ -449,8 +482,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the publicationDate
      */
+    @AuraEnabled
     public String getPublicationDate() {
-      return publication_date_serialized_name;
+      return publicationDate;
     }
  
     /**
@@ -460,8 +494,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the title
      */
+    @AuraEnabled
     public String getTitle() {
-      return title_serialized_name;
+      return title;
     }
  
     /**
@@ -471,8 +506,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the image
      */
+    @AuraEnabled
     public String getImage() {
-      return image_serialized_name;
+      return image;
     }
  
     /**
@@ -482,8 +518,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the feeds
      */
+    @AuraEnabled
     public List<Feed> getFeeds() {
-      return feeds_serialized_name;
+      return feeds;
     }
 
     /**
@@ -492,7 +529,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param authors the new authors
      */
     public void setAuthors(final List<Author> authors) {
-      this.authors_serialized_name = authors;
+      this.authors = authors;
     }
 
     /**
@@ -501,7 +538,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param publicationDate the new publicationDate
      */
     public void setPublicationDate(final String publicationDate) {
-      this.publication_date_serialized_name = publicationDate;
+      this.publicationDate = publicationDate;
     }
 
     /**
@@ -510,7 +547,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param title the new title
      */
     public void setTitle(final String title) {
-      this.title_serialized_name = title;
+      this.title = title;
     }
 
     /**
@@ -519,7 +556,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param image the new image
      */
     public void setImage(final String image) {
-      this.image_serialized_name = image;
+      this.image = image;
     }
 
     /**
@@ -528,7 +565,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param feeds the new feeds
      */
     public void setFeeds(final List<Feed> feeds) {
-      this.feeds_serialized_name = feeds;
+      this.feeds = feeds;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -544,11 +581,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedAuthors != null) {
         for (Integer i = 0; i < deserializedAuthors.size(); i++) {
           Author currentItem = ret.getAuthors().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('authors_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('authors');
           Author newItem = (Author) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Author.class);
           newAuthors.add(newItem);
         }
-        ret.authors_serialized_name = newAuthors;
+        ret.authors = newAuthors;
       }
 
       // calling custom deserializer for feeds
@@ -557,14 +594,20 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedFeeds != null) {
         for (Integer i = 0; i < deserializedFeeds.size(); i++) {
           Feed currentItem = ret.getFeeds().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('feeds_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('feeds');
           Feed newItem = (Feed) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Feed.class);
           newFeeds.add(newItem);
         }
-        ret.feeds_serialized_name = newFeeds;
+        ret.feeds = newFeeds;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('publication_date', 'publicationDate');
+      return mapping;
     }
   }
 
@@ -572,9 +615,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * API usage information for the request.
    */
   public class AnalysisResultsUsage extends IBMWatsonGenericModel {
-    private Long features_serialized_name;
-    private Long text_characters_serialized_name;
-    private Long text_units_serialized_name;
+    private Long features;
+    private Long textCharacters;
+    private Long textUnits;
  
     /**
      * Gets the features.
@@ -583,8 +626,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the features
      */
+    @AuraEnabled
     public Long getFeatures() {
-      return features_serialized_name;
+      return features;
     }
  
     /**
@@ -594,8 +638,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the textCharacters
      */
+    @AuraEnabled
     public Long getTextCharacters() {
-      return text_characters_serialized_name;
+      return textCharacters;
     }
  
     /**
@@ -605,8 +650,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the textUnits
      */
+    @AuraEnabled
     public Long getTextUnits() {
-      return text_units_serialized_name;
+      return textUnits;
     }
 
     /**
@@ -615,7 +661,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param features the new features
      */
     public void setFeatures(final long features) {
-      this.features_serialized_name = features;
+      this.features = features;
     }
 
     /**
@@ -624,7 +670,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param textCharacters the new textCharacters
      */
     public void setTextCharacters(final long textCharacters) {
-      this.text_characters_serialized_name = textCharacters;
+      this.textCharacters = textCharacters;
     }
 
     /**
@@ -633,9 +679,15 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param textUnits the new textUnits
      */
     public void setTextUnits(final long textUnits) {
-      this.text_units_serialized_name = textUnits;
+      this.textUnits = textUnits;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('text_characters', 'textCharacters');
+      mapping.put('text_units', 'textUnits');
+      return mapping;
+    }
   }
 
   /**
@@ -652,7 +704,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Boolean returnAnalyzedText;
     private String language;
     private Long limitTextCharacters;
- 
+
     /**
      * Gets the features.
      *
@@ -663,7 +715,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Features features() {
       return features;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -674,7 +726,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String text() {
       return text;
     }
- 
+
     /**
      * Gets the html.
      *
@@ -685,7 +737,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String html() {
       return html;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -696,7 +748,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String url() {
       return url;
     }
- 
+
     /**
      * Gets the clean.
      *
@@ -709,7 +761,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean clean() {
       return clean;
     }
- 
+
     /**
      * Gets the xpath.
      *
@@ -723,7 +775,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String xpath() {
       return xpath;
     }
- 
+
     /**
      * Gets the fallbackToRaw.
      *
@@ -734,7 +786,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean fallbackToRaw() {
       return fallbackToRaw;
     }
- 
+
     /**
      * Gets the returnAnalyzedText.
      *
@@ -745,7 +797,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean returnAnalyzedText() {
       return returnAnalyzedText;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -759,7 +811,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String language() {
       return language;
     }
- 
+
     /**
      * Gets the limitTextCharacters.
      *
@@ -795,6 +847,16 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new AnalyzeOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (features != null) {
+        mapping.putAll(features.getSdkToApiMapping());
+      }
+      mapping.put('fallbackToRaw', 'fallback_to_raw');
+      mapping.put('returnAnalyzedText', 'return_analyzed_text');
+      mapping.put('limitTextCharacters', 'limit_text_characters');
+      return mapping;
+    }
   }
 
   /**
@@ -977,7 +1039,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The author of the analyzed content.
    */
   public class Author extends IBMWatsonGenericModel {
-    private String name_serialized_name;
+    private String name;
  
     /**
      * Gets the name.
@@ -988,7 +1050,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
 
     /**
@@ -997,9 +1059,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
-
   }
 
   /**
@@ -1007,10 +1068,10 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    *
    * Supported languages: Arabic, English, French, German, Italian, Japanese, Korean, Portuguese, Spanish.
    */
-  public class CategoriesOptions {
-    private Boolean explanation_serialized_name;
-    private Long limit_serialized_name;
-    private String model_serialized_name;
+  public class CategoriesOptions extends IBMWatsonGenericModel {
+    private Boolean explanation;
+    private Long xlimit;
+    private String model;
  
     /**
      * Gets the explanation.
@@ -1021,7 +1082,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the explanation
      */
     public Boolean explanation() {
-      return explanation_serialized_name;
+      return explanation;
     }
  
     /**
@@ -1032,7 +1093,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the xlimit
      */
     public Long xlimit() {
-      return limit_serialized_name;
+      return xlimit;
     }
  
     /**
@@ -1045,13 +1106,13 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the model
      */
     public String model() {
-      return model_serialized_name;
+      return model;
     }
   
     private CategoriesOptions(CategoriesOptionsBuilder builder) {
-      this.explanation_serialized_name = builder.explanation;
-      this.limit_serialized_name = builder.xlimit;
-      this.model_serialized_name = builder.model;
+      this.explanation = builder.explanation;
+      this.xlimit = builder.xlimit;
+      this.model = builder.model;
     }
 
     /**
@@ -1063,6 +1124,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new CategoriesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
   }
 
   /**
@@ -1074,9 +1140,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String model;
 
     private CategoriesOptionsBuilder(CategoriesOptions categoriesOptions) {
-      this.explanation = categoriesOptions.explanation_serialized_name;
-      this.xlimit = categoriesOptions.limit_serialized_name;
-      this.model = categoriesOptions.model_serialized_name;
+      this.explanation = categoriesOptions.explanation;
+      this.xlimit = categoriesOptions.xlimit;
+      this.model = categoriesOptions.model;
     }
 
     /**
@@ -1132,7 +1198,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Relevant text that contributed to the categorization.
    */
   public class CategoriesRelevantText extends IBMWatsonGenericModel {
-    private String text_serialized_name;
+    private String text;
  
     /**
      * Gets the text.
@@ -1143,7 +1209,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -1152,18 +1218,17 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
-
   }
 
   /**
    * A categorization of the analyzed text.
    */
   public class CategoriesResult extends IBMWatsonGenericModel {
-    private String label_serialized_name;
-    private Double score_serialized_name;
-    private CategoriesResultExplanation explanation_serialized_name;
+    private String label;
+    private Double score;
+    private CategoriesResultExplanation explanation;
  
     /**
      * Gets the label.
@@ -1177,7 +1242,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getLabel() {
-      return label_serialized_name;
+      return label;
     }
  
     /**
@@ -1189,7 +1254,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
  
     /**
@@ -1201,7 +1266,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public CategoriesResultExplanation getExplanation() {
-      return explanation_serialized_name;
+      return explanation;
     }
 
     /**
@@ -1210,7 +1275,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param label the new label
      */
     public void setLabel(final String label) {
-      this.label_serialized_name = label;
+      this.label = label;
     }
 
     /**
@@ -1219,7 +1284,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
 
     /**
@@ -1228,7 +1293,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param explanation the new explanation
      */
     public void setExplanation(final CategoriesResultExplanation explanation) {
-      this.explanation_serialized_name = explanation;
+      this.explanation = explanation;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1239,10 +1304,18 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       CategoriesResult ret = (CategoriesResult) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for explanation
-      CategoriesResultExplanation newExplanation = (CategoriesResultExplanation) new CategoriesResultExplanation().deserialize(JSON.serialize(ret.getExplanation()), (Map<String, Object>) jsonMap.get('explanation_serialized_name'), CategoriesResultExplanation.class);
+      CategoriesResultExplanation newExplanation = (CategoriesResultExplanation) new CategoriesResultExplanation().deserialize(JSON.serialize(ret.getExplanation()), (Map<String, Object>) jsonMap.get('explanation'), CategoriesResultExplanation.class);
       ret.setExplanation(newExplanation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (explanation != null) {
+        mapping.putAll(explanation.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1250,7 +1323,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Information that helps to explain what contributed to the categories result.
    */
   public class CategoriesResultExplanation extends IBMWatsonGenericModel {
-    private List<CategoriesRelevantText> relevant_text_serialized_name;
+    private List<CategoriesRelevantText> relevantText;
  
     /**
      * Gets the relevantText.
@@ -1261,8 +1334,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the relevantText
      */
+    @AuraEnabled
     public List<CategoriesRelevantText> getRelevantText() {
-      return relevant_text_serialized_name;
+      return relevantText;
     }
 
     /**
@@ -1271,7 +1345,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param relevantText the new relevantText
      */
     public void setRelevantText(final List<CategoriesRelevantText> relevantText) {
-      this.relevant_text_serialized_name = relevantText;
+      this.relevantText = relevantText;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1287,14 +1361,20 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedRelevantText != null) {
         for (Integer i = 0; i < deserializedRelevantText.size(); i++) {
           CategoriesRelevantText currentItem = ret.getRelevantText().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('relevant_text_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('relevantText');
           CategoriesRelevantText newItem = (CategoriesRelevantText) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), CategoriesRelevantText.class);
           newRelevantText.add(newItem);
         }
-        ret.relevant_text_serialized_name = newRelevantText;
+        ret.relevantText = newRelevantText;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('relevant_text', 'relevantText');
+      return mapping;
     }
   }
 
@@ -1304,8 +1384,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    *
    * Supported languages: English, French, German, Italian, Japanese, Korean, Portuguese, Spanish.
    */
-  public class ConceptsOptions {
-    private Long limit_serialized_name;
+  public class ConceptsOptions extends IBMWatsonGenericModel {
+    private Long xlimit;
  
     /**
      * Gets the xlimit.
@@ -1315,11 +1395,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the xlimit
      */
     public Long xlimit() {
-      return limit_serialized_name;
+      return xlimit;
     }
   
     private ConceptsOptions(ConceptsOptionsBuilder builder) {
-      this.limit_serialized_name = builder.xlimit;
+      this.xlimit = builder.xlimit;
     }
 
     /**
@@ -1331,6 +1411,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new ConceptsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
   }
 
   /**
@@ -1340,7 +1425,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Long xlimit;
 
     private ConceptsOptionsBuilder(ConceptsOptions conceptsOptions) {
-      this.xlimit = conceptsOptions.limit_serialized_name;
+      this.xlimit = conceptsOptions.xlimit;
     }
 
     /**
@@ -1374,9 +1459,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The general concepts referenced or alluded to in the analyzed text.
    */
   public class ConceptsResult extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private Double relevance_serialized_name;
-    private String dbpedia_resource_serialized_name;
+    private String text;
+    private Double relevance;
+    private String dbpediaResource;
  
     /**
      * Gets the text.
@@ -1387,7 +1472,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -1399,7 +1484,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getRelevance() {
-      return relevance_serialized_name;
+      return relevance;
     }
  
     /**
@@ -1411,7 +1496,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getDbpediaResource() {
-      return dbpedia_resource_serialized_name;
+      return dbpediaResource;
     }
 
     /**
@@ -1420,7 +1505,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -1429,7 +1514,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param relevance the new relevance
      */
     public void setRelevance(final Double relevance) {
-      this.relevance_serialized_name = relevance;
+      this.relevance = relevance;
     }
 
     /**
@@ -1438,9 +1523,14 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param dbpediaResource the new dbpediaResource
      */
     public void setDbpediaResource(final String dbpediaResource) {
-      this.dbpedia_resource_serialized_name = dbpediaResource;
+      this.dbpediaResource = dbpediaResource;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dbpedia_resource', 'dbpediaResource');
+      return mapping;
+    }
   }
 
   /**
@@ -1448,7 +1538,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class DeleteModelOptions extends IBMWatsonOptionsModel {
     private String modelId;
- 
+
     /**
      * Gets the modelId.
      *
@@ -1475,6 +1565,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new DeleteModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('modelId', 'model_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1540,9 +1635,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Disambiguation information for the entity.
    */
   public class DisambiguationResult extends IBMWatsonGenericModel {
-    private String name_serialized_name;
-    private String dbpedia_resource_serialized_name;
-    private List<String> subtype_serialized_name;
+    private String name;
+    private String dbpediaResource;
+    private List<String> subtype;
  
     /**
      * Gets the name.
@@ -1553,7 +1648,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -1565,7 +1660,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getDbpediaResource() {
-      return dbpedia_resource_serialized_name;
+      return dbpediaResource;
     }
  
     /**
@@ -1577,7 +1672,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<String> getSubtype() {
-      return subtype_serialized_name;
+      return subtype;
     }
 
     /**
@@ -1586,7 +1681,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -1595,7 +1690,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param dbpediaResource the new dbpediaResource
      */
     public void setDbpediaResource(final String dbpediaResource) {
-      this.dbpedia_resource_serialized_name = dbpediaResource;
+      this.dbpediaResource = dbpediaResource;
     }
 
     /**
@@ -1604,16 +1699,21 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param subtype the new subtype
      */
     public void setSubtype(final List<String> subtype) {
-      this.subtype_serialized_name = subtype;
+      this.subtype = subtype;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('dbpedia_resource', 'dbpediaResource');
+      return mapping;
+    }
   }
 
   /**
    * Emotion results for the document as a whole.
    */
   public class DocumentEmotionResults extends IBMWatsonGenericModel {
-    private EmotionScores emotion_serialized_name;
+    private EmotionScores emotion;
  
     /**
      * Gets the emotion.
@@ -1624,7 +1724,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public EmotionScores getEmotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
 
     /**
@@ -1633,7 +1733,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param emotion the new emotion
      */
     public void setEmotion(final EmotionScores emotion) {
-      this.emotion_serialized_name = emotion;
+      this.emotion = emotion;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1644,7 +1744,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       DocumentEmotionResults ret = (DocumentEmotionResults) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for emotion
-      EmotionScores newEmotion = (EmotionScores) new EmotionScores().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion_serialized_name'), EmotionScores.class);
+      EmotionScores newEmotion = (EmotionScores) new EmotionScores().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion'), EmotionScores.class);
       ret.setEmotion(newEmotion);
 
       return ret;
@@ -1655,8 +1755,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * DocumentSentimentResults.
    */
   public class DocumentSentimentResults extends IBMWatsonGenericModel {
-    private String label_serialized_name;
-    private Double score_serialized_name;
+    private String label;
+    private Double score;
  
     /**
      * Gets the label.
@@ -1667,7 +1767,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getLabel() {
-      return label_serialized_name;
+      return label;
     }
  
     /**
@@ -1679,7 +1779,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
 
     /**
@@ -1688,7 +1788,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param label the new label
      */
     public void setLabel(final String label) {
-      this.label_serialized_name = label;
+      this.label = label;
     }
 
     /**
@@ -1697,9 +1797,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
-
   }
 
   /**
@@ -1709,9 +1808,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    *
    * Supported languages: English.
    */
-  public class EmotionOptions {
-    private Boolean document_serialized_name;
-    private List<String> targets_serialized_name;
+  public class EmotionOptions extends IBMWatsonGenericModel {
+    private Boolean document;
+    private List<String> targets;
  
     /**
      * Gets the document.
@@ -1721,7 +1820,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the document
      */
     public Boolean document() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -1732,12 +1831,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the targets
      */
     public List<String> targets() {
-      return targets_serialized_name;
+      return targets;
     }
   
     private EmotionOptions(EmotionOptionsBuilder builder) {
-      this.document_serialized_name = builder.document;
-      this.targets_serialized_name = builder.targets;
+      this.document = builder.document;
+      this.targets = builder.targets;
     }
 
     /**
@@ -1748,7 +1847,6 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public EmotionOptionsBuilder newBuilder() {
       return new EmotionOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -1759,8 +1857,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private List<String> targets;
 
     private EmotionOptionsBuilder(EmotionOptions emotionOptions) {
-      this.document = emotionOptions.document_serialized_name;
-      this.targets = emotionOptions.targets_serialized_name;
+      this.document = emotionOptions.document;
+      this.targets = emotionOptions.targets;
     }
 
     /**
@@ -1822,8 +1920,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * returned for detected entities, keywords, or user-specified target phrases found in the text.
    */
   public class EmotionResult extends IBMWatsonGenericModel {
-    private DocumentEmotionResults document_serialized_name;
-    private List<TargetedEmotionResults> targets_serialized_name;
+    private DocumentEmotionResults document;
+    private List<TargetedEmotionResults> targets;
  
     /**
      * Gets the document.
@@ -1834,7 +1932,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public DocumentEmotionResults getDocument() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -1846,7 +1944,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<TargetedEmotionResults> getTargets() {
-      return targets_serialized_name;
+      return targets;
     }
 
     /**
@@ -1855,7 +1953,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param document the new document
      */
     public void setDocument(final DocumentEmotionResults document) {
-      this.document_serialized_name = document;
+      this.document = document;
     }
 
     /**
@@ -1864,7 +1962,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param targets the new targets
      */
     public void setTargets(final List<TargetedEmotionResults> targets) {
-      this.targets_serialized_name = targets;
+      this.targets = targets;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1875,7 +1973,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       EmotionResult ret = (EmotionResult) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for document
-      DocumentEmotionResults newDocument = (DocumentEmotionResults) new DocumentEmotionResults().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document_serialized_name'), DocumentEmotionResults.class);
+      DocumentEmotionResults newDocument = (DocumentEmotionResults) new DocumentEmotionResults().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document'), DocumentEmotionResults.class);
       ret.setDocument(newDocument);
 
       // calling custom deserializer for targets
@@ -1884,11 +1982,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedTargets != null) {
         for (Integer i = 0; i < deserializedTargets.size(); i++) {
           TargetedEmotionResults currentItem = ret.getTargets().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('targets_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('targets');
           TargetedEmotionResults newItem = (TargetedEmotionResults) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TargetedEmotionResults.class);
           newTargets.add(newItem);
         }
-        ret.targets_serialized_name = newTargets;
+        ret.targets = newTargets;
       }
 
       return ret;
@@ -1899,11 +1997,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * EmotionScores.
    */
   public class EmotionScores extends IBMWatsonGenericModel {
-    private Double anger_serialized_name;
-    private Double disgust_serialized_name;
-    private Double fear_serialized_name;
-    private Double joy_serialized_name;
-    private Double sadness_serialized_name;
+    private Double anger;
+    private Double disgust;
+    private Double fear;
+    private Double joy;
+    private Double sadness;
  
     /**
      * Gets the anger.
@@ -1914,7 +2012,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getAnger() {
-      return anger_serialized_name;
+      return anger;
     }
  
     /**
@@ -1926,7 +2024,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getDisgust() {
-      return disgust_serialized_name;
+      return disgust;
     }
  
     /**
@@ -1938,7 +2036,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getFear() {
-      return fear_serialized_name;
+      return fear;
     }
  
     /**
@@ -1950,7 +2048,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getJoy() {
-      return joy_serialized_name;
+      return joy;
     }
  
     /**
@@ -1962,7 +2060,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getSadness() {
-      return sadness_serialized_name;
+      return sadness;
     }
 
     /**
@@ -1971,7 +2069,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param anger the new anger
      */
     public void setAnger(final Double anger) {
-      this.anger_serialized_name = anger;
+      this.anger = anger;
     }
 
     /**
@@ -1980,7 +2078,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param disgust the new disgust
      */
     public void setDisgust(final Double disgust) {
-      this.disgust_serialized_name = disgust;
+      this.disgust = disgust;
     }
 
     /**
@@ -1989,7 +2087,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param fear the new fear
      */
     public void setFear(final Double fear) {
-      this.fear_serialized_name = fear;
+      this.fear = fear;
     }
 
     /**
@@ -1998,7 +2096,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param joy the new joy
      */
     public void setJoy(final Double joy) {
-      this.joy_serialized_name = joy;
+      this.joy = joy;
     }
 
     /**
@@ -2007,9 +2105,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param sadness the new sadness
      */
     public void setSadness(final Double sadness) {
-      this.sadness_serialized_name = sadness;
+      this.sadness = sadness;
     }
-
   }
 
   /**
@@ -2019,12 +2116,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Supported languages: English, French, German, Italian, Japanese, Korean, Portuguese, Russian, Spanish, Swedish.
    * Arabic, Chinese, and Dutch are supported only through custom models.
    */
-  public class EntitiesOptions {
-    private Long limit_serialized_name;
-    private Boolean mentions_serialized_name;
-    private String model_serialized_name;
-    private Boolean sentiment_serialized_name;
-    private Boolean emotion_serialized_name;
+  public class EntitiesOptions extends IBMWatsonGenericModel {
+    private Long xlimit;
+    private Boolean mentions;
+    private String model;
+    private Boolean sentiment;
+    private Boolean emotion;
  
     /**
      * Gets the xlimit.
@@ -2034,7 +2131,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the xlimit
      */
     public Long xlimit() {
-      return limit_serialized_name;
+      return xlimit;
     }
  
     /**
@@ -2045,7 +2142,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the mentions
      */
     public Boolean mentions() {
-      return mentions_serialized_name;
+      return mentions;
     }
  
     /**
@@ -2058,7 +2155,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the model
      */
     public String model() {
-      return model_serialized_name;
+      return model;
     }
  
     /**
@@ -2069,7 +2166,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the sentiment
      */
     public Boolean sentiment() {
-      return sentiment_serialized_name;
+      return sentiment;
     }
  
     /**
@@ -2080,15 +2177,15 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the emotion
      */
     public Boolean emotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
   
     private EntitiesOptions(EntitiesOptionsBuilder builder) {
-      this.limit_serialized_name = builder.xlimit;
-      this.mentions_serialized_name = builder.mentions;
-      this.model_serialized_name = builder.model;
-      this.sentiment_serialized_name = builder.sentiment;
-      this.emotion_serialized_name = builder.emotion;
+      this.xlimit = builder.xlimit;
+      this.mentions = builder.mentions;
+      this.model = builder.model;
+      this.sentiment = builder.sentiment;
+      this.emotion = builder.emotion;
     }
 
     /**
@@ -2100,6 +2197,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new EntitiesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
   }
 
   /**
@@ -2113,11 +2215,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Boolean emotion;
 
     private EntitiesOptionsBuilder(EntitiesOptions entitiesOptions) {
-      this.xlimit = entitiesOptions.limit_serialized_name;
-      this.mentions = entitiesOptions.mentions_serialized_name;
-      this.model = entitiesOptions.model_serialized_name;
-      this.sentiment = entitiesOptions.sentiment_serialized_name;
-      this.emotion = entitiesOptions.emotion_serialized_name;
+      this.xlimit = entitiesOptions.xlimit;
+      this.mentions = entitiesOptions.mentions;
+      this.model = entitiesOptions.model;
+      this.sentiment = entitiesOptions.sentiment;
+      this.emotion = entitiesOptions.emotion;
     }
 
     /**
@@ -2195,15 +2297,15 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The important people, places, geopolitical entities and other types of entities in your content.
    */
   public class EntitiesResult extends IBMWatsonGenericModel {
-    private String type_serialized_name;
-    private String text_serialized_name;
-    private Double relevance_serialized_name;
-    private Double confidence_serialized_name;
-    private List<EntityMention> mentions_serialized_name;
-    private Long count_serialized_name;
-    private EmotionScores emotion_serialized_name;
-    private FeatureSentimentResults sentiment_serialized_name;
-    private DisambiguationResult disambiguation_serialized_name;
+    private String xtype;
+    private String text;
+    private Double relevance;
+    private Double confidence;
+    private List<EntityMention> mentions;
+    private Long count;
+    private EmotionScores emotion;
+    private FeatureSentimentResults sentiment;
+    private DisambiguationResult disambiguation;
  
     /**
      * Gets the xtype.
@@ -2214,7 +2316,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -2226,7 +2328,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -2238,7 +2340,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getRelevance() {
-      return relevance_serialized_name;
+      return relevance;
     }
  
     /**
@@ -2252,7 +2354,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
  
     /**
@@ -2264,7 +2366,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<EntityMention> getMentions() {
-      return mentions_serialized_name;
+      return mentions;
     }
  
     /**
@@ -2276,7 +2378,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Long getCount() {
-      return count_serialized_name;
+      return count;
     }
  
     /**
@@ -2288,7 +2390,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public EmotionScores getEmotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
  
     /**
@@ -2300,7 +2402,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public FeatureSentimentResults getSentiment() {
-      return sentiment_serialized_name;
+      return sentiment;
     }
  
     /**
@@ -2312,7 +2414,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public DisambiguationResult getDisambiguation() {
-      return disambiguation_serialized_name;
+      return disambiguation;
     }
 
     /**
@@ -2321,7 +2423,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -2330,7 +2432,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -2339,7 +2441,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param relevance the new relevance
      */
     public void setRelevance(final Double relevance) {
-      this.relevance_serialized_name = relevance;
+      this.relevance = relevance;
     }
 
     /**
@@ -2348,7 +2450,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
 
     /**
@@ -2357,7 +2459,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param mentions the new mentions
      */
     public void setMentions(final List<EntityMention> mentions) {
-      this.mentions_serialized_name = mentions;
+      this.mentions = mentions;
     }
 
     /**
@@ -2366,7 +2468,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param count the new count
      */
     public void setCount(final long count) {
-      this.count_serialized_name = count;
+      this.count = count;
     }
 
     /**
@@ -2375,7 +2477,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param emotion the new emotion
      */
     public void setEmotion(final EmotionScores emotion) {
-      this.emotion_serialized_name = emotion;
+      this.emotion = emotion;
     }
 
     /**
@@ -2384,7 +2486,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param sentiment the new sentiment
      */
     public void setSentiment(final FeatureSentimentResults sentiment) {
-      this.sentiment_serialized_name = sentiment;
+      this.sentiment = sentiment;
     }
 
     /**
@@ -2393,7 +2495,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param disambiguation the new disambiguation
      */
     public void setDisambiguation(final DisambiguationResult disambiguation) {
-      this.disambiguation_serialized_name = disambiguation;
+      this.disambiguation = disambiguation;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2409,26 +2511,35 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedMentions != null) {
         for (Integer i = 0; i < deserializedMentions.size(); i++) {
           EntityMention currentItem = ret.getMentions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('mentions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('mentions');
           EntityMention newItem = (EntityMention) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), EntityMention.class);
           newMentions.add(newItem);
         }
-        ret.mentions_serialized_name = newMentions;
+        ret.mentions = newMentions;
       }
 
       // calling custom deserializer for emotion
-      EmotionScores newEmotion = (EmotionScores) new EmotionScores().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion_serialized_name'), EmotionScores.class);
+      EmotionScores newEmotion = (EmotionScores) new EmotionScores().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion'), EmotionScores.class);
       ret.setEmotion(newEmotion);
 
       // calling custom deserializer for sentiment
-      FeatureSentimentResults newSentiment = (FeatureSentimentResults) new FeatureSentimentResults().deserialize(JSON.serialize(ret.getSentiment()), (Map<String, Object>) jsonMap.get('sentiment_serialized_name'), FeatureSentimentResults.class);
+      FeatureSentimentResults newSentiment = (FeatureSentimentResults) new FeatureSentimentResults().deserialize(JSON.serialize(ret.getSentiment()), (Map<String, Object>) jsonMap.get('sentiment'), FeatureSentimentResults.class);
       ret.setSentiment(newSentiment);
 
       // calling custom deserializer for disambiguation
-      DisambiguationResult newDisambiguation = (DisambiguationResult) new DisambiguationResult().deserialize(JSON.serialize(ret.getDisambiguation()), (Map<String, Object>) jsonMap.get('disambiguation_serialized_name'), DisambiguationResult.class);
+      DisambiguationResult newDisambiguation = (DisambiguationResult) new DisambiguationResult().deserialize(JSON.serialize(ret.getDisambiguation()), (Map<String, Object>) jsonMap.get('disambiguation'), DisambiguationResult.class);
       ret.setDisambiguation(newDisambiguation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      if (disambiguation != null) {
+        mapping.putAll(disambiguation.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2436,9 +2547,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * EntityMention.
    */
   public class EntityMention extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private List<Long> location_serialized_name;
-    private Double confidence_serialized_name;
+    private String text;
+    private List<Long> location;
+    private Double confidence;
  
     /**
      * Gets the text.
@@ -2449,7 +2560,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -2461,7 +2572,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -2475,7 +2586,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
 
     /**
@@ -2484,7 +2595,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -2493,7 +2604,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param location the new location
      */
     public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -2502,16 +2613,15 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
-
   }
 
   /**
    * FeatureSentimentResults.
    */
   public class FeatureSentimentResults extends IBMWatsonGenericModel {
-    private Double score_serialized_name;
+    private Double score;
  
     /**
      * Gets the score.
@@ -2522,7 +2632,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
 
     /**
@@ -2531,25 +2641,24 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
-
   }
 
   /**
    * Analysis features and options.
    */
-  public class Features {
-    private ConceptsOptions concepts_serialized_name;
-    private EmotionOptions emotion_serialized_name;
-    private EntitiesOptions entities_serialized_name;
-    private KeywordsOptions keywords_serialized_name;
-    private MetadataOptions metadata_serialized_name;
-    private RelationsOptions relations_serialized_name;
-    private SemanticRolesOptions semantic_roles_serialized_name;
-    private SentimentOptions sentiment_serialized_name;
-    private CategoriesOptions categories_serialized_name;
-    private SyntaxOptions syntax_serialized_name;
+  public class Features extends IBMWatsonGenericModel {
+    private ConceptsOptions concepts;
+    private EmotionOptions emotion;
+    private EntitiesOptions entities;
+    private KeywordsOptions keywords;
+    private MetadataOptions metadata;
+    private RelationsOptions relations;
+    private SemanticRolesOptions semanticRoles;
+    private SentimentOptions sentiment;
+    private CategoriesOptions categories;
+    private SyntaxOptions syntax;
  
     /**
      * Gets the concepts.
@@ -2562,7 +2671,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the concepts
      */
     public ConceptsOptions concepts() {
-      return concepts_serialized_name;
+      return concepts;
     }
  
     /**
@@ -2577,7 +2686,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the emotion
      */
     public EmotionOptions emotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
  
     /**
@@ -2592,7 +2701,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the entities
      */
     public EntitiesOptions entities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -2605,7 +2714,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the keywords
      */
     public KeywordsOptions keywords() {
-      return keywords_serialized_name;
+      return keywords;
     }
  
     /**
@@ -2617,7 +2726,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the metadata
      */
     public MetadataOptions metadata() {
-      return metadata_serialized_name;
+      return metadata;
     }
  
     /**
@@ -2633,7 +2742,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the relations
      */
     public RelationsOptions relations() {
-      return relations_serialized_name;
+      return relations;
     }
  
     /**
@@ -2646,7 +2755,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the semanticRoles
      */
     public SemanticRolesOptions semanticRoles() {
-      return semantic_roles_serialized_name;
+      return semanticRoles;
     }
  
     /**
@@ -2660,7 +2769,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the sentiment
      */
     public SentimentOptions sentiment() {
-      return sentiment_serialized_name;
+      return sentiment;
     }
  
     /**
@@ -2673,7 +2782,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the categories
      */
     public CategoriesOptions categories() {
-      return categories_serialized_name;
+      return categories;
     }
  
     /**
@@ -2684,20 +2793,20 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the syntax
      */
     public SyntaxOptions syntax() {
-      return syntax_serialized_name;
+      return syntax;
     }
   
     private Features(FeaturesBuilder builder) {
-      this.concepts_serialized_name = builder.concepts;
-      this.emotion_serialized_name = builder.emotion;
-      this.entities_serialized_name = builder.entities;
-      this.keywords_serialized_name = builder.keywords;
-      this.metadata_serialized_name = builder.metadata;
-      this.relations_serialized_name = builder.relations;
-      this.semantic_roles_serialized_name = builder.semanticRoles;
-      this.sentiment_serialized_name = builder.sentiment;
-      this.categories_serialized_name = builder.categories;
-      this.syntax_serialized_name = builder.syntax;
+      this.concepts = builder.concepts;
+      this.emotion = builder.emotion;
+      this.entities = builder.entities;
+      this.keywords = builder.keywords;
+      this.metadata = builder.metadata;
+      this.relations = builder.relations;
+      this.semanticRoles = builder.semanticRoles;
+      this.sentiment = builder.sentiment;
+      this.categories = builder.categories;
+      this.syntax = builder.syntax;
     }
 
     /**
@@ -2709,6 +2818,29 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new FeaturesBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (concepts != null) {
+        mapping.putAll(concepts.getSdkToApiMapping());
+      }
+      if (entities != null) {
+        mapping.putAll(entities.getSdkToApiMapping());
+      }
+      if (keywords != null) {
+        mapping.putAll(keywords.getSdkToApiMapping());
+      }
+      mapping.put('semanticRoles', 'semantic_roles');
+      if (semanticRoles != null) {
+        mapping.putAll(semanticRoles.getSdkToApiMapping());
+      }
+      if (categories != null) {
+        mapping.putAll(categories.getSdkToApiMapping());
+      }
+      if (syntax != null) {
+        mapping.putAll(syntax.getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -2727,16 +2859,16 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private SyntaxOptions syntax;
 
     private FeaturesBuilder(Features features) {
-      this.concepts = features.concepts_serialized_name;
-      this.emotion = features.emotion_serialized_name;
-      this.entities = features.entities_serialized_name;
-      this.keywords = features.keywords_serialized_name;
-      this.metadata = features.metadata_serialized_name;
-      this.relations = features.relations_serialized_name;
-      this.semanticRoles = features.semantic_roles_serialized_name;
-      this.sentiment = features.sentiment_serialized_name;
-      this.categories = features.categories_serialized_name;
-      this.syntax = features.syntax_serialized_name;
+      this.concepts = features.concepts;
+      this.emotion = features.emotion;
+      this.entities = features.entities;
+      this.keywords = features.keywords;
+      this.metadata = features.metadata;
+      this.relations = features.relations;
+      this.semanticRoles = features.semanticRoles;
+      this.sentiment = features.sentiment;
+      this.categories = features.categories;
+      this.syntax = features.syntax;
     }
 
     /**
@@ -2869,7 +3001,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * RSS or ATOM feed found on the webpage.
    */
   public class Feed extends IBMWatsonGenericModel {
-    private String link_serialized_name;
+    private String link;
  
     /**
      * Gets the link.
@@ -2880,7 +3012,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getLink() {
-      return link_serialized_name;
+      return link;
     }
 
     /**
@@ -2889,9 +3021,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param link the new link
      */
     public void setLink(final String link) {
-      this.link_serialized_name = link;
+      this.link = link;
     }
-
   }
 
   /**
@@ -2899,10 +3030,10 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    *
    * Supported languages: English, French, German, Italian, Japanese, Korean, Portuguese, Russian, Spanish, Swedish.
    */
-  public class KeywordsOptions {
-    private Long limit_serialized_name;
-    private Boolean sentiment_serialized_name;
-    private Boolean emotion_serialized_name;
+  public class KeywordsOptions extends IBMWatsonGenericModel {
+    private Long xlimit;
+    private Boolean sentiment;
+    private Boolean emotion;
  
     /**
      * Gets the xlimit.
@@ -2912,7 +3043,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the xlimit
      */
     public Long xlimit() {
-      return limit_serialized_name;
+      return xlimit;
     }
  
     /**
@@ -2923,7 +3054,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the sentiment
      */
     public Boolean sentiment() {
-      return sentiment_serialized_name;
+      return sentiment;
     }
  
     /**
@@ -2934,13 +3065,13 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the emotion
      */
     public Boolean emotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
   
     private KeywordsOptions(KeywordsOptionsBuilder builder) {
-      this.limit_serialized_name = builder.xlimit;
-      this.sentiment_serialized_name = builder.sentiment;
-      this.emotion_serialized_name = builder.emotion;
+      this.xlimit = builder.xlimit;
+      this.sentiment = builder.sentiment;
+      this.emotion = builder.emotion;
     }
 
     /**
@@ -2952,6 +3083,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new KeywordsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
   }
 
   /**
@@ -2963,9 +3099,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Boolean emotion;
 
     private KeywordsOptionsBuilder(KeywordsOptions keywordsOptions) {
-      this.xlimit = keywordsOptions.limit_serialized_name;
-      this.sentiment = keywordsOptions.sentiment_serialized_name;
-      this.emotion = keywordsOptions.emotion_serialized_name;
+      this.xlimit = keywordsOptions.xlimit;
+      this.sentiment = keywordsOptions.sentiment;
+      this.emotion = keywordsOptions.emotion;
     }
 
     /**
@@ -3021,11 +3157,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The important keywords in the content, organized by relevance.
    */
   public class KeywordsResult extends IBMWatsonGenericModel {
-    private Long count_serialized_name;
-    private Double relevance_serialized_name;
-    private String text_serialized_name;
-    private EmotionScores emotion_serialized_name;
-    private FeatureSentimentResults sentiment_serialized_name;
+    private Long count;
+    private Double relevance;
+    private String text;
+    private EmotionScores emotion;
+    private FeatureSentimentResults sentiment;
  
     /**
      * Gets the count.
@@ -3036,7 +3172,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Long getCount() {
-      return count_serialized_name;
+      return count;
     }
  
     /**
@@ -3048,7 +3184,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getRelevance() {
-      return relevance_serialized_name;
+      return relevance;
     }
  
     /**
@@ -3060,7 +3196,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -3072,7 +3208,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public EmotionScores getEmotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
  
     /**
@@ -3084,7 +3220,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public FeatureSentimentResults getSentiment() {
-      return sentiment_serialized_name;
+      return sentiment;
     }
 
     /**
@@ -3093,7 +3229,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param count the new count
      */
     public void setCount(final long count) {
-      this.count_serialized_name = count;
+      this.count = count;
     }
 
     /**
@@ -3102,7 +3238,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param relevance the new relevance
      */
     public void setRelevance(final Double relevance) {
-      this.relevance_serialized_name = relevance;
+      this.relevance = relevance;
     }
 
     /**
@@ -3111,7 +3247,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -3120,7 +3256,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param emotion the new emotion
      */
     public void setEmotion(final EmotionScores emotion) {
-      this.emotion_serialized_name = emotion;
+      this.emotion = emotion;
     }
 
     /**
@@ -3129,7 +3265,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param sentiment the new sentiment
      */
     public void setSentiment(final FeatureSentimentResults sentiment) {
-      this.sentiment_serialized_name = sentiment;
+      this.sentiment = sentiment;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3140,11 +3276,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       KeywordsResult ret = (KeywordsResult) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for emotion
-      EmotionScores newEmotion = (EmotionScores) new EmotionScores().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion_serialized_name'), EmotionScores.class);
+      EmotionScores newEmotion = (EmotionScores) new EmotionScores().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion'), EmotionScores.class);
       ret.setEmotion(newEmotion);
 
       // calling custom deserializer for sentiment
-      FeatureSentimentResults newSentiment = (FeatureSentimentResults) new FeatureSentimentResults().deserialize(JSON.serialize(ret.getSentiment()), (Map<String, Object>) jsonMap.get('sentiment_serialized_name'), FeatureSentimentResults.class);
+      FeatureSentimentResults newSentiment = (FeatureSentimentResults) new FeatureSentimentResults().deserialize(JSON.serialize(ret.getSentiment()), (Map<String, Object>) jsonMap.get('sentiment'), FeatureSentimentResults.class);
       ret.setSentiment(newSentiment);
 
       return ret;
@@ -3168,7 +3304,6 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public ListModelsOptionsBuilder newBuilder() {
       return new ListModelsOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -3212,7 +3347,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Custom models that are available for entities and relations.
    */
   public class ListModelsResults extends IBMWatsonResponseModel {
-    private List<Model> models_serialized_name;
+    private List<Model> models;
  
     /**
      * Gets the models.
@@ -3223,7 +3358,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<Model> getModels() {
-      return models_serialized_name;
+      return models;
     }
 
     /**
@@ -3232,7 +3367,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param models the new models
      */
     public void setModels(final List<Model> models) {
-      this.models_serialized_name = models;
+      this.models = models;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3248,14 +3383,22 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedModels != null) {
         for (Integer i = 0; i < deserializedModels.size(); i++) {
           Model currentItem = ret.getModels().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('models_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('models');
           Model newItem = (Model) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Model.class);
           newModels.add(newItem);
         }
-        ret.models_serialized_name = newModels;
+        ret.models = newModels;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (models != null && models[0] != null) {
+        mapping.putAll(models[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -3263,22 +3406,57 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Returns information from the document, including author name, title, RSS/ATOM feeds, prominent page image, and
    * publication date. Supports URL and HTML input types only.
    */
-  public class MetadataOptions {
+  public class MetadataOptions extends IBMWatsonGenericModel {
+  
+    private MetadataOptions(MetadataOptionsBuilder builder) {
+    }
 
+    /**
+     * New builder.
+     *
+     * @return a MetadataOptions builder
+     */
+    public MetadataOptionsBuilder newBuilder() {
+      return new MetadataOptionsBuilder(this);
+    }
+  }
+
+  /**
+   * MetadataOptions Builder.
+   */
+  public class MetadataOptionsBuilder {
+
+    private MetadataOptionsBuilder(MetadataOptions metadataOptions) {
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public MetadataOptionsBuilder() {
+    }
+
+    /**
+     * Builds a MetadataOptions.
+     *
+     * @return the metadataOptions
+     */
+    public MetadataOptions build() {
+      return new MetadataOptions(this);
+    }
   }
 
   /**
    * Model.
    */
   public class Model extends IBMWatsonGenericModel {
-    private String status_serialized_name;
-    private String model_id_serialized_name;
-    private String language_serialized_name;
-    private String description_serialized_name;
-    private String workspace_id_serialized_name;
-    private String version_serialized_name;
-    private String version_description_serialized_name;
-    private Datetime created_serialized_name;
+    private String status;
+    private String modelId;
+    private String language;
+    private String description;
+    private String workspaceId;
+    private String version;
+    private String versionDescription;
+    private Datetime created;
  
     /**
      * Gets the status.
@@ -3289,7 +3467,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -3301,7 +3479,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getModelId() {
-      return model_id_serialized_name;
+      return modelId;
     }
  
     /**
@@ -3313,7 +3491,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -3325,7 +3503,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -3337,7 +3515,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getWorkspaceId() {
-      return workspace_id_serialized_name;
+      return workspaceId;
     }
  
     /**
@@ -3349,7 +3527,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getVersion() {
-      return version_serialized_name;
+      return version;
     }
  
     /**
@@ -3361,7 +3539,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getVersionDescription() {
-      return version_description_serialized_name;
+      return versionDescription;
     }
  
     /**
@@ -3373,7 +3551,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
 
     /**
@@ -3382,7 +3560,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -3391,7 +3569,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param modelId the new modelId
      */
     public void setModelId(final String modelId) {
-      this.model_id_serialized_name = modelId;
+      this.modelId = modelId;
     }
 
     /**
@@ -3400,7 +3578,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -3409,7 +3587,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -3418,7 +3596,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param workspaceId the new workspaceId
      */
     public void setWorkspaceId(final String workspaceId) {
-      this.workspace_id_serialized_name = workspaceId;
+      this.workspaceId = workspaceId;
     }
 
     /**
@@ -3427,7 +3605,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param version the new version
      */
     public void setVersion(final String version) {
-      this.version_serialized_name = version;
+      this.version = version;
     }
 
     /**
@@ -3436,7 +3614,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param versionDescription the new versionDescription
      */
     public void setVersionDescription(final String versionDescription) {
-      this.version_description_serialized_name = versionDescription;
+      this.versionDescription = versionDescription;
     }
 
     /**
@@ -3445,18 +3623,25 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param created the new created
      */
     public void setCreated(final Datetime created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('model_id', 'modelId');
+      mapping.put('workspace_id', 'workspaceId');
+      mapping.put('version_description', 'versionDescription');
+      return mapping;
+    }
   }
 
   /**
    * RelationArgument.
    */
   public class RelationArgument extends IBMWatsonGenericModel {
-    private List<RelationEntity> entities_serialized_name;
-    private List<Long> location_serialized_name;
-    private String text_serialized_name;
+    private List<RelationEntity> entities;
+    private List<Long> location;
+    private String text;
  
     /**
      * Gets the entities.
@@ -3467,7 +3652,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<RelationEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -3479,7 +3664,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -3491,7 +3676,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -3500,7 +3685,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param entities the new entities
      */
     public void setEntities(final List<RelationEntity> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     /**
@@ -3509,7 +3694,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param location the new location
      */
     public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -3518,7 +3703,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3534,14 +3719,22 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           RelationEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           RelationEntity newItem = (RelationEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RelationEntity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -3549,8 +3742,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * An entity that corresponds with an argument in a relation.
    */
   public class RelationEntity extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private String type_serialized_name;
+    private String text;
+    private String xtype;
  
     /**
      * Gets the text.
@@ -3561,7 +3754,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -3573,7 +3766,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
 
     /**
@@ -3582,7 +3775,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -3591,9 +3784,14 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      return mapping;
+    }
   }
 
   /**
@@ -3604,8 +3802,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Supported languages: Arabic, English, German, Japanese, Korean, Spanish. Chinese, Dutch, French, Italian, and
    * Portuguese custom models are also supported.
    */
-  public class RelationsOptions {
-    private String model_serialized_name;
+  public class RelationsOptions extends IBMWatsonGenericModel {
+    private String model;
  
     /**
      * Gets the model.
@@ -3617,11 +3815,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the model
      */
     public String model() {
-      return model_serialized_name;
+      return model;
     }
   
     private RelationsOptions(RelationsOptionsBuilder builder) {
-      this.model_serialized_name = builder.model;
+      this.model = builder.model;
     }
 
     /**
@@ -3632,7 +3830,6 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public RelationsOptionsBuilder newBuilder() {
       return new RelationsOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -3642,7 +3839,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String model;
 
     private RelationsOptionsBuilder(RelationsOptions relationsOptions) {
-      this.model = relationsOptions.model_serialized_name;
+      this.model = relationsOptions.model;
     }
 
     /**
@@ -3676,10 +3873,10 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The relations between entities found in the content.
    */
   public class RelationsResult extends IBMWatsonGenericModel {
-    private Double score_serialized_name;
-    private String sentence_serialized_name;
-    private String type_serialized_name;
-    private List<RelationArgument> arguments_serialized_name;
+    private Double score;
+    private String sentence;
+    private String xtype;
+    private List<RelationArgument> arguments;
  
     /**
      * Gets the score.
@@ -3690,7 +3887,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
  
     /**
@@ -3702,7 +3899,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getSentence() {
-      return sentence_serialized_name;
+      return sentence;
     }
  
     /**
@@ -3714,7 +3911,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -3726,7 +3923,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<RelationArgument> getArguments() {
-      return arguments_serialized_name;
+      return arguments;
     }
 
     /**
@@ -3735,7 +3932,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
 
     /**
@@ -3744,7 +3941,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param sentence the new sentence
      */
     public void setSentence(final String sentence) {
-      this.sentence_serialized_name = sentence;
+      this.sentence = sentence;
     }
 
     /**
@@ -3753,7 +3950,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -3762,7 +3959,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param arguments the new arguments
      */
     public void setArguments(final List<RelationArgument> arguments) {
-      this.arguments_serialized_name = arguments;
+      this.arguments = arguments;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -3778,14 +3975,23 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedArguments != null) {
         for (Integer i = 0; i < deserializedArguments.size(); i++) {
           RelationArgument currentItem = ret.getArguments().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('arguments_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('arguments');
           RelationArgument newItem = (RelationArgument) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RelationArgument.class);
           newArguments.add(newItem);
         }
-        ret.arguments_serialized_name = newArguments;
+        ret.arguments = newArguments;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      if (arguments != null && arguments[0] != null) {
+        mapping.putAll(arguments[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -3793,8 +3999,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * SemanticRolesEntity.
    */
   public class SemanticRolesEntity extends IBMWatsonGenericModel {
-    private String type_serialized_name;
-    private String text_serialized_name;
+    private String xtype;
+    private String text;
  
     /**
      * Gets the xtype.
@@ -3805,7 +4011,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -3817,7 +4023,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -3826,7 +4032,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -3835,16 +4041,21 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      return mapping;
+    }
   }
 
   /**
    * SemanticRolesKeyword.
    */
   public class SemanticRolesKeyword extends IBMWatsonGenericModel {
-    private String text_serialized_name;
+    private String text;
  
     /**
      * Gets the text.
@@ -3855,7 +4066,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
 
     /**
@@ -3864,9 +4075,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
-
   }
 
   /**
@@ -3874,10 +4084,10 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    *
    * Supported languages: English, German, Japanese, Korean, Spanish.
    */
-  public class SemanticRolesOptions {
-    private Long limit_serialized_name;
-    private Boolean keywords_serialized_name;
-    private Boolean entities_serialized_name;
+  public class SemanticRolesOptions extends IBMWatsonGenericModel {
+    private Long xlimit;
+    private Boolean keywords;
+    private Boolean entities;
  
     /**
      * Gets the xlimit.
@@ -3887,7 +4097,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the xlimit
      */
     public Long xlimit() {
-      return limit_serialized_name;
+      return xlimit;
     }
  
     /**
@@ -3898,7 +4108,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the keywords
      */
     public Boolean keywords() {
-      return keywords_serialized_name;
+      return keywords;
     }
  
     /**
@@ -3909,13 +4119,13 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the entities
      */
     public Boolean entities() {
-      return entities_serialized_name;
+      return entities;
     }
   
     private SemanticRolesOptions(SemanticRolesOptionsBuilder builder) {
-      this.limit_serialized_name = builder.xlimit;
-      this.keywords_serialized_name = builder.keywords;
-      this.entities_serialized_name = builder.entities;
+      this.xlimit = builder.xlimit;
+      this.keywords = builder.keywords;
+      this.entities = builder.entities;
     }
 
     /**
@@ -3927,6 +4137,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new SemanticRolesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('xlimit', 'limit');
+      return mapping;
+    }
   }
 
   /**
@@ -3938,9 +4153,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Boolean entities;
 
     private SemanticRolesOptionsBuilder(SemanticRolesOptions semanticRolesOptions) {
-      this.xlimit = semanticRolesOptions.limit_serialized_name;
-      this.keywords = semanticRolesOptions.keywords_serialized_name;
-      this.entities = semanticRolesOptions.entities_serialized_name;
+      this.xlimit = semanticRolesOptions.xlimit;
+      this.keywords = semanticRolesOptions.keywords;
+      this.entities = semanticRolesOptions.entities;
     }
 
     /**
@@ -3996,10 +4211,10 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The object containing the actions and the objects the actions act upon.
    */
   public class SemanticRolesResult extends IBMWatsonGenericModel {
-    private String sentence_serialized_name;
-    private SemanticRolesResultSubject subject_serialized_name;
-    private SemanticRolesResultAction action_serialized_name;
-    private SemanticRolesResultObject object_serialized_name;
+    private String sentence;
+    private SemanticRolesResultSubject subject;
+    private SemanticRolesResultAction action;
+    private SemanticRolesResultObject xobject;
  
     /**
      * Gets the sentence.
@@ -4010,7 +4225,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getSentence() {
-      return sentence_serialized_name;
+      return sentence;
     }
  
     /**
@@ -4022,7 +4237,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public SemanticRolesResultSubject getSubject() {
-      return subject_serialized_name;
+      return subject;
     }
  
     /**
@@ -4034,7 +4249,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public SemanticRolesResultAction getAction() {
-      return action_serialized_name;
+      return action;
     }
  
     /**
@@ -4046,7 +4261,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public SemanticRolesResultObject getXobject() {
-      return object_serialized_name;
+      return xobject;
     }
 
     /**
@@ -4055,7 +4270,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param sentence the new sentence
      */
     public void setSentence(final String sentence) {
-      this.sentence_serialized_name = sentence;
+      this.sentence = sentence;
     }
 
     /**
@@ -4064,7 +4279,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param subject the new subject
      */
     public void setSubject(final SemanticRolesResultSubject subject) {
-      this.subject_serialized_name = subject;
+      this.subject = subject;
     }
 
     /**
@@ -4073,7 +4288,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param action the new action
      */
     public void setAction(final SemanticRolesResultAction action) {
-      this.action_serialized_name = action;
+      this.action = action;
     }
 
     /**
@@ -4082,7 +4297,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param xobject the new xobject
      */
     public void setXobject(final SemanticRolesResultObject xobject) {
-      this.object_serialized_name = xobject;
+      this.xobject = xobject;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4093,18 +4308,27 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       SemanticRolesResult ret = (SemanticRolesResult) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for subject
-      SemanticRolesResultSubject newSubject = (SemanticRolesResultSubject) new SemanticRolesResultSubject().deserialize(JSON.serialize(ret.getSubject()), (Map<String, Object>) jsonMap.get('subject_serialized_name'), SemanticRolesResultSubject.class);
+      SemanticRolesResultSubject newSubject = (SemanticRolesResultSubject) new SemanticRolesResultSubject().deserialize(JSON.serialize(ret.getSubject()), (Map<String, Object>) jsonMap.get('subject'), SemanticRolesResultSubject.class);
       ret.setSubject(newSubject);
 
       // calling custom deserializer for action
-      SemanticRolesResultAction newAction = (SemanticRolesResultAction) new SemanticRolesResultAction().deserialize(JSON.serialize(ret.getAction()), (Map<String, Object>) jsonMap.get('action_serialized_name'), SemanticRolesResultAction.class);
+      SemanticRolesResultAction newAction = (SemanticRolesResultAction) new SemanticRolesResultAction().deserialize(JSON.serialize(ret.getAction()), (Map<String, Object>) jsonMap.get('action'), SemanticRolesResultAction.class);
       ret.setAction(newAction);
 
       // calling custom deserializer for xobject
-      SemanticRolesResultObject newXobject = (SemanticRolesResultObject) new SemanticRolesResultObject().deserialize(JSON.serialize(ret.getXobject()), (Map<String, Object>) jsonMap.get('object_serialized_name'), SemanticRolesResultObject.class);
+      SemanticRolesResultObject newXobject = (SemanticRolesResultObject) new SemanticRolesResultObject().deserialize(JSON.serialize(ret.getXobject()), (Map<String, Object>) jsonMap.get('xobject'), SemanticRolesResultObject.class);
       ret.setXobject(newXobject);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (subject != null) {
+        mapping.putAll(subject.getApiToSdkMapping());
+      }
+      mapping.put('object', 'xobject');
+      return mapping;
     }
   }
 
@@ -4112,9 +4336,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The extracted action from the sentence.
    */
   public class SemanticRolesResultAction extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private String normalized_serialized_name;
-    private SemanticRolesVerb verb_serialized_name;
+    private String text;
+    private String normalized;
+    private SemanticRolesVerb verb;
  
     /**
      * Gets the text.
@@ -4123,8 +4347,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the text
      */
+    @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4134,8 +4359,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the normalized
      */
+    @AuraEnabled
     public String getNormalized() {
-      return normalized_serialized_name;
+      return normalized;
     }
  
     /**
@@ -4143,8 +4369,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the verb
      */
+    @AuraEnabled
     public SemanticRolesVerb getVerb() {
-      return verb_serialized_name;
+      return verb;
     }
 
     /**
@@ -4153,7 +4380,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4162,7 +4389,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param normalized the new normalized
      */
     public void setNormalized(final String normalized) {
-      this.normalized_serialized_name = normalized;
+      this.normalized = normalized;
     }
 
     /**
@@ -4171,7 +4398,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param verb the new verb
      */
     public void setVerb(final SemanticRolesVerb verb) {
-      this.verb_serialized_name = verb;
+      this.verb = verb;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4182,7 +4409,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       SemanticRolesResultAction ret = (SemanticRolesResultAction) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for verb
-      SemanticRolesVerb newVerb = (SemanticRolesVerb) new SemanticRolesVerb().deserialize(JSON.serialize(ret.getVerb()), (Map<String, Object>) jsonMap.get('verb_serialized_name'), SemanticRolesVerb.class);
+      SemanticRolesVerb newVerb = (SemanticRolesVerb) new SemanticRolesVerb().deserialize(JSON.serialize(ret.getVerb()), (Map<String, Object>) jsonMap.get('verb'), SemanticRolesVerb.class);
       ret.setVerb(newVerb);
 
       return ret;
@@ -4193,8 +4420,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The extracted object from the sentence.
    */
   public class SemanticRolesResultObject extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private List<SemanticRolesKeyword> keywords_serialized_name;
+    private String text;
+    private List<SemanticRolesKeyword> keywords;
  
     /**
      * Gets the text.
@@ -4203,8 +4430,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the text
      */
+    @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4214,8 +4442,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the keywords
      */
+    @AuraEnabled
     public List<SemanticRolesKeyword> getKeywords() {
-      return keywords_serialized_name;
+      return keywords;
     }
 
     /**
@@ -4224,7 +4453,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4233,7 +4462,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param keywords the new keywords
      */
     public void setKeywords(final List<SemanticRolesKeyword> keywords) {
-      this.keywords_serialized_name = keywords;
+      this.keywords = keywords;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4249,11 +4478,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedKeywords != null) {
         for (Integer i = 0; i < deserializedKeywords.size(); i++) {
           SemanticRolesKeyword currentItem = ret.getKeywords().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('keywords_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('keywords');
           SemanticRolesKeyword newItem = (SemanticRolesKeyword) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SemanticRolesKeyword.class);
           newKeywords.add(newItem);
         }
-        ret.keywords_serialized_name = newKeywords;
+        ret.keywords = newKeywords;
       }
 
       return ret;
@@ -4264,9 +4493,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The extracted subject from the sentence.
    */
   public class SemanticRolesResultSubject extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private List<SemanticRolesEntity> entities_serialized_name;
-    private List<SemanticRolesKeyword> keywords_serialized_name;
+    private String text;
+    private List<SemanticRolesEntity> entities;
+    private List<SemanticRolesKeyword> keywords;
  
     /**
      * Gets the text.
@@ -4275,8 +4504,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the text
      */
+    @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4286,8 +4516,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the entities
      */
+    @AuraEnabled
     public List<SemanticRolesEntity> getEntities() {
-      return entities_serialized_name;
+      return entities;
     }
  
     /**
@@ -4297,8 +4528,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      *
      * @return the keywords
      */
+    @AuraEnabled
     public List<SemanticRolesKeyword> getKeywords() {
-      return keywords_serialized_name;
+      return keywords;
     }
 
     /**
@@ -4307,7 +4539,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4316,7 +4548,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param entities the new entities
      */
     public void setEntities(final List<SemanticRolesEntity> entities) {
-      this.entities_serialized_name = entities;
+      this.entities = entities;
     }
 
     /**
@@ -4325,7 +4557,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param keywords the new keywords
      */
     public void setKeywords(final List<SemanticRolesKeyword> keywords) {
-      this.keywords_serialized_name = keywords;
+      this.keywords = keywords;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4341,11 +4573,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedEntities != null) {
         for (Integer i = 0; i < deserializedEntities.size(); i++) {
           SemanticRolesEntity currentItem = ret.getEntities().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('entities_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('entities');
           SemanticRolesEntity newItem = (SemanticRolesEntity) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SemanticRolesEntity.class);
           newEntities.add(newItem);
         }
-        ret.entities_serialized_name = newEntities;
+        ret.entities = newEntities;
       }
 
       // calling custom deserializer for keywords
@@ -4354,14 +4586,22 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedKeywords != null) {
         for (Integer i = 0; i < deserializedKeywords.size(); i++) {
           SemanticRolesKeyword currentItem = ret.getKeywords().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('keywords_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('keywords');
           SemanticRolesKeyword newItem = (SemanticRolesKeyword) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SemanticRolesKeyword.class);
           newKeywords.add(newItem);
         }
-        ret.keywords_serialized_name = newKeywords;
+        ret.keywords = newKeywords;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (entities != null && entities[0] != null) {
+        mapping.putAll(entities[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -4369,8 +4609,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * SemanticRolesVerb.
    */
   public class SemanticRolesVerb extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private String tense_serialized_name;
+    private String text;
+    private String tense;
  
     /**
      * Gets the text.
@@ -4381,7 +4621,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4393,7 +4633,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getTense() {
-      return tense_serialized_name;
+      return tense;
     }
 
     /**
@@ -4402,7 +4642,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4411,17 +4651,16 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param tense the new tense
      */
     public void setTense(final String tense) {
-      this.tense_serialized_name = tense;
+      this.tense = tense;
     }
-
   }
 
   /**
    * SentenceResult.
    */
   public class SentenceResult extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private List<Long> location_serialized_name;
+    private String text;
+    private List<Long> location;
  
     /**
      * Gets the text.
@@ -4432,7 +4671,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4444,7 +4683,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
     }
 
     /**
@@ -4453,7 +4692,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4462,9 +4701,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param location the new location
      */
     public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
-
   }
 
   /**
@@ -4473,9 +4711,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    *
    *  Supported languages: Arabic, English, French, German, Italian, Japanese, Korean, Portuguese, Russian, Spanish.
    */
-  public class SentimentOptions {
-    private Boolean document_serialized_name;
-    private List<String> targets_serialized_name;
+  public class SentimentOptions extends IBMWatsonGenericModel {
+    private Boolean document;
+    private List<String> targets;
  
     /**
      * Gets the document.
@@ -4485,7 +4723,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the document
      */
     public Boolean document() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -4496,12 +4734,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the targets
      */
     public List<String> targets() {
-      return targets_serialized_name;
+      return targets;
     }
   
     private SentimentOptions(SentimentOptionsBuilder builder) {
-      this.document_serialized_name = builder.document;
-      this.targets_serialized_name = builder.targets;
+      this.document = builder.document;
+      this.targets = builder.targets;
     }
 
     /**
@@ -4512,7 +4750,6 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public SentimentOptionsBuilder newBuilder() {
       return new SentimentOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -4523,8 +4760,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private List<String> targets;
 
     private SentimentOptionsBuilder(SentimentOptions sentimentOptions) {
-      this.document = sentimentOptions.document_serialized_name;
-      this.targets = sentimentOptions.targets_serialized_name;
+      this.document = sentimentOptions.document;
+      this.targets = sentimentOptions.targets;
     }
 
     /**
@@ -4585,8 +4822,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * The sentiment of the content.
    */
   public class SentimentResult extends IBMWatsonGenericModel {
-    private DocumentSentimentResults document_serialized_name;
-    private List<TargetedSentimentResults> targets_serialized_name;
+    private DocumentSentimentResults document;
+    private List<TargetedSentimentResults> targets;
  
     /**
      * Gets the document.
@@ -4597,7 +4834,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public DocumentSentimentResults getDocument() {
-      return document_serialized_name;
+      return document;
     }
  
     /**
@@ -4609,7 +4846,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<TargetedSentimentResults> getTargets() {
-      return targets_serialized_name;
+      return targets;
     }
 
     /**
@@ -4618,7 +4855,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param document the new document
      */
     public void setDocument(final DocumentSentimentResults document) {
-      this.document_serialized_name = document;
+      this.document = document;
     }
 
     /**
@@ -4627,7 +4864,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param targets the new targets
      */
     public void setTargets(final List<TargetedSentimentResults> targets) {
-      this.targets_serialized_name = targets;
+      this.targets = targets;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4638,7 +4875,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       SentimentResult ret = (SentimentResult) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for document
-      DocumentSentimentResults newDocument = (DocumentSentimentResults) new DocumentSentimentResults().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document_serialized_name'), DocumentSentimentResults.class);
+      DocumentSentimentResults newDocument = (DocumentSentimentResults) new DocumentSentimentResults().deserialize(JSON.serialize(ret.getDocument()), (Map<String, Object>) jsonMap.get('document'), DocumentSentimentResults.class);
       ret.setDocument(newDocument);
 
       // calling custom deserializer for targets
@@ -4647,11 +4884,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedTargets != null) {
         for (Integer i = 0; i < deserializedTargets.size(); i++) {
           TargetedSentimentResults currentItem = ret.getTargets().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('targets_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('targets');
           TargetedSentimentResults newItem = (TargetedSentimentResults) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TargetedSentimentResults.class);
           newTargets.add(newItem);
         }
-        ret.targets_serialized_name = newTargets;
+        ret.targets = newTargets;
       }
 
       return ret;
@@ -4661,9 +4898,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   /**
    * Returns tokens and sentences from the input text.
    */
-  public class SyntaxOptions {
-    private SyntaxOptionsTokens tokens_serialized_name;
-    private Boolean sentences_serialized_name;
+  public class SyntaxOptions extends IBMWatsonGenericModel {
+    private SyntaxOptionsTokens tokens;
+    private Boolean sentences;
  
     /**
      * Gets the tokens.
@@ -4673,7 +4910,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the tokens
      */
     public SyntaxOptionsTokens tokens() {
-      return tokens_serialized_name;
+      return tokens;
     }
  
     /**
@@ -4684,12 +4921,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the sentences
      */
     public Boolean sentences() {
-      return sentences_serialized_name;
+      return sentences;
     }
   
     private SyntaxOptions(SyntaxOptionsBuilder builder) {
-      this.tokens_serialized_name = builder.tokens;
-      this.sentences_serialized_name = builder.sentences;
+      this.tokens = builder.tokens;
+      this.sentences = builder.sentences;
     }
 
     /**
@@ -4701,6 +4938,13 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new SyntaxOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (tokens != null) {
+        mapping.putAll(tokens.getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -4711,8 +4955,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Boolean sentences;
 
     private SyntaxOptionsBuilder(SyntaxOptions syntaxOptions) {
-      this.tokens = syntaxOptions.tokens_serialized_name;
-      this.sentences = syntaxOptions.sentences_serialized_name;
+      this.tokens = syntaxOptions.tokens;
+      this.sentences = syntaxOptions.sentences;
     }
 
     /**
@@ -4756,9 +5000,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   /**
    * Tokenization options.
    */
-  public class SyntaxOptionsTokens {
-    private Boolean lemma_serialized_name;
-    private Boolean part_of_speech_serialized_name;
+  public class SyntaxOptionsTokens extends IBMWatsonGenericModel {
+    private Boolean lemma;
+    private Boolean partOfSpeech;
  
     /**
      * Gets the lemma.
@@ -4768,7 +5012,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the lemma
      */
     public Boolean getLemma() {
-      return lemma_serialized_name;
+      return lemma;
     }
  
     /**
@@ -4779,35 +5023,86 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @return the partOfSpeech
      */
     public Boolean getPartOfSpeech() {
-      return part_of_speech_serialized_name;
+      return partOfSpeech;
+    }
+  
+    private SyntaxOptionsTokens(SyntaxOptionsTokensBuilder builder) {
+      this.lemma = builder.lemma;
+      this.partOfSpeech = builder.partOfSpeech;
     }
 
     /**
-     * Sets the lemma.
+     * New builder.
      *
-     * @param lemma the new lemma
+     * @return a SyntaxOptionsTokens builder
      */
-    public void setLemma(final Boolean lemma) {
-      this.lemma_serialized_name = lemma;
+    public SyntaxOptionsTokensBuilder newBuilder() {
+      return new SyntaxOptionsTokensBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('partOfSpeech', 'part_of_speech');
+      return mapping;
+    }
+  }
+
+  /**
+   * SyntaxOptionsTokens Builder.
+   */
+  public class SyntaxOptionsTokensBuilder {
+    private Boolean lemma;
+    private Boolean partOfSpeech;
+
+    private SyntaxOptionsTokensBuilder(SyntaxOptionsTokens syntaxOptionsTokens) {
+      this.lemma = syntaxOptionsTokens.lemma;
+      this.partOfSpeech = syntaxOptionsTokens.partOfSpeech;
     }
 
     /**
-     * Sets the partOfSpeech.
-     *
-     * @param partOfSpeech the new partOfSpeech
+     * Instantiates a new builder.
      */
-    public void setPartOfSpeech(final Boolean partOfSpeech) {
-      this.part_of_speech_serialized_name = partOfSpeech;
+    public SyntaxOptionsTokensBuilder() {
     }
 
+    /**
+     * Builds a SyntaxOptionsTokens.
+     *
+     * @return the syntaxOptionsTokens
+     */
+    public SyntaxOptionsTokens build() {
+      return new SyntaxOptionsTokens(this);
+    }
+
+    /**
+     * Set the lemma.
+     *
+     * @param lemma the lemma
+     * @return the SyntaxOptionsTokens builder
+     */
+    public SyntaxOptionsTokensBuilder setLemma(Boolean lemma) {
+      this.lemma = lemma;
+      return this;
+    }
+
+    /**
+     * Set the partOfSpeech.
+     *
+     * @param partOfSpeech the partOfSpeech
+     * @return the SyntaxOptionsTokens builder
+     */
+    public SyntaxOptionsTokensBuilder setPartOfSpeech(Boolean partOfSpeech) {
+      this.partOfSpeech = partOfSpeech;
+      return this;
+    }
   }
 
   /**
    * Tokens and sentences returned from syntax analysis.
    */
   public class SyntaxResult extends IBMWatsonGenericModel {
-    private List<TokenResult> tokens_serialized_name;
-    private List<SentenceResult> sentences_serialized_name;
+    private List<TokenResult> tokens;
+    private List<SentenceResult> sentences;
  
     /**
      * Gets the tokens.
@@ -4816,7 +5111,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<TokenResult> getTokens() {
-      return tokens_serialized_name;
+      return tokens;
     }
  
     /**
@@ -4826,7 +5121,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<SentenceResult> getSentences() {
-      return sentences_serialized_name;
+      return sentences;
     }
 
     /**
@@ -4835,7 +5130,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param tokens the new tokens
      */
     public void setTokens(final List<TokenResult> tokens) {
-      this.tokens_serialized_name = tokens;
+      this.tokens = tokens;
     }
 
     /**
@@ -4844,7 +5139,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param sentences the new sentences
      */
     public void setSentences(final List<SentenceResult> sentences) {
-      this.sentences_serialized_name = sentences;
+      this.sentences = sentences;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4860,11 +5155,11 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedTokens != null) {
         for (Integer i = 0; i < deserializedTokens.size(); i++) {
           TokenResult currentItem = ret.getTokens().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('tokens_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('tokens');
           TokenResult newItem = (TokenResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TokenResult.class);
           newTokens.add(newItem);
         }
-        ret.tokens_serialized_name = newTokens;
+        ret.tokens = newTokens;
       }
 
       // calling custom deserializer for sentences
@@ -4873,14 +5168,22 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       if (deserializedSentences != null) {
         for (Integer i = 0; i < deserializedSentences.size(); i++) {
           SentenceResult currentItem = ret.getSentences().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('sentences_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('sentences');
           SentenceResult newItem = (SentenceResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SentenceResult.class);
           newSentences.add(newItem);
         }
-        ret.sentences_serialized_name = newSentences;
+        ret.sentences = newSentences;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (tokens != null && tokens[0] != null) {
+        mapping.putAll(tokens[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -4888,8 +5191,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * Emotion results for a specified target.
    */
   public class TargetedEmotionResults extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private EmotionScores emotion_serialized_name;
+    private String text;
+    private EmotionScores emotion;
  
     /**
      * Gets the text.
@@ -4900,7 +5203,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4912,7 +5215,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public EmotionScores getEmotion() {
-      return emotion_serialized_name;
+      return emotion;
     }
 
     /**
@@ -4921,7 +5224,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4930,7 +5233,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param emotion the new emotion
      */
     public void setEmotion(final EmotionScores emotion) {
-      this.emotion_serialized_name = emotion;
+      this.emotion = emotion;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -4941,7 +5244,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       TargetedEmotionResults ret = (TargetedEmotionResults) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for emotion
-      EmotionScores newEmotion = (EmotionScores) new EmotionScores().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion_serialized_name'), EmotionScores.class);
+      EmotionScores newEmotion = (EmotionScores) new EmotionScores().deserialize(JSON.serialize(ret.getEmotion()), (Map<String, Object>) jsonMap.get('emotion'), EmotionScores.class);
       ret.setEmotion(newEmotion);
 
       return ret;
@@ -4952,8 +5255,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    * TargetedSentimentResults.
    */
   public class TargetedSentimentResults extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private Double score_serialized_name;
+    private String text;
+    private Double score;
  
     /**
      * Gets the text.
@@ -4964,7 +5267,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -4976,7 +5279,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
 
     /**
@@ -4985,7 +5288,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -4994,19 +5297,18 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
-
   }
 
   /**
    * TokenResult.
    */
   public class TokenResult extends IBMWatsonGenericModel {
-    private String text_serialized_name;
-    private String part_of_speech_serialized_name;
-    private List<Long> location_serialized_name;
-    private String lemma_serialized_name;
+    private String text;
+    private String partOfSpeech;
+    private List<Long> location;
+    private String lemma;
  
     /**
      * Gets the text.
@@ -5017,7 +5319,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -5030,7 +5332,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getPartOfSpeech() {
-      return part_of_speech_serialized_name;
+      return partOfSpeech;
     }
  
     /**
@@ -5042,7 +5344,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public List<Long> getLocation() {
-      return location_serialized_name;
+      return location;
     }
  
     /**
@@ -5054,7 +5356,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     @AuraEnabled
     public String getLemma() {
-      return lemma_serialized_name;
+      return lemma;
     }
 
     /**
@@ -5063,7 +5365,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -5072,7 +5374,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param partOfSpeech the new partOfSpeech
      */
     public void setPartOfSpeech(final String partOfSpeech) {
-      this.part_of_speech_serialized_name = partOfSpeech;
+      this.partOfSpeech = partOfSpeech;
     }
 
     /**
@@ -5081,7 +5383,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param location the new location
      */
     public void setLocation(final List<Long> location) {
-      this.location_serialized_name = location;
+      this.location = location;
     }
 
     /**
@@ -5090,9 +5392,14 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param lemma the new lemma
      */
     public void setLemma(final String lemma) {
-      this.lemma_serialized_name = lemma;
+      this.lemma = lemma;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('part_of_speech', 'partOfSpeech');
+      return mapping;
+    }
   }
 
 }

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
@@ -17,7 +17,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private List<SemanticRolesResult> semanticRoles;
     private SentimentResult sentiment;
     private SyntaxResult syntax;
- 
+
     /**
      * Gets the language.
      *
@@ -29,7 +29,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the analyzedText.
      *
@@ -41,7 +41,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getAnalyzedText() {
       return analyzedText;
     }
- 
+
     /**
      * Gets the retrievedUrl.
      *
@@ -53,7 +53,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getRetrievedUrl() {
       return retrievedUrl;
     }
- 
+
     /**
      * Gets the usage.
      *
@@ -65,7 +65,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public AnalysisResultsUsage getUsage() {
       return usage;
     }
- 
+
     /**
      * Gets the concepts.
      *
@@ -77,7 +77,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<ConceptsResult> getConcepts() {
       return concepts;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -89,7 +89,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<EntitiesResult> getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the keywords.
      *
@@ -101,7 +101,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<KeywordsResult> getKeywords() {
       return keywords;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -113,7 +113,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<CategoriesResult> getCategories() {
       return categories;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -125,7 +125,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public EmotionResult getEmotion() {
       return emotion;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -137,7 +137,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public AnalysisResultsMetadata getMetadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the relations.
      *
@@ -149,7 +149,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<RelationsResult> getRelations() {
       return relations;
     }
- 
+
     /**
      * Gets the semanticRoles.
      *
@@ -161,7 +161,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<SemanticRolesResult> getSemanticRoles() {
       return semanticRoles;
     }
- 
+
     /**
      * Gets the sentiment.
      *
@@ -173,7 +173,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public SentimentResult getSentiment() {
       return sentiment;
     }
- 
+
     /**
      * Gets the syntax.
      *
@@ -420,35 +420,18 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('analyzed_text', 'analyzedText');
-      mapping.put('retrieved_url', 'retrievedUrl');
-      if (usage != null) {
-        mapping.putAll(usage.getApiToSdkMapping());
-      }
-      if (concepts != null && concepts[0] != null) {
-        mapping.putAll(concepts[0].getApiToSdkMapping());
-      }
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
-      if (categories != null && categories[0] != null) {
-        mapping.putAll(categories[0].getApiToSdkMapping());
-      }
-      if (metadata != null) {
-        mapping.putAll(metadata.getApiToSdkMapping());
-      }
-      if (relations != null && relations[0] != null) {
-        mapping.putAll(relations[0].getApiToSdkMapping());
-      }
-      mapping.put('semantic_roles', 'semanticRoles');
-      if (semanticRoles != null && semanticRoles[0] != null) {
-        mapping.putAll(semanticRoles[0].getApiToSdkMapping());
-      }
-      if (syntax != null) {
-        mapping.putAll(syntax.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'analyzed_text', 'analyzedText');
+      mapping.put(parentLabel + 'retrieved_url', 'retrievedUrl');
+      mapping.putAll(((IBMWatsonGenericModel) AnalysisResultsUsage.class.newInstance()).addToApiToSdkMapping(parentLabel + 'usage/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) ConceptsResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'concepts/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) EntitiesResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) CategoriesResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'categories/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) AnalysisResultsMetadata.class.newInstance()).addToApiToSdkMapping(parentLabel + 'metadata/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) RelationsResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'relations/', mapping));
+      mapping.put(parentLabel + 'semantic_roles', 'semanticRoles');
+      mapping.putAll(((IBMWatsonGenericModel) SemanticRolesResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'semantic_roles/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) SyntaxResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'syntax/', mapping));
       return mapping;
     }
   }
@@ -462,7 +445,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String title;
     private String image;
     private List<Feed> feeds;
- 
+
     /**
      * Gets the authors.
      *
@@ -474,7 +457,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<Author> getAuthors() {
       return authors;
     }
- 
+
     /**
      * Gets the publicationDate.
      *
@@ -486,7 +469,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getPublicationDate() {
       return publicationDate;
     }
- 
+
     /**
      * Gets the title.
      *
@@ -498,7 +481,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getTitle() {
       return title;
     }
- 
+
     /**
      * Gets the image.
      *
@@ -510,7 +493,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getImage() {
       return image;
     }
- 
+
     /**
      * Gets the feeds.
      *
@@ -604,9 +587,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('publication_date', 'publicationDate');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'publication_date', 'publicationDate');
       return mapping;
     }
   }
@@ -618,7 +600,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Long features;
     private Long textCharacters;
     private Long textUnits;
- 
+
     /**
      * Gets the features.
      *
@@ -630,7 +612,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Long getFeatures() {
       return features;
     }
- 
+
     /**
      * Gets the textCharacters.
      *
@@ -642,7 +624,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Long getTextCharacters() {
       return textCharacters;
     }
- 
+
     /**
      * Gets the textUnits.
      *
@@ -682,10 +664,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       this.textUnits = textUnits;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('text_characters', 'textCharacters');
-      mapping.put('text_units', 'textUnits');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'text_characters', 'textCharacters');
+      mapping.put(parentLabel + 'text_units', 'textUnits');
       return mapping;
     }
   }
@@ -850,7 +831,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public override Map<String, String> getSdkToApiMapping() {
       Map<String, String> mapping = new Map<String, String>();
       if (features != null) {
-        mapping.putAll(features.getSdkToApiMapping());
+        mapping.putAll(features.addToSdkToApiMapping('', mapping));
       }
       mapping.put('fallbackToRaw', 'fallback_to_raw');
       mapping.put('returnAnalyzedText', 'return_analyzed_text');
@@ -1040,7 +1021,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class Author extends IBMWatsonGenericModel {
     private String name;
- 
+
     /**
      * Gets the name.
      *
@@ -1072,7 +1053,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Boolean explanation;
     private Long xlimit;
     private String model;
- 
+
     /**
      * Gets the explanation.
      *
@@ -1084,7 +1065,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean explanation() {
       return explanation;
     }
- 
+
     /**
      * Gets the xlimit.
      *
@@ -1095,7 +1076,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Long xlimit() {
       return xlimit;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -1124,9 +1105,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new CategoriesOptionsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
   }
@@ -1199,7 +1179,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class CategoriesRelevantText extends IBMWatsonGenericModel {
     private String text;
- 
+
     /**
      * Gets the text.
      *
@@ -1229,7 +1209,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String label;
     private Double score;
     private CategoriesResultExplanation explanation;
- 
+
     /**
      * Gets the label.
      *
@@ -1244,7 +1224,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getLabel() {
       return label;
     }
- 
+
     /**
      * Gets the score.
      *
@@ -1256,7 +1236,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getScore() {
       return score;
     }
- 
+
     /**
      * Gets the explanation.
      *
@@ -1310,11 +1290,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (explanation != null) {
-        mapping.putAll(explanation.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) CategoriesResultExplanation.class.newInstance()).addToApiToSdkMapping(parentLabel + 'explanation/', mapping));
       return mapping;
     }
   }
@@ -1324,7 +1301,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class CategoriesResultExplanation extends IBMWatsonGenericModel {
     private List<CategoriesRelevantText> relevantText;
- 
+
     /**
      * Gets the relevantText.
      *
@@ -1371,9 +1348,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('relevant_text', 'relevantText');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'relevant_text', 'relevantText');
       return mapping;
     }
   }
@@ -1386,7 +1366,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class ConceptsOptions extends IBMWatsonGenericModel {
     private Long xlimit;
- 
+
     /**
      * Gets the xlimit.
      *
@@ -1411,9 +1391,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new ConceptsOptionsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
   }
@@ -1462,7 +1445,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String text;
     private Double relevance;
     private String dbpediaResource;
- 
+
     /**
      * Gets the text.
      *
@@ -1474,7 +1457,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the relevance.
      *
@@ -1486,7 +1469,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getRelevance() {
       return relevance;
     }
- 
+
     /**
      * Gets the dbpediaResource.
      *
@@ -1526,9 +1509,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       this.dbpediaResource = dbpediaResource;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dbpedia_resource', 'dbpediaResource');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'dbpedia_resource', 'dbpediaResource');
       return mapping;
     }
   }
@@ -1638,7 +1620,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String name;
     private String dbpediaResource;
     private List<String> subtype;
- 
+
     /**
      * Gets the name.
      *
@@ -1650,7 +1632,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the dbpediaResource.
      *
@@ -1662,7 +1644,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getDbpediaResource() {
       return dbpediaResource;
     }
- 
+
     /**
      * Gets the subtype.
      *
@@ -1702,9 +1684,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       this.subtype = subtype;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('dbpedia_resource', 'dbpediaResource');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'dbpedia_resource', 'dbpediaResource');
       return mapping;
     }
   }
@@ -1714,7 +1695,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class DocumentEmotionResults extends IBMWatsonGenericModel {
     private EmotionScores emotion;
- 
+
     /**
      * Gets the emotion.
      *
@@ -1757,7 +1738,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class DocumentSentimentResults extends IBMWatsonGenericModel {
     private String label;
     private Double score;
- 
+
     /**
      * Gets the label.
      *
@@ -1769,7 +1750,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getLabel() {
       return label;
     }
- 
+
     /**
      * Gets the score.
      *
@@ -1811,7 +1792,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class EmotionOptions extends IBMWatsonGenericModel {
     private Boolean document;
     private List<String> targets;
- 
+
     /**
      * Gets the document.
      *
@@ -1822,7 +1803,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean document() {
       return document;
     }
- 
+
     /**
      * Gets the targets.
      *
@@ -1922,7 +1903,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class EmotionResult extends IBMWatsonGenericModel {
     private DocumentEmotionResults document;
     private List<TargetedEmotionResults> targets;
- 
+
     /**
      * Gets the document.
      *
@@ -1934,7 +1915,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public DocumentEmotionResults getDocument() {
       return document;
     }
- 
+
     /**
      * Gets the targets.
      *
@@ -2002,7 +1983,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Double fear;
     private Double joy;
     private Double sadness;
- 
+
     /**
      * Gets the anger.
      *
@@ -2014,7 +1995,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getAnger() {
       return anger;
     }
- 
+
     /**
      * Gets the disgust.
      *
@@ -2026,7 +2007,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getDisgust() {
       return disgust;
     }
- 
+
     /**
      * Gets the fear.
      *
@@ -2038,7 +2019,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getFear() {
       return fear;
     }
- 
+
     /**
      * Gets the joy.
      *
@@ -2050,7 +2031,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getJoy() {
       return joy;
     }
- 
+
     /**
      * Gets the sadness.
      *
@@ -2122,7 +2103,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String model;
     private Boolean sentiment;
     private Boolean emotion;
- 
+
     /**
      * Gets the xlimit.
      *
@@ -2133,7 +2114,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Long xlimit() {
       return xlimit;
     }
- 
+
     /**
      * Gets the mentions.
      *
@@ -2144,7 +2125,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean mentions() {
       return mentions;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -2157,7 +2138,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String model() {
       return model;
     }
- 
+
     /**
      * Gets the sentiment.
      *
@@ -2168,7 +2149,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean sentiment() {
       return sentiment;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -2197,9 +2178,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new EntitiesOptionsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
   }
@@ -2306,7 +2290,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private EmotionScores emotion;
     private FeatureSentimentResults sentiment;
     private DisambiguationResult disambiguation;
- 
+
     /**
      * Gets the xtype.
      *
@@ -2318,7 +2302,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -2330,7 +2314,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the relevance.
      *
@@ -2342,7 +2326,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getRelevance() {
       return relevance;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -2356,7 +2340,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getConfidence() {
       return confidence;
     }
- 
+
     /**
      * Gets the mentions.
      *
@@ -2368,7 +2352,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<EntityMention> getMentions() {
       return mentions;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -2380,7 +2364,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Long getCount() {
       return count;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -2392,7 +2376,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public EmotionScores getEmotion() {
       return emotion;
     }
- 
+
     /**
      * Gets the sentiment.
      *
@@ -2404,7 +2388,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public FeatureSentimentResults getSentiment() {
       return sentiment;
     }
- 
+
     /**
      * Gets the disambiguation.
      *
@@ -2533,12 +2517,13 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
-      if (disambiguation != null) {
-        mapping.putAll(disambiguation.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'type', 'xtype');
+      mapping.putAll(((IBMWatsonGenericModel) DisambiguationResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'disambiguation/', mapping));
       return mapping;
     }
   }
@@ -2550,7 +2535,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String text;
     private List<Long> location;
     private Double confidence;
- 
+
     /**
      * Gets the text.
      *
@@ -2562,7 +2547,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -2574,7 +2559,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<Long> getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -2622,7 +2607,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class FeatureSentimentResults extends IBMWatsonGenericModel {
     private Double score;
- 
+
     /**
      * Gets the score.
      *
@@ -2659,7 +2644,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private SentimentOptions sentiment;
     private CategoriesOptions categories;
     private SyntaxOptions syntax;
- 
+
     /**
      * Gets the concepts.
      *
@@ -2673,7 +2658,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public ConceptsOptions concepts() {
       return concepts;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -2688,7 +2673,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public EmotionOptions emotion() {
       return emotion;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -2703,7 +2688,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public EntitiesOptions entities() {
       return entities;
     }
- 
+
     /**
      * Gets the keywords.
      *
@@ -2716,7 +2701,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public KeywordsOptions keywords() {
       return keywords;
     }
- 
+
     /**
      * Gets the metadata.
      *
@@ -2728,7 +2713,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public MetadataOptions metadata() {
       return metadata;
     }
- 
+
     /**
      * Gets the relations.
      *
@@ -2744,7 +2729,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public RelationsOptions relations() {
       return relations;
     }
- 
+
     /**
      * Gets the semanticRoles.
      *
@@ -2757,7 +2742,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public SemanticRolesOptions semanticRoles() {
       return semanticRoles;
     }
- 
+
     /**
      * Gets the sentiment.
      *
@@ -2771,7 +2756,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public SentimentOptions sentiment() {
       return sentiment;
     }
- 
+
     /**
      * Gets the categories.
      *
@@ -2784,7 +2769,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public CategoriesOptions categories() {
       return categories;
     }
- 
+
     /**
      * Gets the syntax.
      *
@@ -2818,26 +2803,25 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new FeaturesBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (concepts != null) {
-        mapping.putAll(concepts.getSdkToApiMapping());
+        mapping.putAll(concepts.addToSdkToApiMapping(parentLabel + 'concepts/', mapping));
       }
       if (entities != null) {
-        mapping.putAll(entities.getSdkToApiMapping());
+        mapping.putAll(entities.addToSdkToApiMapping(parentLabel + 'entities/', mapping));
       }
       if (keywords != null) {
-        mapping.putAll(keywords.getSdkToApiMapping());
+        mapping.putAll(keywords.addToSdkToApiMapping(parentLabel + 'keywords/', mapping));
       }
-      mapping.put('semanticRoles', 'semantic_roles');
+      mapping.put(parentLabel + 'semanticRoles', 'semantic_roles');
       if (semanticRoles != null) {
-        mapping.putAll(semanticRoles.getSdkToApiMapping());
+        mapping.putAll(semanticRoles.addToSdkToApiMapping(parentLabel + 'semanticRoles/', mapping));
       }
       if (categories != null) {
-        mapping.putAll(categories.getSdkToApiMapping());
+        mapping.putAll(categories.addToSdkToApiMapping(parentLabel + 'categories/', mapping));
       }
       if (syntax != null) {
-        mapping.putAll(syntax.getSdkToApiMapping());
+        mapping.putAll(syntax.addToSdkToApiMapping(parentLabel + 'syntax/', mapping));
       }
       return mapping;
     }
@@ -3002,7 +2986,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class Feed extends IBMWatsonGenericModel {
     private String link;
- 
+
     /**
      * Gets the link.
      *
@@ -3034,7 +3018,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Long xlimit;
     private Boolean sentiment;
     private Boolean emotion;
- 
+
     /**
      * Gets the xlimit.
      *
@@ -3045,7 +3029,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Long xlimit() {
       return xlimit;
     }
- 
+
     /**
      * Gets the sentiment.
      *
@@ -3056,7 +3040,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean sentiment() {
       return sentiment;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -3083,9 +3067,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new KeywordsOptionsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
   }
@@ -3162,7 +3149,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String text;
     private EmotionScores emotion;
     private FeatureSentimentResults sentiment;
- 
+
     /**
      * Gets the count.
      *
@@ -3174,7 +3161,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Long getCount() {
       return count;
     }
- 
+
     /**
      * Gets the relevance.
      *
@@ -3186,7 +3173,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getRelevance() {
       return relevance;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -3198,7 +3185,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -3210,7 +3197,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public EmotionScores getEmotion() {
       return emotion;
     }
- 
+
     /**
      * Gets the sentiment.
      *
@@ -3348,7 +3335,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class ListModelsResults extends IBMWatsonResponseModel {
     private List<Model> models;
- 
+
     /**
      * Gets the models.
      *
@@ -3393,11 +3380,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (models != null && models[0] != null) {
-        mapping.putAll(models[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Model.class.newInstance()).addToApiToSdkMapping(parentLabel + 'models/', mapping));
       return mapping;
     }
   }
@@ -3457,7 +3441,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String version;
     private String versionDescription;
     private Datetime created;
- 
+
     /**
      * Gets the status.
      *
@@ -3469,7 +3453,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the modelId.
      *
@@ -3481,7 +3465,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getModelId() {
       return modelId;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -3493,7 +3477,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -3505,7 +3489,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the workspaceId.
      *
@@ -3517,7 +3501,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getWorkspaceId() {
       return workspaceId;
     }
- 
+
     /**
      * Gets the version.
      *
@@ -3529,7 +3513,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getVersion() {
       return version;
     }
- 
+
     /**
      * Gets the versionDescription.
      *
@@ -3541,7 +3525,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getVersionDescription() {
       return versionDescription;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -3626,11 +3610,10 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       this.created = created;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('model_id', 'modelId');
-      mapping.put('workspace_id', 'workspaceId');
-      mapping.put('version_description', 'versionDescription');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'model_id', 'modelId');
+      mapping.put(parentLabel + 'workspace_id', 'workspaceId');
+      mapping.put(parentLabel + 'version_description', 'versionDescription');
       return mapping;
     }
   }
@@ -3642,7 +3625,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private List<RelationEntity> entities;
     private List<Long> location;
     private String text;
- 
+
     /**
      * Gets the entities.
      *
@@ -3654,7 +3637,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<RelationEntity> getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -3666,7 +3649,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<Long> getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -3729,11 +3712,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) RelationEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
       return mapping;
     }
   }
@@ -3744,7 +3724,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class RelationEntity extends IBMWatsonGenericModel {
     private String text;
     private String xtype;
- 
+
     /**
      * Gets the text.
      *
@@ -3756,7 +3736,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the xtype.
      *
@@ -3787,9 +3767,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       this.xtype = xtype;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'type', 'xtype');
       return mapping;
     }
   }
@@ -3804,7 +3783,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class RelationsOptions extends IBMWatsonGenericModel {
     private String model;
- 
+
     /**
      * Gets the model.
      *
@@ -3877,7 +3856,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String sentence;
     private String xtype;
     private List<RelationArgument> arguments;
- 
+
     /**
      * Gets the score.
      *
@@ -3889,7 +3868,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Double getScore() {
       return score;
     }
- 
+
     /**
      * Gets the sentence.
      *
@@ -3901,7 +3880,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getSentence() {
       return sentence;
     }
- 
+
     /**
      * Gets the xtype.
      *
@@ -3913,7 +3892,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the arguments.
      *
@@ -3985,12 +3964,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
-      if (arguments != null && arguments[0] != null) {
-        mapping.putAll(arguments[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'type', 'xtype');
+      mapping.putAll(((IBMWatsonGenericModel) RelationArgument.class.newInstance()).addToApiToSdkMapping(parentLabel + 'arguments/', mapping));
       return mapping;
     }
   }
@@ -4001,7 +3977,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class SemanticRolesEntity extends IBMWatsonGenericModel {
     private String xtype;
     private String text;
- 
+
     /**
      * Gets the xtype.
      *
@@ -4013,7 +3989,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -4044,9 +4020,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       this.text = text;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'type', 'xtype');
       return mapping;
     }
   }
@@ -4056,7 +4035,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
    */
   public class SemanticRolesKeyword extends IBMWatsonGenericModel {
     private String text;
- 
+
     /**
      * Gets the text.
      *
@@ -4088,7 +4067,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private Long xlimit;
     private Boolean keywords;
     private Boolean entities;
- 
+
     /**
      * Gets the xlimit.
      *
@@ -4099,7 +4078,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Long xlimit() {
       return xlimit;
     }
- 
+
     /**
      * Gets the keywords.
      *
@@ -4110,7 +4089,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean keywords() {
       return keywords;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -4137,9 +4116,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new SemanticRolesOptionsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('xlimit', 'limit');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'xlimit', 'limit');
       return mapping;
     }
   }
@@ -4215,7 +4197,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private SemanticRolesResultSubject subject;
     private SemanticRolesResultAction action;
     private SemanticRolesResultObject xobject;
- 
+
     /**
      * Gets the sentence.
      *
@@ -4227,7 +4209,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getSentence() {
       return sentence;
     }
- 
+
     /**
      * Gets the subject.
      *
@@ -4239,7 +4221,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public SemanticRolesResultSubject getSubject() {
       return subject;
     }
- 
+
     /**
      * Gets the action.
      *
@@ -4251,7 +4233,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public SemanticRolesResultAction getAction() {
       return action;
     }
- 
+
     /**
      * Gets the xobject.
      *
@@ -4322,12 +4304,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (subject != null) {
-        mapping.putAll(subject.getApiToSdkMapping());
-      }
-      mapping.put('object', 'xobject');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) SemanticRolesResultSubject.class.newInstance()).addToApiToSdkMapping(parentLabel + 'subject/', mapping));
+      mapping.put(parentLabel + 'object', 'xobject');
       return mapping;
     }
   }
@@ -4339,7 +4318,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String text;
     private String normalized;
     private SemanticRolesVerb verb;
- 
+
     /**
      * Gets the text.
      *
@@ -4351,7 +4330,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the normalized.
      *
@@ -4363,7 +4342,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getNormalized() {
       return normalized;
     }
- 
+
     /**
      * Gets the verb.
      *
@@ -4422,7 +4401,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class SemanticRolesResultObject extends IBMWatsonGenericModel {
     private String text;
     private List<SemanticRolesKeyword> keywords;
- 
+
     /**
      * Gets the text.
      *
@@ -4434,7 +4413,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the keywords.
      *
@@ -4496,7 +4475,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String text;
     private List<SemanticRolesEntity> entities;
     private List<SemanticRolesKeyword> keywords;
- 
+
     /**
      * Gets the text.
      *
@@ -4508,7 +4487,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the entities.
      *
@@ -4520,7 +4499,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<SemanticRolesEntity> getEntities() {
       return entities;
     }
- 
+
     /**
      * Gets the keywords.
      *
@@ -4596,11 +4575,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (entities != null && entities[0] != null) {
-        mapping.putAll(entities[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) SemanticRolesEntity.class.newInstance()).addToApiToSdkMapping(parentLabel + 'entities/', mapping));
       return mapping;
     }
   }
@@ -4611,7 +4587,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class SemanticRolesVerb extends IBMWatsonGenericModel {
     private String text;
     private String tense;
- 
+
     /**
      * Gets the text.
      *
@@ -4623,7 +4599,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the tense.
      *
@@ -4661,7 +4637,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class SentenceResult extends IBMWatsonGenericModel {
     private String text;
     private List<Long> location;
- 
+
     /**
      * Gets the text.
      *
@@ -4673,7 +4649,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -4714,7 +4690,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class SentimentOptions extends IBMWatsonGenericModel {
     private Boolean document;
     private List<String> targets;
- 
+
     /**
      * Gets the document.
      *
@@ -4725,7 +4701,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean document() {
       return document;
     }
- 
+
     /**
      * Gets the targets.
      *
@@ -4824,7 +4800,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class SentimentResult extends IBMWatsonGenericModel {
     private DocumentSentimentResults document;
     private List<TargetedSentimentResults> targets;
- 
+
     /**
      * Gets the document.
      *
@@ -4836,7 +4812,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public DocumentSentimentResults getDocument() {
       return document;
     }
- 
+
     /**
      * Gets the targets.
      *
@@ -4901,7 +4877,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class SyntaxOptions extends IBMWatsonGenericModel {
     private SyntaxOptionsTokens tokens;
     private Boolean sentences;
- 
+
     /**
      * Gets the tokens.
      *
@@ -4912,7 +4888,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public SyntaxOptionsTokens tokens() {
       return tokens;
     }
- 
+
     /**
      * Gets the sentences.
      *
@@ -4938,10 +4914,9 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new SyntaxOptionsBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (tokens != null) {
-        mapping.putAll(tokens.getSdkToApiMapping());
+        mapping.putAll(tokens.addToSdkToApiMapping(parentLabel + 'tokens/', mapping));
       }
       return mapping;
     }
@@ -5003,7 +4978,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class SyntaxOptionsTokens extends IBMWatsonGenericModel {
     private Boolean lemma;
     private Boolean partOfSpeech;
- 
+
     /**
      * Gets the lemma.
      *
@@ -5014,7 +4989,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Boolean getLemma() {
       return lemma;
     }
- 
+
     /**
      * Gets the partOfSpeech.
      *
@@ -5040,9 +5015,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return new SyntaxOptionsTokensBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('partOfSpeech', 'part_of_speech');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'partOfSpeech', 'part_of_speech');
       return mapping;
     }
   }
@@ -5080,7 +5054,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param lemma the lemma
      * @return the SyntaxOptionsTokens builder
      */
-    public SyntaxOptionsTokensBuilder setLemma(Boolean lemma) {
+    public SyntaxOptionsTokensBuilder lemma(Boolean lemma) {
       this.lemma = lemma;
       return this;
     }
@@ -5091,7 +5065,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      * @param partOfSpeech the partOfSpeech
      * @return the SyntaxOptionsTokens builder
      */
-    public SyntaxOptionsTokensBuilder setPartOfSpeech(Boolean partOfSpeech) {
+    public SyntaxOptionsTokensBuilder partOfSpeech(Boolean partOfSpeech) {
       this.partOfSpeech = partOfSpeech;
       return this;
     }
@@ -5103,7 +5077,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class SyntaxResult extends IBMWatsonGenericModel {
     private List<TokenResult> tokens;
     private List<SentenceResult> sentences;
- 
+
     /**
      * Gets the tokens.
      *
@@ -5113,7 +5087,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<TokenResult> getTokens() {
       return tokens;
     }
- 
+
     /**
      * Gets the sentences.
      *
@@ -5178,11 +5152,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (tokens != null && tokens[0] != null) {
-        mapping.putAll(tokens[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) TokenResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tokens/', mapping));
       return mapping;
     }
   }
@@ -5193,7 +5164,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class TargetedEmotionResults extends IBMWatsonGenericModel {
     private String text;
     private EmotionScores emotion;
- 
+
     /**
      * Gets the text.
      *
@@ -5205,7 +5176,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the emotion.
      *
@@ -5257,7 +5228,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class TargetedSentimentResults extends IBMWatsonGenericModel {
     private String text;
     private Double score;
- 
+
     /**
      * Gets the text.
      *
@@ -5269,7 +5240,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the score.
      *
@@ -5309,7 +5280,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     private String partOfSpeech;
     private List<Long> location;
     private String lemma;
- 
+
     /**
      * Gets the text.
      *
@@ -5321,7 +5292,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the partOfSpeech.
      *
@@ -5334,7 +5305,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public String getPartOfSpeech() {
       return partOfSpeech;
     }
- 
+
     /**
      * Gets the location.
      *
@@ -5346,7 +5317,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public List<Long> getLocation() {
       return location;
     }
- 
+
     /**
      * Gets the lemma.
      *
@@ -5395,9 +5366,8 @@ public class IBMNaturalLanguageUnderstandingV1Models {
       this.lemma = lemma;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('part_of_speech', 'partOfSpeech');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'part_of_speech', 'partOfSpeech');
       return mapping;
     }
   }

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Test.cls
@@ -88,7 +88,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
       .xlimit(12L)
       .explanation(true)
       .build();
-    IBMNaturalLanguageUnderstandingV1Models.MetadataOptions metadata = new IBMNaturalLanguageUnderstandingV1Models.MetadataOptions();
+    IBMNaturalLanguageUnderstandingV1Models.MetadataOptions metadata = new IBMNaturalLanguageUnderstandingV1Models.MetadataOptionsBuilder().build();
     IBMNaturalLanguageUnderstandingV1Models.SyntaxOptions syntax = new IBMNaturalLanguageUnderstandingV1Models.SyntaxOptionsBuilder().build();
     IBMNaturalLanguageUnderstandingV1Models.Features features = new IBMNaturalLanguageUnderstandingV1Models.FeaturesBuilder()
       .concepts(concepts)
@@ -191,9 +191,10 @@ private class IBMNaturalLanguageUnderstandingV1Test {
   }
 
   static testMethod void testSytntaxOptions() {
-    IBMNaturalLanguageUnderstandingV1Models.SyntaxOptionsTokens token = new IBMNaturalLanguageUnderstandingV1Models.SyntaxOptionsTokens();
-    token.setLemma(true);
-    token.setPartOfSpeech(true);
+    IBMNaturalLanguageUnderstandingV1Models.SyntaxOptionsTokens token = new IBMNaturalLanguageUnderstandingV1Models.SyntaxOptionsTokensBuilder()
+      .lemma(true)
+      .partOfSpeech(true)
+      .build();
     IBMNaturalLanguageUnderstandingV1Models.SyntaxOptions options = new IBMNaturalLanguageUnderstandingV1Models.SyntaxOptionsBuilder()
       .sentences(true)
       .tokens(token)

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3Models.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3Models.cls
@@ -7,7 +7,7 @@ public class IBMPersonalityInsightsV3Models {
     private String name;
     private String category;
     private Double percentage;
- 
+
     /**
      * Gets the traitId.
      *
@@ -20,7 +20,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getTraitId() {
       return traitId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -32,7 +32,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the category.
      *
@@ -44,7 +44,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getCategory() {
       return category;
     }
- 
+
     /**
      * Gets the percentage.
      *
@@ -94,9 +94,12 @@ public class IBMPersonalityInsightsV3Models {
       this.percentage = percentage;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('trait_id', 'traitId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'trait_id', 'traitId');
       return mapping;
     }
   }
@@ -108,7 +111,7 @@ public class IBMPersonalityInsightsV3Models {
     private String consumptionPreferenceId;
     private String name;
     private Double score;
- 
+
     /**
      * Gets the consumptionPreferenceId.
      *
@@ -121,7 +124,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getConsumptionPreferenceId() {
       return consumptionPreferenceId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -133,7 +136,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the score.
      *
@@ -179,9 +182,12 @@ public class IBMPersonalityInsightsV3Models {
       this.score = score;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('consumption_preference_id', 'consumptionPreferenceId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'consumption_preference_id', 'consumptionPreferenceId');
       return mapping;
     }
   }
@@ -193,7 +199,7 @@ public class IBMPersonalityInsightsV3Models {
     private String consumptionPreferenceCategoryId;
     private String name;
     private List<ConsumptionPreferences> consumptionPreferences;
- 
+
     /**
      * Gets the consumptionPreferenceCategoryId.
      *
@@ -206,7 +212,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getConsumptionPreferenceCategoryId() {
       return consumptionPreferenceCategoryId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -218,7 +224,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the consumptionPreferences.
      *
@@ -281,13 +287,14 @@ public class IBMPersonalityInsightsV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('consumption_preference_category_id', 'consumptionPreferenceCategoryId');
-      mapping.put('consumption_preferences', 'consumptionPreferences');
-      if (consumptionPreferences != null && consumptionPreferences[0] != null) {
-        mapping.putAll(consumptionPreferences[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'consumption_preference_category_id', 'consumptionPreferenceCategoryId');
+      mapping.put(parentLabel + 'consumption_preferences', 'consumptionPreferences');
+      mapping.putAll(((IBMWatsonGenericModel) ConsumptionPreferences.class.newInstance()).addToApiToSdkMapping(parentLabel + 'consumption_preferences/', mapping));
       return mapping;
     }
   }
@@ -297,7 +304,7 @@ public class IBMPersonalityInsightsV3Models {
    */
   public class Content extends IBMWatsonGenericModel {
     private List<ContentItem> contentItems;
- 
+
     /**
      * Gets the contentItems.
      *
@@ -399,7 +406,7 @@ public class IBMPersonalityInsightsV3Models {
     private String parentid;
     private Boolean reply;
     private Boolean forward;
- 
+
     /**
      * Gets the content.
      *
@@ -411,7 +418,7 @@ public class IBMPersonalityInsightsV3Models {
     public String content() {
       return content;
     }
- 
+
     /**
      * Gets the id.
      *
@@ -422,7 +429,7 @@ public class IBMPersonalityInsightsV3Models {
     public String id() {
       return id;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -434,7 +441,7 @@ public class IBMPersonalityInsightsV3Models {
     public Long created() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -446,7 +453,7 @@ public class IBMPersonalityInsightsV3Models {
     public Long updated() {
       return updated;
     }
- 
+
     /**
      * Gets the contenttype.
      *
@@ -458,7 +465,7 @@ public class IBMPersonalityInsightsV3Models {
     public String contenttype() {
       return contenttype;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -474,7 +481,7 @@ public class IBMPersonalityInsightsV3Models {
     public String language() {
       return language;
     }
- 
+
     /**
      * Gets the parentid.
      *
@@ -486,7 +493,7 @@ public class IBMPersonalityInsightsV3Models {
     public String parentid() {
       return parentid;
     }
- 
+
     /**
      * Gets the reply.
      *
@@ -497,7 +504,7 @@ public class IBMPersonalityInsightsV3Models {
     public Boolean reply() {
       return reply;
     }
- 
+
     /**
      * Gets the forward.
      *
@@ -695,7 +702,7 @@ public class IBMPersonalityInsightsV3Models {
     private List<Behavior> behavior;
     private List<ConsumptionPreferencesCategory> consumptionPreferences;
     private List<Warning> warnings;
- 
+
     /**
      * Gets the processedLanguage.
      *
@@ -707,7 +714,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getProcessedLanguage() {
       return processedLanguage;
     }
- 
+
     /**
      * Gets the wordCount.
      *
@@ -719,7 +726,7 @@ public class IBMPersonalityInsightsV3Models {
     public Long getWordCount() {
       return wordCount;
     }
- 
+
     /**
      * Gets the wordCountMessage.
      *
@@ -732,7 +739,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getWordCountMessage() {
       return wordCountMessage;
     }
- 
+
     /**
      * Gets the personality.
      *
@@ -745,7 +752,7 @@ public class IBMPersonalityInsightsV3Models {
     public List<Trait> getPersonality() {
       return personality;
     }
- 
+
     /**
      * Gets the needs.
      *
@@ -757,7 +764,7 @@ public class IBMPersonalityInsightsV3Models {
     public List<Trait> getNeeds() {
       return needs;
     }
- 
+
     /**
      * Gets the values.
      *
@@ -769,7 +776,7 @@ public class IBMPersonalityInsightsV3Models {
     public List<Trait> getValues() {
       return values;
     }
- 
+
     /**
      * Gets the behavior.
      *
@@ -783,7 +790,7 @@ public class IBMPersonalityInsightsV3Models {
     public List<Behavior> getBehavior() {
       return behavior;
     }
- 
+
     /**
      * Gets the consumptionPreferences.
      *
@@ -797,7 +804,7 @@ public class IBMPersonalityInsightsV3Models {
     public List<ConsumptionPreferencesCategory> getConsumptionPreferences() {
       return consumptionPreferences;
     }
- 
+
     /**
      * Gets the warnings.
      *
@@ -980,30 +987,21 @@ public class IBMPersonalityInsightsV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('processed_language', 'processedLanguage');
-      mapping.put('word_count', 'wordCount');
-      mapping.put('word_count_message', 'wordCountMessage');
-      if (personality != null && personality[0] != null) {
-        mapping.putAll(personality[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (needs != null && needs[0] != null) {
-        mapping.putAll(needs[0].getApiToSdkMapping());
-      }
-      if (values != null && values[0] != null) {
-        mapping.putAll(values[0].getApiToSdkMapping());
-      }
-      if (behavior != null && behavior[0] != null) {
-        mapping.putAll(behavior[0].getApiToSdkMapping());
-      }
-      mapping.put('consumption_preferences', 'consumptionPreferences');
-      if (consumptionPreferences != null && consumptionPreferences[0] != null) {
-        mapping.putAll(consumptionPreferences[0].getApiToSdkMapping());
-      }
-      if (warnings != null && warnings[0] != null) {
-        mapping.putAll(warnings[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'processed_language', 'processedLanguage');
+      mapping.put(parentLabel + 'word_count', 'wordCount');
+      mapping.put(parentLabel + 'word_count_message', 'wordCountMessage');
+      mapping.putAll(((IBMWatsonGenericModel) Trait.class.newInstance()).addToApiToSdkMapping(parentLabel + 'personality/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Trait.class.newInstance()).addToApiToSdkMapping(parentLabel + 'needs/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Trait.class.newInstance()).addToApiToSdkMapping(parentLabel + 'values/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Behavior.class.newInstance()).addToApiToSdkMapping(parentLabel + 'behavior/', mapping));
+      mapping.put(parentLabel + 'consumption_preferences', 'consumptionPreferences');
+      mapping.putAll(((IBMWatsonGenericModel) ConsumptionPreferencesCategory.class.newInstance()).addToApiToSdkMapping(parentLabel + 'consumption_preferences/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) Warning.class.newInstance()).addToApiToSdkMapping(parentLabel + 'warnings/', mapping));
       return mapping;
     }
   }
@@ -1316,7 +1314,7 @@ public class IBMPersonalityInsightsV3Models {
     private Double rawScore;
     private Boolean significant;
     private List<Trait> children;
- 
+
     /**
      * Gets the traitId.
      *
@@ -1332,7 +1330,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getTraitId() {
       return traitId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -1344,7 +1342,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the category.
      *
@@ -1357,7 +1355,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getCategory() {
       return category;
     }
- 
+
     /**
      * Gets the percentile.
      *
@@ -1371,7 +1369,7 @@ public class IBMPersonalityInsightsV3Models {
     public Double getPercentile() {
       return percentile;
     }
- 
+
     /**
      * Gets the rawScore.
      *
@@ -1390,7 +1388,7 @@ public class IBMPersonalityInsightsV3Models {
     public Double getRawScore() {
       return rawScore;
     }
- 
+
     /**
      * Gets the significant.
      *
@@ -1405,7 +1403,7 @@ public class IBMPersonalityInsightsV3Models {
     public Boolean getSignificant() {
       return significant;
     }
- 
+
     /**
      * Gets the children.
      *
@@ -1505,13 +1503,14 @@ public class IBMPersonalityInsightsV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('trait_id', 'traitId');
-      mapping.put('raw_score', 'rawScore');
-      if (children != null && children[0] != null) {
-        mapping.putAll(children[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'trait_id', 'traitId');
+      mapping.put(parentLabel + 'raw_score', 'rawScore');
+      mapping.putAll(((IBMWatsonGenericModel) Trait.class.newInstance()).addToApiToSdkMapping(parentLabel + 'children/', mapping));
       return mapping;
     }
   }
@@ -1522,7 +1521,7 @@ public class IBMPersonalityInsightsV3Models {
   public class Warning extends IBMWatsonGenericModel {
     private String warningId;
     private String message;
- 
+
     /**
      * Gets the warningId.
      *
@@ -1534,7 +1533,7 @@ public class IBMPersonalityInsightsV3Models {
     public String getWarningId() {
       return warningId;
     }
- 
+
     /**
      * Gets the message.
      *
@@ -1575,9 +1574,12 @@ public class IBMPersonalityInsightsV3Models {
       this.message = message;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('warning_id', 'warningId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'warning_id', 'warningId');
       return mapping;
     }
   }

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3Models.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3Models.cls
@@ -3,10 +3,10 @@ public class IBMPersonalityInsightsV3Models {
    * The temporal behavior for the input content.
    */
   public class Behavior extends IBMWatsonGenericModel {
-    private String trait_id_serialized_name;
-    private String name_serialized_name;
-    private String category_serialized_name;
-    private Double percentage_serialized_name;
+    private String traitId;
+    private String name;
+    private String category;
+    private Double percentage;
  
     /**
      * Gets the traitId.
@@ -18,7 +18,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getTraitId() {
-      return trait_id_serialized_name;
+      return traitId;
     }
  
     /**
@@ -30,7 +30,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -42,7 +42,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getCategory() {
-      return category_serialized_name;
+      return category;
     }
  
     /**
@@ -55,7 +55,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public Double getPercentage() {
-      return percentage_serialized_name;
+      return percentage;
     }
 
     /**
@@ -64,7 +64,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param traitId the new traitId
      */
     public void setTraitId(final String traitId) {
-      this.trait_id_serialized_name = traitId;
+      this.traitId = traitId;
     }
 
     /**
@@ -73,7 +73,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -82,7 +82,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param category the new category
      */
     public void setCategory(final String category) {
-      this.category_serialized_name = category;
+      this.category = category;
     }
 
     /**
@@ -91,18 +91,23 @@ public class IBMPersonalityInsightsV3Models {
      * @param percentage the new percentage
      */
     public void setPercentage(final Double percentage) {
-      this.percentage_serialized_name = percentage;
+      this.percentage = percentage;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('trait_id', 'traitId');
+      return mapping;
+    }
   }
 
   /**
    * A consumption preference that the service inferred from the input content.
    */
   public class ConsumptionPreferences extends IBMWatsonGenericModel {
-    private String consumption_preference_id_serialized_name;
-    private String name_serialized_name;
-    private Double score_serialized_name;
+    private String consumptionPreferenceId;
+    private String name;
+    private Double score;
  
     /**
      * Gets the consumptionPreferenceId.
@@ -114,7 +119,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getConsumptionPreferenceId() {
-      return consumption_preference_id_serialized_name;
+      return consumptionPreferenceId;
     }
  
     /**
@@ -126,7 +131,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -144,7 +149,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
 
     /**
@@ -153,7 +158,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param consumptionPreferenceId the new consumptionPreferenceId
      */
     public void setConsumptionPreferenceId(final String consumptionPreferenceId) {
-      this.consumption_preference_id_serialized_name = consumptionPreferenceId;
+      this.consumptionPreferenceId = consumptionPreferenceId;
     }
 
     /**
@@ -162,7 +167,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -171,18 +176,23 @@ public class IBMPersonalityInsightsV3Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('consumption_preference_id', 'consumptionPreferenceId');
+      return mapping;
+    }
   }
 
   /**
    * The consumption preferences that the service inferred from the input content.
    */
   public class ConsumptionPreferencesCategory extends IBMWatsonGenericModel {
-    private String consumption_preference_category_id_serialized_name;
-    private String name_serialized_name;
-    private List<ConsumptionPreferences> consumption_preferences_serialized_name;
+    private String consumptionPreferenceCategoryId;
+    private String name;
+    private List<ConsumptionPreferences> consumptionPreferences;
  
     /**
      * Gets the consumptionPreferenceCategoryId.
@@ -194,7 +204,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getConsumptionPreferenceCategoryId() {
-      return consumption_preference_category_id_serialized_name;
+      return consumptionPreferenceCategoryId;
     }
  
     /**
@@ -206,7 +216,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -218,7 +228,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public List<ConsumptionPreferences> getConsumptionPreferences() {
-      return consumption_preferences_serialized_name;
+      return consumptionPreferences;
     }
 
     /**
@@ -227,7 +237,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param consumptionPreferenceCategoryId the new consumptionPreferenceCategoryId
      */
     public void setConsumptionPreferenceCategoryId(final String consumptionPreferenceCategoryId) {
-      this.consumption_preference_category_id_serialized_name = consumptionPreferenceCategoryId;
+      this.consumptionPreferenceCategoryId = consumptionPreferenceCategoryId;
     }
 
     /**
@@ -236,7 +246,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -245,7 +255,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param consumptionPreferences the new consumptionPreferences
      */
     public void setConsumptionPreferences(final List<ConsumptionPreferences> consumptionPreferences) {
-      this.consumption_preferences_serialized_name = consumptionPreferences;
+      this.consumptionPreferences = consumptionPreferences;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -261,22 +271,32 @@ public class IBMPersonalityInsightsV3Models {
       if (deserializedConsumptionPreferences != null) {
         for (Integer i = 0; i < deserializedConsumptionPreferences.size(); i++) {
           ConsumptionPreferences currentItem = ret.getConsumptionPreferences().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('consumption_preferences_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('consumptionPreferences');
           ConsumptionPreferences newItem = (ConsumptionPreferences) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ConsumptionPreferences.class);
           newConsumptionPreferences.add(newItem);
         }
-        ret.consumption_preferences_serialized_name = newConsumptionPreferences;
+        ret.consumptionPreferences = newConsumptionPreferences;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('consumption_preference_category_id', 'consumptionPreferenceCategoryId');
+      mapping.put('consumption_preferences', 'consumptionPreferences');
+      if (consumptionPreferences != null && consumptionPreferences[0] != null) {
+        mapping.putAll(consumptionPreferences[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
   /**
    * The full input content that the service is to analyze.
    */
-  public class Content {
-    private List<ContentItem> contentItems_serialized_name;
+  public class Content extends IBMWatsonGenericModel {
+    private List<ContentItem> contentItems;
  
     /**
      * Gets the contentItems.
@@ -286,12 +306,12 @@ public class IBMPersonalityInsightsV3Models {
      * @return the contentItems
      */
     public List<ContentItem> contentItems() {
-      return contentItems_serialized_name;
+      return contentItems;
     }
   
     private Content(ContentBuilder builder) {
       IBMWatsonValidator.notNull(builder.contentItems, 'contentItems cannot be null');
-      this.contentItems_serialized_name = builder.contentItems;
+      this.contentItems = builder.contentItems;
     }
 
     /**
@@ -302,7 +322,6 @@ public class IBMPersonalityInsightsV3Models {
     public ContentBuilder newBuilder() {
       return new ContentBuilder(this);
     }
-
   }
 
   /**
@@ -312,7 +331,7 @@ public class IBMPersonalityInsightsV3Models {
     private List<ContentItem> contentItems;
 
     private ContentBuilder(Content content) {
-      this.contentItems = content.contentItems_serialized_name;
+      this.contentItems = content.contentItems;
     }
 
     /**
@@ -370,16 +389,16 @@ public class IBMPersonalityInsightsV3Models {
   /**
    * An input content item that the service is to analyze.
    */
-  public class ContentItem {
-    private String content_serialized_name;
-    private String id_serialized_name;
-    private Long created_serialized_name;
-    private Long updated_serialized_name;
-    private String contenttype_serialized_name;
-    private String language_serialized_name;
-    private String parentid_serialized_name;
-    private Boolean reply_serialized_name;
-    private Boolean forward_serialized_name;
+  public class ContentItem extends IBMWatsonGenericModel {
+    private String content;
+    private String id;
+    private Long created;
+    private Long updated;
+    private String contenttype;
+    private String language;
+    private String parentid;
+    private Boolean reply;
+    private Boolean forward;
  
     /**
      * Gets the content.
@@ -390,7 +409,7 @@ public class IBMPersonalityInsightsV3Models {
      * @return the content
      */
     public String content() {
-      return content_serialized_name;
+      return content;
     }
  
     /**
@@ -401,7 +420,7 @@ public class IBMPersonalityInsightsV3Models {
      * @return the id
      */
     public String id() {
-      return id_serialized_name;
+      return id;
     }
  
     /**
@@ -413,7 +432,7 @@ public class IBMPersonalityInsightsV3Models {
      * @return the created
      */
     public Long created() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -425,7 +444,7 @@ public class IBMPersonalityInsightsV3Models {
      * @return the updated
      */
     public Long updated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -437,7 +456,7 @@ public class IBMPersonalityInsightsV3Models {
      * @return the contenttype
      */
     public String contenttype() {
-      return contenttype_serialized_name;
+      return contenttype;
     }
  
     /**
@@ -453,7 +472,7 @@ public class IBMPersonalityInsightsV3Models {
      * @return the language
      */
     public String language() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -465,7 +484,7 @@ public class IBMPersonalityInsightsV3Models {
      * @return the parentid
      */
     public String parentid() {
-      return parentid_serialized_name;
+      return parentid;
     }
  
     /**
@@ -476,7 +495,7 @@ public class IBMPersonalityInsightsV3Models {
      * @return the reply
      */
     public Boolean reply() {
-      return reply_serialized_name;
+      return reply;
     }
  
     /**
@@ -487,20 +506,20 @@ public class IBMPersonalityInsightsV3Models {
      * @return the forward
      */
     public Boolean forward() {
-      return forward_serialized_name;
+      return forward;
     }
   
     private ContentItem(ContentItemBuilder builder) {
       IBMWatsonValidator.notNull(builder.content, 'content cannot be null');
-      this.content_serialized_name = builder.content;
-      this.id_serialized_name = builder.id;
-      this.created_serialized_name = builder.created;
-      this.updated_serialized_name = builder.updated;
-      this.contenttype_serialized_name = builder.contenttype;
-      this.language_serialized_name = builder.language;
-      this.parentid_serialized_name = builder.parentid;
-      this.reply_serialized_name = builder.reply;
-      this.forward_serialized_name = builder.forward;
+      this.content = builder.content;
+      this.id = builder.id;
+      this.created = builder.created;
+      this.updated = builder.updated;
+      this.contenttype = builder.contenttype;
+      this.language = builder.language;
+      this.parentid = builder.parentid;
+      this.reply = builder.reply;
+      this.forward = builder.forward;
     }
 
     /**
@@ -511,7 +530,6 @@ public class IBMPersonalityInsightsV3Models {
     public ContentItemBuilder newBuilder() {
       return new ContentItemBuilder(this);
     }
-
   }
 
   /**
@@ -529,15 +547,15 @@ public class IBMPersonalityInsightsV3Models {
     private Boolean forward;
 
     private ContentItemBuilder(ContentItem contentItem) {
-      this.content = contentItem.content_serialized_name;
-      this.id = contentItem.id_serialized_name;
-      this.created = contentItem.created_serialized_name;
-      this.updated = contentItem.updated_serialized_name;
-      this.contenttype = contentItem.contenttype_serialized_name;
-      this.language = contentItem.language_serialized_name;
-      this.parentid = contentItem.parentid_serialized_name;
-      this.reply = contentItem.reply_serialized_name;
-      this.forward = contentItem.forward_serialized_name;
+      this.content = contentItem.content;
+      this.id = contentItem.id;
+      this.created = contentItem.created;
+      this.updated = contentItem.updated;
+      this.contenttype = contentItem.contenttype;
+      this.language = contentItem.language;
+      this.parentid = contentItem.parentid;
+      this.reply = contentItem.reply;
+      this.forward = contentItem.forward;
     }
 
     /**
@@ -668,15 +686,15 @@ public class IBMPersonalityInsightsV3Models {
    * The personality profile that the service generated for the input content.
    */
   public class Profile extends IBMWatsonResponseModel {
-    private String processed_language_serialized_name;
-    private Long word_count_serialized_name;
-    private String word_count_message_serialized_name;
-    private List<Trait> personality_serialized_name;
-    private List<Trait> needs_serialized_name;
-    private List<Trait> values_serialized_name;
-    private List<Behavior> behavior_serialized_name;
-    private List<ConsumptionPreferencesCategory> consumption_preferences_serialized_name;
-    private List<Warning> warnings_serialized_name;
+    private String processedLanguage;
+    private Long wordCount;
+    private String wordCountMessage;
+    private List<Trait> personality;
+    private List<Trait> needs;
+    private List<Trait> values;
+    private List<Behavior> behavior;
+    private List<ConsumptionPreferencesCategory> consumptionPreferences;
+    private List<Warning> warnings;
  
     /**
      * Gets the processedLanguage.
@@ -687,7 +705,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getProcessedLanguage() {
-      return processed_language_serialized_name;
+      return processedLanguage;
     }
  
     /**
@@ -699,7 +717,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public Long getWordCount() {
-      return word_count_serialized_name;
+      return wordCount;
     }
  
     /**
@@ -712,7 +730,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getWordCountMessage() {
-      return word_count_message_serialized_name;
+      return wordCountMessage;
     }
  
     /**
@@ -725,7 +743,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public List<Trait> getPersonality() {
-      return personality_serialized_name;
+      return personality;
     }
  
     /**
@@ -737,7 +755,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public List<Trait> getNeeds() {
-      return needs_serialized_name;
+      return needs;
     }
  
     /**
@@ -749,7 +767,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public List<Trait> getValues() {
-      return values_serialized_name;
+      return values;
     }
  
     /**
@@ -763,7 +781,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public List<Behavior> getBehavior() {
-      return behavior_serialized_name;
+      return behavior;
     }
  
     /**
@@ -777,7 +795,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public List<ConsumptionPreferencesCategory> getConsumptionPreferences() {
-      return consumption_preferences_serialized_name;
+      return consumptionPreferences;
     }
  
     /**
@@ -790,7 +808,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public List<Warning> getWarnings() {
-      return warnings_serialized_name;
+      return warnings;
     }
 
     /**
@@ -799,7 +817,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param processedLanguage the new processedLanguage
      */
     public void setProcessedLanguage(final String processedLanguage) {
-      this.processed_language_serialized_name = processedLanguage;
+      this.processedLanguage = processedLanguage;
     }
 
     /**
@@ -808,7 +826,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param wordCount the new wordCount
      */
     public void setWordCount(final long wordCount) {
-      this.word_count_serialized_name = wordCount;
+      this.wordCount = wordCount;
     }
 
     /**
@@ -817,7 +835,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param wordCountMessage the new wordCountMessage
      */
     public void setWordCountMessage(final String wordCountMessage) {
-      this.word_count_message_serialized_name = wordCountMessage;
+      this.wordCountMessage = wordCountMessage;
     }
 
     /**
@@ -826,7 +844,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param personality the new personality
      */
     public void setPersonality(final List<Trait> personality) {
-      this.personality_serialized_name = personality;
+      this.personality = personality;
     }
 
     /**
@@ -835,7 +853,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param needs the new needs
      */
     public void setNeeds(final List<Trait> needs) {
-      this.needs_serialized_name = needs;
+      this.needs = needs;
     }
 
     /**
@@ -844,7 +862,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param values the new values
      */
     public void setValues(final List<Trait> values) {
-      this.values_serialized_name = values;
+      this.values = values;
     }
 
     /**
@@ -853,7 +871,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param behavior the new behavior
      */
     public void setBehavior(final List<Behavior> behavior) {
-      this.behavior_serialized_name = behavior;
+      this.behavior = behavior;
     }
 
     /**
@@ -862,7 +880,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param consumptionPreferences the new consumptionPreferences
      */
     public void setConsumptionPreferences(final List<ConsumptionPreferencesCategory> consumptionPreferences) {
-      this.consumption_preferences_serialized_name = consumptionPreferences;
+      this.consumptionPreferences = consumptionPreferences;
     }
 
     /**
@@ -871,7 +889,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param warnings the new warnings
      */
     public void setWarnings(final List<Warning> warnings) {
-      this.warnings_serialized_name = warnings;
+      this.warnings = warnings;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -887,11 +905,11 @@ public class IBMPersonalityInsightsV3Models {
       if (deserializedPersonality != null) {
         for (Integer i = 0; i < deserializedPersonality.size(); i++) {
           Trait currentItem = ret.getPersonality().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('personality_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('personality');
           Trait newItem = (Trait) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Trait.class);
           newPersonality.add(newItem);
         }
-        ret.personality_serialized_name = newPersonality;
+        ret.personality = newPersonality;
       }
 
       // calling custom deserializer for needs
@@ -900,11 +918,11 @@ public class IBMPersonalityInsightsV3Models {
       if (deserializedNeeds != null) {
         for (Integer i = 0; i < deserializedNeeds.size(); i++) {
           Trait currentItem = ret.getNeeds().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('needs_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('needs');
           Trait newItem = (Trait) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Trait.class);
           newNeeds.add(newItem);
         }
-        ret.needs_serialized_name = newNeeds;
+        ret.needs = newNeeds;
       }
 
       // calling custom deserializer for values
@@ -913,11 +931,11 @@ public class IBMPersonalityInsightsV3Models {
       if (deserializedValues != null) {
         for (Integer i = 0; i < deserializedValues.size(); i++) {
           Trait currentItem = ret.getValues().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('values_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('values');
           Trait newItem = (Trait) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Trait.class);
           newValues.add(newItem);
         }
-        ret.values_serialized_name = newValues;
+        ret.values = newValues;
       }
 
       // calling custom deserializer for behavior
@@ -926,11 +944,11 @@ public class IBMPersonalityInsightsV3Models {
       if (deserializedBehavior != null) {
         for (Integer i = 0; i < deserializedBehavior.size(); i++) {
           Behavior currentItem = ret.getBehavior().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('behavior_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('behavior');
           Behavior newItem = (Behavior) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Behavior.class);
           newBehavior.add(newItem);
         }
-        ret.behavior_serialized_name = newBehavior;
+        ret.behavior = newBehavior;
       }
 
       // calling custom deserializer for consumptionPreferences
@@ -939,11 +957,11 @@ public class IBMPersonalityInsightsV3Models {
       if (deserializedConsumptionPreferences != null) {
         for (Integer i = 0; i < deserializedConsumptionPreferences.size(); i++) {
           ConsumptionPreferencesCategory currentItem = ret.getConsumptionPreferences().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('consumption_preferences_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('consumptionPreferences');
           ConsumptionPreferencesCategory newItem = (ConsumptionPreferencesCategory) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ConsumptionPreferencesCategory.class);
           newConsumptionPreferences.add(newItem);
         }
-        ret.consumption_preferences_serialized_name = newConsumptionPreferences;
+        ret.consumptionPreferences = newConsumptionPreferences;
       }
 
       // calling custom deserializer for warnings
@@ -952,14 +970,41 @@ public class IBMPersonalityInsightsV3Models {
       if (deserializedWarnings != null) {
         for (Integer i = 0; i < deserializedWarnings.size(); i++) {
           Warning currentItem = ret.getWarnings().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('warnings_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('warnings');
           Warning newItem = (Warning) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Warning.class);
           newWarnings.add(newItem);
         }
-        ret.warnings_serialized_name = newWarnings;
+        ret.warnings = newWarnings;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('processed_language', 'processedLanguage');
+      mapping.put('word_count', 'wordCount');
+      mapping.put('word_count_message', 'wordCountMessage');
+      if (personality != null && personality[0] != null) {
+        mapping.putAll(personality[0].getApiToSdkMapping());
+      }
+      if (needs != null && needs[0] != null) {
+        mapping.putAll(needs[0].getApiToSdkMapping());
+      }
+      if (values != null && values[0] != null) {
+        mapping.putAll(values[0].getApiToSdkMapping());
+      }
+      if (behavior != null && behavior[0] != null) {
+        mapping.putAll(behavior[0].getApiToSdkMapping());
+      }
+      mapping.put('consumption_preferences', 'consumptionPreferences');
+      if (consumptionPreferences != null && consumptionPreferences[0] != null) {
+        mapping.putAll(consumptionPreferences[0].getApiToSdkMapping());
+      }
+      if (warnings != null && warnings[0] != null) {
+        mapping.putAll(warnings[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -975,7 +1020,7 @@ public class IBMPersonalityInsightsV3Models {
     private Boolean rawScores;
     private Boolean csvHeaders;
     private Boolean consumptionPreferences;
- 
+
     /**
      * Gets the content.
      *
@@ -989,7 +1034,7 @@ public class IBMPersonalityInsightsV3Models {
     public Content content() {
       return content;
     }
- 
+
     /**
      * Gets the body.
      *
@@ -1003,20 +1048,18 @@ public class IBMPersonalityInsightsV3Models {
     public String body() {
       return body;
     }
- 
+
     /**
      * Gets the contentType.
      *
      * The type of the input. For more information, see **Content types** in the method description.
-     *
-     * Default: `text/plain`.
      *
      * @return the contentType
      */
     public String contentType() {
       return contentType;
     }
- 
+
     /**
      * Gets the contentLanguage.
      *
@@ -1035,7 +1078,7 @@ public class IBMPersonalityInsightsV3Models {
     public String contentLanguage() {
       return contentLanguage;
     }
- 
+
     /**
      * Gets the acceptLanguage.
      *
@@ -1048,7 +1091,7 @@ public class IBMPersonalityInsightsV3Models {
     public String acceptLanguage() {
       return acceptLanguage;
     }
- 
+
     /**
      * Gets the rawScores.
      *
@@ -1060,7 +1103,7 @@ public class IBMPersonalityInsightsV3Models {
     public Boolean rawScores() {
       return rawScores;
     }
- 
+
     /**
      * Gets the csvHeaders.
      *
@@ -1072,7 +1115,7 @@ public class IBMPersonalityInsightsV3Models {
     public Boolean csvHeaders() {
       return csvHeaders;
     }
- 
+
     /**
      * Gets the consumptionPreferences.
      *
@@ -1106,6 +1149,16 @@ public class IBMPersonalityInsightsV3Models {
       return new ProfileOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('contentType', 'Content-Type');
+      mapping.put('contentLanguage', 'Content-Language');
+      mapping.put('acceptLanguage', 'Accept-Language');
+      mapping.put('rawScores', 'raw_scores');
+      mapping.put('csvHeaders', 'csv_headers');
+      mapping.put('consumptionPreferences', 'consumption_preferences');
+      return mapping;
+    }
   }
 
   /**
@@ -1256,13 +1309,13 @@ public class IBMPersonalityInsightsV3Models {
    * The characteristics that the service inferred from the input content.
    */
   public class Trait extends IBMWatsonGenericModel {
-    private String trait_id_serialized_name;
-    private String name_serialized_name;
-    private String category_serialized_name;
-    private Double percentile_serialized_name;
-    private Double raw_score_serialized_name;
-    private Boolean significant_serialized_name;
-    private List<Trait> children_serialized_name;
+    private String traitId;
+    private String name;
+    private String category;
+    private Double percentile;
+    private Double rawScore;
+    private Boolean significant;
+    private List<Trait> children;
  
     /**
      * Gets the traitId.
@@ -1277,7 +1330,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getTraitId() {
-      return trait_id_serialized_name;
+      return traitId;
     }
  
     /**
@@ -1289,7 +1342,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -1302,7 +1355,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getCategory() {
-      return category_serialized_name;
+      return category;
     }
  
     /**
@@ -1316,7 +1369,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public Double getPercentile() {
-      return percentile_serialized_name;
+      return percentile;
     }
  
     /**
@@ -1335,7 +1388,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public Double getRawScore() {
-      return raw_score_serialized_name;
+      return rawScore;
     }
  
     /**
@@ -1350,7 +1403,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public Boolean getSignificant() {
-      return significant_serialized_name;
+      return significant;
     }
  
     /**
@@ -1363,7 +1416,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public List<Trait> getChildren() {
-      return children_serialized_name;
+      return children;
     }
 
     /**
@@ -1372,7 +1425,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param traitId the new traitId
      */
     public void setTraitId(final String traitId) {
-      this.trait_id_serialized_name = traitId;
+      this.traitId = traitId;
     }
 
     /**
@@ -1381,7 +1434,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -1390,7 +1443,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param category the new category
      */
     public void setCategory(final String category) {
-      this.category_serialized_name = category;
+      this.category = category;
     }
 
     /**
@@ -1399,7 +1452,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param percentile the new percentile
      */
     public void setPercentile(final Double percentile) {
-      this.percentile_serialized_name = percentile;
+      this.percentile = percentile;
     }
 
     /**
@@ -1408,7 +1461,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param rawScore the new rawScore
      */
     public void setRawScore(final Double rawScore) {
-      this.raw_score_serialized_name = rawScore;
+      this.rawScore = rawScore;
     }
 
     /**
@@ -1417,7 +1470,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param significant the new significant
      */
     public void setSignificant(final Boolean significant) {
-      this.significant_serialized_name = significant;
+      this.significant = significant;
     }
 
     /**
@@ -1426,7 +1479,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param children the new children
      */
     public void setChildren(final List<Trait> children) {
-      this.children_serialized_name = children;
+      this.children = children;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1442,14 +1495,24 @@ public class IBMPersonalityInsightsV3Models {
       if (deserializedChildren != null) {
         for (Integer i = 0; i < deserializedChildren.size(); i++) {
           Trait currentItem = ret.getChildren().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('children_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('children');
           Trait newItem = (Trait) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Trait.class);
           newChildren.add(newItem);
         }
-        ret.children_serialized_name = newChildren;
+        ret.children = newChildren;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('trait_id', 'traitId');
+      mapping.put('raw_score', 'rawScore');
+      if (children != null && children[0] != null) {
+        mapping.putAll(children[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1457,8 +1520,8 @@ public class IBMPersonalityInsightsV3Models {
    * A warning message that is associated with the input content.
    */
   public class Warning extends IBMWatsonGenericModel {
-    private String warning_id_serialized_name;
-    private String message_serialized_name;
+    private String warningId;
+    private String message;
  
     /**
      * Gets the warningId.
@@ -1469,7 +1532,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getWarningId() {
-      return warning_id_serialized_name;
+      return warningId;
     }
  
     /**
@@ -1491,7 +1554,7 @@ public class IBMPersonalityInsightsV3Models {
      */
     @AuraEnabled
     public String getMessage() {
-      return message_serialized_name;
+      return message;
     }
 
     /**
@@ -1500,7 +1563,7 @@ public class IBMPersonalityInsightsV3Models {
      * @param warningId the new warningId
      */
     public void setWarningId(final String warningId) {
-      this.warning_id_serialized_name = warningId;
+      this.warningId = warningId;
     }
 
     /**
@@ -1509,9 +1572,14 @@ public class IBMPersonalityInsightsV3Models {
      * @param message the new message
      */
     public void setMessage(final String message) {
-      this.message_serialized_name = message;
+      this.message = message;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('warning_id', 'warningId');
+      return mapping;
+    }
   }
 
 }

--- a/force-app/main/default/classes/IBMSpeechToTextV1.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1.cls
@@ -651,7 +651,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     if (createLanguageModelOptions.description() != null) {
       contentJson.put('description', createLanguageModelOptions.description());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createLanguageModelOptions.getSdkToApiMapping()));
 
     return (IBMSpeechToTextV1Models.LanguageModel) createServiceCall(builder.build(), IBMSpeechToTextV1Models.LanguageModel.class);
   }
@@ -1120,7 +1120,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('words', addWordsOptions.words());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, addWordsOptions.getSdkToApiMapping()));
 
     createServiceCall(builder.build(), null);
   }
@@ -1182,7 +1182,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     if (addWordOptions.displayAs() != null) {
       contentJson.put('display_as', addWordOptions.displayAs());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, addWordOptions.getSdkToApiMapping()));
 
     createServiceCall(builder.build(), null);
   }
@@ -1418,7 +1418,7 @@ public class IBMSpeechToTextV1 extends IBMWatsonService {
     if (createAcousticModelOptions.description() != null) {
       contentJson.put('description', createAcousticModelOptions.description());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createAcousticModelOptions.getSdkToApiMapping()));
 
     return (IBMSpeechToTextV1Models.AcousticModel) createServiceCall(builder.build(), IBMSpeechToTextV1Models.AcousticModel.class);
   }

--- a/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
@@ -3,18 +3,18 @@ public class IBMSpeechToTextV1Models {
    * Information about an existing custom acoustic model.
    */
   public class AcousticModel extends IBMWatsonResponseModel {
-    private String customization_id_serialized_name;
-    private String created_serialized_name;
-    private String updated_serialized_name;
-    private String language_serialized_name;
-    private List<String> versions_serialized_name;
-    private String owner_serialized_name;
-    private String name_serialized_name;
-    private String description_serialized_name;
-    private String base_model_name_serialized_name;
-    private String status_serialized_name;
-    private Long progress_serialized_name;
-    private String warnings_serialized_name;
+    private String customizationId;
+    private String created;
+    private String updated;
+    private String language;
+    private List<String> versions;
+    private String owner;
+    private String name;
+    private String description;
+    private String baseModelName;
+    private String status;
+    private Long progress;
+    private String warnings;
  
     /**
      * Gets the customizationId.
@@ -26,7 +26,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getCustomizationId() {
-      return customization_id_serialized_name;
+      return customizationId;
     }
  
     /**
@@ -39,7 +39,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -53,7 +53,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -65,7 +65,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -79,7 +79,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<String> getVersions() {
-      return versions_serialized_name;
+      return versions;
     }
  
     /**
@@ -91,7 +91,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getOwner() {
-      return owner_serialized_name;
+      return owner;
     }
  
     /**
@@ -103,7 +103,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -115,7 +115,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -127,7 +127,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getBaseModelName() {
-      return base_model_name_serialized_name;
+      return baseModelName;
     }
  
     /**
@@ -147,7 +147,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -161,7 +161,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getProgress() {
-      return progress_serialized_name;
+      return progress;
     }
  
     /**
@@ -174,7 +174,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getWarnings() {
-      return warnings_serialized_name;
+      return warnings;
     }
 
     /**
@@ -183,7 +183,7 @@ public class IBMSpeechToTextV1Models {
      * @param customizationId the new customizationId
      */
     public void setCustomizationId(final String customizationId) {
-      this.customization_id_serialized_name = customizationId;
+      this.customizationId = customizationId;
     }
 
     /**
@@ -192,7 +192,7 @@ public class IBMSpeechToTextV1Models {
      * @param created the new created
      */
     public void setCreated(final String created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
     /**
@@ -201,7 +201,7 @@ public class IBMSpeechToTextV1Models {
      * @param updated the new updated
      */
     public void setUpdated(final String updated) {
-      this.updated_serialized_name = updated;
+      this.updated = updated;
     }
 
     /**
@@ -210,7 +210,7 @@ public class IBMSpeechToTextV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -219,7 +219,7 @@ public class IBMSpeechToTextV1Models {
      * @param versions the new versions
      */
     public void setVersions(final List<String> versions) {
-      this.versions_serialized_name = versions;
+      this.versions = versions;
     }
 
     /**
@@ -228,7 +228,7 @@ public class IBMSpeechToTextV1Models {
      * @param owner the new owner
      */
     public void setOwner(final String owner) {
-      this.owner_serialized_name = owner;
+      this.owner = owner;
     }
 
     /**
@@ -237,7 +237,7 @@ public class IBMSpeechToTextV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -246,7 +246,7 @@ public class IBMSpeechToTextV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -255,7 +255,7 @@ public class IBMSpeechToTextV1Models {
      * @param baseModelName the new baseModelName
      */
     public void setBaseModelName(final String baseModelName) {
-      this.base_model_name_serialized_name = baseModelName;
+      this.baseModelName = baseModelName;
     }
 
     /**
@@ -264,7 +264,7 @@ public class IBMSpeechToTextV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -273,7 +273,7 @@ public class IBMSpeechToTextV1Models {
      * @param progress the new progress
      */
     public void setProgress(final long progress) {
-      this.progress_serialized_name = progress;
+      this.progress = progress;
     }
 
     /**
@@ -282,16 +282,22 @@ public class IBMSpeechToTextV1Models {
      * @param warnings the new warnings
      */
     public void setWarnings(final String warnings) {
-      this.warnings_serialized_name = warnings;
+      this.warnings = warnings;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customization_id', 'customizationId');
+      mapping.put('base_model_name', 'baseModelName');
+      return mapping;
+    }
   }
 
   /**
    * Information about existing custom acoustic models.
    */
   public class AcousticModels extends IBMWatsonResponseModel {
-    private List<AcousticModel> customizations_serialized_name;
+    private List<AcousticModel> customizations;
  
     /**
      * Gets the customizations.
@@ -304,7 +310,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<AcousticModel> getCustomizations() {
-      return customizations_serialized_name;
+      return customizations;
     }
 
     /**
@@ -313,7 +319,7 @@ public class IBMSpeechToTextV1Models {
      * @param customizations the new customizations
      */
     public void setCustomizations(final List<AcousticModel> customizations) {
-      this.customizations_serialized_name = customizations;
+      this.customizations = customizations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -329,14 +335,22 @@ public class IBMSpeechToTextV1Models {
       if (deserializedCustomizations != null) {
         for (Integer i = 0; i < deserializedCustomizations.size(); i++) {
           AcousticModel currentItem = ret.getCustomizations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('customizations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('customizations');
           AcousticModel newItem = (AcousticModel) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), AcousticModel.class);
           newCustomizations.add(newItem);
         }
-        ret.customizations_serialized_name = newCustomizations;
+        ret.customizations = newCustomizations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (customizations != null && customizations[0] != null) {
+        mapping.putAll(customizations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -350,7 +364,7 @@ public class IBMSpeechToTextV1Models {
     private String contentType;
     private String containedContentType;
     private Boolean allowOverwrite;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -362,7 +376,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the audioName.
      *
@@ -380,7 +394,7 @@ public class IBMSpeechToTextV1Models {
     public String audioName() {
       return audioName;
     }
- 
+
     /**
      * Gets the audioResource.
      *
@@ -394,7 +408,7 @@ public class IBMSpeechToTextV1Models {
     public IBMWatsonFile audioResource() {
       return audioResource;
     }
- 
+
     /**
      * Gets the contentType.
      *
@@ -409,7 +423,7 @@ public class IBMSpeechToTextV1Models {
     public String contentType() {
       return contentType;
     }
- 
+
     /**
      * Gets the containedContentType.
      *
@@ -431,7 +445,7 @@ public class IBMSpeechToTextV1Models {
     public String containedContentType() {
       return containedContentType;
     }
- 
+
     /**
      * Gets the allowOverwrite.
      *
@@ -467,6 +481,16 @@ public class IBMSpeechToTextV1Models {
       return new AddAudioOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('audioName', 'audio_name');
+      mapping.put('audioResource', 'audio_resource');
+      mapping.put('contentType', 'Content-Type');
+      mapping.put('containedContentType', 'Contained-Content-Type');
+      mapping.put('allowOverwrite', 'allow_overwrite');
+      return mapping;
+    }
   }
 
   /**
@@ -605,7 +629,7 @@ public class IBMSpeechToTextV1Models {
     private String corpusName;
     private IBMWatsonFile corpusFile;
     private Boolean allowOverwrite;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -617,7 +641,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the corpusName.
      *
@@ -638,7 +662,7 @@ public class IBMSpeechToTextV1Models {
     public String corpusName() {
       return corpusName;
     }
- 
+
     /**
      * Gets the corpusFile.
      *
@@ -656,7 +680,7 @@ public class IBMSpeechToTextV1Models {
     public IBMWatsonFile corpusFile() {
       return corpusFile;
     }
- 
+
     /**
      * Gets the allowOverwrite.
      *
@@ -690,6 +714,14 @@ public class IBMSpeechToTextV1Models {
       return new AddCorpusOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('corpusName', 'corpus_name');
+      mapping.put('corpusFile', 'corpus_file');
+      mapping.put('allowOverwrite', 'allow_overwrite');
+      return mapping;
+    }
   }
 
   /**
@@ -803,7 +835,7 @@ public class IBMSpeechToTextV1Models {
     private IBMWatsonFile grammarFile;
     private String contentType;
     private Boolean allowOverwrite;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -815,7 +847,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the grammarName.
      *
@@ -836,7 +868,7 @@ public class IBMSpeechToTextV1Models {
     public String grammarName() {
       return grammarName;
     }
- 
+
     /**
      * Gets the grammarFile.
      *
@@ -852,7 +884,7 @@ public class IBMSpeechToTextV1Models {
     public IBMWatsonFile grammarFile() {
       return grammarFile;
     }
- 
+
     /**
      * Gets the contentType.
      *
@@ -866,7 +898,7 @@ public class IBMSpeechToTextV1Models {
     public String contentType() {
       return contentType;
     }
- 
+
     /**
      * Gets the allowOverwrite.
      *
@@ -902,6 +934,15 @@ public class IBMSpeechToTextV1Models {
       return new AddGrammarOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('grammarName', 'grammar_name');
+      mapping.put('grammarFile', 'grammar_file');
+      mapping.put('contentType', 'Content-Type');
+      mapping.put('allowOverwrite', 'allow_overwrite');
+      return mapping;
+    }
   }
 
   /**
@@ -1030,7 +1071,7 @@ public class IBMSpeechToTextV1Models {
     private String word;
     private List<String> soundsLike;
     private String displayAs;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -1042,7 +1083,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the wordName.
      *
@@ -1056,7 +1097,7 @@ public class IBMSpeechToTextV1Models {
     public String wordName() {
       return wordName;
     }
- 
+
     /**
      * Gets the word.
      *
@@ -1071,7 +1112,7 @@ public class IBMSpeechToTextV1Models {
     public String word() {
       return word;
     }
- 
+
     /**
      * Gets the soundsLike.
      *
@@ -1091,7 +1132,7 @@ public class IBMSpeechToTextV1Models {
     public List<String> soundsLike() {
       return soundsLike;
     }
- 
+
     /**
      * Gets the displayAs.
      *
@@ -1125,6 +1166,14 @@ public class IBMSpeechToTextV1Models {
       return new AddWordOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('wordName', 'word_name');
+      mapping.put('soundsLike', 'sounds_like');
+      mapping.put('displayAs', 'display_as');
+      return mapping;
+    }
   }
 
   /**
@@ -1262,7 +1311,7 @@ public class IBMSpeechToTextV1Models {
   public class AddWordsOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private List<CustomWord> words;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -1274,7 +1323,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the words.
      *
@@ -1304,6 +1353,14 @@ public class IBMSpeechToTextV1Models {
       return new AddWordsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      if (words != null && words[0] != null) {
+        mapping.putAll(words[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -1400,10 +1457,10 @@ public class IBMSpeechToTextV1Models {
    * Information about an audio resource from a custom acoustic model.
    */
   public class AudioDetails extends IBMWatsonGenericModel {
-    private String type_serialized_name;
-    private String codec_serialized_name;
-    private Long frequency_serialized_name;
-    private String compression_serialized_name;
+    private String xtype;
+    private String codec;
+    private Long frequency;
+    private String compression;
  
     /**
      * Gets the xtype.
@@ -1418,7 +1475,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getXtype() {
-      return type_serialized_name;
+      return xtype;
     }
  
     /**
@@ -1430,7 +1487,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getCodec() {
-      return codec_serialized_name;
+      return codec;
     }
  
     /**
@@ -1443,7 +1500,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getFrequency() {
-      return frequency_serialized_name;
+      return frequency;
     }
  
     /**
@@ -1459,7 +1516,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getCompression() {
-      return compression_serialized_name;
+      return compression;
     }
 
     /**
@@ -1468,7 +1525,7 @@ public class IBMSpeechToTextV1Models {
      * @param xtype the new xtype
      */
     public void setXtype(final String xtype) {
-      this.type_serialized_name = xtype;
+      this.xtype = xtype;
     }
 
     /**
@@ -1477,7 +1534,7 @@ public class IBMSpeechToTextV1Models {
      * @param codec the new codec
      */
     public void setCodec(final String codec) {
-      this.codec_serialized_name = codec;
+      this.codec = codec;
     }
 
     /**
@@ -1486,7 +1543,7 @@ public class IBMSpeechToTextV1Models {
      * @param frequency the new frequency
      */
     public void setFrequency(final long frequency) {
-      this.frequency_serialized_name = frequency;
+      this.frequency = frequency;
     }
 
     /**
@@ -1495,21 +1552,26 @@ public class IBMSpeechToTextV1Models {
      * @param compression the new compression
      */
     public void setCompression(final String compression) {
-      this.compression_serialized_name = compression;
+      this.compression = compression;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('type', 'xtype');
+      return mapping;
+    }
   }
 
   /**
    * Information about an audio resource from a custom acoustic model.
    */
   public class AudioListing extends IBMWatsonResponseModel {
-    private Long duration_serialized_name;
-    private String name_serialized_name;
-    private AudioDetails details_serialized_name;
-    private String status_serialized_name;
-    private AudioResource container_serialized_name;
-    private List<AudioResource> audio_serialized_name;
+    private Long duration;
+    private String name;
+    private AudioDetails details;
+    private String status;
+    private AudioResource container;
+    private List<AudioResource> audio;
  
     /**
      * Gets the duration.
@@ -1521,7 +1583,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getDuration() {
-      return duration_serialized_name;
+      return duration;
     }
  
     /**
@@ -1533,7 +1595,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -1546,7 +1608,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public AudioDetails getDetails() {
-      return details_serialized_name;
+      return details;
     }
  
     /**
@@ -1565,7 +1627,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -1578,7 +1640,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public AudioResource getContainer() {
-      return container_serialized_name;
+      return container;
     }
  
     /**
@@ -1591,7 +1653,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<AudioResource> getAudio() {
-      return audio_serialized_name;
+      return audio;
     }
 
     /**
@@ -1600,7 +1662,7 @@ public class IBMSpeechToTextV1Models {
      * @param duration the new duration
      */
     public void setDuration(final long duration) {
-      this.duration_serialized_name = duration;
+      this.duration = duration;
     }
 
     /**
@@ -1609,7 +1671,7 @@ public class IBMSpeechToTextV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -1618,7 +1680,7 @@ public class IBMSpeechToTextV1Models {
      * @param details the new details
      */
     public void setDetails(final AudioDetails details) {
-      this.details_serialized_name = details;
+      this.details = details;
     }
 
     /**
@@ -1627,7 +1689,7 @@ public class IBMSpeechToTextV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -1636,7 +1698,7 @@ public class IBMSpeechToTextV1Models {
      * @param container the new container
      */
     public void setContainer(final AudioResource container) {
-      this.container_serialized_name = container;
+      this.container = container;
     }
 
     /**
@@ -1645,7 +1707,7 @@ public class IBMSpeechToTextV1Models {
      * @param audio the new audio
      */
     public void setAudio(final List<AudioResource> audio) {
-      this.audio_serialized_name = audio;
+      this.audio = audio;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1656,11 +1718,11 @@ public class IBMSpeechToTextV1Models {
       AudioListing ret = (AudioListing) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for details
-      AudioDetails newDetails = (AudioDetails) new AudioDetails().deserialize(JSON.serialize(ret.getDetails()), (Map<String, Object>) jsonMap.get('details_serialized_name'), AudioDetails.class);
+      AudioDetails newDetails = (AudioDetails) new AudioDetails().deserialize(JSON.serialize(ret.getDetails()), (Map<String, Object>) jsonMap.get('details'), AudioDetails.class);
       ret.setDetails(newDetails);
 
       // calling custom deserializer for container
-      AudioResource newContainer = (AudioResource) new AudioResource().deserialize(JSON.serialize(ret.getContainer()), (Map<String, Object>) jsonMap.get('container_serialized_name'), AudioResource.class);
+      AudioResource newContainer = (AudioResource) new AudioResource().deserialize(JSON.serialize(ret.getContainer()), (Map<String, Object>) jsonMap.get('container'), AudioResource.class);
       ret.setContainer(newContainer);
 
       // calling custom deserializer for audio
@@ -1669,14 +1731,28 @@ public class IBMSpeechToTextV1Models {
       if (deserializedAudio != null) {
         for (Integer i = 0; i < deserializedAudio.size(); i++) {
           AudioResource currentItem = ret.getAudio().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('audio_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('audio');
           AudioResource newItem = (AudioResource) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), AudioResource.class);
           newAudio.add(newItem);
         }
-        ret.audio_serialized_name = newAudio;
+        ret.audio = newAudio;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (details != null) {
+        mapping.putAll(details.getApiToSdkMapping());
+      }
+      if (container != null) {
+        mapping.putAll(container.getApiToSdkMapping());
+      }
+      if (audio != null && audio[0] != null) {
+        mapping.putAll(audio[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1684,8 +1760,8 @@ public class IBMSpeechToTextV1Models {
    * If audio metrics are requested, information about the signal characteristics of the input audio.
    */
   public class AudioMetrics extends IBMWatsonGenericModel {
-    private Double sampling_interval_serialized_name;
-    private AudioMetricsDetails accumulated_serialized_name;
+    private Double samplingInterval;
+    private AudioMetricsDetails accumulated;
  
     /**
      * Gets the samplingInterval.
@@ -1698,7 +1774,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getSamplingInterval() {
-      return sampling_interval_serialized_name;
+      return samplingInterval;
     }
  
     /**
@@ -1710,7 +1786,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public AudioMetricsDetails getAccumulated() {
-      return accumulated_serialized_name;
+      return accumulated;
     }
 
     /**
@@ -1719,7 +1795,7 @@ public class IBMSpeechToTextV1Models {
      * @param samplingInterval the new samplingInterval
      */
     public void setSamplingInterval(final Double samplingInterval) {
-      this.sampling_interval_serialized_name = samplingInterval;
+      this.samplingInterval = samplingInterval;
     }
 
     /**
@@ -1728,7 +1804,7 @@ public class IBMSpeechToTextV1Models {
      * @param accumulated the new accumulated
      */
     public void setAccumulated(final AudioMetricsDetails accumulated) {
-      this.accumulated_serialized_name = accumulated;
+      this.accumulated = accumulated;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1739,10 +1815,19 @@ public class IBMSpeechToTextV1Models {
       AudioMetrics ret = (AudioMetrics) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for accumulated
-      AudioMetricsDetails newAccumulated = (AudioMetricsDetails) new AudioMetricsDetails().deserialize(JSON.serialize(ret.getAccumulated()), (Map<String, Object>) jsonMap.get('accumulated_serialized_name'), AudioMetricsDetails.class);
+      AudioMetricsDetails newAccumulated = (AudioMetricsDetails) new AudioMetricsDetails().deserialize(JSON.serialize(ret.getAccumulated()), (Map<String, Object>) jsonMap.get('accumulated'), AudioMetricsDetails.class);
       ret.setAccumulated(newAccumulated);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('sampling_interval', 'samplingInterval');
+      if (accumulated != null) {
+        mapping.putAll(accumulated.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1750,15 +1835,15 @@ public class IBMSpeechToTextV1Models {
    * Detailed information about the signal characteristics of the input audio.
    */
   public class AudioMetricsDetails extends IBMWatsonGenericModel {
-    private Boolean final_serialized_name;
-    private Double end_time_serialized_name;
-    private Double signal_to_noise_ratio_serialized_name;
-    private Double speech_ratio_serialized_name;
-    private Double high_frequency_loss_serialized_name;
-    private List<AudioMetricsHistogramBin> direct_current_offset_serialized_name;
-    private List<AudioMetricsHistogramBin> clipping_rate_serialized_name;
-    private List<AudioMetricsHistogramBin> speech_level_serialized_name;
-    private List<AudioMetricsHistogramBin> non_speech_level_serialized_name;
+    private Boolean xfinal;
+    private Double endTime;
+    private Double signalToNoiseRatio;
+    private Double speechRatio;
+    private Double highFrequencyLoss;
+    private List<AudioMetricsHistogramBin> directCurrentOffset;
+    private List<AudioMetricsHistogramBin> clippingRate;
+    private List<AudioMetricsHistogramBin> speechLevel;
+    private List<AudioMetricsHistogramBin> nonSpeechLevel;
  
     /**
      * Gets the xfinal.
@@ -1771,7 +1856,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Boolean getXfinal() {
-      return final_serialized_name;
+      return xfinal;
     }
  
     /**
@@ -1783,7 +1868,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getEndTime() {
-      return end_time_serialized_name;
+      return endTime;
     }
  
     /**
@@ -1797,7 +1882,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getSignalToNoiseRatio() {
-      return signal_to_noise_ratio_serialized_name;
+      return signalToNoiseRatio;
     }
  
     /**
@@ -1809,7 +1894,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getSpeechRatio() {
-      return speech_ratio_serialized_name;
+      return speechRatio;
     }
  
     /**
@@ -1825,7 +1910,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getHighFrequencyLoss() {
-      return high_frequency_loss_serialized_name;
+      return highFrequencyLoss;
     }
  
     /**
@@ -1838,7 +1923,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<AudioMetricsHistogramBin> getDirectCurrentOffset() {
-      return direct_current_offset_serialized_name;
+      return directCurrentOffset;
     }
  
     /**
@@ -1854,7 +1939,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<AudioMetricsHistogramBin> getClippingRate() {
-      return clipping_rate_serialized_name;
+      return clippingRate;
     }
  
     /**
@@ -1868,7 +1953,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<AudioMetricsHistogramBin> getSpeechLevel() {
-      return speech_level_serialized_name;
+      return speechLevel;
     }
  
     /**
@@ -1882,7 +1967,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<AudioMetricsHistogramBin> getNonSpeechLevel() {
-      return non_speech_level_serialized_name;
+      return nonSpeechLevel;
     }
 
     /**
@@ -1891,7 +1976,7 @@ public class IBMSpeechToTextV1Models {
      * @param xfinal the new xfinal
      */
     public void setXfinal(final Boolean xfinal) {
-      this.final_serialized_name = xfinal;
+      this.xfinal = xfinal;
     }
 
     /**
@@ -1900,7 +1985,7 @@ public class IBMSpeechToTextV1Models {
      * @param endTime the new endTime
      */
     public void setEndTime(final Double endTime) {
-      this.end_time_serialized_name = endTime;
+      this.endTime = endTime;
     }
 
     /**
@@ -1909,7 +1994,7 @@ public class IBMSpeechToTextV1Models {
      * @param signalToNoiseRatio the new signalToNoiseRatio
      */
     public void setSignalToNoiseRatio(final Double signalToNoiseRatio) {
-      this.signal_to_noise_ratio_serialized_name = signalToNoiseRatio;
+      this.signalToNoiseRatio = signalToNoiseRatio;
     }
 
     /**
@@ -1918,7 +2003,7 @@ public class IBMSpeechToTextV1Models {
      * @param speechRatio the new speechRatio
      */
     public void setSpeechRatio(final Double speechRatio) {
-      this.speech_ratio_serialized_name = speechRatio;
+      this.speechRatio = speechRatio;
     }
 
     /**
@@ -1927,7 +2012,7 @@ public class IBMSpeechToTextV1Models {
      * @param highFrequencyLoss the new highFrequencyLoss
      */
     public void setHighFrequencyLoss(final Double highFrequencyLoss) {
-      this.high_frequency_loss_serialized_name = highFrequencyLoss;
+      this.highFrequencyLoss = highFrequencyLoss;
     }
 
     /**
@@ -1936,7 +2021,7 @@ public class IBMSpeechToTextV1Models {
      * @param directCurrentOffset the new directCurrentOffset
      */
     public void setDirectCurrentOffset(final List<AudioMetricsHistogramBin> directCurrentOffset) {
-      this.direct_current_offset_serialized_name = directCurrentOffset;
+      this.directCurrentOffset = directCurrentOffset;
     }
 
     /**
@@ -1945,7 +2030,7 @@ public class IBMSpeechToTextV1Models {
      * @param clippingRate the new clippingRate
      */
     public void setClippingRate(final List<AudioMetricsHistogramBin> clippingRate) {
-      this.clipping_rate_serialized_name = clippingRate;
+      this.clippingRate = clippingRate;
     }
 
     /**
@@ -1954,7 +2039,7 @@ public class IBMSpeechToTextV1Models {
      * @param speechLevel the new speechLevel
      */
     public void setSpeechLevel(final List<AudioMetricsHistogramBin> speechLevel) {
-      this.speech_level_serialized_name = speechLevel;
+      this.speechLevel = speechLevel;
     }
 
     /**
@@ -1963,7 +2048,7 @@ public class IBMSpeechToTextV1Models {
      * @param nonSpeechLevel the new nonSpeechLevel
      */
     public void setNonSpeechLevel(final List<AudioMetricsHistogramBin> nonSpeechLevel) {
-      this.non_speech_level_serialized_name = nonSpeechLevel;
+      this.nonSpeechLevel = nonSpeechLevel;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1979,11 +2064,11 @@ public class IBMSpeechToTextV1Models {
       if (deserializedDirectCurrentOffset != null) {
         for (Integer i = 0; i < deserializedDirectCurrentOffset.size(); i++) {
           AudioMetricsHistogramBin currentItem = ret.getDirectCurrentOffset().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('direct_current_offset_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('directCurrentOffset');
           AudioMetricsHistogramBin newItem = (AudioMetricsHistogramBin) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), AudioMetricsHistogramBin.class);
           newDirectCurrentOffset.add(newItem);
         }
-        ret.direct_current_offset_serialized_name = newDirectCurrentOffset;
+        ret.directCurrentOffset = newDirectCurrentOffset;
       }
 
       // calling custom deserializer for clippingRate
@@ -1992,11 +2077,11 @@ public class IBMSpeechToTextV1Models {
       if (deserializedClippingRate != null) {
         for (Integer i = 0; i < deserializedClippingRate.size(); i++) {
           AudioMetricsHistogramBin currentItem = ret.getClippingRate().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('clipping_rate_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('clippingRate');
           AudioMetricsHistogramBin newItem = (AudioMetricsHistogramBin) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), AudioMetricsHistogramBin.class);
           newClippingRate.add(newItem);
         }
-        ret.clipping_rate_serialized_name = newClippingRate;
+        ret.clippingRate = newClippingRate;
       }
 
       // calling custom deserializer for speechLevel
@@ -2005,11 +2090,11 @@ public class IBMSpeechToTextV1Models {
       if (deserializedSpeechLevel != null) {
         for (Integer i = 0; i < deserializedSpeechLevel.size(); i++) {
           AudioMetricsHistogramBin currentItem = ret.getSpeechLevel().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('speech_level_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('speechLevel');
           AudioMetricsHistogramBin newItem = (AudioMetricsHistogramBin) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), AudioMetricsHistogramBin.class);
           newSpeechLevel.add(newItem);
         }
-        ret.speech_level_serialized_name = newSpeechLevel;
+        ret.speechLevel = newSpeechLevel;
       }
 
       // calling custom deserializer for nonSpeechLevel
@@ -2018,14 +2103,40 @@ public class IBMSpeechToTextV1Models {
       if (deserializedNonSpeechLevel != null) {
         for (Integer i = 0; i < deserializedNonSpeechLevel.size(); i++) {
           AudioMetricsHistogramBin currentItem = ret.getNonSpeechLevel().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('non_speech_level_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('nonSpeechLevel');
           AudioMetricsHistogramBin newItem = (AudioMetricsHistogramBin) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), AudioMetricsHistogramBin.class);
           newNonSpeechLevel.add(newItem);
         }
-        ret.non_speech_level_serialized_name = newNonSpeechLevel;
+        ret.nonSpeechLevel = newNonSpeechLevel;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('final', 'xfinal');
+      mapping.put('end_time', 'endTime');
+      mapping.put('signal_to_noise_ratio', 'signalToNoiseRatio');
+      mapping.put('speech_ratio', 'speechRatio');
+      mapping.put('high_frequency_loss', 'highFrequencyLoss');
+      mapping.put('direct_current_offset', 'directCurrentOffset');
+      if (directCurrentOffset != null && directCurrentOffset[0] != null) {
+        mapping.putAll(directCurrentOffset[0].getApiToSdkMapping());
+      }
+      mapping.put('clipping_rate', 'clippingRate');
+      if (clippingRate != null && clippingRate[0] != null) {
+        mapping.putAll(clippingRate[0].getApiToSdkMapping());
+      }
+      mapping.put('speech_level', 'speechLevel');
+      if (speechLevel != null && speechLevel[0] != null) {
+        mapping.putAll(speechLevel[0].getApiToSdkMapping());
+      }
+      mapping.put('non_speech_level', 'nonSpeechLevel');
+      if (nonSpeechLevel != null && nonSpeechLevel[0] != null) {
+        mapping.putAll(nonSpeechLevel[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2035,9 +2146,9 @@ public class IBMSpeechToTextV1Models {
    * infinity and the first boundary, and between the last boundary and positive infinity, respectively.
    */
   public class AudioMetricsHistogramBin extends IBMWatsonGenericModel {
-    private Double begin_serialized_name;
-    private Double end_serialized_name;
-    private Long count_serialized_name;
+    private Double xbegin;
+    private Double xend;
+    private Long count;
  
     /**
      * Gets the xbegin.
@@ -2048,7 +2159,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getXbegin() {
-      return begin_serialized_name;
+      return xbegin;
     }
  
     /**
@@ -2060,7 +2171,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getXend() {
-      return end_serialized_name;
+      return xend;
     }
  
     /**
@@ -2072,7 +2183,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getCount() {
-      return count_serialized_name;
+      return count;
     }
 
     /**
@@ -2081,7 +2192,7 @@ public class IBMSpeechToTextV1Models {
      * @param xbegin the new xbegin
      */
     public void setXbegin(final Double xbegin) {
-      this.begin_serialized_name = xbegin;
+      this.xbegin = xbegin;
     }
 
     /**
@@ -2090,7 +2201,7 @@ public class IBMSpeechToTextV1Models {
      * @param xend the new xend
      */
     public void setXend(final Double xend) {
-      this.end_serialized_name = xend;
+      this.xend = xend;
     }
 
     /**
@@ -2099,19 +2210,25 @@ public class IBMSpeechToTextV1Models {
      * @param count the new count
      */
     public void setCount(final long count) {
-      this.count_serialized_name = count;
+      this.count = count;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('begin', 'xbegin');
+      mapping.put('end', 'xend');
+      return mapping;
+    }
   }
 
   /**
    * Information about an audio resource from a custom acoustic model.
    */
   public class AudioResource extends IBMWatsonGenericModel {
-    private Long duration_serialized_name;
-    private String name_serialized_name;
-    private AudioDetails details_serialized_name;
-    private String status_serialized_name;
+    private Long duration;
+    private String name;
+    private AudioDetails details;
+    private String status;
  
     /**
      * Gets the duration.
@@ -2122,7 +2239,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getDuration() {
-      return duration_serialized_name;
+      return duration;
     }
  
     /**
@@ -2137,7 +2254,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -2150,7 +2267,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public AudioDetails getDetails() {
-      return details_serialized_name;
+      return details;
     }
  
     /**
@@ -2168,7 +2285,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
 
     /**
@@ -2177,7 +2294,7 @@ public class IBMSpeechToTextV1Models {
      * @param duration the new duration
      */
     public void setDuration(final long duration) {
-      this.duration_serialized_name = duration;
+      this.duration = duration;
     }
 
     /**
@@ -2186,7 +2303,7 @@ public class IBMSpeechToTextV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -2195,7 +2312,7 @@ public class IBMSpeechToTextV1Models {
      * @param details the new details
      */
     public void setDetails(final AudioDetails details) {
-      this.details_serialized_name = details;
+      this.details = details;
     }
 
     /**
@@ -2204,7 +2321,7 @@ public class IBMSpeechToTextV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2215,10 +2332,18 @@ public class IBMSpeechToTextV1Models {
       AudioResource ret = (AudioResource) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for details
-      AudioDetails newDetails = (AudioDetails) new AudioDetails().deserialize(JSON.serialize(ret.getDetails()), (Map<String, Object>) jsonMap.get('details_serialized_name'), AudioDetails.class);
+      AudioDetails newDetails = (AudioDetails) new AudioDetails().deserialize(JSON.serialize(ret.getDetails()), (Map<String, Object>) jsonMap.get('details'), AudioDetails.class);
       ret.setDetails(newDetails);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (details != null) {
+        mapping.putAll(details.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2226,8 +2351,8 @@ public class IBMSpeechToTextV1Models {
    * Information about the audio resources from a custom acoustic model.
    */
   public class AudioResources extends IBMWatsonResponseModel {
-    private Double total_minutes_of_audio_serialized_name;
-    private List<AudioResource> audio_serialized_name;
+    private Double totalMinutesOfAudio;
+    private List<AudioResource> audio;
  
     /**
      * Gets the totalMinutesOfAudio.
@@ -2240,7 +2365,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getTotalMinutesOfAudio() {
-      return total_minutes_of_audio_serialized_name;
+      return totalMinutesOfAudio;
     }
  
     /**
@@ -2253,7 +2378,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<AudioResource> getAudio() {
-      return audio_serialized_name;
+      return audio;
     }
 
     /**
@@ -2262,7 +2387,7 @@ public class IBMSpeechToTextV1Models {
      * @param totalMinutesOfAudio the new totalMinutesOfAudio
      */
     public void setTotalMinutesOfAudio(final Double totalMinutesOfAudio) {
-      this.total_minutes_of_audio_serialized_name = totalMinutesOfAudio;
+      this.totalMinutesOfAudio = totalMinutesOfAudio;
     }
 
     /**
@@ -2271,7 +2396,7 @@ public class IBMSpeechToTextV1Models {
      * @param audio the new audio
      */
     public void setAudio(final List<AudioResource> audio) {
-      this.audio_serialized_name = audio;
+      this.audio = audio;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2287,14 +2412,23 @@ public class IBMSpeechToTextV1Models {
       if (deserializedAudio != null) {
         for (Integer i = 0; i < deserializedAudio.size(); i++) {
           AudioResource currentItem = ret.getAudio().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('audio_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('audio');
           AudioResource newItem = (AudioResource) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), AudioResource.class);
           newAudio.add(newItem);
         }
-        ret.audio_serialized_name = newAudio;
+        ret.audio = newAudio;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('total_minutes_of_audio', 'totalMinutesOfAudio');
+      if (audio != null && audio[0] != null) {
+        mapping.putAll(audio[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2303,7 +2437,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class CheckJobOptions extends IBMWatsonOptionsModel {
     private String id;
- 
+
     /**
      * Gets the id.
      *
@@ -2330,7 +2464,6 @@ public class IBMSpeechToTextV1Models {
     public CheckJobOptionsBuilder newBuilder() {
       return new CheckJobOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -2409,7 +2542,6 @@ public class IBMSpeechToTextV1Models {
     public CheckJobsOptionsBuilder newBuilder() {
       return new CheckJobsOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -2453,7 +2585,7 @@ public class IBMSpeechToTextV1Models {
    * Information about the corpora from a custom language model.
    */
   public class Corpora extends IBMWatsonResponseModel {
-    private List<Corpus> corpora_serialized_name;
+    private List<Corpus> corpora;
  
     /**
      * Gets the corpora.
@@ -2465,7 +2597,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<Corpus> getCorpora() {
-      return corpora_serialized_name;
+      return corpora;
     }
 
     /**
@@ -2474,7 +2606,7 @@ public class IBMSpeechToTextV1Models {
      * @param corpora the new corpora
      */
     public void setCorpora(final List<Corpus> corpora) {
-      this.corpora_serialized_name = corpora;
+      this.corpora = corpora;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2490,14 +2622,22 @@ public class IBMSpeechToTextV1Models {
       if (deserializedCorpora != null) {
         for (Integer i = 0; i < deserializedCorpora.size(); i++) {
           Corpus currentItem = ret.getCorpora().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('corpora_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('corpora');
           Corpus newItem = (Corpus) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Corpus.class);
           newCorpora.add(newItem);
         }
-        ret.corpora_serialized_name = newCorpora;
+        ret.corpora = newCorpora;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (corpora != null && corpora[0] != null) {
+        mapping.putAll(corpora[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2505,11 +2645,11 @@ public class IBMSpeechToTextV1Models {
    * Information about a corpus from a custom language model.
    */
   public class Corpus extends IBMWatsonResponseModel {
-    private String name_serialized_name;
-    private Long total_words_serialized_name;
-    private Long out_of_vocabulary_words_serialized_name;
-    private String status_serialized_name;
-    private String error_serialized_name;
+    private String name;
+    private Long totalWords;
+    private Long outOfVocabularyWords;
+    private String status;
+    private String error;
  
     /**
      * Gets the name.
@@ -2520,7 +2660,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -2532,7 +2672,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getTotalWords() {
-      return total_words_serialized_name;
+      return totalWords;
     }
  
     /**
@@ -2544,7 +2684,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getOutOfVocabularyWords() {
-      return out_of_vocabulary_words_serialized_name;
+      return outOfVocabularyWords;
     }
  
     /**
@@ -2562,7 +2702,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -2575,7 +2715,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getError() {
-      return error_serialized_name;
+      return error;
     }
 
     /**
@@ -2584,7 +2724,7 @@ public class IBMSpeechToTextV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -2593,7 +2733,7 @@ public class IBMSpeechToTextV1Models {
      * @param totalWords the new totalWords
      */
     public void setTotalWords(final long totalWords) {
-      this.total_words_serialized_name = totalWords;
+      this.totalWords = totalWords;
     }
 
     /**
@@ -2602,7 +2742,7 @@ public class IBMSpeechToTextV1Models {
      * @param outOfVocabularyWords the new outOfVocabularyWords
      */
     public void setOutOfVocabularyWords(final long outOfVocabularyWords) {
-      this.out_of_vocabulary_words_serialized_name = outOfVocabularyWords;
+      this.outOfVocabularyWords = outOfVocabularyWords;
     }
 
     /**
@@ -2611,7 +2751,7 @@ public class IBMSpeechToTextV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -2620,9 +2760,15 @@ public class IBMSpeechToTextV1Models {
      * @param error the new error
      */
     public void setError(final String error) {
-      this.error_serialized_name = error;
+      this.error = error;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('total_words', 'totalWords');
+      mapping.put('out_of_vocabulary_words', 'outOfVocabularyWords');
+      return mapping;
+    }
   }
 
   /**
@@ -2632,7 +2778,7 @@ public class IBMSpeechToTextV1Models {
     private String name;
     private String baseModelName;
     private String description;
- 
+
     /**
      * Gets the name.
      *
@@ -2645,7 +2791,7 @@ public class IBMSpeechToTextV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the baseModelName.
      *
@@ -2660,7 +2806,7 @@ public class IBMSpeechToTextV1Models {
     public String baseModelName() {
       return baseModelName;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -2691,6 +2837,11 @@ public class IBMSpeechToTextV1Models {
       return new CreateAcousticModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('baseModelName', 'base_model_name');
+      return mapping;
+    }
   }
 
   /**
@@ -2811,7 +2962,7 @@ public class IBMSpeechToTextV1Models {
     private Boolean processingMetrics;
     private Double processingMetricsInterval;
     private Boolean audioMetrics;
- 
+
     /**
      * Gets the audio.
      *
@@ -2822,7 +2973,7 @@ public class IBMSpeechToTextV1Models {
     public IBMWatsonFile audio() {
       return audio;
     }
- 
+
     /**
      * Gets the contentType.
      *
@@ -2834,7 +2985,7 @@ public class IBMSpeechToTextV1Models {
     public String contentType() {
       return contentType;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -2846,7 +2997,7 @@ public class IBMSpeechToTextV1Models {
     public String model() {
       return model;
     }
- 
+
     /**
      * Gets the callbackUrl.
      *
@@ -2862,7 +3013,7 @@ public class IBMSpeechToTextV1Models {
     public String callbackUrl() {
       return callbackUrl;
     }
- 
+
     /**
      * Gets the events.
      *
@@ -2888,7 +3039,7 @@ public class IBMSpeechToTextV1Models {
     public String events() {
       return events;
     }
- 
+
     /**
      * Gets the userToken.
      *
@@ -2901,7 +3052,7 @@ public class IBMSpeechToTextV1Models {
     public String userToken() {
       return userToken;
     }
- 
+
     /**
      * Gets the resultsTtl.
      *
@@ -2914,7 +3065,7 @@ public class IBMSpeechToTextV1Models {
     public Long resultsTtl() {
       return resultsTtl;
     }
- 
+
     /**
      * Gets the languageCustomizationId.
      *
@@ -2931,7 +3082,7 @@ public class IBMSpeechToTextV1Models {
     public String languageCustomizationId() {
       return languageCustomizationId;
     }
- 
+
     /**
      * Gets the acousticCustomizationId.
      *
@@ -2946,7 +3097,7 @@ public class IBMSpeechToTextV1Models {
     public String acousticCustomizationId() {
       return acousticCustomizationId;
     }
- 
+
     /**
      * Gets the baseModelVersion.
      *
@@ -2961,7 +3112,7 @@ public class IBMSpeechToTextV1Models {
     public String baseModelVersion() {
       return baseModelVersion;
     }
- 
+
     /**
      * Gets the customizationWeight.
      *
@@ -2984,7 +3135,7 @@ public class IBMSpeechToTextV1Models {
     public Double customizationWeight() {
       return customizationWeight;
     }
- 
+
     /**
      * Gets the inactivityTimeout.
      *
@@ -2998,7 +3149,7 @@ public class IBMSpeechToTextV1Models {
     public Long inactivityTimeout() {
       return inactivityTimeout;
     }
- 
+
     /**
      * Gets the keywords.
      *
@@ -3013,7 +3164,7 @@ public class IBMSpeechToTextV1Models {
     public List<String> keywords() {
       return keywords;
     }
- 
+
     /**
      * Gets the keywordsThreshold.
      *
@@ -3028,7 +3179,7 @@ public class IBMSpeechToTextV1Models {
     public Double keywordsThreshold() {
       return keywordsThreshold;
     }
- 
+
     /**
      * Gets the maxAlternatives.
      *
@@ -3041,7 +3192,7 @@ public class IBMSpeechToTextV1Models {
     public Long maxAlternatives() {
       return maxAlternatives;
     }
- 
+
     /**
      * Gets the wordAlternativesThreshold.
      *
@@ -3056,7 +3207,7 @@ public class IBMSpeechToTextV1Models {
     public Double wordAlternativesThreshold() {
       return wordAlternativesThreshold;
     }
- 
+
     /**
      * Gets the wordConfidence.
      *
@@ -3069,7 +3220,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean wordConfidence() {
       return wordConfidence;
     }
- 
+
     /**
      * Gets the timestamps.
      *
@@ -3081,7 +3232,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean timestamps() {
       return timestamps;
     }
- 
+
     /**
      * Gets the profanityFilter.
      *
@@ -3095,7 +3246,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean profanityFilter() {
       return profanityFilter;
     }
- 
+
     /**
      * Gets the smartFormatting.
      *
@@ -3114,7 +3265,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean smartFormatting() {
       return smartFormatting;
     }
- 
+
     /**
      * Gets the speakerLabels.
      *
@@ -3134,7 +3285,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean speakerLabels() {
       return speakerLabels;
     }
- 
+
     /**
      * Gets the customizationId.
      *
@@ -3146,7 +3297,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the grammarName.
      *
@@ -3161,7 +3312,7 @@ public class IBMSpeechToTextV1Models {
     public String grammarName() {
       return grammarName;
     }
- 
+
     /**
      * Gets the redaction.
      *
@@ -3184,7 +3335,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean redaction() {
       return redaction;
     }
- 
+
     /**
      * Gets the processingMetrics.
      *
@@ -3198,7 +3349,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean processingMetrics() {
       return processingMetrics;
     }
- 
+
     /**
      * Gets the processingMetricsInterval.
      *
@@ -3217,7 +3368,7 @@ public class IBMSpeechToTextV1Models {
     public Double processingMetricsInterval() {
       return processingMetricsInterval;
     }
- 
+
     /**
      * Gets the audioMetrics.
      *
@@ -3271,6 +3422,31 @@ public class IBMSpeechToTextV1Models {
       return new CreateJobOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('contentType', 'Content-Type');
+      mapping.put('callbackUrl', 'callback_url');
+      mapping.put('userToken', 'user_token');
+      mapping.put('resultsTtl', 'results_ttl');
+      mapping.put('languageCustomizationId', 'language_customization_id');
+      mapping.put('acousticCustomizationId', 'acoustic_customization_id');
+      mapping.put('baseModelVersion', 'base_model_version');
+      mapping.put('customizationWeight', 'customization_weight');
+      mapping.put('inactivityTimeout', 'inactivity_timeout');
+      mapping.put('keywordsThreshold', 'keywords_threshold');
+      mapping.put('maxAlternatives', 'max_alternatives');
+      mapping.put('wordAlternativesThreshold', 'word_alternatives_threshold');
+      mapping.put('wordConfidence', 'word_confidence');
+      mapping.put('profanityFilter', 'profanity_filter');
+      mapping.put('smartFormatting', 'smart_formatting');
+      mapping.put('speakerLabels', 'speaker_labels');
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('grammarName', 'grammar_name');
+      mapping.put('processingMetrics', 'processing_metrics');
+      mapping.put('processingMetricsInterval', 'processing_metrics_interval');
+      mapping.put('audioMetrics', 'audio_metrics');
+      return mapping;
+    }
   }
 
   /**
@@ -3694,7 +3870,7 @@ public class IBMSpeechToTextV1Models {
     private String baseModelName;
     private String dialect;
     private String description;
- 
+
     /**
      * Gets the name.
      *
@@ -3707,7 +3883,7 @@ public class IBMSpeechToTextV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the baseModelName.
      *
@@ -3723,7 +3899,7 @@ public class IBMSpeechToTextV1Models {
     public String baseModelName() {
       return baseModelName;
     }
- 
+
     /**
      * Gets the dialect.
      *
@@ -3742,7 +3918,7 @@ public class IBMSpeechToTextV1Models {
     public String dialect() {
       return dialect;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -3774,6 +3950,11 @@ public class IBMSpeechToTextV1Models {
       return new CreateLanguageModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('baseModelName', 'base_model_name');
+      return mapping;
+    }
   }
 
   /**
@@ -3879,10 +4060,10 @@ public class IBMSpeechToTextV1Models {
   /**
    * Information about a word that is to be added to a custom language model.
    */
-  public class CustomWord {
-    private String word_serialized_name;
-    private List<String> sounds_like_serialized_name;
-    private String display_as_serialized_name;
+  public class CustomWord extends IBMWatsonGenericModel {
+    private String word;
+    private List<String> soundsLike;
+    private String displayAs;
  
     /**
      * Gets the word.
@@ -3896,7 +4077,7 @@ public class IBMSpeechToTextV1Models {
      * @return the word
      */
     public String getWord() {
-      return word_serialized_name;
+      return word;
     }
  
     /**
@@ -3916,7 +4097,7 @@ public class IBMSpeechToTextV1Models {
      * @return the soundsLike
      */
     public List<String> getSoundsLike() {
-      return sounds_like_serialized_name;
+      return soundsLike;
     }
  
     /**
@@ -3929,36 +4110,109 @@ public class IBMSpeechToTextV1Models {
      * @return the displayAs
      */
     public String getDisplayAs() {
-      return display_as_serialized_name;
+      return displayAs;
+    }
+  
+    private CustomWord(CustomWordBuilder builder) {
+      this.word = builder.word;
+      this.soundsLike = builder.soundsLike;
+      this.displayAs = builder.displayAs;
     }
 
     /**
-     * Sets the word.
+     * New builder.
      *
-     * @param word the new word
+     * @return a CustomWord builder
      */
-    public void setWord(final String word) {
-      this.word_serialized_name = word;
+    public CustomWordBuilder newBuilder() {
+      return new CustomWordBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('soundsLike', 'sounds_like');
+      mapping.put('displayAs', 'display_as');
+      return mapping;
+    }
+  }
+
+  /**
+   * CustomWord Builder.
+   */
+  public class CustomWordBuilder {
+    private String word;
+    private List<String> soundsLike;
+    private String displayAs;
+
+    private CustomWordBuilder(CustomWord customWord) {
+      this.word = customWord.word;
+      this.soundsLike = customWord.soundsLike;
+      this.displayAs = customWord.displayAs;
     }
 
     /**
-     * Sets the soundsLike.
+     * Instantiates a new builder.
+     */
+    public CustomWordBuilder() {
+    }
+
+    /**
+     * Builds a CustomWord.
+     *
+     * @return the customWord
+     */
+    public CustomWord build() {
+      return new CustomWord(this);
+    }
+
+    /**
+     * Adds an soundsLike to soundsLike.
      *
      * @param soundsLike the new soundsLike
+     * @return the CustomWord builder
      */
-    public void setSoundsLike(final List<String> soundsLike) {
-      this.sounds_like_serialized_name = soundsLike;
+    public CustomWordBuilder addSoundsLike(String soundsLike) {
+      IBMWatsonValidator.notNull(soundsLike, 'soundsLike cannot be null');
+      if (this.soundsLike == null) {
+        this.soundsLike = new List<String>();
+      }
+      this.soundsLike.add(soundsLike);
+      return this;
     }
 
     /**
-     * Sets the displayAs.
+     * Set the word.
      *
-     * @param displayAs the new displayAs
+     * @param word the word
+     * @return the CustomWord builder
      */
-    public void setDisplayAs(final String displayAs) {
-      this.display_as_serialized_name = displayAs;
+    public CustomWordBuilder setWord(String word) {
+      this.word = word;
+      return this;
     }
 
+    /**
+     * Set the soundsLike.
+     * Existing soundsLike will be replaced.
+     *
+     * @param soundsLike the soundsLike
+     * @return the CustomWord builder
+     */
+    public CustomWordBuilder setSoundsLike(List<String> soundsLike) {
+      this.soundsLike = soundsLike;
+      return this;
+    }
+
+    /**
+     * Set the displayAs.
+     *
+     * @param displayAs the displayAs
+     * @return the CustomWord builder
+     */
+    public CustomWordBuilder setDisplayAs(String displayAs) {
+      this.displayAs = displayAs;
+      return this;
+    }
   }
 
   /**
@@ -3966,7 +4220,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class DeleteAcousticModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -3994,6 +4248,11 @@ public class IBMSpeechToTextV1Models {
       return new DeleteAcousticModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4061,7 +4320,7 @@ public class IBMSpeechToTextV1Models {
   public class DeleteAudioOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String audioName;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -4073,7 +4332,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the audioName.
      *
@@ -4102,6 +4361,12 @@ public class IBMSpeechToTextV1Models {
       return new DeleteAudioOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('audioName', 'audio_name');
+      return mapping;
+    }
   }
 
   /**
@@ -4184,7 +4449,7 @@ public class IBMSpeechToTextV1Models {
   public class DeleteCorpusOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String corpusName;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -4196,7 +4461,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the corpusName.
      *
@@ -4225,6 +4490,12 @@ public class IBMSpeechToTextV1Models {
       return new DeleteCorpusOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('corpusName', 'corpus_name');
+      return mapping;
+    }
   }
 
   /**
@@ -4307,7 +4578,7 @@ public class IBMSpeechToTextV1Models {
   public class DeleteGrammarOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String grammarName;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -4319,7 +4590,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the grammarName.
      *
@@ -4348,6 +4619,12 @@ public class IBMSpeechToTextV1Models {
       return new DeleteGrammarOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('grammarName', 'grammar_name');
+      return mapping;
+    }
   }
 
   /**
@@ -4429,7 +4706,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class DeleteJobOptions extends IBMWatsonOptionsModel {
     private String id;
- 
+
     /**
      * Gets the id.
      *
@@ -4456,7 +4733,6 @@ public class IBMSpeechToTextV1Models {
     public DeleteJobOptionsBuilder newBuilder() {
       return new DeleteJobOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -4523,7 +4799,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class DeleteLanguageModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -4551,6 +4827,11 @@ public class IBMSpeechToTextV1Models {
       return new DeleteLanguageModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4617,7 +4898,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class DeleteUserDataOptions extends IBMWatsonOptionsModel {
     private String customerId;
- 
+
     /**
      * Gets the customerId.
      *
@@ -4644,6 +4925,11 @@ public class IBMSpeechToTextV1Models {
       return new DeleteUserDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customerId', 'customer_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4711,7 +4997,7 @@ public class IBMSpeechToTextV1Models {
   public class DeleteWordOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String wordName;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -4723,7 +5009,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the wordName.
      *
@@ -4754,6 +5040,12 @@ public class IBMSpeechToTextV1Models {
       return new DeleteWordOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('wordName', 'word_name');
+      return mapping;
+    }
   }
 
   /**
@@ -4835,7 +5127,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class GetAcousticModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -4863,6 +5155,11 @@ public class IBMSpeechToTextV1Models {
       return new GetAcousticModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -4930,7 +5227,7 @@ public class IBMSpeechToTextV1Models {
   public class GetAudioOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String audioName;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -4942,7 +5239,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the audioName.
      *
@@ -4971,6 +5268,12 @@ public class IBMSpeechToTextV1Models {
       return new GetAudioOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('audioName', 'audio_name');
+      return mapping;
+    }
   }
 
   /**
@@ -5053,7 +5356,7 @@ public class IBMSpeechToTextV1Models {
   public class GetCorpusOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String corpusName;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -5065,7 +5368,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the corpusName.
      *
@@ -5094,6 +5397,12 @@ public class IBMSpeechToTextV1Models {
       return new GetCorpusOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('corpusName', 'corpus_name');
+      return mapping;
+    }
   }
 
   /**
@@ -5176,7 +5485,7 @@ public class IBMSpeechToTextV1Models {
   public class GetGrammarOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String grammarName;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -5188,7 +5497,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the grammarName.
      *
@@ -5217,6 +5526,12 @@ public class IBMSpeechToTextV1Models {
       return new GetGrammarOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('grammarName', 'grammar_name');
+      return mapping;
+    }
   }
 
   /**
@@ -5298,7 +5613,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class GetLanguageModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -5326,6 +5641,11 @@ public class IBMSpeechToTextV1Models {
       return new GetLanguageModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -5392,7 +5712,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class GetModelOptions extends IBMWatsonOptionsModel {
     private String modelId;
- 
+
     /**
      * Gets the modelId.
      *
@@ -5419,6 +5739,11 @@ public class IBMSpeechToTextV1Models {
       return new GetModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('modelId', 'model_id');
+      return mapping;
+    }
   }
 
   /**
@@ -5486,7 +5811,7 @@ public class IBMSpeechToTextV1Models {
   public class GetWordOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String wordName;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -5498,7 +5823,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the wordName.
      *
@@ -5529,6 +5854,12 @@ public class IBMSpeechToTextV1Models {
       return new GetWordOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('wordName', 'word_name');
+      return mapping;
+    }
   }
 
   /**
@@ -5609,10 +5940,10 @@ public class IBMSpeechToTextV1Models {
    * Information about a grammar from a custom language model.
    */
   public class Grammar extends IBMWatsonResponseModel {
-    private String name_serialized_name;
-    private Long out_of_vocabulary_words_serialized_name;
-    private String status_serialized_name;
-    private String error_serialized_name;
+    private String name;
+    private Long outOfVocabularyWords;
+    private String status;
+    private String error;
  
     /**
      * Gets the name.
@@ -5623,7 +5954,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -5635,7 +5966,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getOutOfVocabularyWords() {
-      return out_of_vocabulary_words_serialized_name;
+      return outOfVocabularyWords;
     }
  
     /**
@@ -5653,7 +5984,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -5667,7 +5998,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getError() {
-      return error_serialized_name;
+      return error;
     }
 
     /**
@@ -5676,7 +6007,7 @@ public class IBMSpeechToTextV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -5685,7 +6016,7 @@ public class IBMSpeechToTextV1Models {
      * @param outOfVocabularyWords the new outOfVocabularyWords
      */
     public void setOutOfVocabularyWords(final long outOfVocabularyWords) {
-      this.out_of_vocabulary_words_serialized_name = outOfVocabularyWords;
+      this.outOfVocabularyWords = outOfVocabularyWords;
     }
 
     /**
@@ -5694,7 +6025,7 @@ public class IBMSpeechToTextV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -5703,16 +6034,21 @@ public class IBMSpeechToTextV1Models {
      * @param error the new error
      */
     public void setError(final String error) {
-      this.error_serialized_name = error;
+      this.error = error;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('out_of_vocabulary_words', 'outOfVocabularyWords');
+      return mapping;
+    }
   }
 
   /**
    * Information about the grammars from a custom language model.
    */
   public class Grammars extends IBMWatsonResponseModel {
-    private List<Grammar> grammars_serialized_name;
+    private List<Grammar> grammars;
  
     /**
      * Gets the grammars.
@@ -5724,7 +6060,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<Grammar> getGrammars() {
-      return grammars_serialized_name;
+      return grammars;
     }
 
     /**
@@ -5733,7 +6069,7 @@ public class IBMSpeechToTextV1Models {
      * @param grammars the new grammars
      */
     public void setGrammars(final List<Grammar> grammars) {
-      this.grammars_serialized_name = grammars;
+      this.grammars = grammars;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -5749,14 +6085,22 @@ public class IBMSpeechToTextV1Models {
       if (deserializedGrammars != null) {
         for (Integer i = 0; i < deserializedGrammars.size(); i++) {
           Grammar currentItem = ret.getGrammars().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('grammars_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('grammars');
           Grammar newItem = (Grammar) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Grammar.class);
           newGrammars.add(newItem);
         }
-        ret.grammars_serialized_name = newGrammars;
+        ret.grammars = newGrammars;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (grammars != null && grammars[0] != null) {
+        mapping.putAll(grammars[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -5764,10 +6108,10 @@ public class IBMSpeechToTextV1Models {
    * Information about a match for a keyword from speech recognition results.
    */
   public class KeywordResult extends IBMWatsonGenericModel {
-    private String normalized_text_serialized_name;
-    private Double start_time_serialized_name;
-    private Double end_time_serialized_name;
-    private Double confidence_serialized_name;
+    private String normalizedText;
+    private Double startTime;
+    private Double endTime;
+    private Double confidence;
  
     /**
      * Gets the normalizedText.
@@ -5778,7 +6122,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getNormalizedText() {
-      return normalized_text_serialized_name;
+      return normalizedText;
     }
  
     /**
@@ -5790,7 +6134,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getStartTime() {
-      return start_time_serialized_name;
+      return startTime;
     }
  
     /**
@@ -5802,7 +6146,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getEndTime() {
-      return end_time_serialized_name;
+      return endTime;
     }
  
     /**
@@ -5814,7 +6158,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
 
     /**
@@ -5823,7 +6167,7 @@ public class IBMSpeechToTextV1Models {
      * @param normalizedText the new normalizedText
      */
     public void setNormalizedText(final String normalizedText) {
-      this.normalized_text_serialized_name = normalizedText;
+      this.normalizedText = normalizedText;
     }
 
     /**
@@ -5832,7 +6176,7 @@ public class IBMSpeechToTextV1Models {
      * @param startTime the new startTime
      */
     public void setStartTime(final Double startTime) {
-      this.start_time_serialized_name = startTime;
+      this.startTime = startTime;
     }
 
     /**
@@ -5841,7 +6185,7 @@ public class IBMSpeechToTextV1Models {
      * @param endTime the new endTime
      */
     public void setEndTime(final Double endTime) {
-      this.end_time_serialized_name = endTime;
+      this.endTime = endTime;
     }
 
     /**
@@ -5850,29 +6194,28 @@ public class IBMSpeechToTextV1Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
-
   }
 
   /**
    * Information about an existing custom language model.
    */
   public class LanguageModel extends IBMWatsonResponseModel {
-    private String customization_id_serialized_name;
-    private String created_serialized_name;
-    private String updated_serialized_name;
-    private String language_serialized_name;
-    private String dialect_serialized_name;
-    private List<String> versions_serialized_name;
-    private String owner_serialized_name;
-    private String name_serialized_name;
-    private String description_serialized_name;
-    private String base_model_name_serialized_name;
-    private String status_serialized_name;
-    private Long progress_serialized_name;
-    private String error_serialized_name;
-    private String warnings_serialized_name;
+    private String customizationId;
+    private String created;
+    private String updated;
+    private String language;
+    private String dialect;
+    private List<String> versions;
+    private String owner;
+    private String name;
+    private String description;
+    private String baseModelName;
+    private String status;
+    private Long progress;
+    private String error;
+    private String warnings;
  
     /**
      * Gets the customizationId.
@@ -5884,7 +6227,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getCustomizationId() {
-      return customization_id_serialized_name;
+      return customizationId;
     }
  
     /**
@@ -5897,7 +6240,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -5911,7 +6254,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -5923,7 +6266,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -5940,7 +6283,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getDialect() {
-      return dialect_serialized_name;
+      return dialect;
     }
  
     /**
@@ -5954,7 +6297,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<String> getVersions() {
-      return versions_serialized_name;
+      return versions;
     }
  
     /**
@@ -5966,7 +6309,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getOwner() {
-      return owner_serialized_name;
+      return owner;
     }
  
     /**
@@ -5978,7 +6321,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -5990,7 +6333,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -6002,7 +6345,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getBaseModelName() {
-      return base_model_name_serialized_name;
+      return baseModelName;
     }
  
     /**
@@ -6022,7 +6365,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -6036,7 +6379,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getProgress() {
-      return progress_serialized_name;
+      return progress;
     }
  
     /**
@@ -6050,7 +6393,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getError() {
-      return error_serialized_name;
+      return error;
     }
  
     /**
@@ -6063,7 +6406,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getWarnings() {
-      return warnings_serialized_name;
+      return warnings;
     }
 
     /**
@@ -6072,7 +6415,7 @@ public class IBMSpeechToTextV1Models {
      * @param customizationId the new customizationId
      */
     public void setCustomizationId(final String customizationId) {
-      this.customization_id_serialized_name = customizationId;
+      this.customizationId = customizationId;
     }
 
     /**
@@ -6081,7 +6424,7 @@ public class IBMSpeechToTextV1Models {
      * @param created the new created
      */
     public void setCreated(final String created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
     /**
@@ -6090,7 +6433,7 @@ public class IBMSpeechToTextV1Models {
      * @param updated the new updated
      */
     public void setUpdated(final String updated) {
-      this.updated_serialized_name = updated;
+      this.updated = updated;
     }
 
     /**
@@ -6099,7 +6442,7 @@ public class IBMSpeechToTextV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -6108,7 +6451,7 @@ public class IBMSpeechToTextV1Models {
      * @param dialect the new dialect
      */
     public void setDialect(final String dialect) {
-      this.dialect_serialized_name = dialect;
+      this.dialect = dialect;
     }
 
     /**
@@ -6117,7 +6460,7 @@ public class IBMSpeechToTextV1Models {
      * @param versions the new versions
      */
     public void setVersions(final List<String> versions) {
-      this.versions_serialized_name = versions;
+      this.versions = versions;
     }
 
     /**
@@ -6126,7 +6469,7 @@ public class IBMSpeechToTextV1Models {
      * @param owner the new owner
      */
     public void setOwner(final String owner) {
-      this.owner_serialized_name = owner;
+      this.owner = owner;
     }
 
     /**
@@ -6135,7 +6478,7 @@ public class IBMSpeechToTextV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -6144,7 +6487,7 @@ public class IBMSpeechToTextV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -6153,7 +6496,7 @@ public class IBMSpeechToTextV1Models {
      * @param baseModelName the new baseModelName
      */
     public void setBaseModelName(final String baseModelName) {
-      this.base_model_name_serialized_name = baseModelName;
+      this.baseModelName = baseModelName;
     }
 
     /**
@@ -6162,7 +6505,7 @@ public class IBMSpeechToTextV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -6171,7 +6514,7 @@ public class IBMSpeechToTextV1Models {
      * @param progress the new progress
      */
     public void setProgress(final long progress) {
-      this.progress_serialized_name = progress;
+      this.progress = progress;
     }
 
     /**
@@ -6180,7 +6523,7 @@ public class IBMSpeechToTextV1Models {
      * @param error the new error
      */
     public void setError(final String error) {
-      this.error_serialized_name = error;
+      this.error = error;
     }
 
     /**
@@ -6189,16 +6532,22 @@ public class IBMSpeechToTextV1Models {
      * @param warnings the new warnings
      */
     public void setWarnings(final String warnings) {
-      this.warnings_serialized_name = warnings;
+      this.warnings = warnings;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customization_id', 'customizationId');
+      mapping.put('base_model_name', 'baseModelName');
+      return mapping;
+    }
   }
 
   /**
    * Information about existing custom language models.
    */
   public class LanguageModels extends IBMWatsonResponseModel {
-    private List<LanguageModel> customizations_serialized_name;
+    private List<LanguageModel> customizations;
  
     /**
      * Gets the customizations.
@@ -6211,7 +6560,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<LanguageModel> getCustomizations() {
-      return customizations_serialized_name;
+      return customizations;
     }
 
     /**
@@ -6220,7 +6569,7 @@ public class IBMSpeechToTextV1Models {
      * @param customizations the new customizations
      */
     public void setCustomizations(final List<LanguageModel> customizations) {
-      this.customizations_serialized_name = customizations;
+      this.customizations = customizations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -6236,14 +6585,22 @@ public class IBMSpeechToTextV1Models {
       if (deserializedCustomizations != null) {
         for (Integer i = 0; i < deserializedCustomizations.size(); i++) {
           LanguageModel currentItem = ret.getCustomizations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('customizations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('customizations');
           LanguageModel newItem = (LanguageModel) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), LanguageModel.class);
           newCustomizations.add(newItem);
         }
-        ret.customizations_serialized_name = newCustomizations;
+        ret.customizations = newCustomizations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (customizations != null && customizations[0] != null) {
+        mapping.putAll(customizations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -6252,7 +6609,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class ListAcousticModelsOptions extends IBMWatsonOptionsModel {
     private String language;
- 
+
     /**
      * Gets the language.
      *
@@ -6279,7 +6636,6 @@ public class IBMSpeechToTextV1Models {
     public ListAcousticModelsOptionsBuilder newBuilder() {
       return new ListAcousticModelsOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -6337,7 +6693,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class ListAudioOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -6365,6 +6721,11 @@ public class IBMSpeechToTextV1Models {
       return new ListAudioOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -6431,7 +6792,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class ListCorporaOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -6459,6 +6820,11 @@ public class IBMSpeechToTextV1Models {
       return new ListCorporaOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -6525,7 +6891,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class ListGrammarsOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -6553,6 +6919,11 @@ public class IBMSpeechToTextV1Models {
       return new ListGrammarsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -6619,7 +6990,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class ListLanguageModelsOptions extends IBMWatsonOptionsModel {
     private String language;
- 
+
     /**
      * Gets the language.
      *
@@ -6646,7 +7017,6 @@ public class IBMSpeechToTextV1Models {
     public ListLanguageModelsOptionsBuilder newBuilder() {
       return new ListLanguageModelsOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -6716,7 +7086,6 @@ public class IBMSpeechToTextV1Models {
     public ListModelsOptionsBuilder newBuilder() {
       return new ListModelsOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -6763,7 +7132,7 @@ public class IBMSpeechToTextV1Models {
     private String customizationId;
     private String wordType;
     private String xsort;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -6775,7 +7144,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the wordType.
      *
@@ -6790,7 +7159,7 @@ public class IBMSpeechToTextV1Models {
     public String wordType() {
       return wordType;
     }
- 
+
     /**
      * Gets the xsort.
      *
@@ -6824,6 +7193,13 @@ public class IBMSpeechToTextV1Models {
       return new ListWordsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('wordType', 'word_type');
+      mapping.put('xsort', 'sort');
+      return mapping;
+    }
   }
 
   /**
@@ -6915,10 +7291,10 @@ public class IBMSpeechToTextV1Models {
    * Detailed timing information about the service's processing of the input audio.
    */
   public class ProcessedAudio extends IBMWatsonGenericModel {
-    private Double received_serialized_name;
-    private Double seen_by_engine_serialized_name;
-    private Double transcription_serialized_name;
-    private Double speaker_labels_serialized_name;
+    private Double received;
+    private Double seenByEngine;
+    private Double transcription;
+    private Double speakerLabels;
  
     /**
      * Gets the received.
@@ -6932,7 +7308,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getReceived() {
-      return received_serialized_name;
+      return received;
     }
  
     /**
@@ -6948,7 +7324,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getSeenByEngine() {
-      return seen_by_engine_serialized_name;
+      return seenByEngine;
     }
  
     /**
@@ -6960,7 +7336,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getTranscription() {
-      return transcription_serialized_name;
+      return transcription;
     }
  
     /**
@@ -6975,7 +7351,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getSpeakerLabels() {
-      return speaker_labels_serialized_name;
+      return speakerLabels;
     }
 
     /**
@@ -6984,7 +7360,7 @@ public class IBMSpeechToTextV1Models {
      * @param received the new received
      */
     public void setReceived(final Double received) {
-      this.received_serialized_name = received;
+      this.received = received;
     }
 
     /**
@@ -6993,7 +7369,7 @@ public class IBMSpeechToTextV1Models {
      * @param seenByEngine the new seenByEngine
      */
     public void setSeenByEngine(final Double seenByEngine) {
-      this.seen_by_engine_serialized_name = seenByEngine;
+      this.seenByEngine = seenByEngine;
     }
 
     /**
@@ -7002,7 +7378,7 @@ public class IBMSpeechToTextV1Models {
      * @param transcription the new transcription
      */
     public void setTranscription(final Double transcription) {
-      this.transcription_serialized_name = transcription;
+      this.transcription = transcription;
     }
 
     /**
@@ -7011,9 +7387,15 @@ public class IBMSpeechToTextV1Models {
      * @param speakerLabels the new speakerLabels
      */
     public void setSpeakerLabels(final Double speakerLabels) {
-      this.speaker_labels_serialized_name = speakerLabels;
+      this.speakerLabels = speakerLabels;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('seen_by_engine', 'seenByEngine');
+      mapping.put('speaker_labels', 'speakerLabels');
+      return mapping;
+    }
   }
 
   /**
@@ -7021,9 +7403,9 @@ public class IBMSpeechToTextV1Models {
    * metrics are not available with the synchronous **Recognize audio** method.
    */
   public class ProcessingMetrics extends IBMWatsonGenericModel {
-    private ProcessedAudio processed_audio_serialized_name;
-    private Double wall_clock_since_first_byte_received_serialized_name;
-    private Boolean periodic_serialized_name;
+    private ProcessedAudio processedAudio;
+    private Double wallClockSinceFirstByteReceived;
+    private Boolean periodic;
  
     /**
      * Gets the processedAudio.
@@ -7034,7 +7416,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public ProcessedAudio getProcessedAudio() {
-      return processed_audio_serialized_name;
+      return processedAudio;
     }
  
     /**
@@ -7051,7 +7433,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getWallClockSinceFirstByteReceived() {
-      return wall_clock_since_first_byte_received_serialized_name;
+      return wallClockSinceFirstByteReceived;
     }
  
     /**
@@ -7069,7 +7451,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Boolean getPeriodic() {
-      return periodic_serialized_name;
+      return periodic;
     }
 
     /**
@@ -7078,7 +7460,7 @@ public class IBMSpeechToTextV1Models {
      * @param processedAudio the new processedAudio
      */
     public void setProcessedAudio(final ProcessedAudio processedAudio) {
-      this.processed_audio_serialized_name = processedAudio;
+      this.processedAudio = processedAudio;
     }
 
     /**
@@ -7087,7 +7469,7 @@ public class IBMSpeechToTextV1Models {
      * @param wallClockSinceFirstByteReceived the new wallClockSinceFirstByteReceived
      */
     public void setWallClockSinceFirstByteReceived(final Double wallClockSinceFirstByteReceived) {
-      this.wall_clock_since_first_byte_received_serialized_name = wallClockSinceFirstByteReceived;
+      this.wallClockSinceFirstByteReceived = wallClockSinceFirstByteReceived;
     }
 
     /**
@@ -7096,7 +7478,7 @@ public class IBMSpeechToTextV1Models {
      * @param periodic the new periodic
      */
     public void setPeriodic(final Boolean periodic) {
-      this.periodic_serialized_name = periodic;
+      this.periodic = periodic;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7107,10 +7489,20 @@ public class IBMSpeechToTextV1Models {
       ProcessingMetrics ret = (ProcessingMetrics) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for processedAudio
-      ProcessedAudio newProcessedAudio = (ProcessedAudio) new ProcessedAudio().deserialize(JSON.serialize(ret.getProcessedAudio()), (Map<String, Object>) jsonMap.get('processed_audio_serialized_name'), ProcessedAudio.class);
+      ProcessedAudio newProcessedAudio = (ProcessedAudio) new ProcessedAudio().deserialize(JSON.serialize(ret.getProcessedAudio()), (Map<String, Object>) jsonMap.get('processedAudio'), ProcessedAudio.class);
       ret.setProcessedAudio(newProcessedAudio);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('processed_audio', 'processedAudio');
+      if (processedAudio != null) {
+        mapping.putAll(processedAudio.getApiToSdkMapping());
+      }
+      mapping.put('wall_clock_since_first_byte_received', 'wallClockSinceFirstByteReceived');
+      return mapping;
     }
   }
 
@@ -7118,14 +7510,14 @@ public class IBMSpeechToTextV1Models {
    * Information about a current asynchronous speech recognition job.
    */
   public class RecognitionJob extends IBMWatsonResponseModel {
-    private String id_serialized_name;
-    private String status_serialized_name;
-    private String created_serialized_name;
-    private String updated_serialized_name;
-    private String url_serialized_name;
-    private String user_token_serialized_name;
-    private List<SpeechRecognitionResults> results_serialized_name;
-    private List<String> warnings_serialized_name;
+    private String id;
+    private String status;
+    private String created;
+    private String updated;
+    private String url;
+    private String userToken;
+    private List<SpeechRecognitionResults> results;
+    private List<String> warnings;
  
     /**
      * Gets the id.
@@ -7136,7 +7528,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getId() {
-      return id_serialized_name;
+      return id;
     }
  
     /**
@@ -7156,7 +7548,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -7169,7 +7561,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -7183,7 +7575,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
  
     /**
@@ -7196,7 +7588,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
  
     /**
@@ -7209,7 +7601,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getUserToken() {
-      return user_token_serialized_name;
+      return userToken;
     }
  
     /**
@@ -7222,7 +7614,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<SpeechRecognitionResults> getResults() {
-      return results_serialized_name;
+      return results;
     }
  
     /**
@@ -7237,7 +7629,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<String> getWarnings() {
-      return warnings_serialized_name;
+      return warnings;
     }
 
     /**
@@ -7246,7 +7638,7 @@ public class IBMSpeechToTextV1Models {
      * @param id the new id
      */
     public void setId(final String id) {
-      this.id_serialized_name = id;
+      this.id = id;
     }
 
     /**
@@ -7255,7 +7647,7 @@ public class IBMSpeechToTextV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -7264,7 +7656,7 @@ public class IBMSpeechToTextV1Models {
      * @param created the new created
      */
     public void setCreated(final String created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
     /**
@@ -7273,7 +7665,7 @@ public class IBMSpeechToTextV1Models {
      * @param updated the new updated
      */
     public void setUpdated(final String updated) {
-      this.updated_serialized_name = updated;
+      this.updated = updated;
     }
 
     /**
@@ -7282,7 +7674,7 @@ public class IBMSpeechToTextV1Models {
      * @param url the new url
      */
     public void setUrl(final String url) {
-      this.url_serialized_name = url;
+      this.url = url;
     }
 
     /**
@@ -7291,7 +7683,7 @@ public class IBMSpeechToTextV1Models {
      * @param userToken the new userToken
      */
     public void setUserToken(final String userToken) {
-      this.user_token_serialized_name = userToken;
+      this.userToken = userToken;
     }
 
     /**
@@ -7300,7 +7692,7 @@ public class IBMSpeechToTextV1Models {
      * @param results the new results
      */
     public void setResults(final List<SpeechRecognitionResults> results) {
-      this.results_serialized_name = results;
+      this.results = results;
     }
 
     /**
@@ -7309,7 +7701,7 @@ public class IBMSpeechToTextV1Models {
      * @param warnings the new warnings
      */
     public void setWarnings(final List<String> warnings) {
-      this.warnings_serialized_name = warnings;
+      this.warnings = warnings;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7325,14 +7717,23 @@ public class IBMSpeechToTextV1Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           SpeechRecognitionResults currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           SpeechRecognitionResults newItem = (SpeechRecognitionResults) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SpeechRecognitionResults.class);
           newResults.add(newItem);
         }
-        ret.results_serialized_name = newResults;
+        ret.results = newResults;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('user_token', 'userToken');
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7340,7 +7741,7 @@ public class IBMSpeechToTextV1Models {
    * Information about current asynchronous speech recognition jobs.
    */
   public class RecognitionJobs extends IBMWatsonResponseModel {
-    private List<RecognitionJob> recognitions_serialized_name;
+    private List<RecognitionJob> recognitions;
  
     /**
      * Gets the recognitions.
@@ -7352,7 +7753,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<RecognitionJob> getRecognitions() {
-      return recognitions_serialized_name;
+      return recognitions;
     }
 
     /**
@@ -7361,7 +7762,7 @@ public class IBMSpeechToTextV1Models {
      * @param recognitions the new recognitions
      */
     public void setRecognitions(final List<RecognitionJob> recognitions) {
-      this.recognitions_serialized_name = recognitions;
+      this.recognitions = recognitions;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -7377,14 +7778,22 @@ public class IBMSpeechToTextV1Models {
       if (deserializedRecognitions != null) {
         for (Integer i = 0; i < deserializedRecognitions.size(); i++) {
           RecognitionJob currentItem = ret.getRecognitions().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('recognitions_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('recognitions');
           RecognitionJob newItem = (RecognitionJob) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), RecognitionJob.class);
           newRecognitions.add(newItem);
         }
-        ret.recognitions_serialized_name = newRecognitions;
+        ret.recognitions = newRecognitions;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (recognitions != null && recognitions[0] != null) {
+        mapping.putAll(recognitions[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -7413,7 +7822,7 @@ public class IBMSpeechToTextV1Models {
     private String grammarName;
     private Boolean redaction;
     private Boolean audioMetrics;
- 
+
     /**
      * Gets the audio.
      *
@@ -7424,7 +7833,7 @@ public class IBMSpeechToTextV1Models {
     public IBMWatsonFile audio() {
       return audio;
     }
- 
+
     /**
      * Gets the contentType.
      *
@@ -7436,7 +7845,7 @@ public class IBMSpeechToTextV1Models {
     public String contentType() {
       return contentType;
     }
- 
+
     /**
      * Gets the model.
      *
@@ -7448,7 +7857,7 @@ public class IBMSpeechToTextV1Models {
     public String model() {
       return model;
     }
- 
+
     /**
      * Gets the languageCustomizationId.
      *
@@ -7465,7 +7874,7 @@ public class IBMSpeechToTextV1Models {
     public String languageCustomizationId() {
       return languageCustomizationId;
     }
- 
+
     /**
      * Gets the acousticCustomizationId.
      *
@@ -7480,7 +7889,7 @@ public class IBMSpeechToTextV1Models {
     public String acousticCustomizationId() {
       return acousticCustomizationId;
     }
- 
+
     /**
      * Gets the baseModelVersion.
      *
@@ -7495,7 +7904,7 @@ public class IBMSpeechToTextV1Models {
     public String baseModelVersion() {
       return baseModelVersion;
     }
- 
+
     /**
      * Gets the customizationWeight.
      *
@@ -7518,7 +7927,7 @@ public class IBMSpeechToTextV1Models {
     public Double customizationWeight() {
       return customizationWeight;
     }
- 
+
     /**
      * Gets the inactivityTimeout.
      *
@@ -7532,7 +7941,7 @@ public class IBMSpeechToTextV1Models {
     public Long inactivityTimeout() {
       return inactivityTimeout;
     }
- 
+
     /**
      * Gets the keywords.
      *
@@ -7547,7 +7956,7 @@ public class IBMSpeechToTextV1Models {
     public List<String> keywords() {
       return keywords;
     }
- 
+
     /**
      * Gets the keywordsThreshold.
      *
@@ -7562,7 +7971,7 @@ public class IBMSpeechToTextV1Models {
     public Double keywordsThreshold() {
       return keywordsThreshold;
     }
- 
+
     /**
      * Gets the maxAlternatives.
      *
@@ -7575,7 +7984,7 @@ public class IBMSpeechToTextV1Models {
     public Long maxAlternatives() {
       return maxAlternatives;
     }
- 
+
     /**
      * Gets the wordAlternativesThreshold.
      *
@@ -7590,7 +7999,7 @@ public class IBMSpeechToTextV1Models {
     public Double wordAlternativesThreshold() {
       return wordAlternativesThreshold;
     }
- 
+
     /**
      * Gets the wordConfidence.
      *
@@ -7603,7 +8012,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean wordConfidence() {
       return wordConfidence;
     }
- 
+
     /**
      * Gets the timestamps.
      *
@@ -7615,7 +8024,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean timestamps() {
       return timestamps;
     }
- 
+
     /**
      * Gets the profanityFilter.
      *
@@ -7629,7 +8038,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean profanityFilter() {
       return profanityFilter;
     }
- 
+
     /**
      * Gets the smartFormatting.
      *
@@ -7648,7 +8057,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean smartFormatting() {
       return smartFormatting;
     }
- 
+
     /**
      * Gets the speakerLabels.
      *
@@ -7668,7 +8077,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean speakerLabels() {
       return speakerLabels;
     }
- 
+
     /**
      * Gets the customizationId.
      *
@@ -7680,7 +8089,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the grammarName.
      *
@@ -7695,7 +8104,7 @@ public class IBMSpeechToTextV1Models {
     public String grammarName() {
       return grammarName;
     }
- 
+
     /**
      * Gets the redaction.
      *
@@ -7718,7 +8127,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean redaction() {
       return redaction;
     }
- 
+
     /**
      * Gets the audioMetrics.
      *
@@ -7766,6 +8175,26 @@ public class IBMSpeechToTextV1Models {
       return new RecognizeOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('contentType', 'Content-Type');
+      mapping.put('languageCustomizationId', 'language_customization_id');
+      mapping.put('acousticCustomizationId', 'acoustic_customization_id');
+      mapping.put('baseModelVersion', 'base_model_version');
+      mapping.put('customizationWeight', 'customization_weight');
+      mapping.put('inactivityTimeout', 'inactivity_timeout');
+      mapping.put('keywordsThreshold', 'keywords_threshold');
+      mapping.put('maxAlternatives', 'max_alternatives');
+      mapping.put('wordAlternativesThreshold', 'word_alternatives_threshold');
+      mapping.put('wordConfidence', 'word_confidence');
+      mapping.put('profanityFilter', 'profanity_filter');
+      mapping.put('smartFormatting', 'smart_formatting');
+      mapping.put('speakerLabels', 'speaker_labels');
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('grammarName', 'grammar_name');
+      mapping.put('audioMetrics', 'audio_metrics');
+      return mapping;
+    }
   }
 
   /**
@@ -8109,7 +8538,7 @@ public class IBMSpeechToTextV1Models {
   public class RegisterCallbackOptions extends IBMWatsonOptionsModel {
     private String callbackUrl;
     private String userSecret;
- 
+
     /**
      * Gets the callbackUrl.
      *
@@ -8122,7 +8551,7 @@ public class IBMSpeechToTextV1Models {
     public String callbackUrl() {
       return callbackUrl;
     }
- 
+
     /**
      * Gets the userSecret.
      *
@@ -8153,6 +8582,12 @@ public class IBMSpeechToTextV1Models {
       return new RegisterCallbackOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('callbackUrl', 'callback_url');
+      mapping.put('userSecret', 'user_secret');
+      return mapping;
+    }
   }
 
   /**
@@ -8231,8 +8666,8 @@ public class IBMSpeechToTextV1Models {
    * Information about a request to register a callback for asynchronous speech recognition.
    */
   public class RegisterStatus extends IBMWatsonResponseModel {
-    private String status_serialized_name;
-    private String url_serialized_name;
+    private String status;
+    private String url;
  
     /**
      * Gets the status.
@@ -8245,7 +8680,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -8257,7 +8692,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
 
     /**
@@ -8266,7 +8701,7 @@ public class IBMSpeechToTextV1Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -8275,9 +8710,8 @@ public class IBMSpeechToTextV1Models {
      * @param url the new url
      */
     public void setUrl(final String url) {
-      this.url_serialized_name = url;
+      this.url = url;
     }
-
   }
 
   /**
@@ -8285,7 +8719,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class ResetAcousticModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -8313,6 +8747,11 @@ public class IBMSpeechToTextV1Models {
       return new ResetAcousticModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -8379,7 +8818,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class ResetLanguageModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -8407,6 +8846,11 @@ public class IBMSpeechToTextV1Models {
       return new ResetLanguageModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -8472,11 +8916,11 @@ public class IBMSpeechToTextV1Models {
    * Information about the speakers from speech recognition results.
    */
   public class SpeakerLabelsResult extends IBMWatsonGenericModel {
-    private Double from_serialized_name;
-    private Double to_serialized_name;
-    private Long speaker_serialized_name;
-    private Double confidence_serialized_name;
-    private Boolean final_serialized_name;
+    private Double xfrom;
+    private Double to;
+    private Long speaker;
+    private Double confidence;
+    private Boolean finalResults;
  
     /**
      * Gets the xfrom.
@@ -8488,7 +8932,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getXfrom() {
-      return from_serialized_name;
+      return xfrom;
     }
  
     /**
@@ -8500,7 +8944,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getTo() {
-      return to_serialized_name;
+      return to;
     }
  
     /**
@@ -8514,7 +8958,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getSpeaker() {
-      return speaker_serialized_name;
+      return speaker;
     }
  
     /**
@@ -8526,7 +8970,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
  
     /**
@@ -8540,7 +8984,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Boolean getFinalResults() {
-      return final_serialized_name;
+      return finalResults;
     }
 
     /**
@@ -8549,7 +8993,7 @@ public class IBMSpeechToTextV1Models {
      * @param xfrom the new xfrom
      */
     public void setXfrom(final Double xfrom) {
-      this.from_serialized_name = xfrom;
+      this.xfrom = xfrom;
     }
 
     /**
@@ -8558,7 +9002,7 @@ public class IBMSpeechToTextV1Models {
      * @param to the new to
      */
     public void setTo(final Double to) {
-      this.to_serialized_name = to;
+      this.to = to;
     }
 
     /**
@@ -8567,7 +9011,7 @@ public class IBMSpeechToTextV1Models {
      * @param speaker the new speaker
      */
     public void setSpeaker(final long speaker) {
-      this.speaker_serialized_name = speaker;
+      this.speaker = speaker;
     }
 
     /**
@@ -8576,7 +9020,7 @@ public class IBMSpeechToTextV1Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
 
     /**
@@ -8585,21 +9029,27 @@ public class IBMSpeechToTextV1Models {
      * @param finalResults the new finalResults
      */
     public void setFinalResults(final Boolean finalResults) {
-      this.final_serialized_name = finalResults;
+      this.finalResults = finalResults;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('from', 'xfrom');
+      mapping.put('final', 'finalResults');
+      return mapping;
+    }
   }
 
   /**
    * Information about an available language model.
    */
   public class SpeechModel extends IBMWatsonResponseModel {
-    private String name_serialized_name;
-    private String language_serialized_name;
-    private Long rate_serialized_name;
-    private String url_serialized_name;
-    private SupportedFeatures supported_features_serialized_name;
-    private String description_serialized_name;
+    private String name;
+    private String language;
+    private Long rate;
+    private String url;
+    private SupportedFeatures supportedFeatures;
+    private String description;
  
     /**
      * Gets the name.
@@ -8610,7 +9060,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -8622,7 +9072,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -8634,7 +9084,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getRate() {
-      return rate_serialized_name;
+      return rate;
     }
  
     /**
@@ -8646,7 +9096,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
  
     /**
@@ -8658,7 +9108,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public SupportedFeatures getSupportedFeatures() {
-      return supported_features_serialized_name;
+      return supportedFeatures;
     }
  
     /**
@@ -8670,7 +9120,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
 
     /**
@@ -8679,7 +9129,7 @@ public class IBMSpeechToTextV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -8688,7 +9138,7 @@ public class IBMSpeechToTextV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -8697,7 +9147,7 @@ public class IBMSpeechToTextV1Models {
      * @param rate the new rate
      */
     public void setRate(final long rate) {
-      this.rate_serialized_name = rate;
+      this.rate = rate;
     }
 
     /**
@@ -8706,7 +9156,7 @@ public class IBMSpeechToTextV1Models {
      * @param url the new url
      */
     public void setUrl(final String url) {
-      this.url_serialized_name = url;
+      this.url = url;
     }
 
     /**
@@ -8715,7 +9165,7 @@ public class IBMSpeechToTextV1Models {
      * @param supportedFeatures the new supportedFeatures
      */
     public void setSupportedFeatures(final SupportedFeatures supportedFeatures) {
-      this.supported_features_serialized_name = supportedFeatures;
+      this.supportedFeatures = supportedFeatures;
     }
 
     /**
@@ -8724,7 +9174,7 @@ public class IBMSpeechToTextV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8735,10 +9185,19 @@ public class IBMSpeechToTextV1Models {
       SpeechModel ret = (SpeechModel) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for supportedFeatures
-      SupportedFeatures newSupportedFeatures = (SupportedFeatures) new SupportedFeatures().deserialize(JSON.serialize(ret.getSupportedFeatures()), (Map<String, Object>) jsonMap.get('supported_features_serialized_name'), SupportedFeatures.class);
+      SupportedFeatures newSupportedFeatures = (SupportedFeatures) new SupportedFeatures().deserialize(JSON.serialize(ret.getSupportedFeatures()), (Map<String, Object>) jsonMap.get('supportedFeatures'), SupportedFeatures.class);
       ret.setSupportedFeatures(newSupportedFeatures);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('supported_features', 'supportedFeatures');
+      if (supportedFeatures != null) {
+        mapping.putAll(supportedFeatures.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -8746,7 +9205,7 @@ public class IBMSpeechToTextV1Models {
    * Information about the available language models.
    */
   public class SpeechModels extends IBMWatsonResponseModel {
-    private List<SpeechModel> models_serialized_name;
+    private List<SpeechModel> models;
  
     /**
      * Gets the models.
@@ -8757,7 +9216,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<SpeechModel> getModels() {
-      return models_serialized_name;
+      return models;
     }
 
     /**
@@ -8766,7 +9225,7 @@ public class IBMSpeechToTextV1Models {
      * @param models the new models
      */
     public void setModels(final List<SpeechModel> models) {
-      this.models_serialized_name = models;
+      this.models = models;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -8782,14 +9241,22 @@ public class IBMSpeechToTextV1Models {
       if (deserializedModels != null) {
         for (Integer i = 0; i < deserializedModels.size(); i++) {
           SpeechModel currentItem = ret.getModels().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('models_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('models');
           SpeechModel newItem = (SpeechModel) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SpeechModel.class);
           newModels.add(newItem);
         }
-        ret.models_serialized_name = newModels;
+        ret.models = newModels;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (models != null && models[0] != null) {
+        mapping.putAll(models[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -8797,10 +9264,10 @@ public class IBMSpeechToTextV1Models {
    * An alternative transcript from speech recognition results.
    */
   public class SpeechRecognitionAlternative extends IBMWatsonGenericModel {
-    private String transcript_serialized_name;
-    private Double confidence_serialized_name;
-    private List<List<String>> timestamps_serialized_name;
-    private List<List<String>> word_confidence_serialized_name;
+    private String transcript;
+    private Double confidence;
+    private List<String> timestamps;
+    private List<String> wordConfidence;
  
     /**
      * Gets the transcript.
@@ -8811,7 +9278,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getTranscript() {
-      return transcript_serialized_name;
+      return transcript;
     }
  
     /**
@@ -8824,7 +9291,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
  
     /**
@@ -8837,8 +9304,8 @@ public class IBMSpeechToTextV1Models {
      * @return the timestamps
      */
     @AuraEnabled
-    public List<List<String>> getTimestamps() {
-      return timestamps_serialized_name;
+    public List<String> getTimestamps() {
+      return timestamps;
     }
  
     /**
@@ -8851,8 +9318,8 @@ public class IBMSpeechToTextV1Models {
      * @return the wordConfidence
      */
     @AuraEnabled
-    public List<List<String>> getWordConfidence() {
-      return word_confidence_serialized_name;
+    public List<String> getWordConfidence() {
+      return wordConfidence;
     }
 
     /**
@@ -8861,7 +9328,7 @@ public class IBMSpeechToTextV1Models {
      * @param transcript the new transcript
      */
     public void setTranscript(final String transcript) {
-      this.transcript_serialized_name = transcript;
+      this.transcript = transcript;
     }
 
     /**
@@ -8870,7 +9337,7 @@ public class IBMSpeechToTextV1Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
 
     /**
@@ -8878,8 +9345,8 @@ public class IBMSpeechToTextV1Models {
      *
      * @param timestamps the new timestamps
      */
-    public void setTimestamps(final List<List<String>> timestamps) {
-      this.timestamps_serialized_name = timestamps;
+    public void setTimestamps(final List<String> timestamps) {
+      this.timestamps = timestamps;
     }
 
     /**
@@ -8887,20 +9354,25 @@ public class IBMSpeechToTextV1Models {
      *
      * @param wordConfidence the new wordConfidence
      */
-    public void setWordConfidence(final List<List<String>> wordConfidence) {
-      this.word_confidence_serialized_name = wordConfidence;
+    public void setWordConfidence(final List<String> wordConfidence) {
+      this.wordConfidence = wordConfidence;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('word_confidence', 'wordConfidence');
+      return mapping;
+    }
   }
 
   /**
    * Component results for a speech recognition request.
    */
   public class SpeechRecognitionResult extends IBMWatsonGenericModel {
-    private Boolean final_serialized_name;
-    private List<SpeechRecognitionAlternative> alternatives_serialized_name;
-    private Map<String, List<KeywordResult>> keywords_result_serialized_name;
-    private List<WordAlternativeResults> word_alternatives_serialized_name;
+    private Boolean finalResults;
+    private List<SpeechRecognitionAlternative> alternatives;
+    private IBMWatsonMapModel keywordsResult;
+    private List<WordAlternativeResults> wordAlternatives;
  
     /**
      * Gets the finalResults.
@@ -8912,7 +9384,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Boolean getFinalResults() {
-      return final_serialized_name;
+      return finalResults;
     }
  
     /**
@@ -8925,7 +9397,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<SpeechRecognitionAlternative> getAlternatives() {
-      return alternatives_serialized_name;
+      return alternatives;
     }
  
     /**
@@ -8939,8 +9411,8 @@ public class IBMSpeechToTextV1Models {
      * @return the keywordsResult
      */
     @AuraEnabled
-    public Map<String, List<KeywordResult>> getKeywordsResult() {
-      return keywords_result_serialized_name;
+    public IBMWatsonMapModel getKeywordsResult() {
+      return keywordsResult;
     }
  
     /**
@@ -8953,7 +9425,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<WordAlternativeResults> getWordAlternatives() {
-      return word_alternatives_serialized_name;
+      return wordAlternatives;
     }
 
     /**
@@ -8962,7 +9434,7 @@ public class IBMSpeechToTextV1Models {
      * @param finalResults the new finalResults
      */
     public void setFinalResults(final Boolean finalResults) {
-      this.final_serialized_name = finalResults;
+      this.finalResults = finalResults;
     }
 
     /**
@@ -8971,7 +9443,7 @@ public class IBMSpeechToTextV1Models {
      * @param alternatives the new alternatives
      */
     public void setAlternatives(final List<SpeechRecognitionAlternative> alternatives) {
-      this.alternatives_serialized_name = alternatives;
+      this.alternatives = alternatives;
     }
 
     /**
@@ -8979,8 +9451,8 @@ public class IBMSpeechToTextV1Models {
      *
      * @param keywordsResult the new keywordsResult
      */
-    public void setKeywordsResult(final Map<String, List<KeywordResult>> keywordsResult) {
-      this.keywords_result_serialized_name = keywordsResult;
+    public void setKeywordsResult(final IBMWatsonMapModel keywordsResult) {
+      this.keywordsResult = keywordsResult;
     }
 
     /**
@@ -8989,7 +9461,7 @@ public class IBMSpeechToTextV1Models {
      * @param wordAlternatives the new wordAlternatives
      */
     public void setWordAlternatives(final List<WordAlternativeResults> wordAlternatives) {
-      this.word_alternatives_serialized_name = wordAlternatives;
+      this.wordAlternatives = wordAlternatives;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -9005,31 +9477,16 @@ public class IBMSpeechToTextV1Models {
       if (deserializedAlternatives != null) {
         for (Integer i = 0; i < deserializedAlternatives.size(); i++) {
           SpeechRecognitionAlternative currentItem = ret.getAlternatives().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('alternatives_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('alternatives');
           SpeechRecognitionAlternative newItem = (SpeechRecognitionAlternative) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SpeechRecognitionAlternative.class);
           newAlternatives.add(newItem);
         }
-        ret.alternatives_serialized_name = newAlternatives;
+        ret.alternatives = newAlternatives;
       }
 
       // calling custom deserializer for keywordsResult
-      Map<String, List<KeywordResult>> newKeywordsResult = new Map<String, List<KeywordResult>>();
-      Map<String, List<KeywordResult>> deserializedKeywordsResult = ret.getKeywordsResult();
-      if (deserializedKeywordsResult != null) {
-        for (String key : deserializedKeywordsResult.keySet()) {
-          List<KeywordResult> newKeywordResult = new List<KeywordResult>();
-          List<KeywordResult> keywordResultList = deserializedKeywordsResult.get(key);
-          for (Integer i = 0; i < keywordResultList.size(); i++) {
-            KeywordResult currentItem = keywordResultList.get(i);
-            Map<String, Object> itemInMap = (Map<String, Object>) jsonMap.get('keywords_result_serialized_name');
-            Object innerObject = ((List<Object>) itemInMap.get(key)).get(i);
-            KeywordResult newItem = (KeywordResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(innerObject)), KeywordResult.class);
-            newKeywordResult.add(newItem);
-          }
-          newKeywordsResult.put(key, newKeywordResult);
-        }
-        ret.setKeywordsResult(newKeywordsResult);
-      }
+      IBMWatsonMapModel newKeywordsResult = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getKeywordsResult()), (Map<String, Object>) jsonMap.get('keywordsResult'), IBMWatsonMapModel.class);
+      ret.setKeywordsResult(newKeywordsResult);
 
       // calling custom deserializer for wordAlternatives
       List<WordAlternativeResults> newWordAlternatives = new List<WordAlternativeResults>();
@@ -9037,14 +9494,28 @@ public class IBMSpeechToTextV1Models {
       if (deserializedWordAlternatives != null) {
         for (Integer i = 0; i < deserializedWordAlternatives.size(); i++) {
           WordAlternativeResults currentItem = ret.getWordAlternatives().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('word_alternatives_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('wordAlternatives');
           WordAlternativeResults newItem = (WordAlternativeResults) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), WordAlternativeResults.class);
           newWordAlternatives.add(newItem);
         }
-        ret.word_alternatives_serialized_name = newWordAlternatives;
+        ret.wordAlternatives = newWordAlternatives;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('final', 'finalResults');
+      if (alternatives != null && alternatives[0] != null) {
+        mapping.putAll(alternatives[0].getApiToSdkMapping());
+      }
+      mapping.put('keywords_result', 'keywordsResult');
+      mapping.put('word_alternatives', 'wordAlternatives');
+      if (wordAlternatives != null && wordAlternatives[0] != null) {
+        mapping.putAll(wordAlternatives[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -9052,12 +9523,12 @@ public class IBMSpeechToTextV1Models {
    * The complete results for a speech recognition request.
    */
   public class SpeechRecognitionResults extends IBMWatsonResponseModel {
-    private List<SpeechRecognitionResult> results_serialized_name;
-    private Long result_index_serialized_name;
-    private List<SpeakerLabelsResult> speaker_labels_serialized_name;
-    private ProcessingMetrics processing_metrics_serialized_name;
-    private AudioMetrics audio_metrics_serialized_name;
-    private List<String> warnings_serialized_name;
+    private List<SpeechRecognitionResult> results;
+    private Long resultIndex;
+    private List<SpeakerLabelsResult> speakerLabels;
+    private ProcessingMetrics processingMetrics;
+    private AudioMetrics audioMetrics;
+    private List<String> warnings;
  
     /**
      * Gets the results.
@@ -9072,7 +9543,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<SpeechRecognitionResult> getResults() {
-      return results_serialized_name;
+      return results;
     }
  
     /**
@@ -9085,7 +9556,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getResultIndex() {
-      return result_index_serialized_name;
+      return resultIndex;
     }
  
     /**
@@ -9100,7 +9571,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<SpeakerLabelsResult> getSpeakerLabels() {
-      return speaker_labels_serialized_name;
+      return speakerLabels;
     }
  
     /**
@@ -9113,7 +9584,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public ProcessingMetrics getProcessingMetrics() {
-      return processing_metrics_serialized_name;
+      return processingMetrics;
     }
  
     /**
@@ -9125,7 +9596,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public AudioMetrics getAudioMetrics() {
-      return audio_metrics_serialized_name;
+      return audioMetrics;
     }
  
     /**
@@ -9147,7 +9618,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<String> getWarnings() {
-      return warnings_serialized_name;
+      return warnings;
     }
 
     /**
@@ -9156,7 +9627,7 @@ public class IBMSpeechToTextV1Models {
      * @param results the new results
      */
     public void setResults(final List<SpeechRecognitionResult> results) {
-      this.results_serialized_name = results;
+      this.results = results;
     }
 
     /**
@@ -9165,7 +9636,7 @@ public class IBMSpeechToTextV1Models {
      * @param resultIndex the new resultIndex
      */
     public void setResultIndex(final long resultIndex) {
-      this.result_index_serialized_name = resultIndex;
+      this.resultIndex = resultIndex;
     }
 
     /**
@@ -9174,7 +9645,7 @@ public class IBMSpeechToTextV1Models {
      * @param speakerLabels the new speakerLabels
      */
     public void setSpeakerLabels(final List<SpeakerLabelsResult> speakerLabels) {
-      this.speaker_labels_serialized_name = speakerLabels;
+      this.speakerLabels = speakerLabels;
     }
 
     /**
@@ -9183,7 +9654,7 @@ public class IBMSpeechToTextV1Models {
      * @param processingMetrics the new processingMetrics
      */
     public void setProcessingMetrics(final ProcessingMetrics processingMetrics) {
-      this.processing_metrics_serialized_name = processingMetrics;
+      this.processingMetrics = processingMetrics;
     }
 
     /**
@@ -9192,7 +9663,7 @@ public class IBMSpeechToTextV1Models {
      * @param audioMetrics the new audioMetrics
      */
     public void setAudioMetrics(final AudioMetrics audioMetrics) {
-      this.audio_metrics_serialized_name = audioMetrics;
+      this.audioMetrics = audioMetrics;
     }
 
     /**
@@ -9201,7 +9672,7 @@ public class IBMSpeechToTextV1Models {
      * @param warnings the new warnings
      */
     public void setWarnings(final List<String> warnings) {
-      this.warnings_serialized_name = warnings;
+      this.warnings = warnings;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -9217,11 +9688,11 @@ public class IBMSpeechToTextV1Models {
       if (deserializedResults != null) {
         for (Integer i = 0; i < deserializedResults.size(); i++) {
           SpeechRecognitionResult currentItem = ret.getResults().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('results_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('results');
           SpeechRecognitionResult newItem = (SpeechRecognitionResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SpeechRecognitionResult.class);
           newResults.add(newItem);
         }
-        ret.results_serialized_name = newResults;
+        ret.results = newResults;
       }
 
       // calling custom deserializer for speakerLabels
@@ -9230,22 +9701,43 @@ public class IBMSpeechToTextV1Models {
       if (deserializedSpeakerLabels != null) {
         for (Integer i = 0; i < deserializedSpeakerLabels.size(); i++) {
           SpeakerLabelsResult currentItem = ret.getSpeakerLabels().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('speaker_labels_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('speakerLabels');
           SpeakerLabelsResult newItem = (SpeakerLabelsResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SpeakerLabelsResult.class);
           newSpeakerLabels.add(newItem);
         }
-        ret.speaker_labels_serialized_name = newSpeakerLabels;
+        ret.speakerLabels = newSpeakerLabels;
       }
 
       // calling custom deserializer for processingMetrics
-      ProcessingMetrics newProcessingMetrics = (ProcessingMetrics) new ProcessingMetrics().deserialize(JSON.serialize(ret.getProcessingMetrics()), (Map<String, Object>) jsonMap.get('processing_metrics_serialized_name'), ProcessingMetrics.class);
+      ProcessingMetrics newProcessingMetrics = (ProcessingMetrics) new ProcessingMetrics().deserialize(JSON.serialize(ret.getProcessingMetrics()), (Map<String, Object>) jsonMap.get('processingMetrics'), ProcessingMetrics.class);
       ret.setProcessingMetrics(newProcessingMetrics);
 
       // calling custom deserializer for audioMetrics
-      AudioMetrics newAudioMetrics = (AudioMetrics) new AudioMetrics().deserialize(JSON.serialize(ret.getAudioMetrics()), (Map<String, Object>) jsonMap.get('audio_metrics_serialized_name'), AudioMetrics.class);
+      AudioMetrics newAudioMetrics = (AudioMetrics) new AudioMetrics().deserialize(JSON.serialize(ret.getAudioMetrics()), (Map<String, Object>) jsonMap.get('audioMetrics'), AudioMetrics.class);
       ret.setAudioMetrics(newAudioMetrics);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (results != null && results[0] != null) {
+        mapping.putAll(results[0].getApiToSdkMapping());
+      }
+      mapping.put('result_index', 'resultIndex');
+      mapping.put('speaker_labels', 'speakerLabels');
+      if (speakerLabels != null && speakerLabels[0] != null) {
+        mapping.putAll(speakerLabels[0].getApiToSdkMapping());
+      }
+      mapping.put('processing_metrics', 'processingMetrics');
+      if (processingMetrics != null) {
+        mapping.putAll(processingMetrics.getApiToSdkMapping());
+      }
+      mapping.put('audio_metrics', 'audioMetrics');
+      if (audioMetrics != null) {
+        mapping.putAll(audioMetrics.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -9253,8 +9745,8 @@ public class IBMSpeechToTextV1Models {
    * Additional service features that are supported with the model.
    */
   public class SupportedFeatures extends IBMWatsonGenericModel {
-    private Boolean custom_language_model_serialized_name;
-    private Boolean speaker_labels_serialized_name;
+    private Boolean customLanguageModel;
+    private Boolean speakerLabels;
  
     /**
      * Gets the customLanguageModel.
@@ -9266,7 +9758,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Boolean getCustomLanguageModel() {
-      return custom_language_model_serialized_name;
+      return customLanguageModel;
     }
  
     /**
@@ -9278,7 +9770,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Boolean getSpeakerLabels() {
-      return speaker_labels_serialized_name;
+      return speakerLabels;
     }
 
     /**
@@ -9287,7 +9779,7 @@ public class IBMSpeechToTextV1Models {
      * @param customLanguageModel the new customLanguageModel
      */
     public void setCustomLanguageModel(final Boolean customLanguageModel) {
-      this.custom_language_model_serialized_name = customLanguageModel;
+      this.customLanguageModel = customLanguageModel;
     }
 
     /**
@@ -9296,9 +9788,15 @@ public class IBMSpeechToTextV1Models {
      * @param speakerLabels the new speakerLabels
      */
     public void setSpeakerLabels(final Boolean speakerLabels) {
-      this.speaker_labels_serialized_name = speakerLabels;
+      this.speakerLabels = speakerLabels;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('custom_language_model', 'customLanguageModel');
+      mapping.put('speaker_labels', 'speakerLabels');
+      return mapping;
+    }
   }
 
   /**
@@ -9307,7 +9805,7 @@ public class IBMSpeechToTextV1Models {
   public class TrainAcousticModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String customLanguageModelId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -9319,7 +9817,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the customLanguageModelId.
      *
@@ -9351,6 +9849,12 @@ public class IBMSpeechToTextV1Models {
       return new TrainAcousticModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('customLanguageModelId', 'custom_language_model_id');
+      return mapping;
+    }
   }
 
   /**
@@ -9432,7 +9936,7 @@ public class IBMSpeechToTextV1Models {
     private String customizationId;
     private String wordTypeToAdd;
     private Double customizationWeight;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -9444,7 +9948,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the wordTypeToAdd.
      *
@@ -9459,7 +9963,7 @@ public class IBMSpeechToTextV1Models {
     public String wordTypeToAdd() {
       return wordTypeToAdd;
     }
- 
+
     /**
      * Gets the customizationWeight.
      *
@@ -9497,6 +10001,13 @@ public class IBMSpeechToTextV1Models {
       return new TrainLanguageModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('wordTypeToAdd', 'word_type_to_add');
+      mapping.put('customizationWeight', 'customization_weight');
+      return mapping;
+    }
   }
 
   /**
@@ -9588,7 +10099,7 @@ public class IBMSpeechToTextV1Models {
    * The response from training of a custom language or custom acoustic model.
    */
   public class TrainingResponse extends IBMWatsonResponseModel {
-    private List<TrainingWarning> warnings_serialized_name;
+    private List<TrainingWarning> warnings;
  
     /**
      * Gets the warnings.
@@ -9601,7 +10112,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<TrainingWarning> getWarnings() {
-      return warnings_serialized_name;
+      return warnings;
     }
 
     /**
@@ -9610,7 +10121,7 @@ public class IBMSpeechToTextV1Models {
      * @param warnings the new warnings
      */
     public void setWarnings(final List<TrainingWarning> warnings) {
-      this.warnings_serialized_name = warnings;
+      this.warnings = warnings;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -9626,11 +10137,11 @@ public class IBMSpeechToTextV1Models {
       if (deserializedWarnings != null) {
         for (Integer i = 0; i < deserializedWarnings.size(); i++) {
           TrainingWarning currentItem = ret.getWarnings().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('warnings_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('warnings');
           TrainingWarning newItem = (TrainingWarning) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), TrainingWarning.class);
           newWarnings.add(newItem);
         }
-        ret.warnings_serialized_name = newWarnings;
+        ret.warnings = newWarnings;
       }
 
       return ret;
@@ -9641,8 +10152,8 @@ public class IBMSpeechToTextV1Models {
    * A warning from training of a custom language or custom acoustic model.
    */
   public class TrainingWarning extends IBMWatsonGenericModel {
-    private String code_serialized_name;
-    private String message_serialized_name;
+    private String code;
+    private String message;
  
     /**
      * Gets the code.
@@ -9653,7 +10164,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getCode() {
-      return code_serialized_name;
+      return code;
     }
  
     /**
@@ -9667,7 +10178,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getMessage() {
-      return message_serialized_name;
+      return message;
     }
 
     /**
@@ -9676,7 +10187,7 @@ public class IBMSpeechToTextV1Models {
      * @param code the new code
      */
     public void setCode(final String code) {
-      this.code_serialized_name = code;
+      this.code = code;
     }
 
     /**
@@ -9685,9 +10196,8 @@ public class IBMSpeechToTextV1Models {
      * @param message the new message
      */
     public void setMessage(final String message) {
-      this.message_serialized_name = message;
+      this.message = message;
     }
-
   }
 
   /**
@@ -9695,7 +10205,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class UnregisterCallbackOptions extends IBMWatsonOptionsModel {
     private String callbackUrl;
- 
+
     /**
      * Gets the callbackUrl.
      *
@@ -9722,6 +10232,11 @@ public class IBMSpeechToTextV1Models {
       return new UnregisterCallbackOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('callbackUrl', 'callback_url');
+      return mapping;
+    }
   }
 
   /**
@@ -9790,7 +10305,7 @@ public class IBMSpeechToTextV1Models {
     private String customizationId;
     private String customLanguageModelId;
     private Boolean force;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -9802,7 +10317,7 @@ public class IBMSpeechToTextV1Models {
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the customLanguageModelId.
      *
@@ -9815,7 +10330,7 @@ public class IBMSpeechToTextV1Models {
     public String customLanguageModelId() {
       return customLanguageModelId;
     }
- 
+
     /**
      * Gets the force.
      *
@@ -9848,6 +10363,12 @@ public class IBMSpeechToTextV1Models {
       return new UpgradeAcousticModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('customLanguageModelId', 'custom_language_model_id');
+      return mapping;
+    }
   }
 
   /**
@@ -9940,7 +10461,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class UpgradeLanguageModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -9968,6 +10489,11 @@ public class IBMSpeechToTextV1Models {
       return new UpgradeLanguageModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -10033,12 +10559,12 @@ public class IBMSpeechToTextV1Models {
    * Information about a word from a custom language model.
    */
   public class Word extends IBMWatsonResponseModel {
-    private String word_serialized_name;
-    private List<String> sounds_like_serialized_name;
-    private String display_as_serialized_name;
-    private Long count_serialized_name;
-    private List<String> source_serialized_name;
-    private List<WordError> error_serialized_name;
+    private String word;
+    private List<String> soundsLike;
+    private String displayAs;
+    private Long count;
+    private List<String> source;
+    private List<WordError> error;
  
     /**
      * Gets the word.
@@ -10049,7 +10575,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getWord() {
-      return word_serialized_name;
+      return word;
     }
  
     /**
@@ -10063,7 +10589,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<String> getSoundsLike() {
-      return sounds_like_serialized_name;
+      return soundsLike;
     }
  
     /**
@@ -10076,7 +10602,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getDisplayAs() {
-      return display_as_serialized_name;
+      return displayAs;
     }
  
     /**
@@ -10091,7 +10617,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Long getCount() {
-      return count_serialized_name;
+      return count;
     }
  
     /**
@@ -10105,7 +10631,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<String> getSource() {
-      return source_serialized_name;
+      return source;
     }
  
     /**
@@ -10118,7 +10644,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<WordError> getError() {
-      return error_serialized_name;
+      return error;
     }
 
     /**
@@ -10127,7 +10653,7 @@ public class IBMSpeechToTextV1Models {
      * @param word the new word
      */
     public void setWord(final String word) {
-      this.word_serialized_name = word;
+      this.word = word;
     }
 
     /**
@@ -10136,7 +10662,7 @@ public class IBMSpeechToTextV1Models {
      * @param soundsLike the new soundsLike
      */
     public void setSoundsLike(final List<String> soundsLike) {
-      this.sounds_like_serialized_name = soundsLike;
+      this.soundsLike = soundsLike;
     }
 
     /**
@@ -10145,7 +10671,7 @@ public class IBMSpeechToTextV1Models {
      * @param displayAs the new displayAs
      */
     public void setDisplayAs(final String displayAs) {
-      this.display_as_serialized_name = displayAs;
+      this.displayAs = displayAs;
     }
 
     /**
@@ -10154,7 +10680,7 @@ public class IBMSpeechToTextV1Models {
      * @param count the new count
      */
     public void setCount(final long count) {
-      this.count_serialized_name = count;
+      this.count = count;
     }
 
     /**
@@ -10163,7 +10689,7 @@ public class IBMSpeechToTextV1Models {
      * @param source the new source
      */
     public void setSource(final List<String> source) {
-      this.source_serialized_name = source;
+      this.source = source;
     }
 
     /**
@@ -10172,7 +10698,7 @@ public class IBMSpeechToTextV1Models {
      * @param error the new error
      */
     public void setError(final List<WordError> error) {
-      this.error_serialized_name = error;
+      this.error = error;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -10188,14 +10714,21 @@ public class IBMSpeechToTextV1Models {
       if (deserializedError != null) {
         for (Integer i = 0; i < deserializedError.size(); i++) {
           WordError currentItem = ret.getError().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('error_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('error');
           WordError newItem = (WordError) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), WordError.class);
           newError.add(newItem);
         }
-        ret.error_serialized_name = newError;
+        ret.error = newError;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('sounds_like', 'soundsLike');
+      mapping.put('display_as', 'displayAs');
+      return mapping;
     }
   }
 
@@ -10203,8 +10736,8 @@ public class IBMSpeechToTextV1Models {
    * An alternative hypothesis for a word from speech recognition results.
    */
   public class WordAlternativeResult extends IBMWatsonGenericModel {
-    private Double confidence_serialized_name;
-    private String word_serialized_name;
+    private Double confidence;
+    private String word;
  
     /**
      * Gets the confidence.
@@ -10215,7 +10748,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getConfidence() {
-      return confidence_serialized_name;
+      return confidence;
     }
  
     /**
@@ -10227,7 +10760,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getWord() {
-      return word_serialized_name;
+      return word;
     }
 
     /**
@@ -10236,7 +10769,7 @@ public class IBMSpeechToTextV1Models {
      * @param confidence the new confidence
      */
     public void setConfidence(final Double confidence) {
-      this.confidence_serialized_name = confidence;
+      this.confidence = confidence;
     }
 
     /**
@@ -10245,18 +10778,17 @@ public class IBMSpeechToTextV1Models {
      * @param word the new word
      */
     public void setWord(final String word) {
-      this.word_serialized_name = word;
+      this.word = word;
     }
-
   }
 
   /**
    * Information about alternative hypotheses for words from speech recognition results.
    */
   public class WordAlternativeResults extends IBMWatsonGenericModel {
-    private Double start_time_serialized_name;
-    private Double end_time_serialized_name;
-    private List<WordAlternativeResult> alternatives_serialized_name;
+    private Double startTime;
+    private Double endTime;
+    private List<WordAlternativeResult> alternatives;
  
     /**
      * Gets the startTime.
@@ -10267,7 +10799,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getStartTime() {
-      return start_time_serialized_name;
+      return startTime;
     }
  
     /**
@@ -10279,7 +10811,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public Double getEndTime() {
-      return end_time_serialized_name;
+      return endTime;
     }
  
     /**
@@ -10291,7 +10823,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<WordAlternativeResult> getAlternatives() {
-      return alternatives_serialized_name;
+      return alternatives;
     }
 
     /**
@@ -10300,7 +10832,7 @@ public class IBMSpeechToTextV1Models {
      * @param startTime the new startTime
      */
     public void setStartTime(final Double startTime) {
-      this.start_time_serialized_name = startTime;
+      this.startTime = startTime;
     }
 
     /**
@@ -10309,7 +10841,7 @@ public class IBMSpeechToTextV1Models {
      * @param endTime the new endTime
      */
     public void setEndTime(final Double endTime) {
-      this.end_time_serialized_name = endTime;
+      this.endTime = endTime;
     }
 
     /**
@@ -10318,7 +10850,7 @@ public class IBMSpeechToTextV1Models {
      * @param alternatives the new alternatives
      */
     public void setAlternatives(final List<WordAlternativeResult> alternatives) {
-      this.alternatives_serialized_name = alternatives;
+      this.alternatives = alternatives;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -10334,14 +10866,21 @@ public class IBMSpeechToTextV1Models {
       if (deserializedAlternatives != null) {
         for (Integer i = 0; i < deserializedAlternatives.size(); i++) {
           WordAlternativeResult currentItem = ret.getAlternatives().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('alternatives_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('alternatives');
           WordAlternativeResult newItem = (WordAlternativeResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), WordAlternativeResult.class);
           newAlternatives.add(newItem);
         }
-        ret.alternatives_serialized_name = newAlternatives;
+        ret.alternatives = newAlternatives;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('start_time', 'startTime');
+      mapping.put('end_time', 'endTime');
+      return mapping;
     }
   }
 
@@ -10349,7 +10888,7 @@ public class IBMSpeechToTextV1Models {
    * An error associated with a word from a custom language model.
    */
   public class WordError extends IBMWatsonGenericModel {
-    private String element_serialized_name;
+    private String element;
  
     /**
      * Gets the element.
@@ -10364,7 +10903,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public String getElement() {
-      return element_serialized_name;
+      return element;
     }
 
     /**
@@ -10373,16 +10912,15 @@ public class IBMSpeechToTextV1Models {
      * @param element the new element
      */
     public void setElement(final String element) {
-      this.element_serialized_name = element;
+      this.element = element;
     }
-
   }
 
   /**
    * Information about the words from a custom language model.
    */
   public class Words extends IBMWatsonResponseModel {
-    private List<Word> words_serialized_name;
+    private List<Word> words;
  
     /**
      * Gets the words.
@@ -10394,7 +10932,7 @@ public class IBMSpeechToTextV1Models {
      */
     @AuraEnabled
     public List<Word> getWords() {
-      return words_serialized_name;
+      return words;
     }
 
     /**
@@ -10403,7 +10941,7 @@ public class IBMSpeechToTextV1Models {
      * @param words the new words
      */
     public void setWords(final List<Word> words) {
-      this.words_serialized_name = words;
+      this.words = words;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -10419,14 +10957,22 @@ public class IBMSpeechToTextV1Models {
       if (deserializedWords != null) {
         for (Integer i = 0; i < deserializedWords.size(); i++) {
           Word currentItem = ret.getWords().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('words_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('words');
           Word newItem = (Word) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Word.class);
           newWords.add(newItem);
         }
-        ret.words_serialized_name = newWords;
+        ret.words = newWords;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (words != null && words[0] != null) {
+        mapping.putAll(words[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 

--- a/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Models.cls
@@ -15,7 +15,7 @@ public class IBMSpeechToTextV1Models {
     private String status;
     private Long progress;
     private String warnings;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -28,7 +28,7 @@ public class IBMSpeechToTextV1Models {
     public String getCustomizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -41,7 +41,7 @@ public class IBMSpeechToTextV1Models {
     public String getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -55,7 +55,7 @@ public class IBMSpeechToTextV1Models {
     public String getUpdated() {
       return updated;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -67,7 +67,7 @@ public class IBMSpeechToTextV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the versions.
      *
@@ -81,7 +81,7 @@ public class IBMSpeechToTextV1Models {
     public List<String> getVersions() {
       return versions;
     }
- 
+
     /**
      * Gets the owner.
      *
@@ -93,7 +93,7 @@ public class IBMSpeechToTextV1Models {
     public String getOwner() {
       return owner;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -105,7 +105,7 @@ public class IBMSpeechToTextV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -117,7 +117,7 @@ public class IBMSpeechToTextV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the baseModelName.
      *
@@ -129,7 +129,7 @@ public class IBMSpeechToTextV1Models {
     public String getBaseModelName() {
       return baseModelName;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -149,7 +149,7 @@ public class IBMSpeechToTextV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the progress.
      *
@@ -163,7 +163,7 @@ public class IBMSpeechToTextV1Models {
     public Long getProgress() {
       return progress;
     }
- 
+
     /**
      * Gets the warnings.
      *
@@ -285,10 +285,13 @@ public class IBMSpeechToTextV1Models {
       this.warnings = warnings;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('customization_id', 'customizationId');
-      mapping.put('base_model_name', 'baseModelName');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'customization_id', 'customizationId');
+      mapping.put(parentLabel + 'base_model_name', 'baseModelName');
       return mapping;
     }
   }
@@ -298,7 +301,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class AcousticModels extends IBMWatsonResponseModel {
     private List<AcousticModel> customizations;
- 
+
     /**
      * Gets the customizations.
      *
@@ -345,11 +348,8 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (customizations != null && customizations[0] != null) {
-        mapping.putAll(customizations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) AcousticModel.class.newInstance()).addToApiToSdkMapping(parentLabel + 'customizations/', mapping));
       return mapping;
     }
   }
@@ -1357,7 +1357,7 @@ public class IBMSpeechToTextV1Models {
       Map<String, String> mapping = new Map<String, String>();
       mapping.put('customizationId', 'customization_id');
       if (words != null && words[0] != null) {
-        mapping.putAll(words[0].getSdkToApiMapping());
+        mapping.putAll(words[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -1461,7 +1461,7 @@ public class IBMSpeechToTextV1Models {
     private String codec;
     private Long frequency;
     private String compression;
- 
+
     /**
      * Gets the xtype.
      *
@@ -1477,7 +1477,7 @@ public class IBMSpeechToTextV1Models {
     public String getXtype() {
       return xtype;
     }
- 
+
     /**
      * Gets the codec.
      *
@@ -1489,7 +1489,7 @@ public class IBMSpeechToTextV1Models {
     public String getCodec() {
       return codec;
     }
- 
+
     /**
      * Gets the frequency.
      *
@@ -1502,7 +1502,7 @@ public class IBMSpeechToTextV1Models {
     public Long getFrequency() {
       return frequency;
     }
- 
+
     /**
      * Gets the compression.
      *
@@ -1555,9 +1555,12 @@ public class IBMSpeechToTextV1Models {
       this.compression = compression;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('type', 'xtype');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'type', 'xtype');
       return mapping;
     }
   }
@@ -1572,7 +1575,7 @@ public class IBMSpeechToTextV1Models {
     private String status;
     private AudioResource container;
     private List<AudioResource> audio;
- 
+
     /**
      * Gets the duration.
      *
@@ -1585,7 +1588,7 @@ public class IBMSpeechToTextV1Models {
     public Long getDuration() {
       return duration;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -1597,7 +1600,7 @@ public class IBMSpeechToTextV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the details.
      *
@@ -1610,7 +1613,7 @@ public class IBMSpeechToTextV1Models {
     public AudioDetails getDetails() {
       return details;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -1629,7 +1632,7 @@ public class IBMSpeechToTextV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the container.
      *
@@ -1642,7 +1645,7 @@ public class IBMSpeechToTextV1Models {
     public AudioResource getContainer() {
       return container;
     }
- 
+
     /**
      * Gets the audio.
      *
@@ -1741,17 +1744,10 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (details != null) {
-        mapping.putAll(details.getApiToSdkMapping());
-      }
-      if (container != null) {
-        mapping.putAll(container.getApiToSdkMapping());
-      }
-      if (audio != null && audio[0] != null) {
-        mapping.putAll(audio[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) AudioDetails.class.newInstance()).addToApiToSdkMapping(parentLabel + 'details/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) AudioResource.class.newInstance()).addToApiToSdkMapping(parentLabel + 'container/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) AudioResource.class.newInstance()).addToApiToSdkMapping(parentLabel + 'audio/', mapping));
       return mapping;
     }
   }
@@ -1762,7 +1758,7 @@ public class IBMSpeechToTextV1Models {
   public class AudioMetrics extends IBMWatsonGenericModel {
     private Double samplingInterval;
     private AudioMetricsDetails accumulated;
- 
+
     /**
      * Gets the samplingInterval.
      *
@@ -1776,7 +1772,7 @@ public class IBMSpeechToTextV1Models {
     public Double getSamplingInterval() {
       return samplingInterval;
     }
- 
+
     /**
      * Gets the accumulated.
      *
@@ -1821,12 +1817,13 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('sampling_interval', 'samplingInterval');
-      if (accumulated != null) {
-        mapping.putAll(accumulated.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'sampling_interval', 'samplingInterval');
+      mapping.putAll(((IBMWatsonGenericModel) AudioMetricsDetails.class.newInstance()).addToApiToSdkMapping(parentLabel + 'accumulated/', mapping));
       return mapping;
     }
   }
@@ -1844,7 +1841,7 @@ public class IBMSpeechToTextV1Models {
     private List<AudioMetricsHistogramBin> clippingRate;
     private List<AudioMetricsHistogramBin> speechLevel;
     private List<AudioMetricsHistogramBin> nonSpeechLevel;
- 
+
     /**
      * Gets the xfinal.
      *
@@ -1858,7 +1855,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean getXfinal() {
       return xfinal;
     }
- 
+
     /**
      * Gets the endTime.
      *
@@ -1870,7 +1867,7 @@ public class IBMSpeechToTextV1Models {
     public Double getEndTime() {
       return endTime;
     }
- 
+
     /**
      * Gets the signalToNoiseRatio.
      *
@@ -1884,7 +1881,7 @@ public class IBMSpeechToTextV1Models {
     public Double getSignalToNoiseRatio() {
       return signalToNoiseRatio;
     }
- 
+
     /**
      * Gets the speechRatio.
      *
@@ -1896,7 +1893,7 @@ public class IBMSpeechToTextV1Models {
     public Double getSpeechRatio() {
       return speechRatio;
     }
- 
+
     /**
      * Gets the highFrequencyLoss.
      *
@@ -1912,7 +1909,7 @@ public class IBMSpeechToTextV1Models {
     public Double getHighFrequencyLoss() {
       return highFrequencyLoss;
     }
- 
+
     /**
      * Gets the directCurrentOffset.
      *
@@ -1925,7 +1922,7 @@ public class IBMSpeechToTextV1Models {
     public List<AudioMetricsHistogramBin> getDirectCurrentOffset() {
       return directCurrentOffset;
     }
- 
+
     /**
      * Gets the clippingRate.
      *
@@ -1941,7 +1938,7 @@ public class IBMSpeechToTextV1Models {
     public List<AudioMetricsHistogramBin> getClippingRate() {
       return clippingRate;
     }
- 
+
     /**
      * Gets the speechLevel.
      *
@@ -1955,7 +1952,7 @@ public class IBMSpeechToTextV1Models {
     public List<AudioMetricsHistogramBin> getSpeechLevel() {
       return speechLevel;
     }
- 
+
     /**
      * Gets the nonSpeechLevel.
      *
@@ -2113,29 +2110,24 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('final', 'xfinal');
-      mapping.put('end_time', 'endTime');
-      mapping.put('signal_to_noise_ratio', 'signalToNoiseRatio');
-      mapping.put('speech_ratio', 'speechRatio');
-      mapping.put('high_frequency_loss', 'highFrequencyLoss');
-      mapping.put('direct_current_offset', 'directCurrentOffset');
-      if (directCurrentOffset != null && directCurrentOffset[0] != null) {
-        mapping.putAll(directCurrentOffset[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('clipping_rate', 'clippingRate');
-      if (clippingRate != null && clippingRate[0] != null) {
-        mapping.putAll(clippingRate[0].getApiToSdkMapping());
-      }
-      mapping.put('speech_level', 'speechLevel');
-      if (speechLevel != null && speechLevel[0] != null) {
-        mapping.putAll(speechLevel[0].getApiToSdkMapping());
-      }
-      mapping.put('non_speech_level', 'nonSpeechLevel');
-      if (nonSpeechLevel != null && nonSpeechLevel[0] != null) {
-        mapping.putAll(nonSpeechLevel[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'final', 'xfinal');
+      mapping.put(parentLabel + 'end_time', 'endTime');
+      mapping.put(parentLabel + 'signal_to_noise_ratio', 'signalToNoiseRatio');
+      mapping.put(parentLabel + 'speech_ratio', 'speechRatio');
+      mapping.put(parentLabel + 'high_frequency_loss', 'highFrequencyLoss');
+      mapping.put(parentLabel + 'direct_current_offset', 'directCurrentOffset');
+      mapping.putAll(((IBMWatsonGenericModel) AudioMetricsHistogramBin.class.newInstance()).addToApiToSdkMapping(parentLabel + 'direct_current_offset/', mapping));
+      mapping.put(parentLabel + 'clipping_rate', 'clippingRate');
+      mapping.putAll(((IBMWatsonGenericModel) AudioMetricsHistogramBin.class.newInstance()).addToApiToSdkMapping(parentLabel + 'clipping_rate/', mapping));
+      mapping.put(parentLabel + 'speech_level', 'speechLevel');
+      mapping.putAll(((IBMWatsonGenericModel) AudioMetricsHistogramBin.class.newInstance()).addToApiToSdkMapping(parentLabel + 'speech_level/', mapping));
+      mapping.put(parentLabel + 'non_speech_level', 'nonSpeechLevel');
+      mapping.putAll(((IBMWatsonGenericModel) AudioMetricsHistogramBin.class.newInstance()).addToApiToSdkMapping(parentLabel + 'non_speech_level/', mapping));
       return mapping;
     }
   }
@@ -2149,7 +2141,7 @@ public class IBMSpeechToTextV1Models {
     private Double xbegin;
     private Double xend;
     private Long count;
- 
+
     /**
      * Gets the xbegin.
      *
@@ -2161,7 +2153,7 @@ public class IBMSpeechToTextV1Models {
     public Double getXbegin() {
       return xbegin;
     }
- 
+
     /**
      * Gets the xend.
      *
@@ -2173,7 +2165,7 @@ public class IBMSpeechToTextV1Models {
     public Double getXend() {
       return xend;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -2213,10 +2205,13 @@ public class IBMSpeechToTextV1Models {
       this.count = count;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('begin', 'xbegin');
-      mapping.put('end', 'xend');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'begin', 'xbegin');
+      mapping.put(parentLabel + 'end', 'xend');
       return mapping;
     }
   }
@@ -2229,7 +2224,7 @@ public class IBMSpeechToTextV1Models {
     private String name;
     private AudioDetails details;
     private String status;
- 
+
     /**
      * Gets the duration.
      *
@@ -2241,7 +2236,7 @@ public class IBMSpeechToTextV1Models {
     public Long getDuration() {
       return duration;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -2256,7 +2251,7 @@ public class IBMSpeechToTextV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the details.
      *
@@ -2269,7 +2264,7 @@ public class IBMSpeechToTextV1Models {
     public AudioDetails getDetails() {
       return details;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -2338,11 +2333,8 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (details != null) {
-        mapping.putAll(details.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) AudioDetails.class.newInstance()).addToApiToSdkMapping(parentLabel + 'details/', mapping));
       return mapping;
     }
   }
@@ -2353,7 +2345,7 @@ public class IBMSpeechToTextV1Models {
   public class AudioResources extends IBMWatsonResponseModel {
     private Double totalMinutesOfAudio;
     private List<AudioResource> audio;
- 
+
     /**
      * Gets the totalMinutesOfAudio.
      *
@@ -2367,7 +2359,7 @@ public class IBMSpeechToTextV1Models {
     public Double getTotalMinutesOfAudio() {
       return totalMinutesOfAudio;
     }
- 
+
     /**
      * Gets the audio.
      *
@@ -2422,12 +2414,13 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('total_minutes_of_audio', 'totalMinutesOfAudio');
-      if (audio != null && audio[0] != null) {
-        mapping.putAll(audio[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'total_minutes_of_audio', 'totalMinutesOfAudio');
+      mapping.putAll(((IBMWatsonGenericModel) AudioResource.class.newInstance()).addToApiToSdkMapping(parentLabel + 'audio/', mapping));
       return mapping;
     }
   }
@@ -2586,7 +2579,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class Corpora extends IBMWatsonResponseModel {
     private List<Corpus> corpora;
- 
+
     /**
      * Gets the corpora.
      *
@@ -2632,11 +2625,8 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (corpora != null && corpora[0] != null) {
-        mapping.putAll(corpora[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Corpus.class.newInstance()).addToApiToSdkMapping(parentLabel + 'corpora/', mapping));
       return mapping;
     }
   }
@@ -2650,7 +2640,7 @@ public class IBMSpeechToTextV1Models {
     private Long outOfVocabularyWords;
     private String status;
     private String error;
- 
+
     /**
      * Gets the name.
      *
@@ -2662,7 +2652,7 @@ public class IBMSpeechToTextV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the totalWords.
      *
@@ -2674,7 +2664,7 @@ public class IBMSpeechToTextV1Models {
     public Long getTotalWords() {
       return totalWords;
     }
- 
+
     /**
      * Gets the outOfVocabularyWords.
      *
@@ -2686,7 +2676,7 @@ public class IBMSpeechToTextV1Models {
     public Long getOutOfVocabularyWords() {
       return outOfVocabularyWords;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -2704,7 +2694,7 @@ public class IBMSpeechToTextV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the error.
      *
@@ -2763,10 +2753,9 @@ public class IBMSpeechToTextV1Models {
       this.error = error;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('total_words', 'totalWords');
-      mapping.put('out_of_vocabulary_words', 'outOfVocabularyWords');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'total_words', 'totalWords');
+      mapping.put(parentLabel + 'out_of_vocabulary_words', 'outOfVocabularyWords');
       return mapping;
     }
   }
@@ -3273,9 +3262,9 @@ public class IBMSpeechToTextV1Models {
      * multi-person exchange. By default, the service returns no speaker labels. Setting `speaker_labels` to `true`
      * forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.
      *
-     * **Note:** Applies to US English, Japanese, and Spanish transcription only. To determine whether a language model
-     * supports speaker labels, you can also use the **Get a model** method and check that the attribute
-     * `speaker_labels` is set to `true`.
+     * **Note:** Applies to US English, Japanese, and Spanish (both broadband and narrowband models) and UK English
+     * (narrowband model) transcription only. To determine whether a language model supports speaker labels, you can
+     * also use the **Get a model** method and check that the attribute `speaker_labels` is set to `true`.
      *
      * See [Speaker
      * labels](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-output#speaker_labels).
@@ -3903,15 +3892,22 @@ public class IBMSpeechToTextV1Models {
     /**
      * Gets the dialect.
      *
-     * The dialect of the specified language that is to be used with the custom language model. The parameter is
-     * meaningful only for Spanish models, for which the service creates a custom language model that is suited for
-     * speech in one of the following dialects:
-     * * `es-ES` for Castilian Spanish (the default)
-     * * `es-LA` for Latin American Spanish
-     * * `es-US` for North American (Mexican) Spanish
+     * The dialect of the specified language that is to be used with the custom language model. For most languages, the
+     * dialect matches the language of the base model by default. For example, `en-US` is used for either of the US
+     * English language models.
      *
-     * A specified dialect must be valid for the base model. By default, the dialect matches the language of the base
-     * model; for example, `en-US` for either of the US English language models.
+     * For a Spanish language, the service creates a custom language model that is suited for speech in one of the
+     * following dialects:
+     * * `es-ES` for Castilian Spanish (`es-ES` models)
+     * * `es-LA` for Latin American Spanish (`es-AR`, `es-CL`, `es-CO`, and `es-PE` models)
+     * * `es-US` for Mexican (North American) Spanish (`es-MX` models)
+     *
+     * The parameter is meaningful only for Spanish models, for which you can always safely omit the parameter to have
+     * the service create the correct mapping.
+     *
+     * If you specify the `dialect` parameter for non-Spanish language models, its value must match the language of the
+     * base model. If you specify the `dialect` for Spanish language models, its value must match one of the defined
+     * mappings as indicated (`es-ES`, `es-LA`, or `es-MX`). All dialect values are case-insensitive.
      *
      * @return the dialect
      */
@@ -4064,7 +4060,7 @@ public class IBMSpeechToTextV1Models {
     private String word;
     private List<String> soundsLike;
     private String displayAs;
- 
+
     /**
      * Gets the word.
      *
@@ -4079,7 +4075,7 @@ public class IBMSpeechToTextV1Models {
     public String getWord() {
       return word;
     }
- 
+
     /**
      * Gets the soundsLike.
      *
@@ -4099,7 +4095,7 @@ public class IBMSpeechToTextV1Models {
     public List<String> getSoundsLike() {
       return soundsLike;
     }
- 
+
     /**
      * Gets the displayAs.
      *
@@ -4128,10 +4124,9 @@ public class IBMSpeechToTextV1Models {
       return new CustomWordBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('soundsLike', 'sounds_like');
-      mapping.put('displayAs', 'display_as');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'soundsLike', 'sounds_like');
+      mapping.put(parentLabel + 'displayAs', 'display_as');
       return mapping;
     }
   }
@@ -4186,7 +4181,7 @@ public class IBMSpeechToTextV1Models {
      * @param word the word
      * @return the CustomWord builder
      */
-    public CustomWordBuilder setWord(String word) {
+    public CustomWordBuilder word(String word) {
       this.word = word;
       return this;
     }
@@ -4198,7 +4193,7 @@ public class IBMSpeechToTextV1Models {
      * @param soundsLike the soundsLike
      * @return the CustomWord builder
      */
-    public CustomWordBuilder setSoundsLike(List<String> soundsLike) {
+    public CustomWordBuilder soundsLike(List<String> soundsLike) {
       this.soundsLike = soundsLike;
       return this;
     }
@@ -4209,7 +4204,7 @@ public class IBMSpeechToTextV1Models {
      * @param displayAs the displayAs
      * @return the CustomWord builder
      */
-    public CustomWordBuilder setDisplayAs(String displayAs) {
+    public CustomWordBuilder displayAs(String displayAs) {
       this.displayAs = displayAs;
       return this;
     }
@@ -5944,7 +5939,7 @@ public class IBMSpeechToTextV1Models {
     private Long outOfVocabularyWords;
     private String status;
     private String error;
- 
+
     /**
      * Gets the name.
      *
@@ -5956,7 +5951,7 @@ public class IBMSpeechToTextV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the outOfVocabularyWords.
      *
@@ -5968,7 +5963,7 @@ public class IBMSpeechToTextV1Models {
     public Long getOutOfVocabularyWords() {
       return outOfVocabularyWords;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -5986,7 +5981,7 @@ public class IBMSpeechToTextV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the error.
      *
@@ -6037,9 +6032,8 @@ public class IBMSpeechToTextV1Models {
       this.error = error;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('out_of_vocabulary_words', 'outOfVocabularyWords');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'out_of_vocabulary_words', 'outOfVocabularyWords');
       return mapping;
     }
   }
@@ -6049,7 +6043,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class Grammars extends IBMWatsonResponseModel {
     private List<Grammar> grammars;
- 
+
     /**
      * Gets the grammars.
      *
@@ -6095,11 +6089,8 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (grammars != null && grammars[0] != null) {
-        mapping.putAll(grammars[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Grammar.class.newInstance()).addToApiToSdkMapping(parentLabel + 'grammars/', mapping));
       return mapping;
     }
   }
@@ -6112,7 +6103,7 @@ public class IBMSpeechToTextV1Models {
     private Double startTime;
     private Double endTime;
     private Double confidence;
- 
+
     /**
      * Gets the normalizedText.
      *
@@ -6124,7 +6115,7 @@ public class IBMSpeechToTextV1Models {
     public String getNormalizedText() {
       return normalizedText;
     }
- 
+
     /**
      * Gets the startTime.
      *
@@ -6136,7 +6127,7 @@ public class IBMSpeechToTextV1Models {
     public Double getStartTime() {
       return startTime;
     }
- 
+
     /**
      * Gets the endTime.
      *
@@ -6148,7 +6139,7 @@ public class IBMSpeechToTextV1Models {
     public Double getEndTime() {
       return endTime;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -6196,6 +6187,13 @@ public class IBMSpeechToTextV1Models {
     public void setConfidence(final Double confidence) {
       this.confidence = confidence;
     }
+
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'normalized_text', 'normalizedText');
+      mapping.put(parentLabel + 'start_time', 'startTime');
+      mapping.put(parentLabel + 'end_time', 'endTime');
+      return mapping;
+    }
   }
 
   /**
@@ -6216,7 +6214,7 @@ public class IBMSpeechToTextV1Models {
     private Long progress;
     private String error;
     private String warnings;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -6229,7 +6227,7 @@ public class IBMSpeechToTextV1Models {
     public String getCustomizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -6242,7 +6240,7 @@ public class IBMSpeechToTextV1Models {
     public String getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -6256,7 +6254,7 @@ public class IBMSpeechToTextV1Models {
     public String getUpdated() {
       return updated;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -6268,16 +6266,18 @@ public class IBMSpeechToTextV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the dialect.
      *
-     * The dialect of the language for the custom language model. By default, the dialect matches the language of the
-     * base model; for example, `en-US` for either of the US English language models. For Spanish models, the field
-     * indicates the dialect for which the model was created:
-     * * `es-ES` for Castilian Spanish (the default)
-     * * `es-LA` for Latin American Spanish
-     * * `es-US` for North American (Mexican) Spanish.
+     * The dialect of the language for the custom language model. For non-Spanish models, the field matches the language
+     * of the base model; for example, `en-US` for either of the US English language models. For Spanish models, the
+     * field indicates the dialect for which the model was created:
+     * * `es-ES` for Castilian Spanish (`es-ES` models)
+     * * `es-LA` for Latin American Spanish (`es-AR`, `es-CL`, `es-CO`, and `es-PE` models)
+     * * `es-US` for Mexican (North American) Spanish (`es-MX` models)
+     *
+     * Dialect values are case-insensitive.
      *
      * @return the dialect
      */
@@ -6285,7 +6285,7 @@ public class IBMSpeechToTextV1Models {
     public String getDialect() {
       return dialect;
     }
- 
+
     /**
      * Gets the versions.
      *
@@ -6299,7 +6299,7 @@ public class IBMSpeechToTextV1Models {
     public List<String> getVersions() {
       return versions;
     }
- 
+
     /**
      * Gets the owner.
      *
@@ -6311,7 +6311,7 @@ public class IBMSpeechToTextV1Models {
     public String getOwner() {
       return owner;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -6323,7 +6323,7 @@ public class IBMSpeechToTextV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -6335,7 +6335,7 @@ public class IBMSpeechToTextV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the baseModelName.
      *
@@ -6347,7 +6347,7 @@ public class IBMSpeechToTextV1Models {
     public String getBaseModelName() {
       return baseModelName;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -6367,7 +6367,7 @@ public class IBMSpeechToTextV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the progress.
      *
@@ -6381,7 +6381,7 @@ public class IBMSpeechToTextV1Models {
     public Long getProgress() {
       return progress;
     }
- 
+
     /**
      * Gets the error.
      *
@@ -6395,7 +6395,7 @@ public class IBMSpeechToTextV1Models {
     public String getError() {
       return error;
     }
- 
+
     /**
      * Gets the warnings.
      *
@@ -6535,10 +6535,13 @@ public class IBMSpeechToTextV1Models {
       this.warnings = warnings;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('customization_id', 'customizationId');
-      mapping.put('base_model_name', 'baseModelName');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'customization_id', 'customizationId');
+      mapping.put(parentLabel + 'base_model_name', 'baseModelName');
       return mapping;
     }
   }
@@ -6548,7 +6551,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class LanguageModels extends IBMWatsonResponseModel {
     private List<LanguageModel> customizations;
- 
+
     /**
      * Gets the customizations.
      *
@@ -6595,11 +6598,8 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (customizations != null && customizations[0] != null) {
-        mapping.putAll(customizations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) LanguageModel.class.newInstance()).addToApiToSdkMapping(parentLabel + 'customizations/', mapping));
       return mapping;
     }
   }
@@ -7295,7 +7295,7 @@ public class IBMSpeechToTextV1Models {
     private Double seenByEngine;
     private Double transcription;
     private Double speakerLabels;
- 
+
     /**
      * Gets the received.
      *
@@ -7310,7 +7310,7 @@ public class IBMSpeechToTextV1Models {
     public Double getReceived() {
       return received;
     }
- 
+
     /**
      * Gets the seenByEngine.
      *
@@ -7326,7 +7326,7 @@ public class IBMSpeechToTextV1Models {
     public Double getSeenByEngine() {
       return seenByEngine;
     }
- 
+
     /**
      * Gets the transcription.
      *
@@ -7338,7 +7338,7 @@ public class IBMSpeechToTextV1Models {
     public Double getTranscription() {
       return transcription;
     }
- 
+
     /**
      * Gets the speakerLabels.
      *
@@ -7390,10 +7390,9 @@ public class IBMSpeechToTextV1Models {
       this.speakerLabels = speakerLabels;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('seen_by_engine', 'seenByEngine');
-      mapping.put('speaker_labels', 'speakerLabels');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'seen_by_engine', 'seenByEngine');
+      mapping.put(parentLabel + 'speaker_labels', 'speakerLabels');
       return mapping;
     }
   }
@@ -7406,7 +7405,7 @@ public class IBMSpeechToTextV1Models {
     private ProcessedAudio processedAudio;
     private Double wallClockSinceFirstByteReceived;
     private Boolean periodic;
- 
+
     /**
      * Gets the processedAudio.
      *
@@ -7418,7 +7417,7 @@ public class IBMSpeechToTextV1Models {
     public ProcessedAudio getProcessedAudio() {
       return processedAudio;
     }
- 
+
     /**
      * Gets the wallClockSinceFirstByteReceived.
      *
@@ -7435,7 +7434,7 @@ public class IBMSpeechToTextV1Models {
     public Double getWallClockSinceFirstByteReceived() {
       return wallClockSinceFirstByteReceived;
     }
- 
+
     /**
      * Gets the periodic.
      *
@@ -7495,13 +7494,14 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('processed_audio', 'processedAudio');
-      if (processedAudio != null) {
-        mapping.putAll(processedAudio.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('wall_clock_since_first_byte_received', 'wallClockSinceFirstByteReceived');
+      mapping.put(parentLabel + 'processed_audio', 'processedAudio');
+      mapping.putAll(((IBMWatsonGenericModel) ProcessedAudio.class.newInstance()).addToApiToSdkMapping(parentLabel + 'processed_audio/', mapping));
+      mapping.put(parentLabel + 'wall_clock_since_first_byte_received', 'wallClockSinceFirstByteReceived');
       return mapping;
     }
   }
@@ -7518,7 +7518,7 @@ public class IBMSpeechToTextV1Models {
     private String userToken;
     private List<SpeechRecognitionResults> results;
     private List<String> warnings;
- 
+
     /**
      * Gets the id.
      *
@@ -7530,7 +7530,7 @@ public class IBMSpeechToTextV1Models {
     public String getId() {
       return id;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -7550,7 +7550,7 @@ public class IBMSpeechToTextV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -7563,7 +7563,7 @@ public class IBMSpeechToTextV1Models {
     public String getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -7577,7 +7577,7 @@ public class IBMSpeechToTextV1Models {
     public String getUpdated() {
       return updated;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -7590,7 +7590,7 @@ public class IBMSpeechToTextV1Models {
     public String getUrl() {
       return url;
     }
- 
+
     /**
      * Gets the userToken.
      *
@@ -7603,7 +7603,7 @@ public class IBMSpeechToTextV1Models {
     public String getUserToken() {
       return userToken;
     }
- 
+
     /**
      * Gets the results.
      *
@@ -7616,7 +7616,7 @@ public class IBMSpeechToTextV1Models {
     public List<SpeechRecognitionResults> getResults() {
       return results;
     }
- 
+
     /**
      * Gets the warnings.
      *
@@ -7727,12 +7727,9 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('user_token', 'userToken');
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'user_token', 'userToken');
+      mapping.putAll(((IBMWatsonGenericModel) SpeechRecognitionResults.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
       return mapping;
     }
   }
@@ -7742,7 +7739,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class RecognitionJobs extends IBMWatsonResponseModel {
     private List<RecognitionJob> recognitions;
- 
+
     /**
      * Gets the recognitions.
      *
@@ -7788,11 +7785,8 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (recognitions != null && recognitions[0] != null) {
-        mapping.putAll(recognitions[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) RecognitionJob.class.newInstance()).addToApiToSdkMapping(parentLabel + 'recognitions/', mapping));
       return mapping;
     }
   }
@@ -8065,9 +8059,9 @@ public class IBMSpeechToTextV1Models {
      * multi-person exchange. By default, the service returns no speaker labels. Setting `speaker_labels` to `true`
      * forces the `timestamps` parameter to be `true`, regardless of whether you specify `false` for the parameter.
      *
-     * **Note:** Applies to US English, Japanese, and Spanish transcription only. To determine whether a language model
-     * supports speaker labels, you can also use the **Get a model** method and check that the attribute
-     * `speaker_labels` is set to `true`.
+     * **Note:** Applies to US English, Japanese, and Spanish (both broadband and narrowband models) and UK English
+     * (narrowband model) transcription only. To determine whether a language model supports speaker labels, you can
+     * also use the **Get a model** method and check that the attribute `speaker_labels` is set to `true`.
      *
      * See [Speaker
      * labels](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-output#speaker_labels).
@@ -8668,7 +8662,7 @@ public class IBMSpeechToTextV1Models {
   public class RegisterStatus extends IBMWatsonResponseModel {
     private String status;
     private String url;
- 
+
     /**
      * Gets the status.
      *
@@ -8682,7 +8676,7 @@ public class IBMSpeechToTextV1Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -8921,7 +8915,7 @@ public class IBMSpeechToTextV1Models {
     private Long speaker;
     private Double confidence;
     private Boolean finalResults;
- 
+
     /**
      * Gets the xfrom.
      *
@@ -8934,7 +8928,7 @@ public class IBMSpeechToTextV1Models {
     public Double getXfrom() {
       return xfrom;
     }
- 
+
     /**
      * Gets the to.
      *
@@ -8946,7 +8940,7 @@ public class IBMSpeechToTextV1Models {
     public Double getTo() {
       return to;
     }
- 
+
     /**
      * Gets the speaker.
      *
@@ -8960,7 +8954,7 @@ public class IBMSpeechToTextV1Models {
     public Long getSpeaker() {
       return speaker;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -8972,7 +8966,7 @@ public class IBMSpeechToTextV1Models {
     public Double getConfidence() {
       return confidence;
     }
- 
+
     /**
      * Gets the finalResults.
      *
@@ -9032,10 +9026,13 @@ public class IBMSpeechToTextV1Models {
       this.finalResults = finalResults;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('from', 'xfrom');
-      mapping.put('final', 'finalResults');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'from', 'xfrom');
+      mapping.put(parentLabel + 'final', 'finalResults');
       return mapping;
     }
   }
@@ -9050,7 +9047,7 @@ public class IBMSpeechToTextV1Models {
     private String url;
     private SupportedFeatures supportedFeatures;
     private String description;
- 
+
     /**
      * Gets the name.
      *
@@ -9062,7 +9059,7 @@ public class IBMSpeechToTextV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -9074,7 +9071,7 @@ public class IBMSpeechToTextV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the rate.
      *
@@ -9086,7 +9083,7 @@ public class IBMSpeechToTextV1Models {
     public Long getRate() {
       return rate;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -9098,7 +9095,7 @@ public class IBMSpeechToTextV1Models {
     public String getUrl() {
       return url;
     }
- 
+
     /**
      * Gets the supportedFeatures.
      *
@@ -9110,7 +9107,7 @@ public class IBMSpeechToTextV1Models {
     public SupportedFeatures getSupportedFeatures() {
       return supportedFeatures;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -9191,12 +9188,9 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('supported_features', 'supportedFeatures');
-      if (supportedFeatures != null) {
-        mapping.putAll(supportedFeatures.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'supported_features', 'supportedFeatures');
+      mapping.putAll(((IBMWatsonGenericModel) SupportedFeatures.class.newInstance()).addToApiToSdkMapping(parentLabel + 'supported_features/', mapping));
       return mapping;
     }
   }
@@ -9206,7 +9200,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class SpeechModels extends IBMWatsonResponseModel {
     private List<SpeechModel> models;
- 
+
     /**
      * Gets the models.
      *
@@ -9251,11 +9245,8 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (models != null && models[0] != null) {
-        mapping.putAll(models[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) SpeechModel.class.newInstance()).addToApiToSdkMapping(parentLabel + 'models/', mapping));
       return mapping;
     }
   }
@@ -9266,9 +9257,9 @@ public class IBMSpeechToTextV1Models {
   public class SpeechRecognitionAlternative extends IBMWatsonGenericModel {
     private String transcript;
     private Double confidence;
-    private List<String> timestamps;
-    private List<String> wordConfidence;
- 
+    private List<List<String>> timestamps;
+    private List<List<String>> wordConfidence;
+
     /**
      * Gets the transcript.
      *
@@ -9280,7 +9271,7 @@ public class IBMSpeechToTextV1Models {
     public String getTranscript() {
       return transcript;
     }
- 
+
     /**
      * Gets the confidence.
      *
@@ -9293,7 +9284,7 @@ public class IBMSpeechToTextV1Models {
     public Double getConfidence() {
       return confidence;
     }
- 
+
     /**
      * Gets the timestamps.
      *
@@ -9304,10 +9295,10 @@ public class IBMSpeechToTextV1Models {
      * @return the timestamps
      */
     @AuraEnabled
-    public List<String> getTimestamps() {
+    public List<List<String>> getTimestamps() {
       return timestamps;
     }
- 
+
     /**
      * Gets the wordConfidence.
      *
@@ -9318,7 +9309,7 @@ public class IBMSpeechToTextV1Models {
      * @return the wordConfidence
      */
     @AuraEnabled
-    public List<String> getWordConfidence() {
+    public List<List<String>> getWordConfidence() {
       return wordConfidence;
     }
 
@@ -9345,7 +9336,7 @@ public class IBMSpeechToTextV1Models {
      *
      * @param timestamps the new timestamps
      */
-    public void setTimestamps(final List<String> timestamps) {
+    public void setTimestamps(final List<List<String>> timestamps) {
       this.timestamps = timestamps;
     }
 
@@ -9354,13 +9345,12 @@ public class IBMSpeechToTextV1Models {
      *
      * @param wordConfidence the new wordConfidence
      */
-    public void setWordConfidence(final List<String> wordConfidence) {
+    public void setWordConfidence(final List<List<String>> wordConfidence) {
       this.wordConfidence = wordConfidence;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('word_confidence', 'wordConfidence');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'word_confidence', 'wordConfidence');
       return mapping;
     }
   }
@@ -9371,9 +9361,9 @@ public class IBMSpeechToTextV1Models {
   public class SpeechRecognitionResult extends IBMWatsonGenericModel {
     private Boolean finalResults;
     private List<SpeechRecognitionAlternative> alternatives;
-    private IBMWatsonMapModel keywordsResult;
+    private Map<String, List<KeywordResult>> keywordsResult;
     private List<WordAlternativeResults> wordAlternatives;
- 
+
     /**
      * Gets the finalResults.
      *
@@ -9386,7 +9376,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean getFinalResults() {
       return finalResults;
     }
- 
+
     /**
      * Gets the alternatives.
      *
@@ -9399,7 +9389,7 @@ public class IBMSpeechToTextV1Models {
     public List<SpeechRecognitionAlternative> getAlternatives() {
       return alternatives;
     }
- 
+
     /**
      * Gets the keywordsResult.
      *
@@ -9411,10 +9401,10 @@ public class IBMSpeechToTextV1Models {
      * @return the keywordsResult
      */
     @AuraEnabled
-    public IBMWatsonMapModel getKeywordsResult() {
+    public Map<String, List<KeywordResult>> getKeywordsResult() {
       return keywordsResult;
     }
- 
+
     /**
      * Gets the wordAlternatives.
      *
@@ -9451,7 +9441,7 @@ public class IBMSpeechToTextV1Models {
      *
      * @param keywordsResult the new keywordsResult
      */
-    public void setKeywordsResult(final IBMWatsonMapModel keywordsResult) {
+    public void setKeywordsResult(final Map<String, List<KeywordResult>> keywordsResult) {
       this.keywordsResult = keywordsResult;
     }
 
@@ -9485,8 +9475,23 @@ public class IBMSpeechToTextV1Models {
       }
 
       // calling custom deserializer for keywordsResult
-      IBMWatsonMapModel newKeywordsResult = (IBMWatsonMapModel) new IBMWatsonMapModel().deserialize(JSON.serialize(ret.getKeywordsResult()), (Map<String, Object>) jsonMap.get('keywordsResult'), IBMWatsonMapModel.class);
-      ret.setKeywordsResult(newKeywordsResult);
+      Map<String, List<KeywordResult>> newKeywordsResult = new Map<String, List<KeywordResult>>();
+      Map<String, List<KeywordResult>> deserializedKeywordsResult = ret.getKeywordsResult();
+      if (deserializedKeywordsResult != null) {
+        for (String key : deserializedKeywordsResult.keySet()) {
+          List<KeywordResult> newKeywordResult = new List<KeywordResult>();
+          List<KeywordResult> keywordResultList = deserializedKeywordsResult.get(key);
+          for (Integer i = 0; i < keywordResultList.size(); i++) {
+            KeywordResult currentItem = keywordResultList.get(i);
+            Map<String, Object> itemInMap = (Map<String, Object>) jsonMap.get('keywordsResult');
+            Object innerObject = ((List<Object>) itemInMap.get(key)).get(i);
+            KeywordResult newItem = (KeywordResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(innerObject)), KeywordResult.class);
+            newKeywordResult.add(newItem);
+          }
+          newKeywordsResult.put(key, newKeywordResult);
+        }
+        ret.setKeywordsResult(newKeywordsResult);
+      }
 
       // calling custom deserializer for wordAlternatives
       List<WordAlternativeResults> newWordAlternatives = new List<WordAlternativeResults>();
@@ -9504,17 +9509,17 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('final', 'finalResults');
-      if (alternatives != null && alternatives[0] != null) {
-        mapping.putAll(alternatives[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('keywords_result', 'keywordsResult');
-      mapping.put('word_alternatives', 'wordAlternatives');
-      if (wordAlternatives != null && wordAlternatives[0] != null) {
-        mapping.putAll(wordAlternatives[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'final', 'finalResults');
+      mapping.putAll(((IBMWatsonGenericModel) SpeechRecognitionAlternative.class.newInstance()).addToApiToSdkMapping(parentLabel + 'alternatives/', mapping));
+      mapping.put(parentLabel + 'keywords_result', 'keywordsResult');
+      mapping.putAll(((IBMWatsonGenericModel) KeywordResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'keywords_result/keyword/', mapping));
+      mapping.put(parentLabel + 'word_alternatives', 'wordAlternatives');
+      mapping.putAll(((IBMWatsonGenericModel) WordAlternativeResults.class.newInstance()).addToApiToSdkMapping(parentLabel + 'word_alternatives/', mapping));
       return mapping;
     }
   }
@@ -9529,7 +9534,7 @@ public class IBMSpeechToTextV1Models {
     private ProcessingMetrics processingMetrics;
     private AudioMetrics audioMetrics;
     private List<String> warnings;
- 
+
     /**
      * Gets the results.
      *
@@ -9545,7 +9550,7 @@ public class IBMSpeechToTextV1Models {
     public List<SpeechRecognitionResult> getResults() {
       return results;
     }
- 
+
     /**
      * Gets the resultIndex.
      *
@@ -9558,7 +9563,7 @@ public class IBMSpeechToTextV1Models {
     public Long getResultIndex() {
       return resultIndex;
     }
- 
+
     /**
      * Gets the speakerLabels.
      *
@@ -9573,7 +9578,7 @@ public class IBMSpeechToTextV1Models {
     public List<SpeakerLabelsResult> getSpeakerLabels() {
       return speakerLabels;
     }
- 
+
     /**
      * Gets the processingMetrics.
      *
@@ -9586,7 +9591,7 @@ public class IBMSpeechToTextV1Models {
     public ProcessingMetrics getProcessingMetrics() {
       return processingMetrics;
     }
- 
+
     /**
      * Gets the audioMetrics.
      *
@@ -9598,7 +9603,7 @@ public class IBMSpeechToTextV1Models {
     public AudioMetrics getAudioMetrics() {
       return audioMetrics;
     }
- 
+
     /**
      * Gets the warnings.
      *
@@ -9719,24 +9724,15 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (results != null && results[0] != null) {
-        mapping.putAll(results[0].getApiToSdkMapping());
-      }
-      mapping.put('result_index', 'resultIndex');
-      mapping.put('speaker_labels', 'speakerLabels');
-      if (speakerLabels != null && speakerLabels[0] != null) {
-        mapping.putAll(speakerLabels[0].getApiToSdkMapping());
-      }
-      mapping.put('processing_metrics', 'processingMetrics');
-      if (processingMetrics != null) {
-        mapping.putAll(processingMetrics.getApiToSdkMapping());
-      }
-      mapping.put('audio_metrics', 'audioMetrics');
-      if (audioMetrics != null) {
-        mapping.putAll(audioMetrics.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) SpeechRecognitionResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'results/', mapping));
+      mapping.put(parentLabel + 'result_index', 'resultIndex');
+      mapping.put(parentLabel + 'speaker_labels', 'speakerLabels');
+      mapping.putAll(((IBMWatsonGenericModel) SpeakerLabelsResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'speaker_labels/', mapping));
+      mapping.put(parentLabel + 'processing_metrics', 'processingMetrics');
+      mapping.putAll(((IBMWatsonGenericModel) ProcessingMetrics.class.newInstance()).addToApiToSdkMapping(parentLabel + 'processing_metrics/', mapping));
+      mapping.put(parentLabel + 'audio_metrics', 'audioMetrics');
+      mapping.putAll(((IBMWatsonGenericModel) AudioMetrics.class.newInstance()).addToApiToSdkMapping(parentLabel + 'audio_metrics/', mapping));
       return mapping;
     }
   }
@@ -9747,7 +9743,7 @@ public class IBMSpeechToTextV1Models {
   public class SupportedFeatures extends IBMWatsonGenericModel {
     private Boolean customLanguageModel;
     private Boolean speakerLabels;
- 
+
     /**
      * Gets the customLanguageModel.
      *
@@ -9760,7 +9756,7 @@ public class IBMSpeechToTextV1Models {
     public Boolean getCustomLanguageModel() {
       return customLanguageModel;
     }
- 
+
     /**
      * Gets the speakerLabels.
      *
@@ -9791,10 +9787,13 @@ public class IBMSpeechToTextV1Models {
       this.speakerLabels = speakerLabels;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('custom_language_model', 'customLanguageModel');
-      mapping.put('speaker_labels', 'speakerLabels');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'custom_language_model', 'customLanguageModel');
+      mapping.put(parentLabel + 'speaker_labels', 'speakerLabels');
       return mapping;
     }
   }
@@ -10100,7 +10099,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class TrainingResponse extends IBMWatsonResponseModel {
     private List<TrainingWarning> warnings;
- 
+
     /**
      * Gets the warnings.
      *
@@ -10154,7 +10153,7 @@ public class IBMSpeechToTextV1Models {
   public class TrainingWarning extends IBMWatsonGenericModel {
     private String code;
     private String message;
- 
+
     /**
      * Gets the code.
      *
@@ -10166,7 +10165,7 @@ public class IBMSpeechToTextV1Models {
     public String getCode() {
       return code;
     }
- 
+
     /**
      * Gets the message.
      *
@@ -10565,7 +10564,7 @@ public class IBMSpeechToTextV1Models {
     private Long count;
     private List<String> source;
     private List<WordError> error;
- 
+
     /**
      * Gets the word.
      *
@@ -10577,7 +10576,7 @@ public class IBMSpeechToTextV1Models {
     public String getWord() {
       return word;
     }
- 
+
     /**
      * Gets the soundsLike.
      *
@@ -10591,7 +10590,7 @@ public class IBMSpeechToTextV1Models {
     public List<String> getSoundsLike() {
       return soundsLike;
     }
- 
+
     /**
      * Gets the displayAs.
      *
@@ -10604,7 +10603,7 @@ public class IBMSpeechToTextV1Models {
     public String getDisplayAs() {
       return displayAs;
     }
- 
+
     /**
      * Gets the count.
      *
@@ -10619,7 +10618,7 @@ public class IBMSpeechToTextV1Models {
     public Long getCount() {
       return count;
     }
- 
+
     /**
      * Gets the source.
      *
@@ -10633,7 +10632,7 @@ public class IBMSpeechToTextV1Models {
     public List<String> getSource() {
       return source;
     }
- 
+
     /**
      * Gets the error.
      *
@@ -10724,10 +10723,9 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('sounds_like', 'soundsLike');
-      mapping.put('display_as', 'displayAs');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'sounds_like', 'soundsLike');
+      mapping.put(parentLabel + 'display_as', 'displayAs');
       return mapping;
     }
   }
@@ -10738,7 +10736,7 @@ public class IBMSpeechToTextV1Models {
   public class WordAlternativeResult extends IBMWatsonGenericModel {
     private Double confidence;
     private String word;
- 
+
     /**
      * Gets the confidence.
      *
@@ -10750,7 +10748,7 @@ public class IBMSpeechToTextV1Models {
     public Double getConfidence() {
       return confidence;
     }
- 
+
     /**
      * Gets the word.
      *
@@ -10789,7 +10787,7 @@ public class IBMSpeechToTextV1Models {
     private Double startTime;
     private Double endTime;
     private List<WordAlternativeResult> alternatives;
- 
+
     /**
      * Gets the startTime.
      *
@@ -10801,7 +10799,7 @@ public class IBMSpeechToTextV1Models {
     public Double getStartTime() {
       return startTime;
     }
- 
+
     /**
      * Gets the endTime.
      *
@@ -10813,7 +10811,7 @@ public class IBMSpeechToTextV1Models {
     public Double getEndTime() {
       return endTime;
     }
- 
+
     /**
      * Gets the alternatives.
      *
@@ -10876,10 +10874,13 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('start_time', 'startTime');
-      mapping.put('end_time', 'endTime');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'start_time', 'startTime');
+      mapping.put(parentLabel + 'end_time', 'endTime');
       return mapping;
     }
   }
@@ -10889,7 +10890,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class WordError extends IBMWatsonGenericModel {
     private String element;
- 
+
     /**
      * Gets the element.
      *
@@ -10921,7 +10922,7 @@ public class IBMSpeechToTextV1Models {
    */
   public class Words extends IBMWatsonResponseModel {
     private List<Word> words;
- 
+
     /**
      * Gets the words.
      *
@@ -10967,11 +10968,8 @@ public class IBMSpeechToTextV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (words != null && words[0] != null) {
-        mapping.putAll(words[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Word.class.newInstance()).addToApiToSdkMapping(parentLabel + 'words/', mapping));
       return mapping;
     }
   }

--- a/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
@@ -204,10 +204,10 @@ private class IBMSpeechToTextV1Test {
     System.assertEquals(createJob.getresults()[0].getresults()[0].getFinalResults(),true);
     System.assertEquals(createJob.getresults()[0].getresults()[0].getAlternatives()[0].getTranscript(), 'string');
     System.assertEquals(createJob.getresults()[0].getresults()[0].getAlternatives()[0].getConfidence(),0);
-    System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword_serialized_name')[0].getNormalizedText(), 'string');
-    System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword_serialized_name')[0].getStartTime(),0);
-    System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword_serialized_name')[0].getEndTime(),0);
-    System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword_serialized_name')[0].getConfidence(),0);
+    System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword')[0].getNormalizedText(), 'string');
+    System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword')[0].getStartTime(),0);
+    System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword')[0].getEndTime(),0);
+    System.assertEquals(createJob.getresults()[0].getresults()[0].getKeywordsResult().get('keyword')[0].getConfidence(),0);
     System.assertEquals(createJob.getresults()[0].getresults()[0].getWordAlternatives()[0].getStartTime(),0);
     System.assertEquals(createJob.getresults()[0].getresults()[0].getWordAlternatives()[0].getEndTime(),0);
     System.assertEquals(createJob.getresults()[0].getresults()[0].getWordAlternatives()[0].getAlternatives()[0].getConfidence(),0);

--- a/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
@@ -394,13 +394,14 @@ private class IBMSpeechToTextV1Test {
       speechToText.setUsernameAndPassword(username, password);
     }
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
-    IBMSpeechToTextV1Models.CustomWord customWord = new IBMSpeechToTextV1Models.CustomWord();
-    customWord.setWord('tornado');
-    customWord.setSoundsLike(new List<String>{'tornado', 'hurricane'});
-    customWord.setDisplayAs('tornado');
+    IBMSpeechToTextV1Models.CustomWord customWord = new IBMSpeechToTextV1Models.CustomWordBuilder()
+      .word('tornado')
+      .soundsLike(new List<String> { 'tornado', 'hurricane' })
+      .displayAs('tornado')
+      .build();
     IBMSpeechToTextV1Models.AddWordsOptions addWordsOptions = new IBMSpeechToTextV1Models.AddWordsOptionsBuilder()
       .customizationId(customizationId)
-      .words(new List<IBMSpeechToTextV1Models.CustomWord>{ customWord })
+      .words(new List<IBMSpeechToTextV1Models.CustomWord> { customWord })
       .addHeader('Test-Header', 'test_value')
       .build();
     speechToText.addWords(addWordsOptions);

--- a/force-app/main/default/classes/IBMTextToSpeechV1.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1.cls
@@ -81,8 +81,8 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
    * Get a voice.
    *
    * Gets information about the specified voice. The information includes the name, language, gender, and other details
-   * about the voice. Specify a customization ID to obtain information for that custom voice model of the specified
-   * voice. To list information about all available voices, use the **List voices** method.
+   * about the voice. Specify a customization ID to obtain information for a custom voice model that is defined for the
+   * language of the specified voice. To list information about all available voices, use the **List voices** method.
    *
    * **See also:** [Listing a specific
    * voice](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-voices#listVoice).
@@ -210,7 +210,7 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
     }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('text', synthesizeOptions.text());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, synthesizeOptions.getSdkToApiMapping()));
 
     return (IBMWatsonFile) createServiceCall(builder.build(), IBMWatsonFile.class);
   }
@@ -291,7 +291,7 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
     if (createVoiceModelOptions.description() != null) {
       contentJson.put('description', createVoiceModelOptions.description());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, createVoiceModelOptions.getSdkToApiMapping()));
 
     return (IBMTextToSpeechV1Models.VoiceModel) createServiceCall(builder.build(), IBMTextToSpeechV1Models.VoiceModel.class);
   }
@@ -382,7 +382,7 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
     if (updateVoiceModelOptions.words() != null) {
       contentJson.put('words', updateVoiceModelOptions.words());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, updateVoiceModelOptions.getSdkToApiMapping()));
 
     createServiceCall(builder.build(), null);
   }
@@ -489,7 +489,7 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
     }
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('words', addWordsOptions.words());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, addWordsOptions.getSdkToApiMapping()));
 
     createServiceCall(builder.build(), null);
   }
@@ -570,7 +570,7 @@ public class IBMTextToSpeechV1 extends IBMWatsonService {
     if (addWordOptions.partOfSpeech() != null) {
       contentJson.put('part_of_speech', addWordOptions.partOfSpeech());
     }
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, addWordOptions.getSdkToApiMapping()));
 
     createServiceCall(builder.build(), null);
   }

--- a/force-app/main/default/classes/IBMTextToSpeechV1Models.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1Models.cls
@@ -7,19 +7,19 @@ public class IBMTextToSpeechV1Models {
     private String word;
     private String translation;
     private String partOfSpeech;
- 
+
     /**
      * Gets the customizationId.
      *
-     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-     * for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with credentials for the
+     * instance of the service that owns the custom model.
      *
      * @return the customizationId
      */
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the word.
      *
@@ -30,7 +30,7 @@ public class IBMTextToSpeechV1Models {
     public String word() {
       return word;
     }
- 
+
     /**
      * Gets the translation.
      *
@@ -43,7 +43,7 @@ public class IBMTextToSpeechV1Models {
     public String translation() {
       return translation;
     }
- 
+
     /**
      * Gets the partOfSpeech.
      *
@@ -79,6 +79,12 @@ public class IBMTextToSpeechV1Models {
       return new AddWordOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      mapping.put('partOfSpeech', 'part_of_speech');
+      return mapping;
+    }
   }
 
   /**
@@ -201,19 +207,19 @@ public class IBMTextToSpeechV1Models {
   public class AddWordsOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private List<Word> words;
- 
+
     /**
      * Gets the customizationId.
      *
-     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-     * for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with credentials for the
+     * instance of the service that owns the custom model.
      *
      * @return the customizationId
      */
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the words.
      *
@@ -247,6 +253,14 @@ public class IBMTextToSpeechV1Models {
       return new AddWordsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      if (words != null && words[0] != null) {
+        mapping.putAll(words[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -357,7 +371,7 @@ public class IBMTextToSpeechV1Models {
     private String name;
     private String language;
     private String description;
- 
+
     /**
      * Gets the name.
      *
@@ -368,7 +382,7 @@ public class IBMTextToSpeechV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -379,7 +393,7 @@ public class IBMTextToSpeechV1Models {
     public String language() {
       return language;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -407,7 +421,6 @@ public class IBMTextToSpeechV1Models {
     public CreateVoiceModelOptionsBuilder newBuilder() {
       return new CreateVoiceModelOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -500,7 +513,7 @@ public class IBMTextToSpeechV1Models {
    */
   public class DeleteUserDataOptions extends IBMWatsonOptionsModel {
     private String customerId;
- 
+
     /**
      * Gets the customerId.
      *
@@ -527,6 +540,11 @@ public class IBMTextToSpeechV1Models {
       return new DeleteUserDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customerId', 'customer_id');
+      return mapping;
+    }
   }
 
   /**
@@ -593,12 +611,12 @@ public class IBMTextToSpeechV1Models {
    */
   public class DeleteVoiceModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
-     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-     * for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with credentials for the
+     * instance of the service that owns the custom model.
      *
      * @return the customizationId
      */
@@ -621,6 +639,11 @@ public class IBMTextToSpeechV1Models {
       return new DeleteVoiceModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -688,19 +711,19 @@ public class IBMTextToSpeechV1Models {
   public class DeleteWordOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String word;
- 
+
     /**
      * Gets the customizationId.
      *
-     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-     * for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with credentials for the
+     * instance of the service that owns the custom model.
      *
      * @return the customizationId
      */
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the word.
      *
@@ -729,6 +752,11 @@ public class IBMTextToSpeechV1Models {
       return new DeleteWordOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -813,7 +841,7 @@ public class IBMTextToSpeechV1Models {
     private String voice;
     private String format;
     private String customizationId;
- 
+
     /**
      * Gets the text.
      *
@@ -824,7 +852,7 @@ public class IBMTextToSpeechV1Models {
     public String text() {
       return text;
     }
- 
+
     /**
      * Gets the voice.
      *
@@ -836,7 +864,7 @@ public class IBMTextToSpeechV1Models {
     public String voice() {
       return voice;
     }
- 
+
     /**
      * Gets the format.
      *
@@ -848,15 +876,15 @@ public class IBMTextToSpeechV1Models {
     public String format() {
       return format;
     }
- 
+
     /**
      * Gets the customizationId.
      *
      * The customization ID (GUID) of a custom voice model for which the pronunciation is to be returned. The language
      * of a specified custom model must match the language of the specified voice. If the word is not defined in the
      * specified custom model, the service returns the default translation for the custom model's language. You must
-     * make the request with service credentials created for the instance of the service that owns the custom model.
-     * Omit the parameter to see the translation for the specified voice with no customization.
+     * make the request with credentials for the instance of the service that owns the custom model. Omit the parameter
+     * to see the translation for the specified voice with no customization.
      *
      * @return the customizationId
      */
@@ -882,6 +910,11 @@ public class IBMTextToSpeechV1Models {
       return new GetPronunciationOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -987,12 +1020,12 @@ public class IBMTextToSpeechV1Models {
    */
   public class GetVoiceModelOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
-     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-     * for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with credentials for the
+     * instance of the service that owns the custom model.
      *
      * @return the customizationId
      */
@@ -1015,6 +1048,11 @@ public class IBMTextToSpeechV1Models {
       return new GetVoiceModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1082,7 +1120,7 @@ public class IBMTextToSpeechV1Models {
   public class GetVoiceOptions extends IBMWatsonOptionsModel {
     private String voice;
     private String customizationId;
- 
+
     /**
      * Gets the voice.
      *
@@ -1093,13 +1131,13 @@ public class IBMTextToSpeechV1Models {
     public String voice() {
       return voice;
     }
- 
+
     /**
      * Gets the customizationId.
      *
      * The customization ID (GUID) of a custom voice model for which information is to be returned. You must make the
-     * request with service credentials created for the instance of the service that owns the custom model. Omit the
-     * parameter to see information about the specified voice with no customization.
+     * request with credentials for the instance of the service that owns the custom model. Omit the parameter to see
+     * information about the specified voice with no customization.
      *
      * @return the customizationId
      */
@@ -1123,6 +1161,11 @@ public class IBMTextToSpeechV1Models {
       return new GetVoiceOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1203,19 +1246,19 @@ public class IBMTextToSpeechV1Models {
   public class GetWordOptions extends IBMWatsonOptionsModel {
     private String customizationId;
     private String word;
- 
+
     /**
      * Gets the customizationId.
      *
-     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-     * for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with credentials for the
+     * instance of the service that owns the custom model.
      *
      * @return the customizationId
      */
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the word.
      *
@@ -1244,6 +1287,11 @@ public class IBMTextToSpeechV1Models {
       return new GetWordOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1325,12 +1373,12 @@ public class IBMTextToSpeechV1Models {
    */
   public class ListVoiceModelsOptions extends IBMWatsonOptionsModel {
     private String language;
- 
+
     /**
      * Gets the language.
      *
-     * The language for which custom voice models that are owned by the requesting service credentials are to be
-     * returned. Omit the parameter to see all custom voice models that are owned by the requester.
+     * The language for which custom voice models that are owned by the requesting credentials are to be returned. Omit
+     * the parameter to see all custom voice models that are owned by the requester.
      *
      * @return the language
      */
@@ -1351,7 +1399,6 @@ public class IBMTextToSpeechV1Models {
     public ListVoiceModelsOptionsBuilder newBuilder() {
       return new ListVoiceModelsOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -1421,7 +1468,6 @@ public class IBMTextToSpeechV1Models {
     public ListVoicesOptionsBuilder newBuilder() {
       return new ListVoicesOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -1466,12 +1512,12 @@ public class IBMTextToSpeechV1Models {
    */
   public class ListWordsOptions extends IBMWatsonOptionsModel {
     private String customizationId;
- 
+
     /**
      * Gets the customizationId.
      *
-     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-     * for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with credentials for the
+     * instance of the service that owns the custom model.
      *
      * @return the customizationId
      */
@@ -1494,6 +1540,11 @@ public class IBMTextToSpeechV1Models {
       return new ListWordsOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1559,7 +1610,7 @@ public class IBMTextToSpeechV1Models {
    * The pronunciation of the specified text.
    */
   public class Pronunciation extends IBMWatsonResponseModel {
-    private String pronunciation_serialized_name;
+    private String pronunciation;
  
     /**
      * Gets the pronunciation.
@@ -1571,7 +1622,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getPronunciation() {
-      return pronunciation_serialized_name;
+      return pronunciation;
     }
 
     /**
@@ -1580,17 +1631,16 @@ public class IBMTextToSpeechV1Models {
      * @param pronunciation the new pronunciation
      */
     public void setPronunciation(final String pronunciation) {
-      this.pronunciation_serialized_name = pronunciation;
+      this.pronunciation = pronunciation;
     }
-
   }
 
   /**
    * Additional service features that are supported with the voice.
    */
   public class SupportedFeatures extends IBMWatsonGenericModel {
-    private Boolean custom_pronunciation_serialized_name;
-    private Boolean voice_transformation_serialized_name;
+    private Boolean customPronunciation;
+    private Boolean voiceTransformation;
  
     /**
      * Gets the customPronunciation.
@@ -1601,7 +1651,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public Boolean getCustomPronunciation() {
-      return custom_pronunciation_serialized_name;
+      return customPronunciation;
     }
  
     /**
@@ -1614,7 +1664,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public Boolean getVoiceTransformation() {
-      return voice_transformation_serialized_name;
+      return voiceTransformation;
     }
 
     /**
@@ -1623,7 +1673,7 @@ public class IBMTextToSpeechV1Models {
      * @param customPronunciation the new customPronunciation
      */
     public void setCustomPronunciation(final Boolean customPronunciation) {
-      this.custom_pronunciation_serialized_name = customPronunciation;
+      this.customPronunciation = customPronunciation;
     }
 
     /**
@@ -1632,9 +1682,15 @@ public class IBMTextToSpeechV1Models {
      * @param voiceTransformation the new voiceTransformation
      */
     public void setVoiceTransformation(final Boolean voiceTransformation) {
-      this.voice_transformation_serialized_name = voiceTransformation;
+      this.voiceTransformation = voiceTransformation;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('custom_pronunciation', 'customPronunciation');
+      mapping.put('voice_transformation', 'voiceTransformation');
+      return mapping;
+    }
   }
 
   /**
@@ -1645,7 +1701,7 @@ public class IBMTextToSpeechV1Models {
     private String accept;
     private String voice;
     private String customizationId;
- 
+
     /**
      * Gets the text.
      *
@@ -1656,7 +1712,7 @@ public class IBMTextToSpeechV1Models {
     public String text() {
       return text;
     }
- 
+
     /**
      * Gets the accept.
      *
@@ -1664,14 +1720,12 @@ public class IBMTextToSpeechV1Models {
      * specify the audio format. For more information about specifying an audio format, see **Audio formats (accept
      * types)** in the method description.
      *
-     * Default: `audio/ogg;codecs=opus`.
-     *
      * @return the accept
      */
     public String accept() {
       return accept;
     }
- 
+
     /**
      * Gets the voice.
      *
@@ -1682,14 +1736,14 @@ public class IBMTextToSpeechV1Models {
     public String voice() {
       return voice;
     }
- 
+
     /**
      * Gets the customizationId.
      *
      * The customization ID (GUID) of a custom voice model to use for the synthesis. If a custom voice model is
      * specified, it is guaranteed to work only if it matches the language of the indicated voice. You must make the
-     * request with service credentials created for the instance of the service that owns the custom model. Omit the
-     * parameter to use the specified voice with no customization.
+     * request with credentials for the instance of the service that owns the custom model. Omit the parameter to use
+     * the specified voice with no customization.
      *
      * @return the customizationId
      */
@@ -1715,6 +1769,12 @@ public class IBMTextToSpeechV1Models {
       return new SynthesizeOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('accept', 'Accept');
+      mapping.put('customizationId', 'customization_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1819,8 +1879,14 @@ public class IBMTextToSpeechV1Models {
    * Information about the translation for the specified text.
    */
   public class Translation extends IBMWatsonResponseModel {
-    private String translation_serialized_name;
-    private String part_of_speech_serialized_name;
+    private String translation;
+    private String partOfSpeech;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Translation() { }
  
     /**
      * Gets the translation.
@@ -1833,7 +1899,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getTranslation() {
-      return translation_serialized_name;
+      return translation;
     }
  
     /**
@@ -1849,27 +1915,94 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getPartOfSpeech() {
-      return part_of_speech_serialized_name;
+      return partOfSpeech;
+    }
+  
+    private Translation(TranslationBuilder builder) {
+      IBMWatsonValidator.notNull(builder.translation, 'translation cannot be null');
+      this.translation = builder.translation;
+      this.partOfSpeech = builder.partOfSpeech;
     }
 
     /**
-     * Sets the translation.
+     * New builder.
      *
-     * @param translation the new translation
+     * @return a Translation builder
      */
-    public void setTranslation(final String translation) {
-      this.translation_serialized_name = translation;
+    public TranslationBuilder newBuilder() {
+      return new TranslationBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('partOfSpeech', 'part_of_speech');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('part_of_speech', 'partOfSpeech');
+      return mapping;
+    }
+  }
+
+  /**
+   * Translation Builder.
+   */
+  public class TranslationBuilder {
+    private String translation;
+    private String partOfSpeech;
+
+    private TranslationBuilder(Translation translation) {
+      this.translation = translation.translation;
+      this.partOfSpeech = translation.partOfSpeech;
     }
 
     /**
-     * Sets the partOfSpeech.
-     *
-     * @param partOfSpeech the new partOfSpeech
+     * Instantiates a new builder.
      */
-    public void setPartOfSpeech(final String partOfSpeech) {
-      this.part_of_speech_serialized_name = partOfSpeech;
+    public TranslationBuilder() {
     }
 
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param translation the translation
+     */
+    public TranslationBuilder(String translation) {
+      this.translation = translation;
+    }
+
+    /**
+     * Builds a Translation.
+     *
+     * @return the translation
+     */
+    public Translation build() {
+      return new Translation(this);
+    }
+
+    /**
+     * Set the translation.
+     *
+     * @param translation the translation
+     * @return the Translation builder
+     */
+    public TranslationBuilder setTranslation(String translation) {
+      this.translation = translation;
+      return this;
+    }
+
+    /**
+     * Set the partOfSpeech.
+     *
+     * @param partOfSpeech the partOfSpeech
+     * @return the Translation builder
+     */
+    public TranslationBuilder setPartOfSpeech(String partOfSpeech) {
+      this.partOfSpeech = partOfSpeech;
+      return this;
+    }
   }
 
   /**
@@ -1880,19 +2013,19 @@ public class IBMTextToSpeechV1Models {
     private String name;
     private String description;
     private List<Word> words;
- 
+
     /**
      * Gets the customizationId.
      *
-     * The customization ID (GUID) of the custom voice model. You must make the request with service credentials created
-     * for the instance of the service that owns the custom model.
+     * The customization ID (GUID) of the custom voice model. You must make the request with credentials for the
+     * instance of the service that owns the custom model.
      *
      * @return the customizationId
      */
     public String customizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -1903,7 +2036,7 @@ public class IBMTextToSpeechV1Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -1914,7 +2047,7 @@ public class IBMTextToSpeechV1Models {
     public String description() {
       return description;
     }
- 
+
     /**
      * Gets the words.
      *
@@ -1945,6 +2078,14 @@ public class IBMTextToSpeechV1Models {
       return new UpdateVoiceModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customizationId', 'customization_id');
+      if (words != null && words[0] != null) {
+        mapping.putAll(words[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
   }
 
   /**
@@ -2065,14 +2206,14 @@ public class IBMTextToSpeechV1Models {
    * Information about an available voice model.
    */
   public class Voice extends IBMWatsonResponseModel {
-    private String url_serialized_name;
-    private String gender_serialized_name;
-    private String name_serialized_name;
-    private String language_serialized_name;
-    private String description_serialized_name;
-    private Boolean customizable_serialized_name;
-    private SupportedFeatures supported_features_serialized_name;
-    private VoiceModel customization_serialized_name;
+    private String url;
+    private String gender;
+    private String name;
+    private String language;
+    private String description;
+    private Boolean customizable;
+    private SupportedFeatures supportedFeatures;
+    private VoiceModel customization;
  
     /**
      * Gets the url.
@@ -2083,7 +2224,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getUrl() {
-      return url_serialized_name;
+      return url;
     }
  
     /**
@@ -2095,7 +2236,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getGender() {
-      return gender_serialized_name;
+      return gender;
     }
  
     /**
@@ -2107,7 +2248,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -2119,7 +2260,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
@@ -2131,7 +2272,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -2144,7 +2285,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public Boolean getCustomizable() {
-      return customizable_serialized_name;
+      return customizable;
     }
  
     /**
@@ -2156,7 +2297,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public SupportedFeatures getSupportedFeatures() {
-      return supported_features_serialized_name;
+      return supportedFeatures;
     }
  
     /**
@@ -2169,7 +2310,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public VoiceModel getCustomization() {
-      return customization_serialized_name;
+      return customization;
     }
 
     /**
@@ -2178,7 +2319,7 @@ public class IBMTextToSpeechV1Models {
      * @param url the new url
      */
     public void setUrl(final String url) {
-      this.url_serialized_name = url;
+      this.url = url;
     }
 
     /**
@@ -2187,7 +2328,7 @@ public class IBMTextToSpeechV1Models {
      * @param gender the new gender
      */
     public void setGender(final String gender) {
-      this.gender_serialized_name = gender;
+      this.gender = gender;
     }
 
     /**
@@ -2196,7 +2337,7 @@ public class IBMTextToSpeechV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -2205,7 +2346,7 @@ public class IBMTextToSpeechV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -2214,7 +2355,7 @@ public class IBMTextToSpeechV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -2223,7 +2364,7 @@ public class IBMTextToSpeechV1Models {
      * @param customizable the new customizable
      */
     public void setCustomizable(final Boolean customizable) {
-      this.customizable_serialized_name = customizable;
+      this.customizable = customizable;
     }
 
     /**
@@ -2232,7 +2373,7 @@ public class IBMTextToSpeechV1Models {
      * @param supportedFeatures the new supportedFeatures
      */
     public void setSupportedFeatures(final SupportedFeatures supportedFeatures) {
-      this.supported_features_serialized_name = supportedFeatures;
+      this.supportedFeatures = supportedFeatures;
     }
 
     /**
@@ -2241,7 +2382,7 @@ public class IBMTextToSpeechV1Models {
      * @param customization the new customization
      */
     public void setCustomization(final VoiceModel customization) {
-      this.customization_serialized_name = customization;
+      this.customization = customization;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2252,14 +2393,26 @@ public class IBMTextToSpeechV1Models {
       Voice ret = (Voice) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for supportedFeatures
-      SupportedFeatures newSupportedFeatures = (SupportedFeatures) new SupportedFeatures().deserialize(JSON.serialize(ret.getSupportedFeatures()), (Map<String, Object>) jsonMap.get('supported_features_serialized_name'), SupportedFeatures.class);
+      SupportedFeatures newSupportedFeatures = (SupportedFeatures) new SupportedFeatures().deserialize(JSON.serialize(ret.getSupportedFeatures()), (Map<String, Object>) jsonMap.get('supportedFeatures'), SupportedFeatures.class);
       ret.setSupportedFeatures(newSupportedFeatures);
 
       // calling custom deserializer for customization
-      VoiceModel newCustomization = (VoiceModel) new VoiceModel().deserialize(JSON.serialize(ret.getCustomization()), (Map<String, Object>) jsonMap.get('customization_serialized_name'), VoiceModel.class);
+      VoiceModel newCustomization = (VoiceModel) new VoiceModel().deserialize(JSON.serialize(ret.getCustomization()), (Map<String, Object>) jsonMap.get('customization'), VoiceModel.class);
       ret.setCustomization(newCustomization);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('supported_features', 'supportedFeatures');
+      if (supportedFeatures != null) {
+        mapping.putAll(supportedFeatures.getApiToSdkMapping());
+      }
+      if (customization != null) {
+        mapping.putAll(customization.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2267,14 +2420,14 @@ public class IBMTextToSpeechV1Models {
    * Information about an existing custom voice model.
    */
   public class VoiceModel extends IBMWatsonResponseModel {
-    private String customization_id_serialized_name;
-    private String name_serialized_name;
-    private String language_serialized_name;
-    private String owner_serialized_name;
-    private String created_serialized_name;
-    private String last_modified_serialized_name;
-    private String description_serialized_name;
-    private List<Word> words_serialized_name;
+    private String customizationId;
+    private String name;
+    private String language;
+    private String owner;
+    private String created;
+    private String lastModified;
+    private String description;
+    private List<Word> words;
  
     /**
      * Gets the customizationId.
@@ -2286,7 +2439,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getCustomizationId() {
-      return customization_id_serialized_name;
+      return customizationId;
     }
  
     /**
@@ -2298,7 +2451,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -2310,19 +2463,19 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getLanguage() {
-      return language_serialized_name;
+      return language;
     }
  
     /**
      * Gets the owner.
      *
-     * The GUID of the service credentials for the instance of the service that owns the custom voice model.
+     * The GUID of the credentials for the instance of the service that owns the custom voice model.
      *
      * @return the owner
      */
     @AuraEnabled
     public String getOwner() {
-      return owner_serialized_name;
+      return owner;
     }
  
     /**
@@ -2335,21 +2488,21 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
      * Gets the lastModified.
      *
-     * The date and time in Coordinated Universal Time (UTC) at which the custom voice model was last modified. Equals
-     * `created` when a new voice model is first added but has yet to be updated. The value is provided in full ISO 8601
-     * format (`YYYY-MM-DDThh:mm:ss.sTZD`).
+     * The date and time in Coordinated Universal Time (UTC) at which the custom voice model was last modified. The
+     * `created` and `updated` fields are equal when a voice model is first added but has yet to be updated. The value
+     * is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`).
      *
      * @return the lastModified
      */
     @AuraEnabled
     public String getLastModified() {
-      return last_modified_serialized_name;
+      return lastModified;
     }
  
     /**
@@ -2361,7 +2514,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -2376,7 +2529,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public List<Word> getWords() {
-      return words_serialized_name;
+      return words;
     }
 
     /**
@@ -2385,7 +2538,7 @@ public class IBMTextToSpeechV1Models {
      * @param customizationId the new customizationId
      */
     public void setCustomizationId(final String customizationId) {
-      this.customization_id_serialized_name = customizationId;
+      this.customizationId = customizationId;
     }
 
     /**
@@ -2394,7 +2547,7 @@ public class IBMTextToSpeechV1Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -2403,7 +2556,7 @@ public class IBMTextToSpeechV1Models {
      * @param language the new language
      */
     public void setLanguage(final String language) {
-      this.language_serialized_name = language;
+      this.language = language;
     }
 
     /**
@@ -2412,7 +2565,7 @@ public class IBMTextToSpeechV1Models {
      * @param owner the new owner
      */
     public void setOwner(final String owner) {
-      this.owner_serialized_name = owner;
+      this.owner = owner;
     }
 
     /**
@@ -2421,7 +2574,7 @@ public class IBMTextToSpeechV1Models {
      * @param created the new created
      */
     public void setCreated(final String created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
     /**
@@ -2430,7 +2583,7 @@ public class IBMTextToSpeechV1Models {
      * @param lastModified the new lastModified
      */
     public void setLastModified(final String lastModified) {
-      this.last_modified_serialized_name = lastModified;
+      this.lastModified = lastModified;
     }
 
     /**
@@ -2439,7 +2592,7 @@ public class IBMTextToSpeechV1Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -2448,7 +2601,7 @@ public class IBMTextToSpeechV1Models {
      * @param words the new words
      */
     public void setWords(final List<Word> words) {
-      this.words_serialized_name = words;
+      this.words = words;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2464,14 +2617,24 @@ public class IBMTextToSpeechV1Models {
       if (deserializedWords != null) {
         for (Integer i = 0; i < deserializedWords.size(); i++) {
           Word currentItem = ret.getWords().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('words_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('words');
           Word newItem = (Word) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Word.class);
           newWords.add(newItem);
         }
-        ret.words_serialized_name = newWords;
+        ret.words = newWords;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customization_id', 'customizationId');
+      mapping.put('last_modified', 'lastModified');
+      if (words != null && words[0] != null) {
+        mapping.putAll(words[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2479,20 +2642,20 @@ public class IBMTextToSpeechV1Models {
    * Information about existing custom voice models.
    */
   public class VoiceModels extends IBMWatsonResponseModel {
-    private List<VoiceModel> customizations_serialized_name;
+    private List<VoiceModel> customizations;
  
     /**
      * Gets the customizations.
      *
      * An array of `VoiceModel` objects that provides information about each available custom voice model. The array is
-     * empty if the requesting service credentials own no custom voice models (if no language is specified) or own no
-     * custom voice models for the specified language.
+     * empty if the requesting credentials own no custom voice models (if no language is specified) or own no custom
+     * voice models for the specified language.
      *
      * @return the customizations
      */
     @AuraEnabled
     public List<VoiceModel> getCustomizations() {
-      return customizations_serialized_name;
+      return customizations;
     }
 
     /**
@@ -2501,7 +2664,7 @@ public class IBMTextToSpeechV1Models {
      * @param customizations the new customizations
      */
     public void setCustomizations(final List<VoiceModel> customizations) {
-      this.customizations_serialized_name = customizations;
+      this.customizations = customizations;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2517,14 +2680,22 @@ public class IBMTextToSpeechV1Models {
       if (deserializedCustomizations != null) {
         for (Integer i = 0; i < deserializedCustomizations.size(); i++) {
           VoiceModel currentItem = ret.getCustomizations().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('customizations_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('customizations');
           VoiceModel newItem = (VoiceModel) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), VoiceModel.class);
           newCustomizations.add(newItem);
         }
-        ret.customizations_serialized_name = newCustomizations;
+        ret.customizations = newCustomizations;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (customizations != null && customizations[0] != null) {
+        mapping.putAll(customizations[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2532,7 +2703,7 @@ public class IBMTextToSpeechV1Models {
    * Information about all available voice models.
    */
   public class Voices extends IBMWatsonResponseModel {
-    private List<Voice> voices_serialized_name;
+    private List<Voice> voices;
  
     /**
      * Gets the voices.
@@ -2543,7 +2714,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public List<Voice> getVoices() {
-      return voices_serialized_name;
+      return voices;
     }
 
     /**
@@ -2552,7 +2723,7 @@ public class IBMTextToSpeechV1Models {
      * @param voices the new voices
      */
     public void setVoices(final List<Voice> voices) {
-      this.voices_serialized_name = voices;
+      this.voices = voices;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2568,14 +2739,22 @@ public class IBMTextToSpeechV1Models {
       if (deserializedVoices != null) {
         for (Integer i = 0; i < deserializedVoices.size(); i++) {
           Voice currentItem = ret.getVoices().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('voices_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('voices');
           Voice newItem = (Voice) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Voice.class);
           newVoices.add(newItem);
         }
-        ret.voices_serialized_name = newVoices;
+        ret.voices = newVoices;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (voices != null && voices[0] != null) {
+        mapping.putAll(voices[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2583,9 +2762,15 @@ public class IBMTextToSpeechV1Models {
    * Information about a word for the custom voice model.
    */
   public class Word extends IBMWatsonGenericModel {
-    private String word_serialized_name;
-    private String translation_serialized_name;
-    private String part_of_speech_serialized_name;
+    private String word;
+    private String translation;
+    private String partOfSpeech;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Word() { }
  
     /**
      * Gets the word.
@@ -2596,7 +2781,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getWord() {
-      return word_serialized_name;
+      return word;
     }
  
     /**
@@ -2610,7 +2795,7 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getTranslation() {
-      return translation_serialized_name;
+      return translation;
     }
  
     /**
@@ -2626,36 +2811,111 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public String getPartOfSpeech() {
-      return part_of_speech_serialized_name;
+      return partOfSpeech;
+    }
+  
+    private Word(WordBuilder builder) {
+      IBMWatsonValidator.notNull(builder.word, 'word cannot be null');
+      IBMWatsonValidator.notNull(builder.translation, 'translation cannot be null');
+      this.word = builder.word;
+      this.translation = builder.translation;
+      this.partOfSpeech = builder.partOfSpeech;
     }
 
     /**
-     * Sets the word.
+     * New builder.
      *
-     * @param word the new word
+     * @return a Word builder
      */
-    public void setWord(final String word) {
-      this.word_serialized_name = word;
+    public WordBuilder newBuilder() {
+      return new WordBuilder(this);
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('partOfSpeech', 'part_of_speech');
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('part_of_speech', 'partOfSpeech');
+      return mapping;
+    }
+  }
+
+  /**
+   * Word Builder.
+   */
+  public class WordBuilder {
+    private String word;
+    private String translation;
+    private String partOfSpeech;
+
+    private WordBuilder(Word word) {
+      this.word = word.word;
+      this.translation = word.translation;
+      this.partOfSpeech = word.partOfSpeech;
     }
 
     /**
-     * Sets the translation.
-     *
-     * @param translation the new translation
+     * Instantiates a new builder.
      */
-    public void setTranslation(final String translation) {
-      this.translation_serialized_name = translation;
+    public WordBuilder() {
     }
 
     /**
-     * Sets the partOfSpeech.
+     * Instantiates a new builder with required properties.
      *
-     * @param partOfSpeech the new partOfSpeech
+     * @param word the word
+     * @param translation the translation
      */
-    public void setPartOfSpeech(final String partOfSpeech) {
-      this.part_of_speech_serialized_name = partOfSpeech;
+    public WordBuilder(String word, String translation) {
+      this.word = word;
+      this.translation = translation;
     }
 
+    /**
+     * Builds a Word.
+     *
+     * @return the word
+     */
+    public Word build() {
+      return new Word(this);
+    }
+
+    /**
+     * Set the word.
+     *
+     * @param word the word
+     * @return the Word builder
+     */
+    public WordBuilder setWord(String word) {
+      this.word = word;
+      return this;
+    }
+
+    /**
+     * Set the translation.
+     *
+     * @param translation the translation
+     * @return the Word builder
+     */
+    public WordBuilder setTranslation(String translation) {
+      this.translation = translation;
+      return this;
+    }
+
+    /**
+     * Set the partOfSpeech.
+     *
+     * @param partOfSpeech the partOfSpeech
+     * @return the Word builder
+     */
+    public WordBuilder setPartOfSpeech(String partOfSpeech) {
+      this.partOfSpeech = partOfSpeech;
+      return this;
+    }
   }
 
   /**
@@ -2665,7 +2925,13 @@ public class IBMTextToSpeechV1Models {
    * For the **List custom words** method, the words and their translations from the custom voice model.
    */
   public class Words extends IBMWatsonResponseModel {
-    private List<Word> words_serialized_name;
+    private List<Word> words;
+
+    /**
+     * This constructor is strictly for internal serialization/deserialization purposes
+     * and should not be called by the client.
+     */
+    public Words() { }
  
     /**
      * Gets the words.
@@ -2681,16 +2947,21 @@ public class IBMTextToSpeechV1Models {
      */
     @AuraEnabled
     public List<Word> getWords() {
-      return words_serialized_name;
+      return words;
+    }
+  
+    private Words(WordsBuilder builder) {
+      IBMWatsonValidator.notNull(builder.words, 'words cannot be null');
+      this.words = builder.words;
     }
 
     /**
-     * Sets the words.
+     * New builder.
      *
-     * @param words the new words
+     * @return a Words builder
      */
-    public void setWords(final List<Word> words) {
-      this.words_serialized_name = words;
+    public WordsBuilder newBuilder() {
+      return new WordsBuilder(this);
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2699,6 +2970,7 @@ public class IBMTextToSpeechV1Models {
       }
 
       Words ret = (Words) super.deserialize(jsonString, jsonMap, classType);
+      WordsBuilder retBuilder = ret.newBuilder();
 
       // calling custom deserializer for words
       List<Word> newWords = new List<Word>();
@@ -2706,14 +2978,92 @@ public class IBMTextToSpeechV1Models {
       if (deserializedWords != null) {
         for (Integer i = 0; i < deserializedWords.size(); i++) {
           Word currentItem = ret.getWords().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('words_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('words');
           Word newItem = (Word) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Word.class);
           newWords.add(newItem);
         }
-        ret.words_serialized_name = newWords;
+        retBuilder.setWords(newWords);
       }
 
-      return ret;
+      return retBuilder.build();
+    }
+
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (words != null && words[0] != null) {
+        mapping.putAll(words[0].getSdkToApiMapping());
+      }
+      return mapping;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (words != null && words[0] != null) {
+        mapping.putAll(words[0].getApiToSdkMapping());
+      }
+      return mapping;
+    }
+  }
+
+  /**
+   * Words Builder.
+   */
+  public class WordsBuilder {
+    private List<Word> words;
+
+    private WordsBuilder(Words words) {
+      this.words = words.words;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public WordsBuilder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param words the words
+     */
+    public WordsBuilder(List<Word> words) {
+      this.words = words;
+    }
+
+    /**
+     * Builds a Words.
+     *
+     * @return the words
+     */
+    public Words build() {
+      return new Words(this);
+    }
+
+    /**
+     * Adds an words to words.
+     *
+     * @param words the new words
+     * @return the Words builder
+     */
+    public WordsBuilder addWords(Word words) {
+      IBMWatsonValidator.notNull(words, 'words cannot be null');
+      if (this.words == null) {
+        this.words = new List<Word>();
+      }
+      this.words.add(words);
+      return this;
+    }
+
+    /**
+     * Set the words.
+     * Existing words will be replaced.
+     *
+     * @param words the words
+     * @return the Words builder
+     */
+    public WordsBuilder setWords(List<Word> words) {
+      this.words = words;
+      return this;
     }
   }
 

--- a/force-app/main/default/classes/IBMTextToSpeechV1Models.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1Models.cls
@@ -257,7 +257,7 @@ public class IBMTextToSpeechV1Models {
       Map<String, String> mapping = new Map<String, String>();
       mapping.put('customizationId', 'customization_id');
       if (words != null && words[0] != null) {
-        mapping.putAll(words[0].getSdkToApiMapping());
+        mapping.putAll(words[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -1611,7 +1611,7 @@ public class IBMTextToSpeechV1Models {
    */
   public class Pronunciation extends IBMWatsonResponseModel {
     private String pronunciation;
- 
+
     /**
      * Gets the pronunciation.
      *
@@ -1641,7 +1641,7 @@ public class IBMTextToSpeechV1Models {
   public class SupportedFeatures extends IBMWatsonGenericModel {
     private Boolean customPronunciation;
     private Boolean voiceTransformation;
- 
+
     /**
      * Gets the customPronunciation.
      *
@@ -1653,7 +1653,7 @@ public class IBMTextToSpeechV1Models {
     public Boolean getCustomPronunciation() {
       return customPronunciation;
     }
- 
+
     /**
      * Gets the voiceTransformation.
      *
@@ -1685,10 +1685,13 @@ public class IBMTextToSpeechV1Models {
       this.voiceTransformation = voiceTransformation;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('custom_pronunciation', 'customPronunciation');
-      mapping.put('voice_transformation', 'voiceTransformation');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'custom_pronunciation', 'customPronunciation');
+      mapping.put(parentLabel + 'voice_transformation', 'voiceTransformation');
       return mapping;
     }
   }
@@ -1887,7 +1890,7 @@ public class IBMTextToSpeechV1Models {
      * and should not be called by the client.
      */
     public Translation() { }
- 
+
     /**
      * Gets the translation.
      *
@@ -1901,7 +1904,7 @@ public class IBMTextToSpeechV1Models {
     public String getTranslation() {
       return translation;
     }
- 
+
     /**
      * Gets the partOfSpeech.
      *
@@ -1933,15 +1936,13 @@ public class IBMTextToSpeechV1Models {
       return new TranslationBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('partOfSpeech', 'part_of_speech');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'partOfSpeech', 'part_of_speech');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('part_of_speech', 'partOfSpeech');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'part_of_speech', 'partOfSpeech');
       return mapping;
     }
   }
@@ -1988,7 +1989,7 @@ public class IBMTextToSpeechV1Models {
      * @param translation the translation
      * @return the Translation builder
      */
-    public TranslationBuilder setTranslation(String translation) {
+    public TranslationBuilder translation(String translation) {
       this.translation = translation;
       return this;
     }
@@ -1999,7 +2000,7 @@ public class IBMTextToSpeechV1Models {
      * @param partOfSpeech the partOfSpeech
      * @return the Translation builder
      */
-    public TranslationBuilder setPartOfSpeech(String partOfSpeech) {
+    public TranslationBuilder partOfSpeech(String partOfSpeech) {
       this.partOfSpeech = partOfSpeech;
       return this;
     }
@@ -2082,7 +2083,7 @@ public class IBMTextToSpeechV1Models {
       Map<String, String> mapping = new Map<String, String>();
       mapping.put('customizationId', 'customization_id');
       if (words != null && words[0] != null) {
-        mapping.putAll(words[0].getSdkToApiMapping());
+        mapping.putAll(words[0].addToSdkToApiMapping('', mapping));
       }
       return mapping;
     }
@@ -2214,7 +2215,7 @@ public class IBMTextToSpeechV1Models {
     private Boolean customizable;
     private SupportedFeatures supportedFeatures;
     private VoiceModel customization;
- 
+
     /**
      * Gets the url.
      *
@@ -2226,7 +2227,7 @@ public class IBMTextToSpeechV1Models {
     public String getUrl() {
       return url;
     }
- 
+
     /**
      * Gets the gender.
      *
@@ -2238,7 +2239,7 @@ public class IBMTextToSpeechV1Models {
     public String getGender() {
       return gender;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -2250,7 +2251,7 @@ public class IBMTextToSpeechV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -2262,7 +2263,7 @@ public class IBMTextToSpeechV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -2274,7 +2275,7 @@ public class IBMTextToSpeechV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the customizable.
      *
@@ -2287,7 +2288,7 @@ public class IBMTextToSpeechV1Models {
     public Boolean getCustomizable() {
       return customizable;
     }
- 
+
     /**
      * Gets the supportedFeatures.
      *
@@ -2299,7 +2300,7 @@ public class IBMTextToSpeechV1Models {
     public SupportedFeatures getSupportedFeatures() {
       return supportedFeatures;
     }
- 
+
     /**
      * Gets the customization.
      *
@@ -2403,15 +2404,10 @@ public class IBMTextToSpeechV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('supported_features', 'supportedFeatures');
-      if (supportedFeatures != null) {
-        mapping.putAll(supportedFeatures.getApiToSdkMapping());
-      }
-      if (customization != null) {
-        mapping.putAll(customization.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'supported_features', 'supportedFeatures');
+      mapping.putAll(((IBMWatsonGenericModel) SupportedFeatures.class.newInstance()).addToApiToSdkMapping(parentLabel + 'supported_features/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) VoiceModel.class.newInstance()).addToApiToSdkMapping(parentLabel + 'customization/', mapping));
       return mapping;
     }
   }
@@ -2428,7 +2424,7 @@ public class IBMTextToSpeechV1Models {
     private String lastModified;
     private String description;
     private List<Word> words;
- 
+
     /**
      * Gets the customizationId.
      *
@@ -2441,7 +2437,7 @@ public class IBMTextToSpeechV1Models {
     public String getCustomizationId() {
       return customizationId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -2453,7 +2449,7 @@ public class IBMTextToSpeechV1Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the language.
      *
@@ -2465,7 +2461,7 @@ public class IBMTextToSpeechV1Models {
     public String getLanguage() {
       return language;
     }
- 
+
     /**
      * Gets the owner.
      *
@@ -2477,7 +2473,7 @@ public class IBMTextToSpeechV1Models {
     public String getOwner() {
       return owner;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -2490,7 +2486,7 @@ public class IBMTextToSpeechV1Models {
     public String getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the lastModified.
      *
@@ -2504,7 +2500,7 @@ public class IBMTextToSpeechV1Models {
     public String getLastModified() {
       return lastModified;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -2516,7 +2512,7 @@ public class IBMTextToSpeechV1Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the words.
      *
@@ -2627,13 +2623,14 @@ public class IBMTextToSpeechV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('customization_id', 'customizationId');
-      mapping.put('last_modified', 'lastModified');
-      if (words != null && words[0] != null) {
-        mapping.putAll(words[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'customization_id', 'customizationId');
+      mapping.put(parentLabel + 'last_modified', 'lastModified');
+      mapping.putAll(((IBMWatsonGenericModel) Word.class.newInstance()).addToApiToSdkMapping(parentLabel + 'words/', mapping));
       return mapping;
     }
   }
@@ -2643,7 +2640,7 @@ public class IBMTextToSpeechV1Models {
    */
   public class VoiceModels extends IBMWatsonResponseModel {
     private List<VoiceModel> customizations;
- 
+
     /**
      * Gets the customizations.
      *
@@ -2690,11 +2687,8 @@ public class IBMTextToSpeechV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (customizations != null && customizations[0] != null) {
-        mapping.putAll(customizations[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) VoiceModel.class.newInstance()).addToApiToSdkMapping(parentLabel + 'customizations/', mapping));
       return mapping;
     }
   }
@@ -2704,7 +2698,7 @@ public class IBMTextToSpeechV1Models {
    */
   public class Voices extends IBMWatsonResponseModel {
     private List<Voice> voices;
- 
+
     /**
      * Gets the voices.
      *
@@ -2749,11 +2743,8 @@ public class IBMTextToSpeechV1Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (voices != null && voices[0] != null) {
-        mapping.putAll(voices[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Voice.class.newInstance()).addToApiToSdkMapping(parentLabel + 'voices/', mapping));
       return mapping;
     }
   }
@@ -2771,7 +2762,7 @@ public class IBMTextToSpeechV1Models {
      * and should not be called by the client.
      */
     public Word() { }
- 
+
     /**
      * Gets the word.
      *
@@ -2783,7 +2774,7 @@ public class IBMTextToSpeechV1Models {
     public String getWord() {
       return word;
     }
- 
+
     /**
      * Gets the translation.
      *
@@ -2797,7 +2788,7 @@ public class IBMTextToSpeechV1Models {
     public String getTranslation() {
       return translation;
     }
- 
+
     /**
      * Gets the partOfSpeech.
      *
@@ -2831,15 +2822,13 @@ public class IBMTextToSpeechV1Models {
       return new WordBuilder(this);
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('partOfSpeech', 'part_of_speech');
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'partOfSpeech', 'part_of_speech');
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('part_of_speech', 'partOfSpeech');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'part_of_speech', 'partOfSpeech');
       return mapping;
     }
   }
@@ -2890,7 +2879,7 @@ public class IBMTextToSpeechV1Models {
      * @param word the word
      * @return the Word builder
      */
-    public WordBuilder setWord(String word) {
+    public WordBuilder word(String word) {
       this.word = word;
       return this;
     }
@@ -2901,7 +2890,7 @@ public class IBMTextToSpeechV1Models {
      * @param translation the translation
      * @return the Word builder
      */
-    public WordBuilder setTranslation(String translation) {
+    public WordBuilder translation(String translation) {
       this.translation = translation;
       return this;
     }
@@ -2912,7 +2901,7 @@ public class IBMTextToSpeechV1Models {
      * @param partOfSpeech the partOfSpeech
      * @return the Word builder
      */
-    public WordBuilder setPartOfSpeech(String partOfSpeech) {
+    public WordBuilder partOfSpeech(String partOfSpeech) {
       this.partOfSpeech = partOfSpeech;
       return this;
     }
@@ -2932,7 +2921,7 @@ public class IBMTextToSpeechV1Models {
      * and should not be called by the client.
      */
     public Words() { }
- 
+
     /**
      * Gets the words.
      *
@@ -2982,25 +2971,21 @@ public class IBMTextToSpeechV1Models {
           Word newItem = (Word) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Word.class);
           newWords.add(newItem);
         }
-        retBuilder.setWords(newWords);
+        retBuilder.words(newWords);
       }
 
       return retBuilder.build();
     }
 
-    public override Map<String, String> getSdkToApiMapping() {
-      Map<String, String> mapping = new Map<String, String>();
+    public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
       if (words != null && words[0] != null) {
-        mapping.putAll(words[0].getSdkToApiMapping());
+        mapping.putAll(words[0].addToSdkToApiMapping(parentLabel + 'words/', mapping));
       }
       return mapping;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (words != null && words[0] != null) {
-        mapping.putAll(words[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Word.class.newInstance()).addToApiToSdkMapping(parentLabel + 'words/', mapping));
       return mapping;
     }
   }
@@ -3061,7 +3046,7 @@ public class IBMTextToSpeechV1Models {
      * @param words the words
      * @return the Words builder
      */
-    public WordsBuilder setWords(List<Word> words) {
+    public WordsBuilder words(List<Word> words) {
       this.words = words;
       return this;
     }

--- a/force-app/main/default/classes/IBMTextToSpeechV1Test.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1Test.cls
@@ -189,9 +189,10 @@ private class IBMTextToSpeechV1Test {
       textToSpeech.setEndPoint(URL);
       textToSpeech.setUsernameAndPassword(username, password);
     }
-    IBMTextToSpeechV1Models.Word word =new IBMTextToSpeechV1Models.Word();
-    word.setWord('Hello');
-    word.setTranslation('de-DE');
+    IBMTextToSpeechV1Models.Word word =new IBMTextToSpeechV1Models.WordBuilder()
+      .word('Hello')
+      .translation('de-DE')
+      .build();
     IBMTextToSpeechV1Models.UpdateVoiceModelOptions options = new IBMTextToSpeechV1Models.UpdateVoiceModelOptionsBuilder()
       .customizationId('customizationId')
       .addWords(word)
@@ -217,9 +218,10 @@ private class IBMTextToSpeechV1Test {
       textToSpeech.setEndPoint(URL);
       textToSpeech.setUsernameAndPassword(username, password);
     }
-    IBMTextToSpeechV1Models.Translation translation = new IBMTextToSpeechV1Models.Translation();
-    translation.setTranslation('de-DE');
-    translation.setPartOfSpeech('Josi');
+    IBMTextToSpeechV1Models.Translation translation = new IBMTextToSpeechV1Models.TranslationBuilder()
+      .translation('de-DE')
+      .partOfSpeech('Josi')
+      .build();
     IBMTextToSpeechV1Models.AddWordOptions options = new IBMTextToSpeechV1Models.AddWordOptionsBuilder()
       .customizationId('customizationId')
       .word('World')
@@ -248,10 +250,11 @@ private class IBMTextToSpeechV1Test {
       textToSpeech.setEndPoint(URL);
       textToSpeech.setUsernameAndPassword(username, password);
     }
-    IBMTextToSpeechV1Models.Word word =new IBMTextToSpeechV1Models.Word();
-    word.setWord('Again');
-    word.setTranslation('de-DE');
-    word.setPartOfSpeech('Josi');
+    IBMTextToSpeechV1Models.Word word =new IBMTextToSpeechV1Models.WordBuilder()
+      .word('Again')
+      .translation('de-DE')
+      .partOfSpeech('Josi')
+      .build();
     List<IBMTextToSpeechV1Models.Word> words = new List<IBMTextToSpeechV1Models.Word>{ word };
     IBMTextToSpeechV1Models.AddWordsOptions options = new IBMTextToSpeechV1Models.AddWordsOptionsBuilder('customizationId', words)
       .customizationId('customizationId')

--- a/force-app/main/default/classes/IBMToneAnalyzerV3.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3.cls
@@ -152,7 +152,7 @@ public class IBMToneAnalyzerV3 extends IBMWatsonService {
     builder.query('version', versionDate);
     final Map<String, Object> contentJson = new Map<String, Object>();
     contentJson.put('utterances', toneChatOptions.utterances());
-    builder.bodyJson(JSON.serialize(contentJson, true));
+    builder.bodyJson(IBMWatsonJSONUtil.serialize(contentJson, toneChatOptions.getSdkToApiMapping()));
 
     return (IBMToneAnalyzerV3Models.UtteranceAnalyses) createServiceCall(builder.build(), IBMToneAnalyzerV3Models.UtteranceAnalyses.class);
   }

--- a/force-app/main/default/classes/IBMToneAnalyzerV3Models.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3Models.cls
@@ -3,9 +3,9 @@ public class IBMToneAnalyzerV3Models {
    * The results of the analysis for the full input content.
    */
   public class DocumentAnalysis extends IBMWatsonGenericModel {
-    private List<ToneScore> tones_serialized_name;
-    private List<ToneCategory> tone_categories_serialized_name;
-    private String warning_serialized_name;
+    private List<ToneScore> tones;
+    private List<ToneCategory> toneCategories;
+    private String warning;
  
     /**
      * Gets the tones.
@@ -18,7 +18,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public List<ToneScore> getTones() {
-      return tones_serialized_name;
+      return tones;
     }
  
     /**
@@ -32,7 +32,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public List<ToneCategory> getToneCategories() {
-      return tone_categories_serialized_name;
+      return toneCategories;
     }
  
     /**
@@ -46,7 +46,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getWarning() {
-      return warning_serialized_name;
+      return warning;
     }
 
     /**
@@ -55,7 +55,7 @@ public class IBMToneAnalyzerV3Models {
      * @param tones the new tones
      */
     public void setTones(final List<ToneScore> tones) {
-      this.tones_serialized_name = tones;
+      this.tones = tones;
     }
 
     /**
@@ -64,7 +64,7 @@ public class IBMToneAnalyzerV3Models {
      * @param toneCategories the new toneCategories
      */
     public void setToneCategories(final List<ToneCategory> toneCategories) {
-      this.tone_categories_serialized_name = toneCategories;
+      this.toneCategories = toneCategories;
     }
 
     /**
@@ -73,7 +73,7 @@ public class IBMToneAnalyzerV3Models {
      * @param warning the new warning
      */
     public void setWarning(final String warning) {
-      this.warning_serialized_name = warning;
+      this.warning = warning;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -89,11 +89,11 @@ public class IBMToneAnalyzerV3Models {
       if (deserializedTones != null) {
         for (Integer i = 0; i < deserializedTones.size(); i++) {
           ToneScore currentItem = ret.getTones().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('tones_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('tones');
           ToneScore newItem = (ToneScore) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ToneScore.class);
           newTones.add(newItem);
         }
-        ret.tones_serialized_name = newTones;
+        ret.tones = newTones;
       }
 
       // calling custom deserializer for toneCategories
@@ -102,14 +102,26 @@ public class IBMToneAnalyzerV3Models {
       if (deserializedToneCategories != null) {
         for (Integer i = 0; i < deserializedToneCategories.size(); i++) {
           ToneCategory currentItem = ret.getToneCategories().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('tone_categories_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('toneCategories');
           ToneCategory newItem = (ToneCategory) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ToneCategory.class);
           newToneCategories.add(newItem);
         }
-        ret.tone_categories_serialized_name = newToneCategories;
+        ret.toneCategories = newToneCategories;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (tones != null && tones[0] != null) {
+        mapping.putAll(tones[0].getApiToSdkMapping());
+      }
+      mapping.put('tone_categories', 'toneCategories');
+      if (toneCategories != null && toneCategories[0] != null) {
+        mapping.putAll(toneCategories[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -117,12 +129,12 @@ public class IBMToneAnalyzerV3Models {
    * The results of the analysis for the individual sentences of the input content.
    */
   public class SentenceAnalysis extends IBMWatsonGenericModel {
-    private Long sentence_id_serialized_name;
-    private String text_serialized_name;
-    private List<ToneScore> tones_serialized_name;
-    private List<ToneCategory> tone_categories_serialized_name;
-    private Long input_from_serialized_name;
-    private Long input_to_serialized_name;
+    private Long sentenceId;
+    private String text;
+    private List<ToneScore> tones;
+    private List<ToneCategory> toneCategories;
+    private Long inputFrom;
+    private Long inputTo;
  
     /**
      * Gets the sentenceId.
@@ -134,7 +146,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public Long getSentenceId() {
-      return sentence_id_serialized_name;
+      return sentenceId;
     }
  
     /**
@@ -146,7 +158,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getText() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -160,7 +172,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public List<ToneScore> getTones() {
-      return tones_serialized_name;
+      return tones;
     }
  
     /**
@@ -174,7 +186,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public List<ToneCategory> getToneCategories() {
-      return tone_categories_serialized_name;
+      return toneCategories;
     }
  
     /**
@@ -187,7 +199,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public Long getInputFrom() {
-      return input_from_serialized_name;
+      return inputFrom;
     }
  
     /**
@@ -200,7 +212,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public Long getInputTo() {
-      return input_to_serialized_name;
+      return inputTo;
     }
 
     /**
@@ -209,7 +221,7 @@ public class IBMToneAnalyzerV3Models {
      * @param sentenceId the new sentenceId
      */
     public void setSentenceId(final long sentenceId) {
-      this.sentence_id_serialized_name = sentenceId;
+      this.sentenceId = sentenceId;
     }
 
     /**
@@ -218,7 +230,7 @@ public class IBMToneAnalyzerV3Models {
      * @param text the new text
      */
     public void setText(final String text) {
-      this.text_serialized_name = text;
+      this.text = text;
     }
 
     /**
@@ -227,7 +239,7 @@ public class IBMToneAnalyzerV3Models {
      * @param tones the new tones
      */
     public void setTones(final List<ToneScore> tones) {
-      this.tones_serialized_name = tones;
+      this.tones = tones;
     }
 
     /**
@@ -236,7 +248,7 @@ public class IBMToneAnalyzerV3Models {
      * @param toneCategories the new toneCategories
      */
     public void setToneCategories(final List<ToneCategory> toneCategories) {
-      this.tone_categories_serialized_name = toneCategories;
+      this.toneCategories = toneCategories;
     }
 
     /**
@@ -245,7 +257,7 @@ public class IBMToneAnalyzerV3Models {
      * @param inputFrom the new inputFrom
      */
     public void setInputFrom(final long inputFrom) {
-      this.input_from_serialized_name = inputFrom;
+      this.inputFrom = inputFrom;
     }
 
     /**
@@ -254,7 +266,7 @@ public class IBMToneAnalyzerV3Models {
      * @param inputTo the new inputTo
      */
     public void setInputTo(final long inputTo) {
-      this.input_to_serialized_name = inputTo;
+      this.inputTo = inputTo;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -270,11 +282,11 @@ public class IBMToneAnalyzerV3Models {
       if (deserializedTones != null) {
         for (Integer i = 0; i < deserializedTones.size(); i++) {
           ToneScore currentItem = ret.getTones().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('tones_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('tones');
           ToneScore newItem = (ToneScore) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ToneScore.class);
           newTones.add(newItem);
         }
-        ret.tones_serialized_name = newTones;
+        ret.tones = newTones;
       }
 
       // calling custom deserializer for toneCategories
@@ -283,14 +295,29 @@ public class IBMToneAnalyzerV3Models {
       if (deserializedToneCategories != null) {
         for (Integer i = 0; i < deserializedToneCategories.size(); i++) {
           ToneCategory currentItem = ret.getToneCategories().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('tone_categories_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('toneCategories');
           ToneCategory newItem = (ToneCategory) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ToneCategory.class);
           newToneCategories.add(newItem);
         }
-        ret.tone_categories_serialized_name = newToneCategories;
+        ret.toneCategories = newToneCategories;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('sentence_id', 'sentenceId');
+      if (tones != null && tones[0] != null) {
+        mapping.putAll(tones[0].getApiToSdkMapping());
+      }
+      mapping.put('tone_categories', 'toneCategories');
+      if (toneCategories != null && toneCategories[0] != null) {
+        mapping.putAll(toneCategories[0].getApiToSdkMapping());
+      }
+      mapping.put('input_from', 'inputFrom');
+      mapping.put('input_to', 'inputTo');
+      return mapping;
     }
   }
 
@@ -298,8 +325,8 @@ public class IBMToneAnalyzerV3Models {
    * The tone analysis results for the input from the general-purpose endpoint.
    */
   public class ToneAnalysis extends IBMWatsonResponseModel {
-    private DocumentAnalysis document_tone_serialized_name;
-    private List<SentenceAnalysis> sentences_tone_serialized_name;
+    private DocumentAnalysis documentTone;
+    private List<SentenceAnalysis> sentencesTone;
  
     /**
      * Gets the documentTone.
@@ -310,7 +337,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public DocumentAnalysis getDocumentTone() {
-      return document_tone_serialized_name;
+      return documentTone;
     }
  
     /**
@@ -324,7 +351,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public List<SentenceAnalysis> getSentencesTone() {
-      return sentences_tone_serialized_name;
+      return sentencesTone;
     }
 
     /**
@@ -333,7 +360,7 @@ public class IBMToneAnalyzerV3Models {
      * @param documentTone the new documentTone
      */
     public void setDocumentTone(final DocumentAnalysis documentTone) {
-      this.document_tone_serialized_name = documentTone;
+      this.documentTone = documentTone;
     }
 
     /**
@@ -342,7 +369,7 @@ public class IBMToneAnalyzerV3Models {
      * @param sentencesTone the new sentencesTone
      */
     public void setSentencesTone(final List<SentenceAnalysis> sentencesTone) {
-      this.sentences_tone_serialized_name = sentencesTone;
+      this.sentencesTone = sentencesTone;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -353,7 +380,7 @@ public class IBMToneAnalyzerV3Models {
       ToneAnalysis ret = (ToneAnalysis) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for documentTone
-      DocumentAnalysis newDocumentTone = (DocumentAnalysis) new DocumentAnalysis().deserialize(JSON.serialize(ret.getDocumentTone()), (Map<String, Object>) jsonMap.get('document_tone_serialized_name'), DocumentAnalysis.class);
+      DocumentAnalysis newDocumentTone = (DocumentAnalysis) new DocumentAnalysis().deserialize(JSON.serialize(ret.getDocumentTone()), (Map<String, Object>) jsonMap.get('documentTone'), DocumentAnalysis.class);
       ret.setDocumentTone(newDocumentTone);
 
       // calling custom deserializer for sentencesTone
@@ -362,14 +389,27 @@ public class IBMToneAnalyzerV3Models {
       if (deserializedSentencesTone != null) {
         for (Integer i = 0; i < deserializedSentencesTone.size(); i++) {
           SentenceAnalysis currentItem = ret.getSentencesTone().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('sentences_tone_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('sentencesTone');
           SentenceAnalysis newItem = (SentenceAnalysis) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), SentenceAnalysis.class);
           newSentencesTone.add(newItem);
         }
-        ret.sentences_tone_serialized_name = newSentencesTone;
+        ret.sentencesTone = newSentencesTone;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('document_tone', 'documentTone');
+      if (documentTone != null) {
+        mapping.putAll(documentTone.getApiToSdkMapping());
+      }
+      mapping.put('sentences_tone', 'sentencesTone');
+      if (sentencesTone != null && sentencesTone[0] != null) {
+        mapping.putAll(sentencesTone[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -377,9 +417,9 @@ public class IBMToneAnalyzerV3Models {
    * The category for a tone from the input content.
    */
   public class ToneCategory extends IBMWatsonGenericModel {
-    private List<ToneScore> tones_serialized_name;
-    private String category_id_serialized_name;
-    private String category_name_serialized_name;
+    private List<ToneScore> tones;
+    private String categoryId;
+    private String categoryName;
  
     /**
      * Gets the tones.
@@ -390,7 +430,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public List<ToneScore> getTones() {
-      return tones_serialized_name;
+      return tones;
     }
  
     /**
@@ -403,7 +443,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getCategoryId() {
-      return category_id_serialized_name;
+      return categoryId;
     }
  
     /**
@@ -415,7 +455,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getCategoryName() {
-      return category_name_serialized_name;
+      return categoryName;
     }
 
     /**
@@ -424,7 +464,7 @@ public class IBMToneAnalyzerV3Models {
      * @param tones the new tones
      */
     public void setTones(final List<ToneScore> tones) {
-      this.tones_serialized_name = tones;
+      this.tones = tones;
     }
 
     /**
@@ -433,7 +473,7 @@ public class IBMToneAnalyzerV3Models {
      * @param categoryId the new categoryId
      */
     public void setCategoryId(final String categoryId) {
-      this.category_id_serialized_name = categoryId;
+      this.categoryId = categoryId;
     }
 
     /**
@@ -442,7 +482,7 @@ public class IBMToneAnalyzerV3Models {
      * @param categoryName the new categoryName
      */
     public void setCategoryName(final String categoryName) {
-      this.category_name_serialized_name = categoryName;
+      this.categoryName = categoryName;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -458,14 +498,24 @@ public class IBMToneAnalyzerV3Models {
       if (deserializedTones != null) {
         for (Integer i = 0; i < deserializedTones.size(); i++) {
           ToneScore currentItem = ret.getTones().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('tones_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('tones');
           ToneScore newItem = (ToneScore) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ToneScore.class);
           newTones.add(newItem);
         }
-        ret.tones_serialized_name = newTones;
+        ret.tones = newTones;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (tones != null && tones[0] != null) {
+        mapping.putAll(tones[0].getApiToSdkMapping());
+      }
+      mapping.put('category_id', 'categoryId');
+      mapping.put('category_name', 'categoryName');
+      return mapping;
     }
   }
 
@@ -476,7 +526,7 @@ public class IBMToneAnalyzerV3Models {
     private List<Utterance> utterances;
     private String contentLanguage;
     private String acceptLanguage;
- 
+
     /**
      * Gets the utterances.
      *
@@ -487,7 +537,7 @@ public class IBMToneAnalyzerV3Models {
     public List<Utterance> utterances() {
       return utterances;
     }
- 
+
     /**
      * Gets the contentLanguage.
      *
@@ -503,7 +553,7 @@ public class IBMToneAnalyzerV3Models {
     public String contentLanguage() {
       return contentLanguage;
     }
- 
+
     /**
      * Gets the acceptLanguage.
      *
@@ -534,6 +584,12 @@ public class IBMToneAnalyzerV3Models {
       return new ToneChatOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('contentLanguage', 'Content-Language');
+      mapping.put('acceptLanguage', 'Accept-Language');
+      return mapping;
+    }
   }
 
   /**
@@ -641,9 +697,9 @@ public class IBMToneAnalyzerV3Models {
    * The score for an utterance from the input content.
    */
   public class ToneChatScore extends IBMWatsonGenericModel {
-    private Double score_serialized_name;
-    private String tone_id_serialized_name;
-    private String tone_name_serialized_name;
+    private Double score;
+    private String toneId;
+    private String toneName;
  
     /**
      * Gets the score.
@@ -655,7 +711,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
  
     /**
@@ -668,7 +724,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getToneId() {
-      return tone_id_serialized_name;
+      return toneId;
     }
  
     /**
@@ -680,7 +736,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getToneName() {
-      return tone_name_serialized_name;
+      return toneName;
     }
 
     /**
@@ -689,7 +745,7 @@ public class IBMToneAnalyzerV3Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
 
     /**
@@ -698,7 +754,7 @@ public class IBMToneAnalyzerV3Models {
      * @param toneId the new toneId
      */
     public void setToneId(final String toneId) {
-      this.tone_id_serialized_name = toneId;
+      this.toneId = toneId;
     }
 
     /**
@@ -707,16 +763,22 @@ public class IBMToneAnalyzerV3Models {
      * @param toneName the new toneName
      */
     public void setToneName(final String toneName) {
-      this.tone_name_serialized_name = toneName;
+      this.toneName = toneName;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('tone_id', 'toneId');
+      mapping.put('tone_name', 'toneName');
+      return mapping;
+    }
   }
 
   /**
    * Input for the general-purpose endpoint.
    */
-  public class ToneInput {
-    private String text_serialized_name;
+  public class ToneInput extends IBMWatsonGenericModel {
+    private String text;
  
     /**
      * Gets the text.
@@ -726,12 +788,12 @@ public class IBMToneAnalyzerV3Models {
      * @return the text
      */
     public String text() {
-      return text_serialized_name;
+      return text;
     }
   
     private ToneInput(ToneInputBuilder builder) {
       IBMWatsonValidator.notNull(builder.text, 'text cannot be null');
-      this.text_serialized_name = builder.text;
+      this.text = builder.text;
     }
 
     /**
@@ -742,7 +804,6 @@ public class IBMToneAnalyzerV3Models {
     public ToneInputBuilder newBuilder() {
       return new ToneInputBuilder(this);
     }
-
   }
 
   /**
@@ -752,7 +813,7 @@ public class IBMToneAnalyzerV3Models {
     private String text;
 
     private ToneInputBuilder(ToneInput toneInput) {
-      this.text = toneInput.text_serialized_name;
+      this.text = toneInput.text;
     }
 
     /**
@@ -802,7 +863,7 @@ public class IBMToneAnalyzerV3Models {
     private List<String> tones;
     private String contentLanguage;
     private String acceptLanguage;
- 
+
     /**
      * Gets the toneInput.
      *
@@ -814,7 +875,7 @@ public class IBMToneAnalyzerV3Models {
     public ToneInput toneInput() {
       return toneInput;
     }
- 
+
     /**
      * Gets the body.
      *
@@ -826,7 +887,7 @@ public class IBMToneAnalyzerV3Models {
     public String body() {
       return body;
     }
- 
+
     /**
      * Gets the contentType.
      *
@@ -838,7 +899,7 @@ public class IBMToneAnalyzerV3Models {
     public String contentType() {
       return contentType;
     }
- 
+
     /**
      * Gets the sentences.
      *
@@ -850,7 +911,7 @@ public class IBMToneAnalyzerV3Models {
     public Boolean sentences() {
       return sentences;
     }
- 
+
     /**
      * Gets the tones.
      *
@@ -866,7 +927,7 @@ public class IBMToneAnalyzerV3Models {
     public List<String> tones() {
       return tones;
     }
- 
+
     /**
      * Gets the contentLanguage.
      *
@@ -882,7 +943,7 @@ public class IBMToneAnalyzerV3Models {
     public String contentLanguage() {
       return contentLanguage;
     }
- 
+
     /**
      * Gets the acceptLanguage.
      *
@@ -916,6 +977,14 @@ public class IBMToneAnalyzerV3Models {
       return new ToneOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('toneInput', 'tone_input');
+      mapping.put('contentType', 'Content-Type');
+      mapping.put('contentLanguage', 'Content-Language');
+      mapping.put('acceptLanguage', 'Accept-Language');
+      return mapping;
+    }
   }
 
   /**
@@ -1069,9 +1138,9 @@ public class IBMToneAnalyzerV3Models {
    * The score for a tone from the input content.
    */
   public class ToneScore extends IBMWatsonGenericModel {
-    private Double score_serialized_name;
-    private String tone_id_serialized_name;
-    private String tone_name_serialized_name;
+    private Double score;
+    private String toneId;
+    private String toneName;
  
     /**
      * Gets the score.
@@ -1087,7 +1156,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
  
     /**
@@ -1107,7 +1176,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getToneId() {
-      return tone_id_serialized_name;
+      return toneId;
     }
  
     /**
@@ -1119,7 +1188,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getToneName() {
-      return tone_name_serialized_name;
+      return toneName;
     }
 
     /**
@@ -1128,7 +1197,7 @@ public class IBMToneAnalyzerV3Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
 
     /**
@@ -1137,7 +1206,7 @@ public class IBMToneAnalyzerV3Models {
      * @param toneId the new toneId
      */
     public void setToneId(final String toneId) {
-      this.tone_id_serialized_name = toneId;
+      this.toneId = toneId;
     }
 
     /**
@@ -1146,17 +1215,23 @@ public class IBMToneAnalyzerV3Models {
      * @param toneName the new toneName
      */
     public void setToneName(final String toneName) {
-      this.tone_name_serialized_name = toneName;
+      this.toneName = toneName;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('tone_id', 'toneId');
+      mapping.put('tone_name', 'toneName');
+      return mapping;
+    }
   }
 
   /**
    * An utterance for the input of the general-purpose endpoint.
    */
-  public class Utterance {
-    private String text_serialized_name;
-    private String user_serialized_name;
+  public class Utterance extends IBMWatsonGenericModel {
+    private String text;
+    private String user;
  
     /**
      * Gets the text.
@@ -1167,7 +1242,7 @@ public class IBMToneAnalyzerV3Models {
      * @return the text
      */
     public String text() {
-      return text_serialized_name;
+      return text;
     }
  
     /**
@@ -1178,13 +1253,13 @@ public class IBMToneAnalyzerV3Models {
      * @return the user
      */
     public String user() {
-      return user_serialized_name;
+      return user;
     }
   
     private Utterance(UtteranceBuilder builder) {
       IBMWatsonValidator.notNull(builder.text, 'text cannot be null');
-      this.text_serialized_name = builder.text;
-      this.user_serialized_name = builder.user;
+      this.text = builder.text;
+      this.user = builder.user;
     }
 
     /**
@@ -1195,7 +1270,6 @@ public class IBMToneAnalyzerV3Models {
     public UtteranceBuilder newBuilder() {
       return new UtteranceBuilder(this);
     }
-
   }
 
   /**
@@ -1206,8 +1280,8 @@ public class IBMToneAnalyzerV3Models {
     private String user;
 
     private UtteranceBuilder(Utterance utterance) {
-      this.text = utterance.text_serialized_name;
-      this.user = utterance.user_serialized_name;
+      this.text = utterance.text;
+      this.user = utterance.user;
     }
 
     /**
@@ -1261,8 +1335,8 @@ public class IBMToneAnalyzerV3Models {
    * The results of the analysis for the utterances of the input content.
    */
   public class UtteranceAnalyses extends IBMWatsonResponseModel {
-    private List<UtteranceAnalysis> utterances_tone_serialized_name;
-    private String warning_serialized_name;
+    private List<UtteranceAnalysis> utterancesTone;
+    private String warning;
  
     /**
      * Gets the utterancesTone.
@@ -1273,7 +1347,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public List<UtteranceAnalysis> getUtterancesTone() {
-      return utterances_tone_serialized_name;
+      return utterancesTone;
     }
  
     /**
@@ -1286,7 +1360,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getWarning() {
-      return warning_serialized_name;
+      return warning;
     }
 
     /**
@@ -1295,7 +1369,7 @@ public class IBMToneAnalyzerV3Models {
      * @param utterancesTone the new utterancesTone
      */
     public void setUtterancesTone(final List<UtteranceAnalysis> utterancesTone) {
-      this.utterances_tone_serialized_name = utterancesTone;
+      this.utterancesTone = utterancesTone;
     }
 
     /**
@@ -1304,7 +1378,7 @@ public class IBMToneAnalyzerV3Models {
      * @param warning the new warning
      */
     public void setWarning(final String warning) {
-      this.warning_serialized_name = warning;
+      this.warning = warning;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1320,14 +1394,23 @@ public class IBMToneAnalyzerV3Models {
       if (deserializedUtterancesTone != null) {
         for (Integer i = 0; i < deserializedUtterancesTone.size(); i++) {
           UtteranceAnalysis currentItem = ret.getUtterancesTone().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('utterances_tone_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('utterancesTone');
           UtteranceAnalysis newItem = (UtteranceAnalysis) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), UtteranceAnalysis.class);
           newUtterancesTone.add(newItem);
         }
-        ret.utterances_tone_serialized_name = newUtterancesTone;
+        ret.utterancesTone = newUtterancesTone;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('utterances_tone', 'utterancesTone');
+      if (utterancesTone != null && utterancesTone[0] != null) {
+        mapping.putAll(utterancesTone[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1335,10 +1418,10 @@ public class IBMToneAnalyzerV3Models {
    * The results of the analysis for an utterance of the input content.
    */
   public class UtteranceAnalysis extends IBMWatsonGenericModel {
-    private Long utterance_id_serialized_name;
-    private String utterance_text_serialized_name;
-    private List<ToneChatScore> tones_serialized_name;
-    private String error_serialized_name;
+    private Long utteranceId;
+    private String utteranceText;
+    private List<ToneChatScore> tones;
+    private String error;
  
     /**
      * Gets the utteranceId.
@@ -1350,7 +1433,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public Long getUtteranceId() {
-      return utterance_id_serialized_name;
+      return utteranceId;
     }
  
     /**
@@ -1362,7 +1445,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getUtteranceText() {
-      return utterance_text_serialized_name;
+      return utteranceText;
     }
  
     /**
@@ -1376,7 +1459,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public List<ToneChatScore> getTones() {
-      return tones_serialized_name;
+      return tones;
     }
  
     /**
@@ -1389,7 +1472,7 @@ public class IBMToneAnalyzerV3Models {
      */
     @AuraEnabled
     public String getError() {
-      return error_serialized_name;
+      return error;
     }
 
     /**
@@ -1398,7 +1481,7 @@ public class IBMToneAnalyzerV3Models {
      * @param utteranceId the new utteranceId
      */
     public void setUtteranceId(final long utteranceId) {
-      this.utterance_id_serialized_name = utteranceId;
+      this.utteranceId = utteranceId;
     }
 
     /**
@@ -1407,7 +1490,7 @@ public class IBMToneAnalyzerV3Models {
      * @param utteranceText the new utteranceText
      */
     public void setUtteranceText(final String utteranceText) {
-      this.utterance_text_serialized_name = utteranceText;
+      this.utteranceText = utteranceText;
     }
 
     /**
@@ -1416,7 +1499,7 @@ public class IBMToneAnalyzerV3Models {
      * @param tones the new tones
      */
     public void setTones(final List<ToneChatScore> tones) {
-      this.tones_serialized_name = tones;
+      this.tones = tones;
     }
 
     /**
@@ -1425,7 +1508,7 @@ public class IBMToneAnalyzerV3Models {
      * @param error the new error
      */
     public void setError(final String error) {
-      this.error_serialized_name = error;
+      this.error = error;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1441,14 +1524,24 @@ public class IBMToneAnalyzerV3Models {
       if (deserializedTones != null) {
         for (Integer i = 0; i < deserializedTones.size(); i++) {
           ToneChatScore currentItem = ret.getTones().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('tones_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('tones');
           ToneChatScore newItem = (ToneChatScore) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ToneChatScore.class);
           newTones.add(newItem);
         }
-        ret.tones_serialized_name = newTones;
+        ret.tones = newTones;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('utterance_id', 'utteranceId');
+      mapping.put('utterance_text', 'utteranceText');
+      if (tones != null && tones[0] != null) {
+        mapping.putAll(tones[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 

--- a/force-app/main/default/classes/IBMToneAnalyzerV3Models.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3Models.cls
@@ -6,7 +6,7 @@ public class IBMToneAnalyzerV3Models {
     private List<ToneScore> tones;
     private List<ToneCategory> toneCategories;
     private String warning;
- 
+
     /**
      * Gets the tones.
      *
@@ -20,7 +20,7 @@ public class IBMToneAnalyzerV3Models {
     public List<ToneScore> getTones() {
       return tones;
     }
- 
+
     /**
      * Gets the toneCategories.
      *
@@ -34,7 +34,7 @@ public class IBMToneAnalyzerV3Models {
     public List<ToneCategory> getToneCategories() {
       return toneCategories;
     }
- 
+
     /**
      * Gets the warning.
      *
@@ -112,15 +112,10 @@ public class IBMToneAnalyzerV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (tones != null && tones[0] != null) {
-        mapping.putAll(tones[0].getApiToSdkMapping());
-      }
-      mapping.put('tone_categories', 'toneCategories');
-      if (toneCategories != null && toneCategories[0] != null) {
-        mapping.putAll(toneCategories[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) ToneScore.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tones/', mapping));
+      mapping.put(parentLabel + 'tone_categories', 'toneCategories');
+      mapping.putAll(((IBMWatsonGenericModel) ToneCategory.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tone_categories/', mapping));
       return mapping;
     }
   }
@@ -135,7 +130,7 @@ public class IBMToneAnalyzerV3Models {
     private List<ToneCategory> toneCategories;
     private Long inputFrom;
     private Long inputTo;
- 
+
     /**
      * Gets the sentenceId.
      *
@@ -148,7 +143,7 @@ public class IBMToneAnalyzerV3Models {
     public Long getSentenceId() {
       return sentenceId;
     }
- 
+
     /**
      * Gets the text.
      *
@@ -160,7 +155,7 @@ public class IBMToneAnalyzerV3Models {
     public String getText() {
       return text;
     }
- 
+
     /**
      * Gets the tones.
      *
@@ -174,7 +169,7 @@ public class IBMToneAnalyzerV3Models {
     public List<ToneScore> getTones() {
       return tones;
     }
- 
+
     /**
      * Gets the toneCategories.
      *
@@ -188,7 +183,7 @@ public class IBMToneAnalyzerV3Models {
     public List<ToneCategory> getToneCategories() {
       return toneCategories;
     }
- 
+
     /**
      * Gets the inputFrom.
      *
@@ -201,7 +196,7 @@ public class IBMToneAnalyzerV3Models {
     public Long getInputFrom() {
       return inputFrom;
     }
- 
+
     /**
      * Gets the inputTo.
      *
@@ -305,18 +300,17 @@ public class IBMToneAnalyzerV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('sentence_id', 'sentenceId');
-      if (tones != null && tones[0] != null) {
-        mapping.putAll(tones[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('tone_categories', 'toneCategories');
-      if (toneCategories != null && toneCategories[0] != null) {
-        mapping.putAll(toneCategories[0].getApiToSdkMapping());
-      }
-      mapping.put('input_from', 'inputFrom');
-      mapping.put('input_to', 'inputTo');
+      mapping.put(parentLabel + 'sentence_id', 'sentenceId');
+      mapping.putAll(((IBMWatsonGenericModel) ToneScore.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tones/', mapping));
+      mapping.put(parentLabel + 'tone_categories', 'toneCategories');
+      mapping.putAll(((IBMWatsonGenericModel) ToneCategory.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tone_categories/', mapping));
+      mapping.put(parentLabel + 'input_from', 'inputFrom');
+      mapping.put(parentLabel + 'input_to', 'inputTo');
       return mapping;
     }
   }
@@ -327,7 +321,7 @@ public class IBMToneAnalyzerV3Models {
   public class ToneAnalysis extends IBMWatsonResponseModel {
     private DocumentAnalysis documentTone;
     private List<SentenceAnalysis> sentencesTone;
- 
+
     /**
      * Gets the documentTone.
      *
@@ -339,7 +333,7 @@ public class IBMToneAnalyzerV3Models {
     public DocumentAnalysis getDocumentTone() {
       return documentTone;
     }
- 
+
     /**
      * Gets the sentencesTone.
      *
@@ -399,16 +393,15 @@ public class IBMToneAnalyzerV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('document_tone', 'documentTone');
-      if (documentTone != null) {
-        mapping.putAll(documentTone.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      mapping.put('sentences_tone', 'sentencesTone');
-      if (sentencesTone != null && sentencesTone[0] != null) {
-        mapping.putAll(sentencesTone[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'document_tone', 'documentTone');
+      mapping.putAll(((IBMWatsonGenericModel) DocumentAnalysis.class.newInstance()).addToApiToSdkMapping(parentLabel + 'document_tone/', mapping));
+      mapping.put(parentLabel + 'sentences_tone', 'sentencesTone');
+      mapping.putAll(((IBMWatsonGenericModel) SentenceAnalysis.class.newInstance()).addToApiToSdkMapping(parentLabel + 'sentences_tone/', mapping));
       return mapping;
     }
   }
@@ -420,7 +413,7 @@ public class IBMToneAnalyzerV3Models {
     private List<ToneScore> tones;
     private String categoryId;
     private String categoryName;
- 
+
     /**
      * Gets the tones.
      *
@@ -432,7 +425,7 @@ public class IBMToneAnalyzerV3Models {
     public List<ToneScore> getTones() {
       return tones;
     }
- 
+
     /**
      * Gets the categoryId.
      *
@@ -445,7 +438,7 @@ public class IBMToneAnalyzerV3Models {
     public String getCategoryId() {
       return categoryId;
     }
- 
+
     /**
      * Gets the categoryName.
      *
@@ -508,13 +501,10 @@ public class IBMToneAnalyzerV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (tones != null && tones[0] != null) {
-        mapping.putAll(tones[0].getApiToSdkMapping());
-      }
-      mapping.put('category_id', 'categoryId');
-      mapping.put('category_name', 'categoryName');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) ToneScore.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tones/', mapping));
+      mapping.put(parentLabel + 'category_id', 'categoryId');
+      mapping.put(parentLabel + 'category_name', 'categoryName');
       return mapping;
     }
   }
@@ -700,7 +690,7 @@ public class IBMToneAnalyzerV3Models {
     private Double score;
     private String toneId;
     private String toneName;
- 
+
     /**
      * Gets the score.
      *
@@ -713,7 +703,7 @@ public class IBMToneAnalyzerV3Models {
     public Double getScore() {
       return score;
     }
- 
+
     /**
      * Gets the toneId.
      *
@@ -726,7 +716,7 @@ public class IBMToneAnalyzerV3Models {
     public String getToneId() {
       return toneId;
     }
- 
+
     /**
      * Gets the toneName.
      *
@@ -766,10 +756,9 @@ public class IBMToneAnalyzerV3Models {
       this.toneName = toneName;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('tone_id', 'toneId');
-      mapping.put('tone_name', 'toneName');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'tone_id', 'toneId');
+      mapping.put(parentLabel + 'tone_name', 'toneName');
       return mapping;
     }
   }
@@ -779,7 +768,7 @@ public class IBMToneAnalyzerV3Models {
    */
   public class ToneInput extends IBMWatsonGenericModel {
     private String text;
- 
+
     /**
      * Gets the text.
      *
@@ -1141,7 +1130,7 @@ public class IBMToneAnalyzerV3Models {
     private Double score;
     private String toneId;
     private String toneName;
- 
+
     /**
      * Gets the score.
      *
@@ -1158,7 +1147,7 @@ public class IBMToneAnalyzerV3Models {
     public Double getScore() {
       return score;
     }
- 
+
     /**
      * Gets the toneId.
      *
@@ -1178,7 +1167,7 @@ public class IBMToneAnalyzerV3Models {
     public String getToneId() {
       return toneId;
     }
- 
+
     /**
      * Gets the toneName.
      *
@@ -1218,10 +1207,9 @@ public class IBMToneAnalyzerV3Models {
       this.toneName = toneName;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('tone_id', 'toneId');
-      mapping.put('tone_name', 'toneName');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'tone_id', 'toneId');
+      mapping.put(parentLabel + 'tone_name', 'toneName');
       return mapping;
     }
   }
@@ -1232,7 +1220,7 @@ public class IBMToneAnalyzerV3Models {
   public class Utterance extends IBMWatsonGenericModel {
     private String text;
     private String user;
- 
+
     /**
      * Gets the text.
      *
@@ -1244,7 +1232,7 @@ public class IBMToneAnalyzerV3Models {
     public String text() {
       return text;
     }
- 
+
     /**
      * Gets the user.
      *
@@ -1337,7 +1325,7 @@ public class IBMToneAnalyzerV3Models {
   public class UtteranceAnalyses extends IBMWatsonResponseModel {
     private List<UtteranceAnalysis> utterancesTone;
     private String warning;
- 
+
     /**
      * Gets the utterancesTone.
      *
@@ -1349,7 +1337,7 @@ public class IBMToneAnalyzerV3Models {
     public List<UtteranceAnalysis> getUtterancesTone() {
       return utterancesTone;
     }
- 
+
     /**
      * Gets the warning.
      *
@@ -1404,12 +1392,13 @@ public class IBMToneAnalyzerV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('utterances_tone', 'utterancesTone');
-      if (utterancesTone != null && utterancesTone[0] != null) {
-        mapping.putAll(utterancesTone[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'utterances_tone', 'utterancesTone');
+      mapping.putAll(((IBMWatsonGenericModel) UtteranceAnalysis.class.newInstance()).addToApiToSdkMapping(parentLabel + 'utterances_tone/', mapping));
       return mapping;
     }
   }
@@ -1422,7 +1411,7 @@ public class IBMToneAnalyzerV3Models {
     private String utteranceText;
     private List<ToneChatScore> tones;
     private String error;
- 
+
     /**
      * Gets the utteranceId.
      *
@@ -1435,7 +1424,7 @@ public class IBMToneAnalyzerV3Models {
     public Long getUtteranceId() {
       return utteranceId;
     }
- 
+
     /**
      * Gets the utteranceText.
      *
@@ -1447,7 +1436,7 @@ public class IBMToneAnalyzerV3Models {
     public String getUtteranceText() {
       return utteranceText;
     }
- 
+
     /**
      * Gets the tones.
      *
@@ -1461,7 +1450,7 @@ public class IBMToneAnalyzerV3Models {
     public List<ToneChatScore> getTones() {
       return tones;
     }
- 
+
     /**
      * Gets the error.
      *
@@ -1534,13 +1523,14 @@ public class IBMToneAnalyzerV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('utterance_id', 'utteranceId');
-      mapping.put('utterance_text', 'utteranceText');
-      if (tones != null && tones[0] != null) {
-        mapping.putAll(tones[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'utterance_id', 'utteranceId');
+      mapping.put(parentLabel + 'utterance_text', 'utteranceText');
+      mapping.putAll(((IBMWatsonGenericModel) ToneChatScore.class.newInstance()).addToApiToSdkMapping(parentLabel + 'tones/', mapping));
       return mapping;
     }
   }

--- a/force-app/main/default/classes/IBMVisualRecognitionV3.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3.cls
@@ -141,11 +141,17 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
    * Create a classifier.
    *
    * Train a new multi-faceted classifier on the uploaded image data. Create your custom classifier with positive or
-   * negative examples. Include at least two sets of examples, either two positive example files or one positive and one
-   * negative file. You can upload a maximum of 256 MB per call.
+   * negative example training images. Include at least two sets of examples, either two positive example files or one
+   * positive and one negative file. You can upload a maximum of 256 MB per call.
    *
-   * Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image file names, and classifier and class
-   * names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.
+   * **Tips when creating:**
+   *
+   * - If you set the **X-Watson-Learning-Opt-Out** header parameter to `true` when you create a classifier, the example
+   * training images are not stored. Save your training images locally. For more information, see [Data
+   * collection](#data-collection).
+   *
+   * - Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image file names, and classifier and
+   * class names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.
    *
    * @param createClassifierOptions the {@link IBMVisualRecognitionV3Models.CreateClassifierOptions} containing the options for the call
    * @return the {@link IBMVisualRecognitionV3Models.Classifier} with the response
@@ -239,8 +245,14 @@ public class IBMVisualRecognitionV3 extends IBMWatsonService {
    * Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image file names, and classifier and class
    * names). The service assumes UTF-8 encoding if it encounters non-ASCII characters.
    *
-   * **Tip:** Don't make retraining calls on a classifier until the status is ready. When you submit retraining requests
-   * in parallel, the last request overwrites the previous requests. The retrained property shows the last time the
+   * **Tips about retraining:**
+   *
+   * - You can't update the classifier if the **X-Watson-Learning-Opt-Out** header parameter was set to `true` when the
+   * classifier was created. Training images are not stored in that case. Instead, create another classifier. For more
+   * information, see [Data collection](#data-collection).
+   *
+   * - Don't make retraining calls on a classifier until the status is ready. When you submit retraining requests in
+   * parallel, the last request overwrites the previous requests. The `retrained` property shows the last time the
    * classifier retraining finished.
    *
    * @param updateClassifierOptions the {@link IBMVisualRecognitionV3Models.UpdateClassifierOptions} containing the options for the call

--- a/force-app/main/default/classes/IBMVisualRecognitionV3Models.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3Models.cls
@@ -4,7 +4,7 @@ public class IBMVisualRecognitionV3Models {
    */
   public class ModelClass extends IBMWatsonGenericModel {
     private String className;
- 
+
     /**
      * Gets the className.
      *
@@ -26,9 +26,12 @@ public class IBMVisualRecognitionV3Models {
       this.className = className;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('class', 'className');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'class', 'className');
       return mapping;
     }
   }
@@ -40,7 +43,7 @@ public class IBMVisualRecognitionV3Models {
     private String className;
     private Double score;
     private String typeHierarchy;
- 
+
     /**
      * Gets the className.
      *
@@ -57,7 +60,7 @@ public class IBMVisualRecognitionV3Models {
     public String getClassName() {
       return className;
     }
- 
+
     /**
      * Gets the score.
      *
@@ -70,7 +73,7 @@ public class IBMVisualRecognitionV3Models {
     public Double getScore() {
       return score;
     }
- 
+
     /**
      * Gets the typeHierarchy.
      *
@@ -111,10 +114,13 @@ public class IBMVisualRecognitionV3Models {
       this.typeHierarchy = typeHierarchy;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('class', 'className');
-      mapping.put('type_hierarchy', 'typeHierarchy');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'class', 'className');
+      mapping.put(parentLabel + 'type_hierarchy', 'typeHierarchy');
       return mapping;
     }
   }
@@ -128,7 +134,7 @@ public class IBMVisualRecognitionV3Models {
     private String image;
     private ErrorInfo error;
     private List<ClassifierResult> classifiers;
- 
+
     /**
      * Gets the sourceUrl.
      *
@@ -140,7 +146,7 @@ public class IBMVisualRecognitionV3Models {
     public String getSourceUrl() {
       return sourceUrl;
     }
- 
+
     /**
      * Gets the resolvedUrl.
      *
@@ -152,7 +158,7 @@ public class IBMVisualRecognitionV3Models {
     public String getResolvedUrl() {
       return resolvedUrl;
     }
- 
+
     /**
      * Gets the image.
      *
@@ -164,7 +170,7 @@ public class IBMVisualRecognitionV3Models {
     public String getImage() {
       return image;
     }
- 
+
     /**
      * Gets the error.
      *
@@ -177,7 +183,7 @@ public class IBMVisualRecognitionV3Models {
     public ErrorInfo getError() {
       return error;
     }
- 
+
     /**
      * Gets the classifiers.
      *
@@ -262,16 +268,15 @@ public class IBMVisualRecognitionV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('source_url', 'sourceUrl');
-      mapping.put('resolved_url', 'resolvedUrl');
-      if (error != null) {
-        mapping.putAll(error.getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (classifiers != null && classifiers[0] != null) {
-        mapping.putAll(classifiers[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'source_url', 'sourceUrl');
+      mapping.put(parentLabel + 'resolved_url', 'resolvedUrl');
+      mapping.putAll(((IBMWatsonGenericModel) ErrorInfo.class.newInstance()).addToApiToSdkMapping(parentLabel + 'error/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) ClassifierResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'classifiers/', mapping));
       return mapping;
     }
   }
@@ -284,7 +289,7 @@ public class IBMVisualRecognitionV3Models {
     private Long imagesProcessed;
     private List<ClassifiedImage> images;
     private List<WarningInfo> warnings;
- 
+
     /**
      * Gets the customClasses.
      *
@@ -296,7 +301,7 @@ public class IBMVisualRecognitionV3Models {
     public Long getCustomClasses() {
       return customClasses;
     }
- 
+
     /**
      * Gets the imagesProcessed.
      *
@@ -308,7 +313,7 @@ public class IBMVisualRecognitionV3Models {
     public Long getImagesProcessed() {
       return imagesProcessed;
     }
- 
+
     /**
      * Gets the images.
      *
@@ -320,7 +325,7 @@ public class IBMVisualRecognitionV3Models {
     public List<ClassifiedImage> getImages() {
       return images;
     }
- 
+
     /**
      * Gets the warnings.
      *
@@ -407,16 +412,15 @@ public class IBMVisualRecognitionV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('custom_classes', 'customClasses');
-      mapping.put('images_processed', 'imagesProcessed');
-      if (images != null && images[0] != null) {
-        mapping.putAll(images[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (warnings != null && warnings[0] != null) {
-        mapping.putAll(warnings[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'custom_classes', 'customClasses');
+      mapping.put(parentLabel + 'images_processed', 'imagesProcessed');
+      mapping.putAll(((IBMWatsonGenericModel) ClassifiedImage.class.newInstance()).addToApiToSdkMapping(parentLabel + 'images/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) WarningInfo.class.newInstance()).addToApiToSdkMapping(parentLabel + 'warnings/', mapping));
       return mapping;
     }
   }
@@ -435,7 +439,7 @@ public class IBMVisualRecognitionV3Models {
     private List<ModelClass> classes;
     private Datetime retrained;
     private Datetime updated;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -447,7 +451,7 @@ public class IBMVisualRecognitionV3Models {
     public String getClassifierId() {
       return classifierId;
     }
- 
+
     /**
      * Gets the name.
      *
@@ -459,7 +463,7 @@ public class IBMVisualRecognitionV3Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the owner.
      *
@@ -471,7 +475,7 @@ public class IBMVisualRecognitionV3Models {
     public String getOwner() {
       return owner;
     }
- 
+
     /**
      * Gets the status.
      *
@@ -483,7 +487,7 @@ public class IBMVisualRecognitionV3Models {
     public String getStatus() {
       return status;
     }
- 
+
     /**
      * Gets the coreMlEnabled.
      *
@@ -495,7 +499,7 @@ public class IBMVisualRecognitionV3Models {
     public Boolean getCoreMlEnabled() {
       return coreMlEnabled;
     }
- 
+
     /**
      * Gets the explanation.
      *
@@ -507,7 +511,7 @@ public class IBMVisualRecognitionV3Models {
     public String getExplanation() {
       return explanation;
     }
- 
+
     /**
      * Gets the created.
      *
@@ -519,7 +523,7 @@ public class IBMVisualRecognitionV3Models {
     public Datetime getCreated() {
       return created;
     }
- 
+
     /**
      * Gets the classes.
      *
@@ -531,7 +535,7 @@ public class IBMVisualRecognitionV3Models {
     public List<ModelClass> getClasses() {
       return classes;
     }
- 
+
     /**
      * Gets the retrained.
      *
@@ -544,7 +548,7 @@ public class IBMVisualRecognitionV3Models {
     public Datetime getRetrained() {
       return retrained;
     }
- 
+
     /**
      * Gets the updated.
      *
@@ -671,13 +675,14 @@ public class IBMVisualRecognitionV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('classifier_id', 'classifierId');
-      mapping.put('core_ml_enabled', 'coreMlEnabled');
-      if (classes != null && classes[0] != null) {
-        mapping.putAll(classes[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
+      mapping.put(parentLabel + 'classifier_id', 'classifierId');
+      mapping.put(parentLabel + 'core_ml_enabled', 'coreMlEnabled');
+      mapping.putAll(((IBMWatsonGenericModel) ModelClass.class.newInstance()).addToApiToSdkMapping(parentLabel + 'classes/', mapping));
       return mapping;
     }
   }
@@ -689,7 +694,7 @@ public class IBMVisualRecognitionV3Models {
     private String name;
     private String classifierId;
     private List<ClassResult> classes;
- 
+
     /**
      * Gets the name.
      *
@@ -701,7 +706,7 @@ public class IBMVisualRecognitionV3Models {
     public String getName() {
       return name;
     }
- 
+
     /**
      * Gets the classifierId.
      *
@@ -713,7 +718,7 @@ public class IBMVisualRecognitionV3Models {
     public String getClassifierId() {
       return classifierId;
     }
- 
+
     /**
      * Gets the classes.
      *
@@ -776,12 +781,9 @@ public class IBMVisualRecognitionV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('classifier_id', 'classifierId');
-      if (classes != null && classes[0] != null) {
-        mapping.putAll(classes[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'classifier_id', 'classifierId');
+      mapping.putAll(((IBMWatsonGenericModel) ClassResult.class.newInstance()).addToApiToSdkMapping(parentLabel + 'classes/', mapping));
       return mapping;
     }
   }
@@ -791,7 +793,7 @@ public class IBMVisualRecognitionV3Models {
    */
   public class Classifiers extends IBMWatsonResponseModel {
     private List<Classifier> classifiers;
- 
+
     /**
      * Gets the classifiers.
      *
@@ -836,11 +838,8 @@ public class IBMVisualRecognitionV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (classifiers != null && classifiers[0] != null) {
-        mapping.putAll(classifiers[0].getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Classifier.class.newInstance()).addToApiToSdkMapping(parentLabel + 'classifiers/', mapping));
       return mapping;
     }
   }
@@ -1793,7 +1792,7 @@ public class IBMVisualRecognitionV3Models {
     private Long imagesProcessed;
     private List<ImageWithFaces> images;
     private List<WarningInfo> warnings;
- 
+
     /**
      * Gets the imagesProcessed.
      *
@@ -1805,7 +1804,7 @@ public class IBMVisualRecognitionV3Models {
     public Long getImagesProcessed() {
       return imagesProcessed;
     }
- 
+
     /**
      * Gets the images.
      *
@@ -1817,7 +1816,7 @@ public class IBMVisualRecognitionV3Models {
     public List<ImageWithFaces> getImages() {
       return images;
     }
- 
+
     /**
      * Gets the warnings.
      *
@@ -1895,15 +1894,14 @@ public class IBMVisualRecognitionV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('images_processed', 'imagesProcessed');
-      if (images != null && images[0] != null) {
-        mapping.putAll(images[0].getApiToSdkMapping());
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
       }
-      if (warnings != null && warnings[0] != null) {
-        mapping.putAll(warnings[0].getApiToSdkMapping());
-      }
+      mapping.put(parentLabel + 'images_processed', 'imagesProcessed');
+      mapping.putAll(((IBMWatsonGenericModel) ImageWithFaces.class.newInstance()).addToApiToSdkMapping(parentLabel + 'images/', mapping));
+      mapping.putAll(((IBMWatsonGenericModel) WarningInfo.class.newInstance()).addToApiToSdkMapping(parentLabel + 'warnings/', mapping));
       return mapping;
     }
   }
@@ -1916,7 +1914,7 @@ public class IBMVisualRecognitionV3Models {
     private Long code;
     private String description;
     private String errorId;
- 
+
     /**
      * Gets the code.
      *
@@ -1928,7 +1926,7 @@ public class IBMVisualRecognitionV3Models {
     public Long getCode() {
       return code;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -1940,7 +1938,7 @@ public class IBMVisualRecognitionV3Models {
     public String getDescription() {
       return description;
     }
- 
+
     /**
      * Gets the errorId.
      *
@@ -1980,9 +1978,8 @@ public class IBMVisualRecognitionV3Models {
       this.errorId = errorId;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('error_id', 'errorId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'error_id', 'errorId');
       return mapping;
     }
   }
@@ -1994,7 +1991,7 @@ public class IBMVisualRecognitionV3Models {
     private FaceAge age;
     private FaceGender gender;
     private FaceLocation faceLocation;
- 
+
     /**
      * Gets the age.
      *
@@ -2006,7 +2003,7 @@ public class IBMVisualRecognitionV3Models {
     public FaceAge getAge() {
       return age;
     }
- 
+
     /**
      * Gets the gender.
      *
@@ -2018,7 +2015,7 @@ public class IBMVisualRecognitionV3Models {
     public FaceGender getGender() {
       return gender;
     }
- 
+
     /**
      * Gets the faceLocation.
      *
@@ -2080,12 +2077,9 @@ public class IBMVisualRecognitionV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (gender != null) {
-        mapping.putAll(gender.getApiToSdkMapping());
-      }
-      mapping.put('face_location', 'faceLocation');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) FaceGender.class.newInstance()).addToApiToSdkMapping(parentLabel + 'gender/', mapping));
+      mapping.put(parentLabel + 'face_location', 'faceLocation');
       return mapping;
     }
   }
@@ -2097,7 +2091,7 @@ public class IBMVisualRecognitionV3Models {
     private Long min;
     private Long max;
     private Double score;
- 
+
     /**
      * Gets the min.
      *
@@ -2109,7 +2103,7 @@ public class IBMVisualRecognitionV3Models {
     public Long getMin() {
       return min;
     }
- 
+
     /**
      * Gets the max.
      *
@@ -2121,7 +2115,7 @@ public class IBMVisualRecognitionV3Models {
     public Long getMax() {
       return max;
     }
- 
+
     /**
      * Gets the score.
      *
@@ -2170,7 +2164,7 @@ public class IBMVisualRecognitionV3Models {
     private String gender;
     private String genderLabel;
     private Double score;
- 
+
     /**
      * Gets the gender.
      *
@@ -2182,7 +2176,7 @@ public class IBMVisualRecognitionV3Models {
     public String getGender() {
       return gender;
     }
- 
+
     /**
      * Gets the genderLabel.
      *
@@ -2194,7 +2188,7 @@ public class IBMVisualRecognitionV3Models {
     public String getGenderLabel() {
       return genderLabel;
     }
- 
+
     /**
      * Gets the score.
      *
@@ -2235,9 +2229,8 @@ public class IBMVisualRecognitionV3Models {
       this.score = score;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('gender_label', 'genderLabel');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.put(parentLabel + 'gender_label', 'genderLabel');
       return mapping;
     }
   }
@@ -2250,7 +2243,7 @@ public class IBMVisualRecognitionV3Models {
     private Double height;
     private Double left;
     private Double top;
- 
+
     /**
      * Gets the width.
      *
@@ -2262,7 +2255,7 @@ public class IBMVisualRecognitionV3Models {
     public Double getWidth() {
       return width;
     }
- 
+
     /**
      * Gets the height.
      *
@@ -2274,7 +2267,7 @@ public class IBMVisualRecognitionV3Models {
     public Double getHeight() {
       return height;
     }
- 
+
     /**
      * Gets the left.
      *
@@ -2286,7 +2279,7 @@ public class IBMVisualRecognitionV3Models {
     public Double getLeft() {
       return left;
     }
- 
+
     /**
      * Gets the top.
      *
@@ -2541,7 +2534,7 @@ public class IBMVisualRecognitionV3Models {
     private String sourceUrl;
     private String resolvedUrl;
     private ErrorInfo error;
- 
+
     /**
      * Gets the faces.
      *
@@ -2553,7 +2546,7 @@ public class IBMVisualRecognitionV3Models {
     public List<Face> getFaces() {
       return faces;
     }
- 
+
     /**
      * Gets the image.
      *
@@ -2565,7 +2558,7 @@ public class IBMVisualRecognitionV3Models {
     public String getImage() {
       return image;
     }
- 
+
     /**
      * Gets the sourceUrl.
      *
@@ -2577,7 +2570,7 @@ public class IBMVisualRecognitionV3Models {
     public String getSourceUrl() {
       return sourceUrl;
     }
- 
+
     /**
      * Gets the resolvedUrl.
      *
@@ -2589,7 +2582,7 @@ public class IBMVisualRecognitionV3Models {
     public String getResolvedUrl() {
       return resolvedUrl;
     }
- 
+
     /**
      * Gets the error.
      *
@@ -2675,16 +2668,11 @@ public class IBMVisualRecognitionV3Models {
       return ret;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      if (faces != null && faces[0] != null) {
-        mapping.putAll(faces[0].getApiToSdkMapping());
-      }
-      mapping.put('source_url', 'sourceUrl');
-      mapping.put('resolved_url', 'resolvedUrl');
-      if (error != null) {
-        mapping.putAll(error.getApiToSdkMapping());
-      }
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      mapping.putAll(((IBMWatsonGenericModel) Face.class.newInstance()).addToApiToSdkMapping(parentLabel + 'faces/', mapping));
+      mapping.put(parentLabel + 'source_url', 'sourceUrl');
+      mapping.put(parentLabel + 'resolved_url', 'resolvedUrl');
+      mapping.putAll(((IBMWatsonGenericModel) ErrorInfo.class.newInstance()).addToApiToSdkMapping(parentLabel + 'error/', mapping));
       return mapping;
     }
   }
@@ -2988,7 +2976,7 @@ public class IBMVisualRecognitionV3Models {
   public class WarningInfo extends IBMWatsonGenericModel {
     private String warningId;
     private String description;
- 
+
     /**
      * Gets the warningId.
      *
@@ -3000,7 +2988,7 @@ public class IBMVisualRecognitionV3Models {
     public String getWarningId() {
       return warningId;
     }
- 
+
     /**
      * Gets the description.
      *
@@ -3031,9 +3019,12 @@ public class IBMVisualRecognitionV3Models {
       this.description = description;
     }
 
-    public override Map<String, String> getApiToSdkMapping() {
-      Map<String, String> mapping = new Map<String, String>();
-      mapping.put('warning_id', 'warningId');
+    public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+      // break out of property loop
+      if (parentLabel.split('/').size() > 10) {
+        return mapping;
+      }
+      mapping.put(parentLabel + 'warning_id', 'warningId');
       return mapping;
     }
   }

--- a/force-app/main/default/classes/IBMVisualRecognitionV3Models.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3Models.cls
@@ -3,7 +3,7 @@ public class IBMVisualRecognitionV3Models {
    * A category within a classifier.
    */
   public class ModelClass extends IBMWatsonGenericModel {
-    private String class_serialized_name;
+    private String className;
  
     /**
      * Gets the className.
@@ -14,7 +14,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getClassName() {
-      return class_serialized_name;
+      return className;
     }
 
     /**
@@ -23,18 +23,23 @@ public class IBMVisualRecognitionV3Models {
      * @param className the new className
      */
     public void setClassName(final String className) {
-      this.class_serialized_name = className;
+      this.className = className;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('class', 'className');
+      return mapping;
+    }
   }
 
   /**
    * Result of a class within a classifier.
    */
   public class ClassResult extends IBMWatsonGenericModel {
-    private String class_serialized_name;
-    private Double score_serialized_name;
-    private String type_hierarchy_serialized_name;
+    private String className;
+    private Double score;
+    private String typeHierarchy;
  
     /**
      * Gets the className.
@@ -50,7 +55,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getClassName() {
-      return class_serialized_name;
+      return className;
     }
  
     /**
@@ -63,7 +68,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
  
     /**
@@ -76,7 +81,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getTypeHierarchy() {
-      return type_hierarchy_serialized_name;
+      return typeHierarchy;
     }
 
     /**
@@ -85,7 +90,7 @@ public class IBMVisualRecognitionV3Models {
      * @param className the new className
      */
     public void setClassName(final String className) {
-      this.class_serialized_name = className;
+      this.className = className;
     }
 
     /**
@@ -94,7 +99,7 @@ public class IBMVisualRecognitionV3Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
 
     /**
@@ -103,20 +108,26 @@ public class IBMVisualRecognitionV3Models {
      * @param typeHierarchy the new typeHierarchy
      */
     public void setTypeHierarchy(final String typeHierarchy) {
-      this.type_hierarchy_serialized_name = typeHierarchy;
+      this.typeHierarchy = typeHierarchy;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('class', 'className');
+      mapping.put('type_hierarchy', 'typeHierarchy');
+      return mapping;
+    }
   }
 
   /**
    * Results for one image.
    */
   public class ClassifiedImage extends IBMWatsonGenericModel {
-    private String source_url_serialized_name;
-    private String resolved_url_serialized_name;
-    private String image_serialized_name;
-    private ErrorInfo error_serialized_name;
-    private List<ClassifierResult> classifiers_serialized_name;
+    private String sourceUrl;
+    private String resolvedUrl;
+    private String image;
+    private ErrorInfo error;
+    private List<ClassifierResult> classifiers;
  
     /**
      * Gets the sourceUrl.
@@ -127,7 +138,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getSourceUrl() {
-      return source_url_serialized_name;
+      return sourceUrl;
     }
  
     /**
@@ -139,7 +150,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getResolvedUrl() {
-      return resolved_url_serialized_name;
+      return resolvedUrl;
     }
  
     /**
@@ -151,7 +162,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getImage() {
-      return image_serialized_name;
+      return image;
     }
  
     /**
@@ -164,7 +175,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public ErrorInfo getError() {
-      return error_serialized_name;
+      return error;
     }
  
     /**
@@ -176,7 +187,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public List<ClassifierResult> getClassifiers() {
-      return classifiers_serialized_name;
+      return classifiers;
     }
 
     /**
@@ -185,7 +196,7 @@ public class IBMVisualRecognitionV3Models {
      * @param sourceUrl the new sourceUrl
      */
     public void setSourceUrl(final String sourceUrl) {
-      this.source_url_serialized_name = sourceUrl;
+      this.sourceUrl = sourceUrl;
     }
 
     /**
@@ -194,7 +205,7 @@ public class IBMVisualRecognitionV3Models {
      * @param resolvedUrl the new resolvedUrl
      */
     public void setResolvedUrl(final String resolvedUrl) {
-      this.resolved_url_serialized_name = resolvedUrl;
+      this.resolvedUrl = resolvedUrl;
     }
 
     /**
@@ -203,7 +214,7 @@ public class IBMVisualRecognitionV3Models {
      * @param image the new image
      */
     public void setImage(final String image) {
-      this.image_serialized_name = image;
+      this.image = image;
     }
 
     /**
@@ -212,7 +223,7 @@ public class IBMVisualRecognitionV3Models {
      * @param error the new error
      */
     public void setError(final ErrorInfo error) {
-      this.error_serialized_name = error;
+      this.error = error;
     }
 
     /**
@@ -221,7 +232,7 @@ public class IBMVisualRecognitionV3Models {
      * @param classifiers the new classifiers
      */
     public void setClassifiers(final List<ClassifierResult> classifiers) {
-      this.classifiers_serialized_name = classifiers;
+      this.classifiers = classifiers;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -232,7 +243,7 @@ public class IBMVisualRecognitionV3Models {
       ClassifiedImage ret = (ClassifiedImage) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for error
-      ErrorInfo newError = (ErrorInfo) new ErrorInfo().deserialize(JSON.serialize(ret.getError()), (Map<String, Object>) jsonMap.get('error_serialized_name'), ErrorInfo.class);
+      ErrorInfo newError = (ErrorInfo) new ErrorInfo().deserialize(JSON.serialize(ret.getError()), (Map<String, Object>) jsonMap.get('error'), ErrorInfo.class);
       ret.setError(newError);
 
       // calling custom deserializer for classifiers
@@ -241,14 +252,27 @@ public class IBMVisualRecognitionV3Models {
       if (deserializedClassifiers != null) {
         for (Integer i = 0; i < deserializedClassifiers.size(); i++) {
           ClassifierResult currentItem = ret.getClassifiers().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('classifiers_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('classifiers');
           ClassifierResult newItem = (ClassifierResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ClassifierResult.class);
           newClassifiers.add(newItem);
         }
-        ret.classifiers_serialized_name = newClassifiers;
+        ret.classifiers = newClassifiers;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('source_url', 'sourceUrl');
+      mapping.put('resolved_url', 'resolvedUrl');
+      if (error != null) {
+        mapping.putAll(error.getApiToSdkMapping());
+      }
+      if (classifiers != null && classifiers[0] != null) {
+        mapping.putAll(classifiers[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -256,10 +280,10 @@ public class IBMVisualRecognitionV3Models {
    * Results for all images.
    */
   public class ClassifiedImages extends IBMWatsonResponseModel {
-    private Long custom_classes_serialized_name;
-    private Long images_processed_serialized_name;
-    private List<ClassifiedImage> images_serialized_name;
-    private List<WarningInfo> warnings_serialized_name;
+    private Long customClasses;
+    private Long imagesProcessed;
+    private List<ClassifiedImage> images;
+    private List<WarningInfo> warnings;
  
     /**
      * Gets the customClasses.
@@ -270,7 +294,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Long getCustomClasses() {
-      return custom_classes_serialized_name;
+      return customClasses;
     }
  
     /**
@@ -282,7 +306,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Long getImagesProcessed() {
-      return images_processed_serialized_name;
+      return imagesProcessed;
     }
  
     /**
@@ -294,7 +318,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public List<ClassifiedImage> getImages() {
-      return images_serialized_name;
+      return images;
     }
  
     /**
@@ -308,7 +332,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public List<WarningInfo> getWarnings() {
-      return warnings_serialized_name;
+      return warnings;
     }
 
     /**
@@ -317,7 +341,7 @@ public class IBMVisualRecognitionV3Models {
      * @param customClasses the new customClasses
      */
     public void setCustomClasses(final long customClasses) {
-      this.custom_classes_serialized_name = customClasses;
+      this.customClasses = customClasses;
     }
 
     /**
@@ -326,7 +350,7 @@ public class IBMVisualRecognitionV3Models {
      * @param imagesProcessed the new imagesProcessed
      */
     public void setImagesProcessed(final long imagesProcessed) {
-      this.images_processed_serialized_name = imagesProcessed;
+      this.imagesProcessed = imagesProcessed;
     }
 
     /**
@@ -335,7 +359,7 @@ public class IBMVisualRecognitionV3Models {
      * @param images the new images
      */
     public void setImages(final List<ClassifiedImage> images) {
-      this.images_serialized_name = images;
+      this.images = images;
     }
 
     /**
@@ -344,7 +368,7 @@ public class IBMVisualRecognitionV3Models {
      * @param warnings the new warnings
      */
     public void setWarnings(final List<WarningInfo> warnings) {
-      this.warnings_serialized_name = warnings;
+      this.warnings = warnings;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -360,11 +384,11 @@ public class IBMVisualRecognitionV3Models {
       if (deserializedImages != null) {
         for (Integer i = 0; i < deserializedImages.size(); i++) {
           ClassifiedImage currentItem = ret.getImages().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('images_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('images');
           ClassifiedImage newItem = (ClassifiedImage) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ClassifiedImage.class);
           newImages.add(newItem);
         }
-        ret.images_serialized_name = newImages;
+        ret.images = newImages;
       }
 
       // calling custom deserializer for warnings
@@ -373,14 +397,27 @@ public class IBMVisualRecognitionV3Models {
       if (deserializedWarnings != null) {
         for (Integer i = 0; i < deserializedWarnings.size(); i++) {
           WarningInfo currentItem = ret.getWarnings().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('warnings_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('warnings');
           WarningInfo newItem = (WarningInfo) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), WarningInfo.class);
           newWarnings.add(newItem);
         }
-        ret.warnings_serialized_name = newWarnings;
+        ret.warnings = newWarnings;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('custom_classes', 'customClasses');
+      mapping.put('images_processed', 'imagesProcessed');
+      if (images != null && images[0] != null) {
+        mapping.putAll(images[0].getApiToSdkMapping());
+      }
+      if (warnings != null && warnings[0] != null) {
+        mapping.putAll(warnings[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -388,16 +425,16 @@ public class IBMVisualRecognitionV3Models {
    * Information about a classifier.
    */
   public class Classifier extends IBMWatsonResponseModel {
-    private String classifier_id_serialized_name;
-    private String name_serialized_name;
-    private String owner_serialized_name;
-    private String status_serialized_name;
-    private Boolean core_ml_enabled_serialized_name;
-    private String explanation_serialized_name;
-    private Datetime created_serialized_name;
-    private List<ModelClass> classes_serialized_name;
-    private Datetime retrained_serialized_name;
-    private Datetime updated_serialized_name;
+    private String classifierId;
+    private String name;
+    private String owner;
+    private String status;
+    private Boolean coreMlEnabled;
+    private String explanation;
+    private Datetime created;
+    private List<ModelClass> classes;
+    private Datetime retrained;
+    private Datetime updated;
  
     /**
      * Gets the classifierId.
@@ -408,7 +445,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getClassifierId() {
-      return classifier_id_serialized_name;
+      return classifierId;
     }
  
     /**
@@ -420,7 +457,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -432,7 +469,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getOwner() {
-      return owner_serialized_name;
+      return owner;
     }
  
     /**
@@ -444,7 +481,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getStatus() {
-      return status_serialized_name;
+      return status;
     }
  
     /**
@@ -456,7 +493,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Boolean getCoreMlEnabled() {
-      return core_ml_enabled_serialized_name;
+      return coreMlEnabled;
     }
  
     /**
@@ -468,7 +505,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getExplanation() {
-      return explanation_serialized_name;
+      return explanation;
     }
  
     /**
@@ -480,7 +517,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Datetime getCreated() {
-      return created_serialized_name;
+      return created;
     }
  
     /**
@@ -492,7 +529,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public List<ModelClass> getClasses() {
-      return classes_serialized_name;
+      return classes;
     }
  
     /**
@@ -505,7 +542,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Datetime getRetrained() {
-      return retrained_serialized_name;
+      return retrained;
     }
  
     /**
@@ -518,7 +555,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Datetime getUpdated() {
-      return updated_serialized_name;
+      return updated;
     }
 
     /**
@@ -527,7 +564,7 @@ public class IBMVisualRecognitionV3Models {
      * @param classifierId the new classifierId
      */
     public void setClassifierId(final String classifierId) {
-      this.classifier_id_serialized_name = classifierId;
+      this.classifierId = classifierId;
     }
 
     /**
@@ -536,7 +573,7 @@ public class IBMVisualRecognitionV3Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -545,7 +582,7 @@ public class IBMVisualRecognitionV3Models {
      * @param owner the new owner
      */
     public void setOwner(final String owner) {
-      this.owner_serialized_name = owner;
+      this.owner = owner;
     }
 
     /**
@@ -554,7 +591,7 @@ public class IBMVisualRecognitionV3Models {
      * @param status the new status
      */
     public void setStatus(final String status) {
-      this.status_serialized_name = status;
+      this.status = status;
     }
 
     /**
@@ -563,7 +600,7 @@ public class IBMVisualRecognitionV3Models {
      * @param coreMlEnabled the new coreMlEnabled
      */
     public void setCoreMlEnabled(final Boolean coreMlEnabled) {
-      this.core_ml_enabled_serialized_name = coreMlEnabled;
+      this.coreMlEnabled = coreMlEnabled;
     }
 
     /**
@@ -572,7 +609,7 @@ public class IBMVisualRecognitionV3Models {
      * @param explanation the new explanation
      */
     public void setExplanation(final String explanation) {
-      this.explanation_serialized_name = explanation;
+      this.explanation = explanation;
     }
 
     /**
@@ -581,7 +618,7 @@ public class IBMVisualRecognitionV3Models {
      * @param created the new created
      */
     public void setCreated(final Datetime created) {
-      this.created_serialized_name = created;
+      this.created = created;
     }
 
     /**
@@ -590,7 +627,7 @@ public class IBMVisualRecognitionV3Models {
      * @param classes the new classes
      */
     public void setClasses(final List<ModelClass> classes) {
-      this.classes_serialized_name = classes;
+      this.classes = classes;
     }
 
     /**
@@ -599,7 +636,7 @@ public class IBMVisualRecognitionV3Models {
      * @param retrained the new retrained
      */
     public void setRetrained(final Datetime retrained) {
-      this.retrained_serialized_name = retrained;
+      this.retrained = retrained;
     }
 
     /**
@@ -608,7 +645,7 @@ public class IBMVisualRecognitionV3Models {
      * @param updated the new updated
      */
     public void setUpdated(final Datetime updated) {
-      this.updated_serialized_name = updated;
+      this.updated = updated;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -624,14 +661,24 @@ public class IBMVisualRecognitionV3Models {
       if (deserializedClasses != null) {
         for (Integer i = 0; i < deserializedClasses.size(); i++) {
           ModelClass currentItem = ret.getClasses().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('classes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('classes');
           ModelClass newItem = (ModelClass) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ModelClass.class);
           newClasses.add(newItem);
         }
-        ret.classes_serialized_name = newClasses;
+        ret.classes = newClasses;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifier_id', 'classifierId');
+      mapping.put('core_ml_enabled', 'coreMlEnabled');
+      if (classes != null && classes[0] != null) {
+        mapping.putAll(classes[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -639,9 +686,9 @@ public class IBMVisualRecognitionV3Models {
    * Classifier and score combination.
    */
   public class ClassifierResult extends IBMWatsonGenericModel {
-    private String name_serialized_name;
-    private String classifier_id_serialized_name;
-    private List<ClassResult> classes_serialized_name;
+    private String name;
+    private String classifierId;
+    private List<ClassResult> classes;
  
     /**
      * Gets the name.
@@ -652,7 +699,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getName() {
-      return name_serialized_name;
+      return name;
     }
  
     /**
@@ -664,7 +711,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getClassifierId() {
-      return classifier_id_serialized_name;
+      return classifierId;
     }
  
     /**
@@ -676,7 +723,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public List<ClassResult> getClasses() {
-      return classes_serialized_name;
+      return classes;
     }
 
     /**
@@ -685,7 +732,7 @@ public class IBMVisualRecognitionV3Models {
      * @param name the new name
      */
     public void setName(final String name) {
-      this.name_serialized_name = name;
+      this.name = name;
     }
 
     /**
@@ -694,7 +741,7 @@ public class IBMVisualRecognitionV3Models {
      * @param classifierId the new classifierId
      */
     public void setClassifierId(final String classifierId) {
-      this.classifier_id_serialized_name = classifierId;
+      this.classifierId = classifierId;
     }
 
     /**
@@ -703,7 +750,7 @@ public class IBMVisualRecognitionV3Models {
      * @param classes the new classes
      */
     public void setClasses(final List<ClassResult> classes) {
-      this.classes_serialized_name = classes;
+      this.classes = classes;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -719,14 +766,23 @@ public class IBMVisualRecognitionV3Models {
       if (deserializedClasses != null) {
         for (Integer i = 0; i < deserializedClasses.size(); i++) {
           ClassResult currentItem = ret.getClasses().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('classes_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('classes');
           ClassResult newItem = (ClassResult) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ClassResult.class);
           newClasses.add(newItem);
         }
-        ret.classes_serialized_name = newClasses;
+        ret.classes = newClasses;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifier_id', 'classifierId');
+      if (classes != null && classes[0] != null) {
+        mapping.putAll(classes[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -734,7 +790,7 @@ public class IBMVisualRecognitionV3Models {
    * A container for the list of classifiers.
    */
   public class Classifiers extends IBMWatsonResponseModel {
-    private List<Classifier> classifiers_serialized_name;
+    private List<Classifier> classifiers;
  
     /**
      * Gets the classifiers.
@@ -745,7 +801,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public List<Classifier> getClassifiers() {
-      return classifiers_serialized_name;
+      return classifiers;
     }
 
     /**
@@ -754,7 +810,7 @@ public class IBMVisualRecognitionV3Models {
      * @param classifiers the new classifiers
      */
     public void setClassifiers(final List<Classifier> classifiers) {
-      this.classifiers_serialized_name = classifiers;
+      this.classifiers = classifiers;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -770,14 +826,22 @@ public class IBMVisualRecognitionV3Models {
       if (deserializedClassifiers != null) {
         for (Integer i = 0; i < deserializedClassifiers.size(); i++) {
           Classifier currentItem = ret.getClassifiers().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('classifiers_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('classifiers');
           Classifier newItem = (Classifier) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Classifier.class);
           newClassifiers.add(newItem);
         }
-        ret.classifiers_serialized_name = newClassifiers;
+        ret.classifiers = newClassifiers;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (classifiers != null && classifiers[0] != null) {
+        mapping.putAll(classifiers[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -793,7 +857,7 @@ public class IBMVisualRecognitionV3Models {
     private List<String> owners;
     private List<String> classifierIds;
     private String acceptLanguage;
- 
+
     /**
      * Gets the imagesFile.
      *
@@ -808,7 +872,7 @@ public class IBMVisualRecognitionV3Models {
     public IBMWatsonFile imagesFile() {
       return imagesFile;
     }
- 
+
     /**
      * Gets the imagesFilename.
      *
@@ -819,7 +883,7 @@ public class IBMVisualRecognitionV3Models {
     public String imagesFilename() {
       return imagesFilename;
     }
- 
+
     /**
      * Gets the imagesFileContentType.
      *
@@ -830,7 +894,7 @@ public class IBMVisualRecognitionV3Models {
     public String imagesFileContentType() {
       return imagesFileContentType;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -845,7 +909,7 @@ public class IBMVisualRecognitionV3Models {
     public String url() {
       return url;
     }
- 
+
     /**
      * Gets the threshold.
      *
@@ -857,7 +921,7 @@ public class IBMVisualRecognitionV3Models {
     public Double threshold() {
       return threshold;
     }
- 
+
     /**
      * Gets the owners.
      *
@@ -874,7 +938,7 @@ public class IBMVisualRecognitionV3Models {
     public List<String> owners() {
       return owners;
     }
- 
+
     /**
      * Gets the classifierIds.
      *
@@ -892,7 +956,7 @@ public class IBMVisualRecognitionV3Models {
     public List<String> classifierIds() {
       return classifierIds;
     }
- 
+
     /**
      * Gets the acceptLanguage.
      *
@@ -926,6 +990,15 @@ public class IBMVisualRecognitionV3Models {
       return new ClassifyOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('imagesFile', 'images_file');
+      mapping.put('imagesFilename', 'images_filename');
+      mapping.put('imagesFileContentType', 'images_file_content_type');
+      mapping.put('classifierIds', 'classifier_ids');
+      mapping.put('acceptLanguage', 'Accept-Language');
+      return mapping;
+    }
   }
 
   /**
@@ -1109,7 +1182,7 @@ public class IBMVisualRecognitionV3Models {
     private Map<String, IBMWatsonFile> positiveExamples;
     private IBMWatsonFile negativeExamples;
     private String negativeExamplesFilename;
- 
+
     /**
      * Gets the name.
      *
@@ -1120,7 +1193,7 @@ public class IBMVisualRecognitionV3Models {
     public String name() {
       return name;
     }
- 
+
     /**
      * Gets the positiveExamples.
      *
@@ -1140,7 +1213,7 @@ public class IBMVisualRecognitionV3Models {
     public Map<String, IBMWatsonFile> positiveExamples() {
       return positiveExamples;
     }
- 
+
     /**
      * Gets the negativeExamples.
      *
@@ -1154,7 +1227,7 @@ public class IBMVisualRecognitionV3Models {
     public IBMWatsonFile negativeExamples() {
       return negativeExamples;
     }
- 
+
     /**
      * Gets the negativeExamplesFilename.
      *
@@ -1186,6 +1259,13 @@ public class IBMVisualRecognitionV3Models {
       return new CreateClassifierOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('positiveExamples', 'positive_examples');
+      mapping.put('negativeExamples', 'negative_examples');
+      mapping.put('negativeExamplesFilename', 'negative_examples_filename');
+      return mapping;
+    }
   }
 
   /**
@@ -1309,7 +1389,7 @@ public class IBMVisualRecognitionV3Models {
    */
   public class DeleteClassifierOptions extends IBMWatsonOptionsModel {
     private String classifierId;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -1336,6 +1416,11 @@ public class IBMVisualRecognitionV3Models {
       return new DeleteClassifierOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifierId', 'classifier_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1402,7 +1487,7 @@ public class IBMVisualRecognitionV3Models {
    */
   public class DeleteUserDataOptions extends IBMWatsonOptionsModel {
     private String customerId;
- 
+
     /**
      * Gets the customerId.
      *
@@ -1429,6 +1514,11 @@ public class IBMVisualRecognitionV3Models {
       return new DeleteUserDataOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('customerId', 'customer_id');
+      return mapping;
+    }
   }
 
   /**
@@ -1499,7 +1589,7 @@ public class IBMVisualRecognitionV3Models {
     private String imagesFileContentType;
     private String url;
     private String acceptLanguage;
- 
+
     /**
      * Gets the imagesFile.
      *
@@ -1516,7 +1606,7 @@ public class IBMVisualRecognitionV3Models {
     public IBMWatsonFile imagesFile() {
       return imagesFile;
     }
- 
+
     /**
      * Gets the imagesFilename.
      *
@@ -1527,7 +1617,7 @@ public class IBMVisualRecognitionV3Models {
     public String imagesFilename() {
       return imagesFilename;
     }
- 
+
     /**
      * Gets the imagesFileContentType.
      *
@@ -1538,7 +1628,7 @@ public class IBMVisualRecognitionV3Models {
     public String imagesFileContentType() {
       return imagesFileContentType;
     }
- 
+
     /**
      * Gets the url.
      *
@@ -1553,7 +1643,7 @@ public class IBMVisualRecognitionV3Models {
     public String url() {
       return url;
     }
- 
+
     /**
      * Gets the acceptLanguage.
      *
@@ -1584,6 +1674,14 @@ public class IBMVisualRecognitionV3Models {
       return new DetectFacesOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('imagesFile', 'images_file');
+      mapping.put('imagesFilename', 'images_filename');
+      mapping.put('imagesFileContentType', 'images_file_content_type');
+      mapping.put('acceptLanguage', 'Accept-Language');
+      return mapping;
+    }
   }
 
   /**
@@ -1692,9 +1790,9 @@ public class IBMVisualRecognitionV3Models {
    * Results for all faces.
    */
   public class DetectedFaces extends IBMWatsonResponseModel {
-    private Long images_processed_serialized_name;
-    private List<ImageWithFaces> images_serialized_name;
-    private List<WarningInfo> warnings_serialized_name;
+    private Long imagesProcessed;
+    private List<ImageWithFaces> images;
+    private List<WarningInfo> warnings;
  
     /**
      * Gets the imagesProcessed.
@@ -1705,7 +1803,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Long getImagesProcessed() {
-      return images_processed_serialized_name;
+      return imagesProcessed;
     }
  
     /**
@@ -1717,7 +1815,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public List<ImageWithFaces> getImages() {
-      return images_serialized_name;
+      return images;
     }
  
     /**
@@ -1731,7 +1829,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public List<WarningInfo> getWarnings() {
-      return warnings_serialized_name;
+      return warnings;
     }
 
     /**
@@ -1740,7 +1838,7 @@ public class IBMVisualRecognitionV3Models {
      * @param imagesProcessed the new imagesProcessed
      */
     public void setImagesProcessed(final long imagesProcessed) {
-      this.images_processed_serialized_name = imagesProcessed;
+      this.imagesProcessed = imagesProcessed;
     }
 
     /**
@@ -1749,7 +1847,7 @@ public class IBMVisualRecognitionV3Models {
      * @param images the new images
      */
     public void setImages(final List<ImageWithFaces> images) {
-      this.images_serialized_name = images;
+      this.images = images;
     }
 
     /**
@@ -1758,7 +1856,7 @@ public class IBMVisualRecognitionV3Models {
      * @param warnings the new warnings
      */
     public void setWarnings(final List<WarningInfo> warnings) {
-      this.warnings_serialized_name = warnings;
+      this.warnings = warnings;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1774,11 +1872,11 @@ public class IBMVisualRecognitionV3Models {
       if (deserializedImages != null) {
         for (Integer i = 0; i < deserializedImages.size(); i++) {
           ImageWithFaces currentItem = ret.getImages().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('images_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('images');
           ImageWithFaces newItem = (ImageWithFaces) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), ImageWithFaces.class);
           newImages.add(newItem);
         }
-        ret.images_serialized_name = newImages;
+        ret.images = newImages;
       }
 
       // calling custom deserializer for warnings
@@ -1787,14 +1885,26 @@ public class IBMVisualRecognitionV3Models {
       if (deserializedWarnings != null) {
         for (Integer i = 0; i < deserializedWarnings.size(); i++) {
           WarningInfo currentItem = ret.getWarnings().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('warnings_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('warnings');
           WarningInfo newItem = (WarningInfo) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), WarningInfo.class);
           newWarnings.add(newItem);
         }
-        ret.warnings_serialized_name = newWarnings;
+        ret.warnings = newWarnings;
       }
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('images_processed', 'imagesProcessed');
+      if (images != null && images[0] != null) {
+        mapping.putAll(images[0].getApiToSdkMapping());
+      }
+      if (warnings != null && warnings[0] != null) {
+        mapping.putAll(warnings[0].getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -1803,9 +1913,9 @@ public class IBMVisualRecognitionV3Models {
    * no error.
    */
   public class ErrorInfo extends IBMWatsonResponseModel {
-    private Long code_serialized_name;
-    private String description_serialized_name;
-    private String error_id_serialized_name;
+    private Long code;
+    private String description;
+    private String errorId;
  
     /**
      * Gets the code.
@@ -1816,7 +1926,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Long getCode() {
-      return code_serialized_name;
+      return code;
     }
  
     /**
@@ -1828,7 +1938,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
  
     /**
@@ -1840,7 +1950,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getErrorId() {
-      return error_id_serialized_name;
+      return errorId;
     }
 
     /**
@@ -1849,7 +1959,7 @@ public class IBMVisualRecognitionV3Models {
      * @param code the new code
      */
     public void setCode(final long code) {
-      this.code_serialized_name = code;
+      this.code = code;
     }
 
     /**
@@ -1858,7 +1968,7 @@ public class IBMVisualRecognitionV3Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
     /**
@@ -1867,18 +1977,23 @@ public class IBMVisualRecognitionV3Models {
      * @param errorId the new errorId
      */
     public void setErrorId(final String errorId) {
-      this.error_id_serialized_name = errorId;
+      this.errorId = errorId;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('error_id', 'errorId');
+      return mapping;
+    }
   }
 
   /**
    * Information about the face.
    */
   public class Face extends IBMWatsonGenericModel {
-    private FaceAge age_serialized_name;
-    private FaceGender gender_serialized_name;
-    private FaceLocation face_location_serialized_name;
+    private FaceAge age;
+    private FaceGender gender;
+    private FaceLocation faceLocation;
  
     /**
      * Gets the age.
@@ -1889,7 +2004,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public FaceAge getAge() {
-      return age_serialized_name;
+      return age;
     }
  
     /**
@@ -1901,7 +2016,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public FaceGender getGender() {
-      return gender_serialized_name;
+      return gender;
     }
  
     /**
@@ -1913,7 +2028,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public FaceLocation getFaceLocation() {
-      return face_location_serialized_name;
+      return faceLocation;
     }
 
     /**
@@ -1922,7 +2037,7 @@ public class IBMVisualRecognitionV3Models {
      * @param age the new age
      */
     public void setAge(final FaceAge age) {
-      this.age_serialized_name = age;
+      this.age = age;
     }
 
     /**
@@ -1931,7 +2046,7 @@ public class IBMVisualRecognitionV3Models {
      * @param gender the new gender
      */
     public void setGender(final FaceGender gender) {
-      this.gender_serialized_name = gender;
+      this.gender = gender;
     }
 
     /**
@@ -1940,7 +2055,7 @@ public class IBMVisualRecognitionV3Models {
      * @param faceLocation the new faceLocation
      */
     public void setFaceLocation(final FaceLocation faceLocation) {
-      this.face_location_serialized_name = faceLocation;
+      this.faceLocation = faceLocation;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -1951,18 +2066,27 @@ public class IBMVisualRecognitionV3Models {
       Face ret = (Face) super.deserialize(jsonString, jsonMap, classType);
 
       // calling custom deserializer for age
-      FaceAge newAge = (FaceAge) new FaceAge().deserialize(JSON.serialize(ret.getAge()), (Map<String, Object>) jsonMap.get('age_serialized_name'), FaceAge.class);
+      FaceAge newAge = (FaceAge) new FaceAge().deserialize(JSON.serialize(ret.getAge()), (Map<String, Object>) jsonMap.get('age'), FaceAge.class);
       ret.setAge(newAge);
 
       // calling custom deserializer for gender
-      FaceGender newGender = (FaceGender) new FaceGender().deserialize(JSON.serialize(ret.getGender()), (Map<String, Object>) jsonMap.get('gender_serialized_name'), FaceGender.class);
+      FaceGender newGender = (FaceGender) new FaceGender().deserialize(JSON.serialize(ret.getGender()), (Map<String, Object>) jsonMap.get('gender'), FaceGender.class);
       ret.setGender(newGender);
 
       // calling custom deserializer for faceLocation
-      FaceLocation newFaceLocation = (FaceLocation) new FaceLocation().deserialize(JSON.serialize(ret.getFaceLocation()), (Map<String, Object>) jsonMap.get('face_location_serialized_name'), FaceLocation.class);
+      FaceLocation newFaceLocation = (FaceLocation) new FaceLocation().deserialize(JSON.serialize(ret.getFaceLocation()), (Map<String, Object>) jsonMap.get('faceLocation'), FaceLocation.class);
       ret.setFaceLocation(newFaceLocation);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (gender != null) {
+        mapping.putAll(gender.getApiToSdkMapping());
+      }
+      mapping.put('face_location', 'faceLocation');
+      return mapping;
     }
   }
 
@@ -1970,9 +2094,9 @@ public class IBMVisualRecognitionV3Models {
    * Age information about a face.
    */
   public class FaceAge extends IBMWatsonGenericModel {
-    private Long min_serialized_name;
-    private Long max_serialized_name;
-    private Double score_serialized_name;
+    private Long min;
+    private Long max;
+    private Double score;
  
     /**
      * Gets the min.
@@ -1983,7 +2107,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Long getMin() {
-      return min_serialized_name;
+      return min;
     }
  
     /**
@@ -1995,7 +2119,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Long getMax() {
-      return max_serialized_name;
+      return max;
     }
  
     /**
@@ -2008,7 +2132,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
 
     /**
@@ -2017,7 +2141,7 @@ public class IBMVisualRecognitionV3Models {
      * @param min the new min
      */
     public void setMin(final long min) {
-      this.min_serialized_name = min;
+      this.min = min;
     }
 
     /**
@@ -2026,7 +2150,7 @@ public class IBMVisualRecognitionV3Models {
      * @param max the new max
      */
     public void setMax(final long max) {
-      this.max_serialized_name = max;
+      this.max = max;
     }
 
     /**
@@ -2035,18 +2159,17 @@ public class IBMVisualRecognitionV3Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
-
   }
 
   /**
    * Information about the gender of the face.
    */
   public class FaceGender extends IBMWatsonGenericModel {
-    private String gender_serialized_name;
-    private String gender_label_serialized_name;
-    private Double score_serialized_name;
+    private String gender;
+    private String genderLabel;
+    private Double score;
  
     /**
      * Gets the gender.
@@ -2057,7 +2180,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getGender() {
-      return gender_serialized_name;
+      return gender;
     }
  
     /**
@@ -2069,7 +2192,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getGenderLabel() {
-      return gender_label_serialized_name;
+      return genderLabel;
     }
  
     /**
@@ -2082,7 +2205,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Double getScore() {
-      return score_serialized_name;
+      return score;
     }
 
     /**
@@ -2091,7 +2214,7 @@ public class IBMVisualRecognitionV3Models {
      * @param gender the new gender
      */
     public void setGender(final String gender) {
-      this.gender_serialized_name = gender;
+      this.gender = gender;
     }
 
     /**
@@ -2100,7 +2223,7 @@ public class IBMVisualRecognitionV3Models {
      * @param genderLabel the new genderLabel
      */
     public void setGenderLabel(final String genderLabel) {
-      this.gender_label_serialized_name = genderLabel;
+      this.genderLabel = genderLabel;
     }
 
     /**
@@ -2109,19 +2232,24 @@ public class IBMVisualRecognitionV3Models {
      * @param score the new score
      */
     public void setScore(final Double score) {
-      this.score_serialized_name = score;
+      this.score = score;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('gender_label', 'genderLabel');
+      return mapping;
+    }
   }
 
   /**
    * The location of the bounding box around the face.
    */
   public class FaceLocation extends IBMWatsonGenericModel {
-    private Double width_serialized_name;
-    private Double height_serialized_name;
-    private Double left_serialized_name;
-    private Double top_serialized_name;
+    private Double width;
+    private Double height;
+    private Double left;
+    private Double top;
  
     /**
      * Gets the width.
@@ -2132,7 +2260,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Double getWidth() {
-      return width_serialized_name;
+      return width;
     }
  
     /**
@@ -2144,7 +2272,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Double getHeight() {
-      return height_serialized_name;
+      return height;
     }
  
     /**
@@ -2156,7 +2284,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Double getLeft() {
-      return left_serialized_name;
+      return left;
     }
  
     /**
@@ -2168,7 +2296,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public Double getTop() {
-      return top_serialized_name;
+      return top;
     }
 
     /**
@@ -2177,7 +2305,7 @@ public class IBMVisualRecognitionV3Models {
      * @param width the new width
      */
     public void setWidth(final Double width) {
-      this.width_serialized_name = width;
+      this.width = width;
     }
 
     /**
@@ -2186,7 +2314,7 @@ public class IBMVisualRecognitionV3Models {
      * @param height the new height
      */
     public void setHeight(final Double height) {
-      this.height_serialized_name = height;
+      this.height = height;
     }
 
     /**
@@ -2195,7 +2323,7 @@ public class IBMVisualRecognitionV3Models {
      * @param left the new left
      */
     public void setLeft(final Double left) {
-      this.left_serialized_name = left;
+      this.left = left;
     }
 
     /**
@@ -2204,9 +2332,8 @@ public class IBMVisualRecognitionV3Models {
      * @param top the new top
      */
     public void setTop(final Double top) {
-      this.top_serialized_name = top;
+      this.top = top;
     }
-
   }
 
   /**
@@ -2214,7 +2341,7 @@ public class IBMVisualRecognitionV3Models {
    */
   public class GetClassifierOptions extends IBMWatsonOptionsModel {
     private String classifierId;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -2241,6 +2368,11 @@ public class IBMVisualRecognitionV3Models {
       return new GetClassifierOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifierId', 'classifier_id');
+      return mapping;
+    }
   }
 
   /**
@@ -2307,7 +2439,7 @@ public class IBMVisualRecognitionV3Models {
    */
   public class GetCoreMlModelOptions extends IBMWatsonOptionsModel {
     private String classifierId;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -2334,6 +2466,11 @@ public class IBMVisualRecognitionV3Models {
       return new GetCoreMlModelOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifierId', 'classifier_id');
+      return mapping;
+    }
   }
 
   /**
@@ -2399,11 +2536,11 @@ public class IBMVisualRecognitionV3Models {
    * Information about faces in the image.
    */
   public class ImageWithFaces extends IBMWatsonGenericModel {
-    private List<Face> faces_serialized_name;
-    private String image_serialized_name;
-    private String source_url_serialized_name;
-    private String resolved_url_serialized_name;
-    private ErrorInfo error_serialized_name;
+    private List<Face> faces;
+    private String image;
+    private String sourceUrl;
+    private String resolvedUrl;
+    private ErrorInfo error;
  
     /**
      * Gets the faces.
@@ -2414,7 +2551,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public List<Face> getFaces() {
-      return faces_serialized_name;
+      return faces;
     }
  
     /**
@@ -2426,7 +2563,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getImage() {
-      return image_serialized_name;
+      return image;
     }
  
     /**
@@ -2438,7 +2575,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getSourceUrl() {
-      return source_url_serialized_name;
+      return sourceUrl;
     }
  
     /**
@@ -2450,7 +2587,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getResolvedUrl() {
-      return resolved_url_serialized_name;
+      return resolvedUrl;
     }
  
     /**
@@ -2463,7 +2600,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public ErrorInfo getError() {
-      return error_serialized_name;
+      return error;
     }
 
     /**
@@ -2472,7 +2609,7 @@ public class IBMVisualRecognitionV3Models {
      * @param faces the new faces
      */
     public void setFaces(final List<Face> faces) {
-      this.faces_serialized_name = faces;
+      this.faces = faces;
     }
 
     /**
@@ -2481,7 +2618,7 @@ public class IBMVisualRecognitionV3Models {
      * @param image the new image
      */
     public void setImage(final String image) {
-      this.image_serialized_name = image;
+      this.image = image;
     }
 
     /**
@@ -2490,7 +2627,7 @@ public class IBMVisualRecognitionV3Models {
      * @param sourceUrl the new sourceUrl
      */
     public void setSourceUrl(final String sourceUrl) {
-      this.source_url_serialized_name = sourceUrl;
+      this.sourceUrl = sourceUrl;
     }
 
     /**
@@ -2499,7 +2636,7 @@ public class IBMVisualRecognitionV3Models {
      * @param resolvedUrl the new resolvedUrl
      */
     public void setResolvedUrl(final String resolvedUrl) {
-      this.resolved_url_serialized_name = resolvedUrl;
+      this.resolvedUrl = resolvedUrl;
     }
 
     /**
@@ -2508,7 +2645,7 @@ public class IBMVisualRecognitionV3Models {
      * @param error the new error
      */
     public void setError(final ErrorInfo error) {
-      this.error_serialized_name = error;
+      this.error = error;
     }
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
@@ -2524,18 +2661,31 @@ public class IBMVisualRecognitionV3Models {
       if (deserializedFaces != null) {
         for (Integer i = 0; i < deserializedFaces.size(); i++) {
           Face currentItem = ret.getFaces().get(i);
-          List<Object> itemInMap = (List<Object>) jsonMap.get('faces_serialized_name');
+          List<Object> itemInMap = (List<Object>) jsonMap.get('faces');
           Face newItem = (Face) currentItem.deserialize(JSON.serialize(currentItem), (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(itemInMap.get(i))), Face.class);
           newFaces.add(newItem);
         }
-        ret.faces_serialized_name = newFaces;
+        ret.faces = newFaces;
       }
 
       // calling custom deserializer for error
-      ErrorInfo newError = (ErrorInfo) new ErrorInfo().deserialize(JSON.serialize(ret.getError()), (Map<String, Object>) jsonMap.get('error_serialized_name'), ErrorInfo.class);
+      ErrorInfo newError = (ErrorInfo) new ErrorInfo().deserialize(JSON.serialize(ret.getError()), (Map<String, Object>) jsonMap.get('error'), ErrorInfo.class);
       ret.setError(newError);
 
       return ret;
+    }
+
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      if (faces != null && faces[0] != null) {
+        mapping.putAll(faces[0].getApiToSdkMapping());
+      }
+      mapping.put('source_url', 'sourceUrl');
+      mapping.put('resolved_url', 'resolvedUrl');
+      if (error != null) {
+        mapping.putAll(error.getApiToSdkMapping());
+      }
+      return mapping;
     }
   }
 
@@ -2544,7 +2694,7 @@ public class IBMVisualRecognitionV3Models {
    */
   public class ListClassifiersOptions extends IBMWatsonOptionsModel {
     private Boolean verbose;
- 
+
     /**
      * Gets the verbose.
      *
@@ -2570,7 +2720,6 @@ public class IBMVisualRecognitionV3Models {
     public ListClassifiersOptionsBuilder newBuilder() {
       return new ListClassifiersOptionsBuilder(this);
     }
-
   }
 
   /**
@@ -2631,7 +2780,7 @@ public class IBMVisualRecognitionV3Models {
     private Map<String, IBMWatsonFile> positiveExamples;
     private IBMWatsonFile negativeExamples;
     private String negativeExamplesFilename;
- 
+
     /**
      * Gets the classifierId.
      *
@@ -2642,7 +2791,7 @@ public class IBMVisualRecognitionV3Models {
     public String classifierId() {
       return classifierId;
     }
- 
+
     /**
      * Gets the positiveExamples.
      *
@@ -2662,7 +2811,7 @@ public class IBMVisualRecognitionV3Models {
     public Map<String, IBMWatsonFile> positiveExamples() {
       return positiveExamples;
     }
- 
+
     /**
      * Gets the negativeExamples.
      *
@@ -2676,7 +2825,7 @@ public class IBMVisualRecognitionV3Models {
     public IBMWatsonFile negativeExamples() {
       return negativeExamples;
     }
- 
+
     /**
      * Gets the negativeExamplesFilename.
      *
@@ -2707,6 +2856,14 @@ public class IBMVisualRecognitionV3Models {
       return new UpdateClassifierOptionsBuilder(this);
     }
 
+    public override Map<String, String> getSdkToApiMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('classifierId', 'classifier_id');
+      mapping.put('positiveExamples', 'positive_examples');
+      mapping.put('negativeExamples', 'negative_examples');
+      mapping.put('negativeExamplesFilename', 'negative_examples_filename');
+      return mapping;
+    }
   }
 
   /**
@@ -2829,8 +2986,8 @@ public class IBMVisualRecognitionV3Models {
    * Information about something that went wrong.
    */
   public class WarningInfo extends IBMWatsonGenericModel {
-    private String warning_id_serialized_name;
-    private String description_serialized_name;
+    private String warningId;
+    private String description;
  
     /**
      * Gets the warningId.
@@ -2841,7 +2998,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getWarningId() {
-      return warning_id_serialized_name;
+      return warningId;
     }
  
     /**
@@ -2853,7 +3010,7 @@ public class IBMVisualRecognitionV3Models {
      */
     @AuraEnabled
     public String getDescription() {
-      return description_serialized_name;
+      return description;
     }
 
     /**
@@ -2862,7 +3019,7 @@ public class IBMVisualRecognitionV3Models {
      * @param warningId the new warningId
      */
     public void setWarningId(final String warningId) {
-      this.warning_id_serialized_name = warningId;
+      this.warningId = warningId;
     }
 
     /**
@@ -2871,9 +3028,14 @@ public class IBMVisualRecognitionV3Models {
      * @param description the new description
      */
     public void setDescription(final String description) {
-      this.description_serialized_name = description;
+      this.description = description;
     }
 
+    public override Map<String, String> getApiToSdkMapping() {
+      Map<String, String> mapping = new Map<String, String>();
+      mapping.put('warning_id', 'warningId');
+      return mapping;
+    }
   }
 
 }

--- a/force-app/main/default/classes/IBMWatsonClient.cls
+++ b/force-app/main/default/classes/IBMWatsonClient.cls
@@ -36,7 +36,7 @@ public class IBMWatsonClient {
         httpRequest.setBodyAsBlob(EncodingUtil.base64Decode(form64));
         httpRequest.setHeader('Content-Length', String.valueof(form64.length()));
       } else if (request.getBody().contentType.toString().contains(IBMWatsonHttpMediaType.APPLICATION_JSON)) {
-        httpRequest.setBody(IBMWatsonJSONUtil.serialize(request.getBody().content));
+        httpRequest.setBody(request.getBody().content);
       } else {
         if (request.getBody().content != null) {
           httpRequest.setBody(request.getBody().content);

--- a/force-app/main/default/classes/IBMWatsonDynamicModel.cls
+++ b/force-app/main/default/classes/IBMWatsonDynamicModel.cls
@@ -1,21 +1,21 @@
 public virtual class IBMWatsonDynamicModel extends IBMWatsonGenericModel {
-  private Map<String, Object> additional_properties;
+  private Map<String, Object> additionalProperties;
 
   public Object get(String key) {
-    if (additional_properties == null) {
-      additional_properties = new Map<String, Object>();
+    if (additionalProperties == null) {
+      additionalProperties = new Map<String, Object>();
     }
-    return additional_properties.get(key);
+    return additionalProperties.get(key);
   }
 
   public void put(String key, Object val) {
-    if (additional_properties == null) {
-      additional_properties = new Map<String, Object>();
+    if (additionalProperties == null) {
+      additionalProperties = new Map<String, Object>();
     }
-    additional_properties.put(key, val);
+    additionalProperties.put(key, val);
   }
 
   public Map<String, Object> getDynamicProperties() {
-    return this.additional_properties;
+    return this.additionalProperties;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonDynamicModel.cls
+++ b/force-app/main/default/classes/IBMWatsonDynamicModel.cls
@@ -12,9 +12,7 @@ public virtual class IBMWatsonDynamicModel extends IBMWatsonGenericModel {
     if (additional_properties == null) {
       additional_properties = new Map<String, Object>();
     }
-
-    String valJson = JSON.serialize(val).remove('_serialized_name');
-    additional_properties.put(key.removeEnd('_serialized_name'), JSON.deserializeUntyped(valJson));
+    additional_properties.put(key, val);
   }
 
   public Map<String, Object> getDynamicProperties() {

--- a/force-app/main/default/classes/IBMWatsonDynamicModel.cls
+++ b/force-app/main/default/classes/IBMWatsonDynamicModel.cls
@@ -1,40 +1,5 @@
-public virtual class IBMWatsonDynamicModel {
-
+public virtual class IBMWatsonDynamicModel extends IBMWatsonGenericModel {
   private Map<String, Object> additional_properties;
-
-  /**
-   * Allows user to see the JSON string by default for easier debugging.
-   *
-   * @return serialized String form of this
-   */
-  public override String toString() {
-    // get JSON string representation
-    String jsonString = JSON.serialize(this, true);
-
-    // call custom serializer to raise additional properties
-    jsonString = IBMWatsonJSONUtil.serialize(jsonString);
-
-    // pretty print formatting
-    jsonString = JSON.serializePretty(JSON.deserializeUntyped(jsonString));
-    return jsonString;
-  }
-
-  /**
-   * Allows comparison of custom models based on their serialized String form.
-   *
-   * @param obj the object this is being compared to
-   *
-   * @return Boolean indicating whether or not the two objects are equal
-   */
-  public Boolean equals(Object obj) {
-    if ((obj == null)) {
-      return false;
-    }
-
-    IBMWatsonDynamicModel other = (IBMWatsonDynamicModel) obj;
-
-    return this.toString().equals(other.toString());
-  }
 
   public Object get(String key) {
     if (additional_properties == null) {
@@ -52,20 +17,7 @@ public virtual class IBMWatsonDynamicModel {
     additional_properties.put(key.removeEnd('_serialized_name'), JSON.deserializeUntyped(valJson));
   }
 
-  public virtual Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-    Object ret;
-    if (jsonString.equals('null')) {
-      ret = classType.newInstance();
-    }
-    else {
-      ret = JSON.deserialize(jsonString, classType);
-    }
-
-    return ret;
-  }
-
   public Map<String, Object> getDynamicProperties() {
     return this.additional_properties;
   }
-
 }

--- a/force-app/main/default/classes/IBMWatsonDynamicResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonDynamicResponseModel.cls
@@ -12,9 +12,7 @@ public virtual class IBMWatsonDynamicResponseModel extends IBMWatsonResponseMode
     if (additional_properties == null) {
       additional_properties = new Map<String, Object>();
     }
-
-    String valJson = JSON.serialize(val).remove('_serialized_name');
-    additional_properties.put(key.removeEnd('_serialized_name'), JSON.deserializeUntyped(valJson));
+    additional_properties.put(key, val);
   }
 
   public Map<String, Object> getDynamicProperties() {

--- a/force-app/main/default/classes/IBMWatsonDynamicResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonDynamicResponseModel.cls
@@ -1,21 +1,21 @@
 public virtual class IBMWatsonDynamicResponseModel extends IBMWatsonResponseModel {
-  private Map<String, Object> additional_properties;
+  private Map<String, Object> additionalProperties;
 
   public Object get(String key) {
-    if (additional_properties == null) {
-      additional_properties = new Map<String, Object>();
+    if (additionalProperties == null) {
+      additionalProperties = new Map<String, Object>();
     }
-    return additional_properties.get(key);
+    return additionalProperties.get(key);
   }
 
   public void put(String key, Object val) {
-    if (additional_properties == null) {
-      additional_properties = new Map<String, Object>();
+    if (additionalProperties == null) {
+      additionalProperties = new Map<String, Object>();
     }
-    additional_properties.put(key, val);
+    additionalProperties.put(key, val);
   }
 
   public Map<String, Object> getDynamicProperties() {
-    return this.additional_properties;
+    return this.additionalProperties;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonGenericModel.cls
+++ b/force-app/main/default/classes/IBMWatsonGenericModel.cls
@@ -6,15 +6,12 @@ public virtual class IBMWatsonGenericModel {
    * @return serialized String form of this
    */
   public override String toString() {
-    // get JSON string representation
-    String jsonString = JSON.serialize(this, true);
-
-    // call custom serializer to raise additional properties
-    jsonString = IBMWatsonJSONUtil.serialize(jsonString);
+    // get Map representation and raise additional props
+    Map<String, Object> objectMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this, true));
+    objectMap = IBMWatsonJSONUtil.raiseAdditionalProperties(objectMap);
 
     // pretty print formatting
-    jsonString = JSON.serializePretty(JSON.deserializeUntyped(jsonString));
-    return jsonString;
+    return JSON.serializePretty(objectMap);
   }
 
   /**
@@ -48,5 +45,13 @@ public virtual class IBMWatsonGenericModel {
     }
 
     return ret;
+  }
+
+  public virtual Map<String, String> getSdkToApiMapping() {
+    return new Map<String, String>();
+  }
+
+  public virtual Map<String, String> getApiToSdkMapping() {
+    return new Map<String, String>();
   }
 }

--- a/force-app/main/default/classes/IBMWatsonGenericModel.cls
+++ b/force-app/main/default/classes/IBMWatsonGenericModel.cls
@@ -5,7 +5,7 @@ public virtual class IBMWatsonGenericModel {
    *
    * @return serialized String form of this
    */
-  public override String toString() {
+  public virtual override String toString() {
     // get Map representation and raise additional props
     Map<String, Object> objectMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this, true));
     objectMap = IBMWatsonJSONUtil.raiseAdditionalProperties(objectMap);
@@ -47,11 +47,11 @@ public virtual class IBMWatsonGenericModel {
     return ret;
   }
 
-  public virtual Map<String, String> getSdkToApiMapping() {
-    return new Map<String, String>();
+  public virtual Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
+    return mapping;
   }
 
-  public virtual Map<String, String> getApiToSdkMapping() {
-    return new Map<String, String>();
+  public virtual Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
+    return mapping;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonIAMToken.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMToken.cls
@@ -2,29 +2,47 @@
  * Represents response from IAM API.
  */
 public class IBMWatsonIAMToken extends IBMWatsonGenericModel {
-  private String access_token;
-  private String refresh_token;
-  private String token_type;
-  private Long expires_in;
+  private String accessToken;
+  private String refreshToken;
+  private String tokenType;
+  private Long expiresIn;
   private Long expiration;
 
   public String getAccessToken() {
-    return access_token;
+    return accessToken;
   }
 
   public String getRefreshToken() {
-    return refresh_token;
+    return refreshToken;
   }
 
   public String getTokenType() {
-    return token_type;
+    return tokenType;
   }
 
   public Long getExpiresIn() {
-    return expires_in;
+    return expiresIn;
   }
 
   public Long getExpiration() {
     return expiration;
+  }
+
+  public override Map<String, String> getSdkToApiMapping() {
+    Map<String, String> mapping = new Map<String, String>();
+    mapping.put('accessToken', 'access_token');
+    mapping.put('refreshToken', 'refresh_token');
+    mapping.put('tokenType', 'token_type');
+    mapping.put('expiresIn', 'expires_in');
+    return mapping;
+  }
+
+  public override Map<String, String> getApiToSdkMapping() {
+    Map<String, String> mapping = new Map<String, String>();
+    mapping.put('access_token', 'accessToken');
+    mapping.put('refresh_token', 'refreshToken');
+    mapping.put('token_type', 'tokenType');
+    mapping.put('expires_in', 'expiresIn');
+    return mapping;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonIAMToken.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMToken.cls
@@ -2,29 +2,29 @@
  * Represents response from IAM API.
  */
 public class IBMWatsonIAMToken extends IBMWatsonGenericModel {
-  private String access_token_serialized_name;
-  private String refresh_token_serialized_name;
-  private String token_type_serialized_name;
-  private Long expires_in_serialized_name;
-  private Long expiration_serialized_name;
+  private String access_token;
+  private String refresh_token;
+  private String token_type;
+  private Long expires_in;
+  private Long expiration;
 
   public String getAccessToken() {
-    return access_token_serialized_name;
+    return access_token;
   }
 
   public String getRefreshToken() {
-    return refresh_token_serialized_name;
+    return refresh_token;
   }
 
   public String getTokenType() {
-    return token_type_serialized_name;
+    return token_type;
   }
 
   public Long getExpiresIn() {
-    return expires_in_serialized_name;
+    return expires_in;
   }
 
   public Long getExpiration() {
-    return expiration_serialized_name;
+    return expiration;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonIAMToken.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMToken.cls
@@ -28,8 +28,7 @@ public class IBMWatsonIAMToken extends IBMWatsonGenericModel {
     return expiration;
   }
 
-  public override Map<String, String> getSdkToApiMapping() {
-    Map<String, String> mapping = new Map<String, String>();
+  public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
     mapping.put('accessToken', 'access_token');
     mapping.put('refreshToken', 'refresh_token');
     mapping.put('tokenType', 'token_type');
@@ -37,8 +36,7 @@ public class IBMWatsonIAMToken extends IBMWatsonGenericModel {
     return mapping;
   }
 
-  public override Map<String, String> getApiToSdkMapping() {
-    Map<String, String> mapping = new Map<String, String>();
+  public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
     mapping.put('access_token', 'accessToken');
     mapping.put('refresh_token', 'refreshToken');
     mapping.put('token_type', 'tokenType');

--- a/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
+++ b/force-app/main/default/classes/IBMWatsonIAMTokenManager.cls
@@ -124,9 +124,8 @@ public class IBMWatsonIAMTokenManager implements IBMWatsonAuthenticator {
 
     if (response.isSuccessful() && String.isNotBlank(response.getBody())) {
       Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
-      Map<String, Object> safeJsonMap = IBMWatsonJSONUtil.prepareResponse(jsonMap);
-      String jsonString = JSON.serialize(safeJsonMap);
-      return (IBMWatsonIAMToken) ((IBMWatsonGenericModel) IBMWatsonIAMToken.class.newInstance()).deserialize(jsonString, safeJsonMap, IBMWatsonIAMToken.class);
+      String jsonString = JSON.serialize(jsonMap);
+      return (IBMWatsonIAMToken) ((IBMWatsonGenericModel) IBMWatsonIAMToken.class.newInstance()).deserialize(jsonString, jsonMap, IBMWatsonIAMToken.class);
     } else {
       Map<String, Object> responseMap = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
       String errorMessage = responseMap.get('errorMessage').toString();

--- a/force-app/main/default/classes/IBMWatsonICP4DAuthenticator.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DAuthenticator.cls
@@ -83,8 +83,7 @@ public class IBMWatsonICP4DAuthenticator implements IBMWatsonAuthenticator {
 
     if (response.isSuccessful() && String.isNotBlank(response.getBody())) {
       Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
-      Map<String, Object> safeJsonMap = IBMWatsonJSONUtil.prepareResponse(jsonMap);
-      String jsonString = JSON.serialize(safeJsonMap);
+      String jsonString = JSON.serialize(jsonMap);
       return (IBMWatsonICP4DTokenResponse)JSON.deserialize(jsonString, IBMWatsonICP4DTokenResponse.class);
     } else {
       Map<String, Object> responseMap = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());

--- a/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls
@@ -67,14 +67,12 @@ public class IBMWatsonICP4DTokenResponse extends IBMWatsonGenericModel {
     this.message = message;
   }
 
-  public override Map<String, String> getSdkToApiMapping() {
-    Map<String, String> mapping = new Map<String, String>();
+  public override Map<String, String> addToSdkToApiMapping(String parentLabel, Map<String, String> mapping) {
     mapping.put('accessToken', 'access_token');
     return mapping;
   }
 
-  public override Map<String, String> getApiToSdkMapping() {
-    Map<String, String> mapping = new Map<String, String>();
+  public override Map<String, String> addToApiToSdkMapping(String parentLabel, Map<String, String> mapping) {
     mapping.put('access_token', 'accessToken');
     return mapping;
   }

--- a/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls
@@ -2,68 +2,68 @@
  * This class models a response received from the ICP4D "get token" API.
  */
 public class IBMWatsonICP4DTokenResponse extends IBMWatsonGenericModel {
-  private String username_serialized_name;
-  private String role_serialized_name;
-  private String[] permissions_serialized_name;
-  private String sub_serialized_name;
-  private String iss_serialized_name;
-  private String aud_serialized_name;
-  private String uid_serialized_name;
-  private String accessToken_serialized_name;
-  private String message_serialized_name;
+  private String username;
+  private String role;
+  private String[] permissions;
+  private String sub;
+  private String iss;
+  private String aud;
+  private String uid;
+  private String accessToken;
+  private String message;
 
   public String getUsername() {
-    return username_serialized_name;
+    return username;
   }
   public void setUsername(String username) {
-    this.username_serialized_name = username;
+    this.username = username;
   }
   public String getRole() {
-    return role_serialized_name;
+    return role;
   }
   public void setRole(String role) {
-    this.role_serialized_name = role;
+    this.role = role;
   }
   public String[] getPermissions() {
-    return permissions_serialized_name;
+    return permissions;
   }
   public void setPermissions(String[] permissions) {
-    this.permissions_serialized_name = permissions;
+    this.permissions = permissions;
   }
   public String getSub() {
-    return sub_serialized_name;
+    return sub;
   }
   public void setSub(String sub) {
-    this.sub_serialized_name = sub;
+    this.sub = sub;
   }
   public String getIss() {
-    return iss_serialized_name;
+    return iss;
   }
   public void setIss(String iss) {
-    this.iss_serialized_name = iss;
+    this.iss = iss;
   }
   public String getAud() {
-    return aud_serialized_name;
+    return aud;
   }
   public void setAud(String aud) {
-    this.aud_serialized_name = aud;
+    this.aud = aud;
   }
   public String getUid() {
-    return uid_serialized_name;
+    return uid;
   }
   public void setUid(String uid) {
-    this.uid_serialized_name = uid;
+    this.uid = uid;
   }
   public String getAccessToken() {
-    return accessToken_serialized_name;
+    return accessToken;
   }
   public void setAccessToken(String accessToken) {
-    this.accessToken_serialized_name = accessToken;
+    this.accessToken = accessToken;
   }
   public String getMessage() {
-    return message_serialized_name;
+    return message;
   }
   public void setMessage(String message) {
-    this.message_serialized_name = message;
+    this.message = message;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls
+++ b/force-app/main/default/classes/IBMWatsonICP4DTokenResponse.cls
@@ -66,4 +66,16 @@ public class IBMWatsonICP4DTokenResponse extends IBMWatsonGenericModel {
   public void setMessage(String message) {
     this.message = message;
   }
+
+  public override Map<String, String> getSdkToApiMapping() {
+    Map<String, String> mapping = new Map<String, String>();
+    mapping.put('accessToken', 'access_token');
+    return mapping;
+  }
+
+  public override Map<String, String> getApiToSdkMapping() {
+    Map<String, String> mapping = new Map<String, String>();
+    mapping.put('access_token', 'accessToken');
+    return mapping;
+  }
 }

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -34,54 +34,6 @@ public class IBMWatsonJSONUtil {
   }
 
   /**
-   * Calls appropriate methods to prepare the JSON response for deserialization. This involves removing empty
-   * string values and adding the property suffix to avoid using reserved words.
-   *
-   * @param jsonMap Map<String, Object> representation of the JSON response
-   *
-   * return Map<String, Object> representing our JSON object ready to be deserialized
-   */
-  public static Map<String, Object> prepareResponse(Map<String, Object> jsonMap) {
-    return addPropertySuffix(jsonMap);
-  }
-
-  /**
-   * Adds '_serialized_name' suffix to all property keys.
-   *
-   * @param jsonMap Map<String, Object> representation of the JSON response
-   *
-   * @return Map<String, Object> representing the JSON response with modified keys
-   */
-  public static Map<String, Object> addPropertySuffix(Map<String, Object> jsonMap) {
-    Map<String, Object> safeMap = new Map<String, Object>();
-
-    for (String key : jsonMap.keySet()) {
-      String safeKey = key + '_serialized_name';
-      Object jsonValue = jsonMap.get(key);
-      if (jsonValue instanceof Map<String, Object>) {
-        safeMap.put(safeKey, addPropertySuffix((Map<String, Object>) jsonValue));
-      } else if (jsonValue instanceof List<Object>) {
-        safeMap.put(safeKey, addPropertySuffixList((List<Object>) jsonValue));
-      } else {
-        safeMap.put(safeKey, jsonValue);
-      }
-    }
-    return safeMap;
-  }
-
-  private static List<Object> addPropertySuffixList(List<Object> jsonList) {
-    List<Object> safeList = new List<Object>();
-    for (Object jsonValue : jsonList) {
-      if (jsonValue instanceof Map<String, Object>) {
-        safeList.add(addPropertySuffix((Map<String, Object>) jsonValue));
-      } else {
-        safeList.add(jsonValue);
-      }
-    }
-    return safeList;
-  }
-
-  /**
    * Brings additional properties on dynamic models up one JSON level so that they can
    * be processed properly by the service.
    *

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -42,12 +42,12 @@ public class IBMWatsonJSONUtil {
    * @return Map representing the JSON request with moved additional properties
    */
   public static Map<String, Object> raiseAdditionalProperties(Map<String, Object> jsonMap) {
-    Map<String, Object> additionalProperties = (Map<String, Object>) jsonMap.get('additional_properties');
+    Map<String, Object> additionalProperties = (Map<String, Object>) jsonMap.get('additionalProperties');
     if (additionalProperties != null) {
       for (String key : additionalProperties.keySet()) {
         jsonMap.put(key, additionalProperties.get(key));
       }
-      jsonMap.remove('additional_properties');
+      jsonMap.remove('additionalProperties');
     }
 
     for (String key : jsonMap.keySet()) {

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -4,6 +4,16 @@
  */
 public class IBMWatsonJSONUtil {
 
+  /**
+   * Serializes a map and uses the provided name mapping to create a valid JSON string for
+   * an external API.
+   *
+   * @param jsonMap Map representation of the JSON request
+   * @param propertyNameMapping Map with keys representing property names for the SDK and values
+   *        representing the names accepted by the API
+   *
+   * @return JSON string ready to be sent to the API
+   */
   public static String serialize(Map<String, Object> jsonMap, Map<String, String> propertyNameMapping) {
     // need to make sure everything inside is of core Apex types so that we can manipulate it properly
     jsonMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(jsonMap, true));
@@ -17,21 +27,77 @@ public class IBMWatsonJSONUtil {
     return JSON.serialize(jsonMap);
   }
 
+  /**
+   * Parses through the provided map to change key names according to the supplied mapping.
+   *
+   * @param jsonMap Map representation of the eventual JSON request
+   * @param propertyNameMapping Map with keys representing property names for the SDK and values
+   *        representing the names accepted by the API
+   *
+   * @return Map with modified keys
+   */
   public static Map<String, Object> replacePropertyNames(Map<String, Object> jsonMap, Map<String, String> propertyNameMapping) {
+    return replacePropertyNames(null, jsonMap, propertyNameMapping);
+  }
+
+  /**
+   * Helper function for the public method which tracks a parentProp to help differentiate between
+   * keys of the same name at different levels of the JSON object.
+   *
+   * @param parentProp String representing the current level of the JSON tree, with parents separated by '/'. For
+   *        example: dialog_node/actions/
+   * @param jsonMap Map representation of the JSON object being parsed
+   * @param propertyNameMapping Map with keys representing property names for the SDK and values
+   *        representing the names accepted by the API
+   *
+   * @return Map with modified keys
+   */
+  private static Map<String, Object> replacePropertyNames(String parentProp, Map<String, Object> jsonMap, Map<String, String> propertyNameMapping) {
+    String label = '';
+    if (parentProp != null) {
+      label = parentProp + '/';
+    }
+
     for (String key : jsonMap.keySet()) {
       Object jsonValue = jsonMap.get(key);
       String keyToUse = key;
-      if (propertyNameMapping.containsKey(key)) {
-        keyToUse = propertyNameMapping.get(key);
+
+      if (propertyNameMapping.containsKey(label + key)) {
+        keyToUse = propertyNameMapping.get(label + key);
         jsonMap.put(keyToUse, jsonValue);
         jsonMap.remove(key);
       }
       if (jsonValue instanceof Map<String, Object>) {
-        jsonMap.put(keyToUse, replacePropertyNames((Map<String, Object>) jsonValue, propertyNameMapping));
+        jsonMap.put(keyToUse, replacePropertyNames(label + key, (Map<String, Object>) jsonValue, propertyNameMapping));
+      }
+      if (jsonValue instanceof List<Object>) {
+        jsonMap.put(keyToUse, replacePropertyNamesList(label + key, (List<Object>) jsonValue, propertyNameMapping));
       }
     }
 
     return jsonMap;
+  }
+
+  /**
+   * Helper function for the public method to specifically handle JSON arrays.
+   * @param parentProp String representing the current level of the JSON tree, with parents separated by '/'. For
+   *        example: dialog_node/actions/
+   * @param jsonList List representation of the JSON array being parsed
+   * @param propertyNameMapping Map with keys representing property names for the SDK and values
+   *        representing the names accepted by the API
+   *
+   * @return List with modified keys inside (if there are any)
+   */
+  private static List<Object> replacePropertyNamesList(String parentProp, List<Object> jsonList, Map<String, String> propertyNameMapping) {
+    List<Object> modifiedList = new List<Object>();
+    for (Object val : jsonList) {
+      if (val instanceof Map<String, Object>) {
+        modifiedList.add(replacePropertyNames(parentProp, (Map<String, Object>) val, propertyNameMapping));
+      } else {
+        modifiedList.add(val);
+      }
+    }
+    return modifiedList;
   }
 
   /**
@@ -57,8 +123,31 @@ public class IBMWatsonJSONUtil {
         Map<String, Object> raisedSection = raiseAdditionalProperties((Map<String, Object>) jsonSection);
         jsonMap.put(key, raisedSection);
       }
+      if (jsonSection instanceof List<Object>) {
+        List<Object> raisedSection = raiseAdditionalPropertiesList((List<Object>) jsonSection);
+        jsonMap.put(key, raisedSection);
+      }
     }
 
     return jsonMap;
+  }
+
+  /**
+   * Helper function for the public method to specifically handle JSON arrays.
+   *
+   * @param jsonList List representation of the current JSON array
+   *
+   * @return List with any nested additional properties brought up a level
+   */
+  private static List<Object> raiseAdditionalPropertiesList(List<Object> jsonList) {
+    List<Object> modifiedList = new List<Object>();
+    for (Object val : jsonList) {
+      if (val instanceof Map<String, Object>) {
+        modifiedList.add(raiseAdditionalProperties((Map<String, Object>) val));
+      } else {
+        modifiedList.add(val);
+      }
+    }
+    return modifiedList;
   }
 }

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -20,6 +20,23 @@ public class IBMWatsonJSONUtil {
     return JSON.serialize(jsonMap);
   }
 
+  private static Map<String, Object> replacePropertyNames(Map<String, Object> jsonMap, Map<String, String> propertyNameMapping) {
+    for (String key : jsonMap.keySet()) {
+      Object jsonValue = jsonMap.get(key);
+      String keyToUse = key;
+      if (propertyNameMapping.containsKey(key)) {
+        keyToUse = propertyNameMapping.get(key);
+        jsonMap.put(keyToUse, jsonValue);
+        jsonMap.remove(key);
+      }
+      if (jsonValue instanceof Map<String, Object>) {
+        jsonMap.put(keyToUse, replacePropertyNames((Map<String, Object>) jsonValue, propertyNameMapping));
+      }
+    }
+
+    return jsonMap;
+  }
+
   /**
    * Calls appropriate methods to prepare the JSON response for deserialization. This involves removing empty
    * string values and adding the property suffix to avoid using reserved words.

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -3,6 +3,7 @@
  * scope of the default JSON methods.
  */
 public class IBMWatsonJSONUtil {
+
   public static String serialize(Map<String, Object> jsonMap, Map<String, String> propertyNameMapping) {
     // need to make sure everything inside is of core Apex types so that we can manipulate it properly
     jsonMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(jsonMap, true));
@@ -16,7 +17,7 @@ public class IBMWatsonJSONUtil {
     return JSON.serialize(jsonMap);
   }
 
-  private static Map<String, Object> replacePropertyNames(Map<String, Object> jsonMap, Map<String, String> propertyNameMapping) {
+  public static Map<String, Object> replacePropertyNames(Map<String, Object> jsonMap, Map<String, String> propertyNameMapping) {
     for (String key : jsonMap.keySet()) {
       Object jsonValue = jsonMap.get(key);
       String keyToUse = key;

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -3,20 +3,16 @@
  * scope of the default JSON methods.
  */
 public class IBMWatsonJSONUtil {
+  public static String serialize(Map<String, Object> jsonMap, Map<String, String> propertyNameMapping) {
+    // need to make sure everything inside is of core Apex types so that we can manipulate it properly
+    jsonMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(jsonMap, true));
 
+    // change keys to work with API
+    jsonMap = replacePropertyNames(jsonMap, propertyNameMapping);
 
+    // raise additional properties up a level to play well with API
+    jsonMap = raiseAdditionalProperties(jsonMap);
 
-  /**
-   * Removes '_serialized_name' suffix to match API spec and modifies JSON request string
-   * to properly handle additional properties.
-   *
-   * @param jsonString String representation of the JSON request
-   *
-   * @return String representing our modified JSON request ready to be sent
-   */
-  public static String serialize(String jsonString) {
-    jsonString = jsonString.remove('_serialized_name');
-    Map<String, Object> jsonMap = raiseAdditionalProperties((Map<String, Object>) JSON.deserializeUntyped(jsonString));
     return JSON.serialize(jsonMap);
   }
 

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -89,7 +89,7 @@ public class IBMWatsonJSONUtil {
    *
    * @return Map representing the JSON request with moved additional properties
    */
-  private static Map<String, Object> raiseAdditionalProperties(Map<String, Object> jsonMap) {
+  public static Map<String, Object> raiseAdditionalProperties(Map<String, Object> jsonMap) {
     Map<String, Object> additionalProperties = (Map<String, Object>) jsonMap.get('additional_properties');
     if (additionalProperties != null) {
       for (String key : additionalProperties.keySet()) {

--- a/force-app/main/default/classes/IBMWatsonJSONUtil.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtil.cls
@@ -4,25 +4,7 @@
  */
 public class IBMWatsonJSONUtil {
 
-  private static Set<String> reservedWords;
 
-  static {
-    reservedWords = new Set<String> {
-        'abstract', 'activate', 'and', 'any', 'array', 'as', 'asc', 'autonomous', 'begin', 'bigdecimal', 'blob',
-        'break', 'bulk', 'by', 'byte', 'case', 'cast', 'catch', 'char', 'class', 'collect', 'commit', 'const',
-        'continue', 'convertcurrency', 'decimal', 'default', 'delete', 'desc', 'do', 'else', 'end', 'enum',
-        'exception', 'exit', 'export', 'extends', 'false', 'final', 'finally', 'float', 'for', 'from', 'future',
-        'global', 'goto', 'group', 'having', 'hint', 'if', 'implements', 'import', 'inner', 'insert', 'instanceof',
-        'interface', 'into', 'int', 'join', 'last_90_days', 'last_month', 'last_n_days', 'last_week', 'like',
-        'limit', 'list', 'long', 'loop', 'map', 'merge', 'new', 'next_90_days', 'next_month', 'next_n_days',
-        'next_week', 'not', 'null', 'nulls', 'number', 'object', 'of', 'on', 'or', 'outer', 'override', 'package',
-        'parallel', 'pragma', 'private', 'protected', 'public', 'retrieve', 'return', 'returning', 'rollback',
-        'savepoint', 'search', 'select', 'set', 'short', 'sort', 'stat', 'static', 'super', 'switch',
-        'synchronized', 'system', 'testmethod', 'then', 'this', 'this_month', 'this_week', 'throw', 'today',
-        'tolabel', 'tomorrow', 'transaction', 'trigger', 'true', 'try', 'type', 'undelete', 'update', 'upsert',
-        'using', 'virtual', 'webservice', 'when', 'where', 'while', 'yesterday'
-    };
-  }
 
   /**
    * Removes '_serialized_name' suffix to match API spec and modifies JSON request string

--- a/force-app/main/default/classes/IBMWatsonJSONUtilTest.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtilTest.cls
@@ -1,54 +1,28 @@
 @isTest
 private class IBMWatsonJSONUtilTest {
   /**
-   * Test prepareResponse
-   *
-   */
-  static testMethod void testPrepareResponse() {
-    Map<String, Object> mockExtractedMetadata = new Map<String, Object>();
-    mockExtractedMetadata.put('file_type', 'application/json');
-    mockExtractedMetadata.put('filename', 'my_sweet_file.json');
-    Map<String, Object> mockResponse = new Map<String, Object>();
-    mockResponse.put('foo', 'bar');
-    mockResponse.put('extracted_metadata', mockExtractedMetadata);
-    mockResponse.put('crazy_json', '{"some_serialized_name": "value"}');
-
-    Map<String, Object> expectedExtractedMetadata = new Map<String, Object>();
-    expectedExtractedMetadata.put('file_type_serialized_name', 'application/json');
-    expectedExtractedMetadata.put('filename_serialized_name', 'my_sweet_file.json');
-    Map<String, Object> expectedResponse = new Map<String, Object>();
-    expectedResponse.put('foo_serialized_name', 'bar');
-    expectedResponse.put('crazy_json_serialized_name', '{"some_serialized_name": "value"}');
-    expectedResponse.put('extracted_metadata_serialized_name', expectedExtractedMetadata);
-
-    Map<String, Object> actualResponse = IBMWatsonJSONUtil.prepareResponse(mockResponse);
-
-    System.assertEquals(actualResponse, expectedResponse);
-  }
-
-  /**
    * Test raiseAdditionalProperties
    *
    */
-  static testMethod void testSerialize() {
-    String mockJSON = '{"foo_serialized_name":"bar","additional_properties":{"baz_serialized_name":"bat"}}';
+  /* static testMethod void testSerialize() {
+    String mockJSON = '{"foo":"bar","additional_properties":{"baz":"bat"}}';
 
     String expectedJSON = '{"baz":"bat","foo":"bar"}';
     String actualJSON = IBMWatsonJSONUtil.serialize(mockJSON);
 
     System.assertEquals(actualJSON, expectedJSON);
-  }
+  } */
 
   /**
    * Test raiseAdditionalProperties with nested additional properties
    *
    */
-  static testMethod void testSerializeWithNestedAdditionalProperties() {
-    String mockJSON = '{"foo_serialized_name":"bar","additional_properties":{"baz_serialized_name":"bat"},"bird_serialized_name":{"ohio_serialized_name":"cardinal","additional_properties":{"nest_materials_serialized_name":"twigs"}}}';
+  /* static testMethod void testSerializeWithNestedAdditionalProperties() {
+    String mockJSON = '{"foo":"bar","additional_properties":{"baz":"bat"},"bird":{"ohio":"cardinal","additional_properties":{"nest_materials":"twigs"}}}';
 
     String expectedJSON = '{"baz":"bat","bird":{"nest_materials":"twigs","ohio":"cardinal"},"foo":"bar"}';
     String actualJSON = IBMWatsonJSONUtil.serialize(mockJSON);
 
     System.assertEquals(actualJSON, expectedJSON);
-  }
+  } */
 }

--- a/force-app/main/default/classes/IBMWatsonJSONUtilTest.cls
+++ b/force-app/main/default/classes/IBMWatsonJSONUtilTest.cls
@@ -1,28 +1,104 @@
 @isTest
 private class IBMWatsonJSONUtilTest {
   /**
-   * Test raiseAdditionalProperties
-   *
+   * Test that property names can be replaced with flat JSON.
    */
-  /* static testMethod void testSerialize() {
-    String mockJSON = '{"foo":"bar","additional_properties":{"baz":"bat"}}';
+  static testMethod void testReplacePropertyNamesFlat() {
+    String mockJson = '{"foo":"bar","go":"bucks"}';
+    Map<String, Object> mockObject = (Map<String, Object>) JSON.deserializeUntyped(mockJson);
+    Map<String, String> propertyMapping = new Map<String, String> { 'foo' => 'oof' };
+    String expectedJson = '{"oof":"bar","go":"bucks"}';
+    Map<String, Object> expectedMap = (Map<String, Object>) JSON.deserializeUntyped(expectedJson);
 
-    String expectedJSON = '{"baz":"bat","foo":"bar"}';
-    String actualJSON = IBMWatsonJSONUtil.serialize(mockJSON);
+    Map<String, Object> actualMap = IBMWatsonJSONUtil.replacePropertyNames(mockObject, propertyMapping);
 
-    System.assertEquals(actualJSON, expectedJSON);
-  } */
+    System.assert(expectedMap.equals(actualMap));
+  }
 
   /**
-   * Test raiseAdditionalProperties with nested additional properties
-   *
+   * Test that property names can be replaced with nested JSON.
    */
-  /* static testMethod void testSerializeWithNestedAdditionalProperties() {
-    String mockJSON = '{"foo":"bar","additional_properties":{"baz":"bat"},"bird":{"ohio":"cardinal","additional_properties":{"nest_materials":"twigs"}}}';
+  static testMethod void testReplacePropertyNamesNested() {
+    String mockJson = '{"foo":"bar","ohio":{"city":"columbus"}}';
+    Map<String, Object> mockObject = (Map<String, Object>) JSON.deserializeUntyped(mockJson);
+    Map<String, String> propertyMapping = new Map<String, String> { 'foo' => 'oof', 'ohio/city' => 'capital' };
+    String expectedJson = '{"oof":"bar","ohio":{"capital":"columbus"}}';
+    Map<String, Object> expectedMap = (Map<String, Object>) JSON.deserializeUntyped(expectedJson);
 
-    String expectedJSON = '{"baz":"bat","bird":{"nest_materials":"twigs","ohio":"cardinal"},"foo":"bar"}';
-    String actualJSON = IBMWatsonJSONUtil.serialize(mockJSON);
+    Map<String, Object> actualMap = IBMWatsonJSONUtil.replacePropertyNames(mockObject, propertyMapping);
 
-    System.assertEquals(actualJSON, expectedJSON);
-  } */
+    System.assert(expectedMap.equals(actualMap));
+  }
+
+  /**
+   * Test that property names can be replaced with JSON containing an array.
+   */
+  static testMethod void testReplacePropertyNamesList() {
+    String mockJson = '{"foo":"bar","teams":[{"soccer":"crew"},{"american_football":"browns"}]}';
+    Map<String, Object> mockObject = (Map<String, Object>) JSON.deserializeUntyped(mockJson);
+    Map<String, String> propertyMapping = new Map<String, String> { 'foo' => 'oof', 'teams/american_football' => 'pigskin' };
+    String expectedJson = '{"oof":"bar","teams":[{"soccer":"crew"},{"pigskin":"browns"}]}';
+    Map<String, Object> expectedMap = (Map<String, Object>) JSON.deserializeUntyped(expectedJson);
+
+    Map<String, Object> actualMap = IBMWatsonJSONUtil.replacePropertyNames(mockObject, propertyMapping);
+
+    System.assert(expectedMap.equals(actualMap));
+  }
+
+  /**
+   * Test that additional properties are brought up a level as expected with flat JSON.
+   */
+  static testMethod void testRaiseAdditionalPropertiesFlat() {
+    String mockJson = '{"foo":"bar","additionalProperties":{"drink": "coffee"}}';
+    Map<String, Object> mockObject = (Map<String, Object>) JSON.deserializeUntyped(mockJson);
+    String expectedJson = '{"foo":"bar","drink":"coffee"}';
+    Map<String, Object> expectedMap = (Map<String, Object>) JSON.deserializeUntyped(expectedJson);
+
+    Map<String, Object> actualMap = IBMWatsonJSONUtil.raiseAdditionalProperties(mockObject);
+
+    System.assert(expectedMap.equals(actualMap));
+  }
+
+  /**
+   * Test that additional properties are brought up a level as expected with nested JSON.
+   */
+  static testMethod void testRaiseAdditionalPropertiesNested() {
+    String mockJson = '{"foo":"bar","ohio":{"city":"columbus","additionalProperties": {"very":"cool"}}}';
+    Map<String, Object> mockObject = (Map<String, Object>) JSON.deserializeUntyped(mockJson);
+    String expectedJson = '{"foo":"bar","ohio":{"city":"columbus","very":"cool"}}';
+    Map<String, Object> expectedMap = (Map<String, Object>) JSON.deserializeUntyped(expectedJson);
+
+    Map<String, Object> actualMap = IBMWatsonJSONUtil.raiseAdditionalProperties(mockObject);
+
+    System.assert(expectedMap.equals(actualMap));
+  }
+
+  /**
+   * Test that additional properties are brought up a level as expected with JSON containing an array.
+   */
+  static testMethod void testRaiseAdditionalPropertiesList() {
+    String mockJson = '{"foo":"bar","teams":[{"soccer":"crew","basketball":{"name": "cavaliers","additionalProperties":{"king":"lebron"}}}]}';
+    Map<String, Object> mockObject = (Map<String, Object>) JSON.deserializeUntyped(mockJson);
+    String expectedJson = '{"foo":"bar","teams":[{"soccer":"crew","basketball":{"name": "cavaliers","king":"lebron"}}]}';
+    Map<String, Object> expectedMap = (Map<String, Object>) JSON.deserializeUntyped(expectedJson);
+
+    Map<String, Object> actualMap = IBMWatsonJSONUtil.raiseAdditionalProperties(mockObject);
+
+    System.assert(expectedMap.equals(actualMap));
+  }
+
+  /**
+   * Test that JSON can be serialized properly for our purposes (essentially combining all the above tests).
+   */
+  static testMethod void testSerialize() {
+    String mockJson = '{"foo":"bar","teams":[{"soccer":"crew","additionalProperties":{"mascot":"crew cat"}},{"american_football":"browns"}]}';
+    Map<String, Object> mockObject = (Map<String, Object>) JSON.deserializeUntyped(mockJson);
+    Map<String, String> propertyMapping = new Map<String, String> { 'foo' => 'oof', 'teams/american_football' => 'pigskin' };
+    String expectedJson = '{"oof":"bar","teams":[{"soccer":"crew","mascot":"crew cat"},{"pigskin":"browns"}]}';
+    Map<String, Object> expectedMap = (Map<String, Object>) JSON.deserializeUntyped(expectedJson);
+
+    Map<String, Object> actualMap = (Map<String, Object>) JSON.deserializeUntyped(IBMWatsonJSONUtil.serialize(mockObject, propertyMapping));
+
+    System.assert(expectedMap.equals(actualMap));
+  }
 }

--- a/force-app/main/default/classes/IBMWatsonMockResponses.cls
+++ b/force-app/main/default/classes/IBMWatsonMockResponses.cls
@@ -746,7 +746,11 @@ public class IBMWatsonMockResponses {
                 '],' +
                 '"entities": [' +
                 '{' +
-                  '"entity": "test_entity"' +
+                  '"entity": "test_entity",' +
+                  '"location": [' +
+                    '10' +
+                  '],' +
+                  '"value": "Value of test_entity"' +
                 '}' +
                 ']' +
               '},' +
@@ -3320,14 +3324,14 @@ public class IBMWatsonMockResponses {
               '},' +
               '"text": "text"' +
             '},' +
-            '"value": {' +
+            '"value": [{' +
               '"cell_id": "cell_id",' +
               '"location": {' +
                 '"begin": 0,' +
                 '"end": 1' +
               '},' +
               '"text": "text"' +
-            '}' +
+            '}]' +
           '}' +
           '],' +
           '"title": {' +
@@ -3972,14 +3976,14 @@ public class IBMWatsonMockResponses {
               '},' +
               '"text": "text"' +
             '},' +
-            '"value": {' +
+            '"value": [{' +
               '"cell_id": "cell_id",' +
               '"location": {' +
                 '"begin": 0,' +
                 '"end": 1' +
               '},' +
               '"text": "text"' +
-            '}' +
+            '}]' +
           '}' +
           ']' +
         '}' +

--- a/force-app/main/default/classes/IBMWatsonOptionsModel.cls
+++ b/force-app/main/default/classes/IBMWatsonOptionsModel.cls
@@ -7,4 +7,12 @@ public virtual class IBMWatsonOptionsModel {
   public Map<String, String> requestHeaders() {
     return this.requestHeaders;
   }
+
+  public virtual Map<String, String> getSdkToApiMapping() {
+    return new Map<String, String>();
+  }
+
+  public virtual Map<String, String> getApiToSdkMapping() {
+    return new Map<String, String>();
+  }
 }

--- a/force-app/main/default/classes/IBMWatsonResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonResponseModel.cls
@@ -1,4 +1,4 @@
-public virtual class IBMWatsonResponseModel {
+public virtual class IBMWatsonResponseModel extends IBMWatsonGenericModel {
   private Map<String, String> headers = new Map<String, String>();
 
   /**
@@ -19,35 +19,6 @@ public virtual class IBMWatsonResponseModel {
   }
 
   /**
-   * Allows comparison of custom models based on their serialized String form.
-   *
-   * @param obj the object this is being compared to
-   *
-   * @return Boolean indicating whether or not the two objects are equal
-   */
-  public Boolean equals(Object obj) {
-    if ((obj == null)) {
-      return false;
-    }
-
-    IBMWatsonResponseModel other = (IBMWatsonResponseModel) obj;
-
-    return this.toString().equals(other.toString());
-  }
-
-  public virtual Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
-    Object ret;
-    if (jsonString.equals('null')) {
-      ret = classType.newInstance();
-    }
-    else {
-      ret = JSON.deserialize(jsonString, classType);
-    }
-
-    return ret;
-  }
-
-  /**
    * Gets the response headers attached to this response model.
    */
   public Map<String, String> getHeaders() {
@@ -64,13 +35,5 @@ public virtual class IBMWatsonResponseModel {
       this.headers = new Map<String, String>();
     }
     this.headers.put(name, value);
-  }
-
-  public virtual Map<String, String> getSdkToApiMapping() {
-    return new Map<String, String>();
-  }
-
-  public virtual Map<String, String> getApiToSdkMapping() {
-    return new Map<String, String>();
   }
 }

--- a/force-app/main/default/classes/IBMWatsonResponseModel.cls
+++ b/force-app/main/default/classes/IBMWatsonResponseModel.cls
@@ -7,20 +7,15 @@ public virtual class IBMWatsonResponseModel {
    * @return serialized String form of this
    */
   public override String toString() {
-    // get JSON string representation
-    String jsonString = JSON.serialize(this, true);
-
     // remove response headers from string representation
-    Map<String, Object> fullJsonMap = (Map<String, Object>) JSON.deserializeUntyped(jsonString);
+    Map<String, Object> fullJsonMap = (Map<String, Object>) JSON.deserializeUntyped(JSON.serialize(this, true));
     fullJsonMap.remove('headers');
-    String jsonStringWithoutHeaders = JSON.serialize(fullJsonMap);
 
-    // call custom serializer to raise additional properties
-    jsonStringWithoutHeaders = IBMWatsonJSONUtil.serialize(jsonStringWithoutHeaders);
+    // raise additional props
+    fullJsonMap = IBMWatsonJSONUtil.raiseAdditionalProperties(fullJsonMap);
 
     // pretty print formatting
-    jsonStringWithoutHeaders = JSON.serializePretty(JSON.deserializeUntyped(jsonStringWithoutHeaders));
-    return jsonStringWithoutHeaders;
+    return JSON.serializePretty(fullJsonMap);
   }
 
   /**
@@ -69,5 +64,13 @@ public virtual class IBMWatsonResponseModel {
       this.headers = new Map<String, String>();
     }
     this.headers.put(name, value);
+  }
+
+  public virtual Map<String, String> getSdkToApiMapping() {
+    return new Map<String, String>();
+  }
+
+  public virtual Map<String, String> getApiToSdkMapping() {
+    return new Map<String, String>();
   }
 }

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -113,8 +113,9 @@ public abstract class IBMWatsonService {
       else{
         String responseText = response.getBody();
         if (String.isNotBlank(responseText)) {
-          Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(responseText);
           Object targetObject = targetType.newInstance();
+          Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(responseText);
+          jsonMap = IBMWatsonJSONUtil.replacePropertyNames(jsonMap, ((IBMWatsonResponseModel) targetObject).getApiToSdkMapping());
           String jsonString = JSON.serialize(jsonMap);
           if (targetObject instanceof IBMWatsonDynamicResponseModel) {
             return (IBMWatsonDynamicResponseModel) addResponseHeaders(response, ((IBMWatsonResponseModel) targetObject).deserialize(jsonString, jsonMap, targetType));

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -115,7 +115,7 @@ public abstract class IBMWatsonService {
         if (String.isNotBlank(responseText)) {
           Object targetObject = targetType.newInstance();
           Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(responseText);
-          jsonMap = IBMWatsonJSONUtil.replacePropertyNames(jsonMap, ((IBMWatsonResponseModel) targetObject).getApiToSdkMapping());
+          jsonMap = IBMWatsonJSONUtil.replacePropertyNames(jsonMap, ((IBMWatsonResponseModel) targetObject).addToApiToSdkMapping('', new Map<String, String>()));
           String jsonString = JSON.serialize(jsonMap);
           if (targetObject instanceof IBMWatsonDynamicResponseModel) {
             return (IBMWatsonDynamicResponseModel) addResponseHeaders(response, ((IBMWatsonResponseModel) targetObject).deserialize(jsonString, jsonMap, targetType));

--- a/force-app/main/default/classes/IBMWatsonService.cls
+++ b/force-app/main/default/classes/IBMWatsonService.cls
@@ -114,13 +114,12 @@ public abstract class IBMWatsonService {
         String responseText = response.getBody();
         if (String.isNotBlank(responseText)) {
           Map<String, Object> jsonMap = (Map<String, Object>) JSON.deserializeUntyped(responseText);
-          Map<String, Object> safeJsonMap = IBMWatsonJSONUtil.prepareResponse(jsonMap);
           Object targetObject = targetType.newInstance();
-          String jsonString = JSON.serialize(safeJsonMap);
+          String jsonString = JSON.serialize(jsonMap);
           if (targetObject instanceof IBMWatsonDynamicResponseModel) {
-            return (IBMWatsonDynamicResponseModel) addResponseHeaders(response, ((IBMWatsonResponseModel) targetObject).deserialize(jsonString, safeJsonMap, targetType));
+            return (IBMWatsonDynamicResponseModel) addResponseHeaders(response, ((IBMWatsonResponseModel) targetObject).deserialize(jsonString, jsonMap, targetType));
           } else {
-            return (IBMWatsonResponseModel) addResponseHeaders(response, ((IBMWatsonResponseModel) targetObject).deserialize(jsonString, safeJsonMap, targetType));
+            return (IBMWatsonResponseModel) addResponseHeaders(response, ((IBMWatsonResponseModel) targetObject).deserialize(jsonString, jsonMap, targetType));
           }
         }
       }

--- a/force-app/main/default/classes/IBMWatsonServiceTest.cls
+++ b/force-app/main/default/classes/IBMWatsonServiceTest.cls
@@ -20,7 +20,7 @@ private class IBMWatsonServiceTest {
    * Simple response model to use for testing purposes.
    */
   class TestClass extends IBMWatsonResponseModel {
-    public String test_key_serialized_name;
+    public String test_key;
 
     public override Object deserialize(String jsonString, Map<String, Object> jsonMap, Type classType) {
       if (jsonMap == null) {


### PR DESCRIPTION
In a nutshell, this PR moves all property names to use camelCase, as opposed to before where there was a mix of that and snake_case. To allow for this, there are new functions generated on some models to create "property mappings" between the SDK and API. The `IBMWatsonJSONUtil` class has also been tweaked a lot to actually process this.

Service code for this PR was generated based on this generator PR: . Looking there will give more context and background to the changes.

As far as reviewing this one, the main places to look are:
- `IBMWatsonJSONUtil`
- `IBMWatsonJSONUtilTest`
- `IBMWatsonService`
- `IBMWatsonGenericModel`, `IBMWatsonDynamicModel`, `IBMWatsonOptionsModel`, and `IBMWatsonResponseModel`
- At at least one of the service and model classes to get a sense of what the generated code looks like.