### PR TITLE
Raise code coverage over 75% threshold

### DIFF
--- a/force-app/main/default/classes/IBMAssistantV1Test.cls
+++ b/force-app/main/default/classes/IBMAssistantV1Test.cls
@@ -75,6 +75,8 @@ private class IBMAssistantV1Test {
   private static String label;
   private static String messageToHumanAgent;
   private static String topic;
+  private static String headerKey;
+  private static String headerVal;
 
   static {
     workspaceName = 'test_workspace';
@@ -155,6 +157,33 @@ private class IBMAssistantV1Test {
     label = 'label';
     messageToHumanAgent = 'message_to_human_agent';
     topic = 'topic';
+    headerKey = 'Header-Key';
+    headerVal = 'header_val';
+  }
+
+  static testMethod void testVersionConstructor() {
+    Test.startTest();
+    IBMAssistantV1 service = new IBMAssistantV1('2018-02-16');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMAssistantV1 service = new IBMAssistantV1('2018-02-16', 'username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMAssistantV1 service = new IBMAssistantV1('2018-02-16', config);
+    System.assert(service != null);
+    Test.stopTest();
   }
 
   static testMethod void testCreateWorkspace() {
@@ -263,7 +292,7 @@ private class IBMAssistantV1Test {
       .entities(new List<IBMAssistantV1Models.CreateEntity>{createEntity})
       .language(workspaceLanguage)
       .systemSettings(systemSettings)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createWorkspaceOptions = createWorkspaceOptions.newBuilder().build();
@@ -301,7 +330,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.DeleteWorkspaceOptions deleteOptions = new IBMAssistantV1Models.DeleteWorkspaceOptionsBuilder()
       .workspaceId(workspaceId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -330,7 +359,7 @@ private class IBMAssistantV1Test {
       .xexport(true)
       .includeAudit(true)
       .xsort(xsort)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -390,7 +419,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.UpdateWorkspaceOptions updateOptions = new IBMAssistantV1Models.UpdateWorkspaceOptionsBuilder()
       .workspaceId(workspaceId)
       .systemSettings(systemSettings)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -427,7 +456,7 @@ private class IBMAssistantV1Test {
     assistant.setUsernameAndPassword('username', 'password');
 
     IBMAssistantV1Models.ListWorkspacesOptions listOptions = new IBMAssistantV1Models.ListWorkspacesOptionsBuilder()
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -463,6 +492,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.CreateValue createValue = new IBMAssistantV1Models.CreateValueBuilder()
       .value('value')
       .build();
+    createValue = createValue.newBuilder().build();
     IBMAssistantV1Models.CreateValueOptions createOptions = new IBMAssistantV1Models.CreateValueOptionsBuilder()
       .createValue(createValue)
       .workspaceId(workspaceId)
@@ -471,7 +501,7 @@ private class IBMAssistantV1Test {
       .metadata(metadata)
       .addPatterns(valuePattern)
       .addSynonyms(valueSynonym)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -504,7 +534,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .value(valueName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -531,7 +561,7 @@ private class IBMAssistantV1Test {
       .entity(entityName)
       .value(valueName)
       .xexport(true)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -567,7 +597,7 @@ private class IBMAssistantV1Test {
       .newMetadata(metadata)
       .addNewPatterns(valuePattern)
       .addNewSynonyms(valueSynonym)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -599,7 +629,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.ListValuesOptions listOptions = new IBMAssistantV1Models.ListValuesOptionsBuilder()
       .workspaceId(workspaceId)
       .entity(entityName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -619,6 +649,7 @@ private class IBMAssistantV1Test {
   }
 
   static testMethod void testContext() {
+    Test.startTest();
     String conversationId = 'conversation_id';
 
     IBMAssistantV1Models.Context context = new IBMAssistantV1Models.Context();
@@ -631,9 +662,11 @@ private class IBMAssistantV1Test {
     System.assertEquals(conversationId, context.getConversationId());
     System.assertEquals(systemResponse, context.getXsystem());
     System.assertEquals(metadata, context.getMetadata());
+    Test.stopTest();
   }
 
   static testMethod void testMessageContextMetadata() {
+    Test.startTest();
     String deployment = 'deployment';
     String userId = 'user_id';
 
@@ -643,6 +676,7 @@ private class IBMAssistantV1Test {
 
     System.assertEquals(deployment, metadata.getDeployment());
     System.assertEquals(userId, metadata.getUserId());
+    Test.stopTest();
   }
 
   static testMethod void message() {
@@ -667,7 +701,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .input(input)
       .alternateIntents(alternateIntents)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     messageOptions = messageOptions.newBuilder().build();
@@ -736,7 +770,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .description(intentDescription)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -765,7 +799,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.DeleteIntentOptions deleteOptions = new IBMAssistantV1Models.DeleteIntentOptionsBuilder()
       .workspaceId(workspaceId)
       .intent(intentName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -791,7 +825,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .xexport(true)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -823,7 +857,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.ListIntentsOptions listOptions = new IBMAssistantV1Models.ListIntentsOptionsBuilder()
       .workspaceId(workspaceId)
       .xexport(true)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -862,7 +896,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .newDescription(intentDescription)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -903,7 +937,7 @@ private class IBMAssistantV1Test {
       .text(exampleText)
       .mentions(mentionsList)
       .addMentions(mentions2)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -934,7 +968,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .text('example A')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -960,7 +994,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .intent(intentName)
       .text(exampleText)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -988,7 +1022,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.ListExamplesOptions listOptions = new IBMAssistantV1Models.ListExamplesOptionsBuilder()
       .workspaceId(workspaceId)
       .intent(intentName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1033,7 +1067,7 @@ private class IBMAssistantV1Test {
       .newText(exampleText)
       .newMentions(mentionsList)
       .addNewMentions(mentions2)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1062,7 +1096,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .description(entityDescription)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1093,7 +1127,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.DeleteEntityOptions deleteOptions = new IBMAssistantV1Models.DeleteEntityOptionsBuilder()
       .workspaceId(workspaceId)
       .entity(entityName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1119,7 +1153,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .xexport(true)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1156,7 +1190,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.ListEntitiesOptions listOptions = new IBMAssistantV1Models.ListEntitiesOptionsBuilder()
       .workspaceId(workspaceId)
       .xexport(true)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1198,7 +1232,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .newDescription(entityDescription)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1229,13 +1263,14 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.Synonym synonym = new IBMAssistantV1Models.SynonymBuilder()
       .synonym('synonym')
       .build();
+    synonym = synonym.newBuilder().build();
     IBMAssistantV1Models.CreateSynonymOptions createOptions = new IBMAssistantV1Models.CreateSynonymOptionsBuilder()
       .synonym(synonym)
       .workspaceId(workspaceId)
       .entity(entityName)
       .value(valueName)
       .synonym(valueSynonym)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1265,7 +1300,7 @@ private class IBMAssistantV1Test {
       .entity(entityName)
       .value(valueName)
       .synonym(valueSynonym)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1292,7 +1327,7 @@ private class IBMAssistantV1Test {
       .entity(entityName)
       .value(valueName)
       .synonym(valueSynonym)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1321,7 +1356,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .entity(entityName)
       .value(valueName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1356,7 +1391,7 @@ private class IBMAssistantV1Test {
       .value(valueName)
       .synonym(valueSynonym)
       .newSynonym(valueSynonym)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1385,6 +1420,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.DialogNode dialogNode = new IBMAssistantV1Models.DialogNodeBuilder()
       .dialogNode('dialog_node')
       .build();
+    dialogNode = dialogNode.newBuilder().build();
     IBMAssistantV1Models.CreateDialogNodeOptions createOptions = new IBMAssistantV1Models.CreateDialogNodeOptionsBuilder()
       .dialogNode(dialogNode)
       .workspaceId(workspaceId)
@@ -1393,7 +1429,7 @@ private class IBMAssistantV1Test {
       .digressOut(dialogNodeDigressOut)
       .digressOutSlots(dialogNodeDigressOutSlots)
       .userLabel(userLabel)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1443,7 +1479,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.DeleteDialogNodeOptions deleteOptions = new IBMAssistantV1Models.DeleteDialogNodeOptionsBuilder()
       .workspaceId(workspaceId)
       .dialogNode(dialogNodeName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1468,7 +1504,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.GetDialogNodeOptions getOptions = new IBMAssistantV1Models.GetDialogNodeOptionsBuilder()
       .workspaceId(workspaceId)
       .dialogNode(dialogNodeName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1514,7 +1550,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.ListDialogNodesOptions listOptions = new IBMAssistantV1Models.ListDialogNodesOptionsBuilder()
       .workspaceId(workspaceId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1571,7 +1607,7 @@ private class IBMAssistantV1Test {
       .newDigressOut(dialogNodeDigressOut)
       .newDigressOutSlots(dialogNodeDigressOutSlots)
       .newUserLabel(newUserLabel)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1618,7 +1654,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.ListLogsOptions listOptions = new IBMAssistantV1Models.ListLogsOptionsBuilder()
       .workspaceId(workspaceId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1666,11 +1702,12 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.Counterexample counterexample = new IBMAssistantV1Models.CounterexampleBuilder()
       .text('text')
       .build();
+    counterexample = counterexample.newBuilder().build();
     IBMAssistantV1Models.CreateCounterexampleOptions createOptions = new IBMAssistantV1Models.CreateCounterexampleOptionsBuilder()
       .counterexample(counterexample)
       .workspaceId(workspaceId)
       .text(counterexampleText)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1696,7 +1733,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.CreateCounterexampleOptions createOptions =
       new IBMAssistantV1Models.CreateCounterexampleOptionsBuilder(workspaceId,counterexampleText)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     createOptions = createOptions.newBuilder().build();
@@ -1724,7 +1761,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.DeleteCounterexampleOptions deleteOptions = new IBMAssistantV1Models.DeleteCounterexampleOptionsBuilder()
       .workspaceId(workspaceId)
       .text(counterexampleText)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1749,7 +1786,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.GetCounterexampleOptions getOptions = new IBMAssistantV1Models.GetCounterexampleOptionsBuilder()
       .workspaceId(workspaceId)
       .text(counterexampleText)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     getOptions = getOptions.newBuilder().build();
@@ -1776,7 +1813,7 @@ private class IBMAssistantV1Test {
 
     IBMAssistantV1Models.ListCounterexamplesOptions listOptions = new IBMAssistantV1Models.ListCounterexamplesOptionsBuilder()
       .workspaceId(workspaceId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listOptions = listOptions.newBuilder().build();
@@ -1809,7 +1846,7 @@ private class IBMAssistantV1Test {
       .workspaceId(workspaceId)
       .text(counterexampleText)
       .newText(counterexampleText)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     updateOptions = updateOptions.newBuilder().build();
@@ -1837,7 +1874,7 @@ private class IBMAssistantV1Test {
     String customerId = 'salesforce_sdk_test_id';
     IBMAssistantV1Models.DeleteUserDataOptions deleteOptions = new IBMAssistantV1Models.DeleteUserDataOptionsBuilder()
       .customerId(customerId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1864,6 +1901,7 @@ private class IBMAssistantV1Test {
     IBMAssistantV1Models.ListMentionsOptions listMentionsOptions = new IBMAssistantV1Models.ListMentionsOptionsBuilder()
       .workspaceId(workspaceId)
       .entity(entity)
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     listMentionsOptions = listMentionsOptions.newBuilder().build();

--- a/force-app/main/default/classes/IBMAssistantV2Test.cls
+++ b/force-app/main/default/classes/IBMAssistantV2Test.cls
@@ -35,6 +35,8 @@ private class IBMAssistantV2Test {
   private static String USER_DEFINED;
   private static String RESPONSE_TYPE;
   private static String PREFERENCE;
+  private static String HEADER_NAME;
+  private static String HEADER_VAL;
 
   static {
     VERSION = '2018-09-20';
@@ -72,6 +74,33 @@ private class IBMAssistantV2Test {
     USER_DEFINED = 'user_defined';
     RESPONSE_TYPE = 'type';
     PREFERENCE = 'preference';
+    HEADER_NAME = 'Header-Name';
+    HEADER_VAL = 'header_val';
+  }
+
+  static testMethod void testVersionConstructor() {
+    Test.startTest();
+    IBMAssistantV2 service = new IBMAssistantV2(VERSION);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMAssistantV2 service = new IBMAssistantV2(VERSION, 'username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMAssistantV2 service = new IBMAssistantV2(VERSION, config);
+    System.assert(service != null);
+    Test.stopTest();
   }
 
   static testMethod void testCaptureGroup() {
@@ -335,9 +364,16 @@ private class IBMAssistantV2Test {
       .build();
     service.setIamCredentials(iamOptions);
 
+    IBMAssistantV2Models.MessageInput input = new IBMAssistantV2Models.MessageInputBuilder()
+      .text(TEXT)
+      .build();
+    IBMAssistantV2Models.MessageContext context = new IBMAssistantV2Models.MessageContext();
     IBMAssistantV2Models.MessageOptions messageOptions = new IBMAssistantV2Models.MessageOptionsBuilder()
         .assistantId(ASSISTANT_ID)
         .sessionId(SESSION_ID)
+        .input(input)
+        .context(context)
+        .addHeader(HEADER_NAME, HEADER_VAL)
         .build();
     IBMAssistantV2Models.MessageResponse response = service.message(messageOptions);
 
@@ -392,6 +428,7 @@ private class IBMAssistantV2Test {
 
     IBMAssistantV2Models.CreateSessionOptions createSessionOptions = new IBMAssistantV2Models.CreateSessionOptionsBuilder()
         .assistantId(ASSISTANT_ID)
+        .addHeader(HEADER_NAME, HEADER_VAL)
         .build();
     IBMAssistantV2Models.SessionResponse response = service.createSession(createSessionOptions);
 
@@ -415,6 +452,7 @@ private class IBMAssistantV2Test {
     IBMAssistantV2Models.DeleteSessionOptions deleteSessionOptions = new IBMAssistantV2Models.DeleteSessionOptionsBuilder()
         .assistantId(ASSISTANT_ID)
         .sessionId(SESSION_ID)
+        .addHeader(HEADER_NAME, HEADER_VAL)
         .build();
     service.deleteSession(deleteSessionOptions);
 

--- a/force-app/main/default/classes/IBMCompareComplyV1Test.cls
+++ b/force-app/main/default/classes/IBMCompareComplyV1Test.cls
@@ -148,6 +148,31 @@ private class IBMCompareComplyV1Test {
     NUMERIC_VALUE = 21.0;
   }
 
+  static testMethod void testVersionConstructor() {
+    Test.startTest();
+    IBMCompareComplyV1 service = new IBMCompareComplyV1(VERSION);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMCompareComplyV1 service = new IBMCompareComplyV1(VERSION, 'username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMCompareComplyV1 service = new IBMCompareComplyV1(VERSION, config);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
   static testMethod void testAddFeedbackOptions() {
     Test.startTest();
     IBMCompareComplyV1Models.FeedbackDataInput feedbackDataInput = new IBMCompareComplyV1Models.FeedbackDataInput();
@@ -536,6 +561,7 @@ private class IBMCompareComplyV1Test {
       .model(CONTRACTS)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    convertToHtmlOptions = convertToHtmlOptions.newBuilder().build();
     IBMCompareComplyV1Models.HTMLReturn response = service.convertToHtml(convertToHtmlOptions);
 
     System.assertEquals(NUM_PAGES, response.getNumPages());
@@ -572,6 +598,7 @@ private class IBMCompareComplyV1Test {
       .model(CONTRACTS)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    classifyElementsOptions = classifyElementsOptions.newBuilder().build();
     IBMCompareComplyV1Models.ClassifyReturn response = service.classifyElements(classifyElementsOptions);
 
     System.assertEquals(TITLE, response.getDocument().getTitle());
@@ -762,6 +789,7 @@ private class IBMCompareComplyV1Test {
       .model(TABLES)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    extractTablesOptions = extractTablesOptions.newBuilder().build();
     IBMCompareComplyV1Models.TableReturn response = service.extractTables(extractTablesOptions);
 
     System.assertEquals(HTML, response.getDocument().getHtml());
@@ -862,6 +890,7 @@ private class IBMCompareComplyV1Test {
       .model(CONTRACTS)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    compareDocumentsOptions = compareDocumentsOptions.newBuilder().build();
     IBMCompareComplyV1Models.CompareReturn response = service.compareDocuments(compareDocumentsOptions);
 
     System.assertEquals(TITLE, response.getDocuments().get(0).getTitle());
@@ -922,6 +951,7 @@ private class IBMCompareComplyV1Test {
       .userId(USER_ID)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    addFeedbackOptions = addFeedbackOptions.newBuilder().build();
     IBMCompareComplyV1Models.FeedbackReturn response = service.addFeedback(addFeedbackOptions);
 
     System.assertEquals(FEEDBACK_ID, response.getFeedbackId());
@@ -983,6 +1013,7 @@ private class IBMCompareComplyV1Test {
       .model(CONTRACTS)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    deleteFeedbackOptions = deleteFeedbackOptions.newBuilder().build();
     service.deleteFeedback(deleteFeedbackOptions);
 
     Test.stopTest();
@@ -1008,6 +1039,7 @@ private class IBMCompareComplyV1Test {
       .model(CONTRACTS)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    getFeedbackOptions = getFeedbackOptions.newBuilder().build();
     IBMCompareComplyV1Models.GetFeedback response = service.getFeedback(getFeedbackOptions);
 
     System.assertEquals(FEEDBACK_ID, response.getFeedbackId());
@@ -1081,6 +1113,7 @@ private class IBMCompareComplyV1Test {
       .typeNotChanged(TYPE_NOT_CHANGED)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    listFeedbackOptions = listFeedbackOptions.newBuilder().build();
     IBMCompareComplyV1Models.FeedbackList response = service.listFeedback(listFeedbackOptions);
 
     System.assertEquals(FEEDBACK_ID, response.getFeedback().get(0).getFeedbackId());
@@ -1161,6 +1194,7 @@ private class IBMCompareComplyV1Test {
       .outputCredentialsFile(testCredentialFile)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    createBatchOptions = createBatchOptions.newBuilder().build();
     IBMCompareComplyV1Models.BatchStatus response = service.createBatch(createBatchOptions);
 
     assertBatchStatusResponse(response);
@@ -1186,6 +1220,7 @@ private class IBMCompareComplyV1Test {
       .batchId(BATCH_ID)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    getBatchOptions = getBatchOptions.newBuilder().build();
     IBMCompareComplyV1Models.BatchStatus response = service.getBatch(getBatchOptions);
 
     assertBatchStatusResponse(response);
@@ -1210,6 +1245,7 @@ private class IBMCompareComplyV1Test {
     IBMCompareComplyV1Models.ListBatchesOptions listBatchesOptions = new IBMCompareComplyV1Models.ListBatchesOptionsBuilder()
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    listBatchesOptions = listBatchesOptions.newBuilder().build();
     IBMCompareComplyV1Models.Batches response = service.listBatches(listBatchesOptions);
 
     assertBatchStatusResponse(response.getBatches().get(0));
@@ -1237,6 +1273,7 @@ private class IBMCompareComplyV1Test {
       .model(CONTRACTS)
       .addHeader(HEADER_NAME, HEADER_VALUE)
       .build();
+    updateBatchOptions = updateBatchOptions.newBuilder().build();
     IBMCompareComplyV1Models.BatchStatus response = service.updateBatch(updateBatchOptions);
 
     assertBatchStatusResponse(response);

--- a/force-app/main/default/classes/IBMDiscoveryV1Test.cls
+++ b/force-app/main/default/classes/IBMDiscoveryV1Test.cls
@@ -5,22 +5,59 @@ private class IBMDiscoveryV1Test {
   private static final String ENVIRONMENT_ID = '5ae96bb9-80e5-43ea-916e-1f3412fbc283';
   private static final String CONFIGURATION_ID = 'configuration_id';
 
+  private static String HEADER_KEY;
+  private static String HEADER_VAL;
+
+  static {
+    HEADER_KEY = 'Header-Key';
+    HEADER_VAL = 'header_val';
+  }
+
+  static testMethod void testVersionConstructor() {
+    Test.startTest();
+    IBMDiscoveryV1 service = new IBMDiscoveryV1(VERSION);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMDiscoveryV1 service = new IBMDiscoveryV1(VERSION, 'username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMDiscoveryV1 service = new IBMDiscoveryV1(VERSION, config);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
   static testMethod void testNluEnrichmentConcepts() {
+    Test.startTest();
     Long lim = 5L;
 
     IBMDiscoveryV1Models.NluEnrichmentConcepts concepts = new IBMDiscoveryV1Models.NluEnrichmentConcepts();
     concepts.setXlimit(lim);
 
     System.assertEquals(lim, concepts.getXlimit());
+    Test.stopTest();
   }
 
   static testMethod void testRetrievalDetails() {
+    Test.startTest();
     String retrievalStrategy = 'relevancy_training';
 
     IBMDiscoveryV1Models.RetrievalDetails retrievalDetails = new IBMDiscoveryV1Models.RetrievalDetails();
     retrievalDetails.setDocumentRetrievalStrategy(retrievalStrategy);
 
     System.assertEquals(retrievalStrategy, retrievalDetails.getDocumentRetrievalStrategy());
+    Test.stopTest();
   }
 
   /**
@@ -41,7 +78,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.CreateEnvironmentOptions options = new IBMDiscoveryV1Models.CreateEnvironmentOptionsBuilder()
       .name(text)
       .description('test_environment description')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -73,7 +110,6 @@ private class IBMDiscoveryV1Test {
     *
     */
   static testMethod void testCreateEnvironmentEmpty() {
-
     String body = IBMWatsonMockResponses.environment();
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
@@ -86,8 +122,9 @@ private class IBMDiscoveryV1Test {
       IBMDiscoveryV1Models.CreateEnvironmentOptions options = new IBMDiscoveryV1Models.CreateEnvironmentOptionsBuilder()
         .name(text)
         .description('test_environment description')
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
+      options = options.newBuilder().build();
       IBMDiscoveryV1Models.Environment resp =
         discovery.createEnvironment(options);
     }
@@ -114,7 +151,7 @@ private class IBMDiscoveryV1Test {
     String text = 'test_environment';
     IBMDiscoveryV1Models.ListEnvironmentsOptions options = new IBMDiscoveryV1Models.ListEnvironmentsOptionsBuilder()
       .name(text)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -142,7 +179,7 @@ private class IBMDiscoveryV1Test {
     String text = '5ae96bb9-80e5-43ea-916e-1f3412fbc283';
     IBMDiscoveryV1Models.DeleteEnvironmentOptions options = new IBMDiscoveryV1Models.DeleteEnvironmentOptionsBuilder()
       .environmentId(text)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -165,8 +202,9 @@ private class IBMDiscoveryV1Test {
       String text = '';
       IBMDiscoveryV1Models.DeleteEnvironmentOptions options = new IBMDiscoveryV1Models.DeleteEnvironmentOptionsBuilder()
         .environmentId(text)
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
+      options = options.newBuilder().build();
       discovery.deleteEnvironment(options);
     }
     catch(Exception exptn) {
@@ -191,7 +229,7 @@ private class IBMDiscoveryV1Test {
     String text = '5ae96bb9-80e5-43ea-916e-1f3412fbc283';
     IBMDiscoveryV1Models.GetEnvironmentOptions options = new IBMDiscoveryV1Models.GetEnvironmentOptionsBuilder()
       .environmentId(text)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -218,8 +256,9 @@ private class IBMDiscoveryV1Test {
     try {
       IBMDiscoveryV1Models.GetEnvironmentOptions options = new IBMDiscoveryV1Models.GetEnvironmentOptionsBuilder()
         .environmentId(text)
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
+      options = options.newBuilder().build();
       IBMDiscoveryV1Models.Environment resp =
         discovery.getEnvironment(options);
     }
@@ -245,7 +284,7 @@ private class IBMDiscoveryV1Test {
       .environmentId(ENVIRONMENT_ID)
       .name('test_environment')
       .description('test_environment description')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -271,8 +310,9 @@ private class IBMDiscoveryV1Test {
         .environmentId(ENVIRONMENT_ID)
         .name('')
         .description('test_environment description')
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
+      options = options.newBuilder().build();
       IBMDiscoveryV1Models.Environment resp =
         discovery.updateEnvironment(options);
     }
@@ -298,7 +338,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.ListFieldsOptions options = new IBMDiscoveryV1Models.ListFieldsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .collectionIds(collectionIds)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -402,8 +442,9 @@ private class IBMDiscoveryV1Test {
       IBMDiscoveryV1Models.CreateConfigurationOptions options = new IBMDiscoveryV1Models.CreateConfigurationOptionsBuilder()
         .name('test_environment')
         .description('test_environment description')
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
+      options = options.newBuilder().build();
       IBMDiscoveryV1Models.Configuration resp =
         discovery.createConfiguration(options);
     }
@@ -428,7 +469,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteConfigurationOptions options = new IBMDiscoveryV1Models.DeleteConfigurationOptionsBuilder(ENVIRONMENT_ID, CONFIGURATION_ID)
       .environmentId(ENVIRONMENT_ID)
       .configurationId(CONFIGURATION_ID)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -451,7 +492,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetConfigurationOptions options = new IBMDiscoveryV1Models.GetConfigurationOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .configurationId(CONFIGURATION_ID)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -475,7 +516,7 @@ private class IBMDiscoveryV1Test {
     discovery.setUsernameAndPassword('username', 'password');
     IBMDiscoveryV1Models.ListConfigurationsOptions options = new IBMDiscoveryV1Models.ListConfigurationsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -501,7 +542,7 @@ private class IBMDiscoveryV1Test {
       .name('test_environment')
       .description('test_environment description')
       .configurationId(CONFIGURATION_ID)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -528,8 +569,9 @@ private class IBMDiscoveryV1Test {
         .environmentId(ENVIRONMENT_ID)
         .name('test_environment')
         .description('test_environment description')
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
+      options = options.newBuilder().build();
       IBMDiscoveryV1Models.Configuration resp =
         discovery.updateConfiguration(options);
     }
@@ -556,7 +598,7 @@ private class IBMDiscoveryV1Test {
       .configurationId(CONFIGURATION_ID)
       .name('test_environment')
       .description('test_environment description')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .language('de')
       .build();
     //you can add more attributes using following builder method. This step is not necessary
@@ -582,7 +624,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteCollectionOptions options = new IBMDiscoveryV1Models.DeleteCollectionOptionsBuilder(ENVIRONMENT_ID, CONFIGURATION_ID)
       .environmentId(ENVIRONMENT_ID)
       .collectionId(CONFIGURATION_ID)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -605,7 +647,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetCollectionOptions options = new IBMDiscoveryV1Models.GetCollectionOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -651,7 +693,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetCollectionOptions options = new IBMDiscoveryV1Models.GetCollectionOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -696,7 +738,7 @@ private class IBMDiscoveryV1Test {
     discovery.setUsernameAndPassword('username', 'password');
     IBMDiscoveryV1Models.ListCollectionsOptions options = new IBMDiscoveryV1Models.ListCollectionsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -722,7 +764,7 @@ private class IBMDiscoveryV1Test {
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .name('test_environment')
       .description('test_environment description')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -749,8 +791,9 @@ private class IBMDiscoveryV1Test {
         .environmentId(ENVIRONMENT_ID)
         .name('test_environment')
         .description('test_environment description')
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
+      options = options.newBuilder().build();
       IBMDiscoveryV1Models.Collection resp =
         discovery.updateCollection(options);
     }
@@ -776,7 +819,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.ListCollectionFieldsOptions options = new IBMDiscoveryV1Models.ListCollectionFieldsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -802,7 +845,7 @@ private class IBMDiscoveryV1Test {
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .documentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -826,7 +869,7 @@ private class IBMDiscoveryV1Test {
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .documentId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -874,7 +917,7 @@ private class IBMDiscoveryV1Test {
       .similar(true)
       .similarDocumentIds('doc1,doc2')
       .similarFields('field1,field2')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -916,7 +959,7 @@ private class IBMDiscoveryV1Test {
       .similar(true)
       .similarDocumentIds(new List<String> { 'doc1', 'doc2' })
       .similarFields(new List<String> { 'field1', 'field2' })
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1015,7 +1058,7 @@ private class IBMDiscoveryV1Test {
       .similarDocumentIds('doc1,doc2')
       .similarFields('field1,field2')
       .loggingOptOut(true)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1048,7 +1091,7 @@ private class IBMDiscoveryV1Test {
       .similar(true)
       .similarDocumentIds(new List<String> { 'doc1', 'doc2' })
       .similarFields(new List<String> { 'field1', 'field2' })
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1094,7 +1137,7 @@ private class IBMDiscoveryV1Test {
       .filter('test')
       .addExamples(te)
       .examples(new List<IBMDiscoveryV1Models.TrainingExample>{te})
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1133,7 +1176,7 @@ private class IBMDiscoveryV1Test {
       .documentId('test')
       .relevance(2)
       .crossReference('test')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1158,7 +1201,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteAllTrainingDataOptions options = new IBMDiscoveryV1Models.DeleteAllTrainingDataOptionsBuilder(ENVIRONMENT_ID, '5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1182,7 +1225,7 @@ private class IBMDiscoveryV1Test {
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .queryId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1206,7 +1249,7 @@ private class IBMDiscoveryV1Test {
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .queryId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1235,7 +1278,7 @@ private class IBMDiscoveryV1Test {
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .queryId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .exampleId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1261,7 +1304,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.ListTrainingDataOptions options = new IBMDiscoveryV1Models.ListTrainingDataOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1293,7 +1336,7 @@ private class IBMDiscoveryV1Test {
       .exampleId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .relevance(2)
       .crossReference('test')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1411,6 +1454,7 @@ private class IBMDiscoveryV1Test {
       .document(true)
       .targets(new List<String>{'Target1', 'Target2'})
       .build();
+    enrichmentEmotion = enrichmentEmotion.newBuilder().build();
     IBMDiscoveryV1Models.NluEnrichmentEntities enrichmentEntities = new IBMDiscoveryV1Models.NluEnrichmentEntitiesBuilder()
       .emotion(true)
       .xlimit(5)
@@ -1420,11 +1464,13 @@ private class IBMDiscoveryV1Test {
       .sentenceLocations(true)
       .sentiment(true)
       .build();
+    enrichmentEntities = enrichmentEntities.newBuilder().build();
     IBMDiscoveryV1Models.NluEnrichmentKeywords enrichmentKeywords = new IBMDiscoveryV1Models.NluEnrichmentKeywordsBuilder()
       .emotion(true)
       .xlimit(5)
       .sentiment(true)
       .build();
+    enrichmentKeywords = enrichmentKeywords.newBuilder().build();
     IBMDiscoveryV1Models.NluEnrichmentRelations enrichmentRelations = new IBMDiscoveryV1Models.NluEnrichmentRelations();
     enrichmentRelations.setModel('test');
     IBMDiscoveryV1Models.NluEnrichmentSemanticRoles enrichmentSemanticRoles = new IBMDiscoveryV1Models.NluEnrichmentSemanticRolesBuilder()
@@ -1432,10 +1478,12 @@ private class IBMDiscoveryV1Test {
       .keywords(true)
       .xlimit(5)
       .build();
+    enrichmentSemanticRoles = enrichmentSemanticRoles.newBuilder().build();
     IBMDiscoveryV1Models.NluEnrichmentSentiment enrichmentSentiment = new IBMDiscoveryV1Models.NluEnrichmentSentimentBuilder()
       .document(true)
       .targets(new List<String>{'Target1', 'Target2'})
       .build();
+    enrichmentSentiment = enrichmentSentiment.newBuilder().build();
     IBMDiscoveryV1Models.NluEnrichmentFeatures enrichmentFeatures = new IBMDiscoveryV1Models.NluEnrichmentFeaturesBuilder()
       .emotion(enrichmentEmotion)
       .entities(enrichmentEntities)
@@ -1444,11 +1492,13 @@ private class IBMDiscoveryV1Test {
       .semanticRoles(enrichmentSemanticRoles)
       .sentiment(enrichmentSentiment)
       .build();
+    enrichmentFeatures = enrichmentFeatures.newBuilder().build();
     IBMDiscoveryV1Models.EnrichmentOptions enrichmentOptions = new IBMDiscoveryV1Models.EnrichmentOptionsBuilder()
       .features(enrichmentFeatures)
       .model('test')
       .language('en')
       .build();
+    enrichmentOptions = enrichmentOptions.newBuilder().build();
     enrichment.setOptions(enrichmentOptions);
     configuration.setEnrichments(new List<IBMDiscoveryV1Models.Enrichment>{enrichment});
     configuration.setNormalizations(new List<IBMDiscoveryV1Models.NormalizationOperation>{normalizationOperation});
@@ -1458,7 +1508,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.CreateConfigurationOptions options = new IBMDiscoveryV1Models.CreateConfigurationOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .configuration(configuration)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1531,7 +1581,7 @@ private class IBMDiscoveryV1Test {
       .collectionId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .queryId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
       .exampleId('5ae96bb9-80e5-43ea-916e-1f3412fbc283')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1566,7 +1616,7 @@ private class IBMDiscoveryV1Test {
       .file(testfile)
       .filename('test.txt')
       .fileContentType('text/plain')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
      //you can add more attributes using following builder method. This step is not necessary
      options = options.newBuilder().build();
@@ -1600,7 +1650,7 @@ private class IBMDiscoveryV1Test {
       .file(testfile)
       .filename('test.txt')
       .fileContentType('text/plain')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1634,7 +1684,7 @@ private class IBMDiscoveryV1Test {
       .file(testfile)
       .filename('test.txt')
       .fileContentType('text/plain')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1671,7 +1721,7 @@ private class IBMDiscoveryV1Test {
         .environmentId('environment_id')
         .collectionId('collection_id')
         .expansions(expansions)
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
     IBMDiscoveryV1Models.Expansions createResults = discovery.createExpansions(createOptions);
 
@@ -1705,7 +1755,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.ListExpansionsOptions listOptions = new IBMDiscoveryV1Models.ListExpansionsOptionsBuilder()
         .environmentId('environment_id')
         .collectionId('collection_id')
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
     IBMDiscoveryV1Models.Expansions listResults = discovery.listExpansions(listOptions);
 
@@ -1726,7 +1776,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteExpansionsOptions deleteOptions = new IBMDiscoveryV1Models.DeleteExpansionsOptionsBuilder()
         .environmentId('environment_id')
         .collectionId('collection_id')
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
     discovery.deleteExpansions(deleteOptions);
 
@@ -1755,7 +1805,7 @@ private class IBMDiscoveryV1Test {
       .entity(entity)
       .evidenceCount(10)
       .feature('feature')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     IBMDiscoveryV1Models.QueryEntitiesResponse resp = discovery.queryEntities(options);
 
@@ -1805,8 +1855,9 @@ private class IBMDiscoveryV1Test {
       .evidenceCount(10)
       .filter(filter)
       .xsort('text')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    options = options.newBuilder().build();
     IBMDiscoveryV1Models.QueryRelationsResponse resp = discovery.queryRelations(options);
 
     System.assertEquals(1, resp.getRelations().size());
@@ -1841,7 +1892,7 @@ private class IBMDiscoveryV1Test {
     String customerId = 'salesforce_sdk_test_id';
     IBMDiscoveryV1Models.DeleteUserDataOptions options = new IBMDiscoveryV1Models.DeleteUserDataOptionsBuilder()
       .customerId(customerId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -1850,6 +1901,7 @@ private class IBMDiscoveryV1Test {
   }
 
   static testMethod void testCredentialDetails() {
+    Test.startTest();
     String clientId = 'client_id';
     String clientSecret = 'client_secret';
     String sourceType = 'salesforce';
@@ -1911,6 +1963,7 @@ private class IBMDiscoveryV1Test {
     System.assertEquals(accessKeyId, details.getAccessKeyId());
     System.assertEquals(endpoint, details.getEndpoint());
     System.assertEquals(secretAccessKey, details.getSecretAccessKey());
+    Test.stopTest();
   }
 
   static testMethod void testCreateCredentials() {
@@ -1957,8 +2010,9 @@ private class IBMDiscoveryV1Test {
       .credentials(credentials)
       .credentialDetails(details)
       .status(status)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    options = options.newBuilder().build();
     IBMDiscoveryV1Models.Credentials credentialsResponse = discovery.createCredentials(options);
 
     System.assertEquals(sourceType, credentialsResponse.getSourceType());
@@ -1983,8 +2037,9 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteCredentialsOptions options = new IBMDiscoveryV1Models.DeleteCredentialsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .credentialId('credential_id')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    options = options.newBuilder().build();
     discovery.deleteCredentials(options);
 
     Test.stopTest();
@@ -2003,8 +2058,9 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetCredentialsOptions options = new IBMDiscoveryV1Models.GetCredentialsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
       .credentialId('credential_id')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    options = options.newBuilder().build();
     IBMDiscoveryV1Models.Credentials credentialsResponse = discovery.getCredentials(options);
 
     System.assert(credentialsResponse != null);
@@ -2024,8 +2080,9 @@ private class IBMDiscoveryV1Test {
 
     IBMDiscoveryV1Models.ListCredentialsOptions options = new IBMDiscoveryV1Models.ListCredentialsOptionsBuilder()
       .environmentId(ENVIRONMENT_ID)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    options = options.newBuilder().build();
     IBMDiscoveryV1Models.CredentialsList credentialsResponse = discovery.listCredentials(options);
 
     System.assert(credentialsResponse != null);
@@ -2073,7 +2130,9 @@ private class IBMDiscoveryV1Test {
       .credentials(newCredentials)
       .credentialDetails(newDetails)
       .status(status)
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    options = options.newBuilder().build();
     IBMDiscoveryV1Models.Credentials credentialsResponse = discovery.updateCredentials(options);
 
     System.assertEquals(sourceType, credentialsResponse.getSourceType());
@@ -2111,9 +2170,11 @@ private class IBMDiscoveryV1Test {
     eventData.setSessionToken(sessionToken);
     eventData.setClientTimestamp(dateValue);
     IBMDiscoveryV1Models.CreateEventOptions createEventOptions = new IBMDiscoveryV1Models.CreateEventOptionsBuilder()
-        .xtype(eventType)
-        .data(eventData)
-        .build();
+      .xtype(eventType)
+      .data(eventData)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    createEventOptions = createEventOptions.newBuilder().build();
     IBMDiscoveryV1Models.CreateEventResponse response = discovery.createEvent(createEventOptions);
 
     System.assertEquals(eventType, response.getXtype());
@@ -2147,10 +2208,12 @@ private class IBMDiscoveryV1Test {
     String resultType = 'document';
 
     IBMDiscoveryV1Models.GetMetricsEventRateOptions options = new IBMDiscoveryV1Models.GetMetricsEventRateOptionsBuilder()
-        .startTime(dateValue)
-        .endTime(dateValue)
-        .resultType(resultType)
-        .build();
+      .startTime(dateValue)
+      .endTime(dateValue)
+      .resultType(resultType)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    options = options.newBuilder().build();
 
     IBMDiscoveryV1Models.MetricResponse response = discovery.getMetricsEventRate(options);
 
@@ -2185,10 +2248,12 @@ private class IBMDiscoveryV1Test {
     String resultType = 'document';
 
     IBMDiscoveryV1Models.GetMetricsQueryOptions options = new IBMDiscoveryV1Models.GetMetricsQueryOptionsBuilder()
-        .startTime(dateValue)
-        .endTime(dateValue)
-        .resultType(resultType)
-        .build();
+      .startTime(dateValue)
+      .endTime(dateValue)
+      .resultType(resultType)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    options = options.newBuilder().build();
 
     IBMDiscoveryV1Models.MetricResponse response = discovery.getMetricsQuery(options);
 
@@ -2223,10 +2288,12 @@ private class IBMDiscoveryV1Test {
     String resultType = 'document';
 
     IBMDiscoveryV1Models.GetMetricsQueryEventOptions options = new IBMDiscoveryV1Models.GetMetricsQueryEventOptionsBuilder()
-        .startTime(dateValue)
-        .endTime(dateValue)
-        .resultType(resultType)
-        .build();
+      .startTime(dateValue)
+      .endTime(dateValue)
+      .resultType(resultType)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    options = options.newBuilder().build();
 
     IBMDiscoveryV1Models.MetricResponse response = discovery.getMetricsQueryEvent(options);
 
@@ -2261,10 +2328,12 @@ private class IBMDiscoveryV1Test {
     String resultType = 'document';
 
     IBMDiscoveryV1Models.GetMetricsQueryNoResultsOptions options = new IBMDiscoveryV1Models.GetMetricsQueryNoResultsOptionsBuilder()
-        .startTime(dateValue)
-        .endTime(dateValue)
-        .resultType(resultType)
-        .build();
+      .startTime(dateValue)
+      .endTime(dateValue)
+      .resultType(resultType)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    options = options.newBuilder().build();
 
     IBMDiscoveryV1Models.MetricResponse response = discovery.getMetricsQueryNoResults(options);
 
@@ -2297,7 +2366,9 @@ private class IBMDiscoveryV1Test {
 
     IBMDiscoveryV1Models.GetMetricsQueryTokenEventOptions options = new IBMDiscoveryV1Models.GetMetricsQueryTokenEventOptionsBuilder()
       .count(count)
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    options = options.newBuilder().build();
 
     IBMDiscoveryV1Models.MetricTokenResponse response = discovery.getMetricsQueryTokenEvent(options);
 
@@ -2337,13 +2408,15 @@ private class IBMDiscoveryV1Test {
     String queryId = 'mock_queryid';
 
     IBMDiscoveryV1Models.QueryLogOptions options = new IBMDiscoveryV1Models.QueryLogOptionsBuilder()
-        .xsort(sortList)
-        .addXsort(extraSort)
-        .count(count)
-        .filter(filter)
-        .offset(offset)
-        .query(naturalLanguageQuery)
-        .build();
+      .xsort(sortList)
+      .addXsort(extraSort)
+      .count(count)
+      .filter(filter)
+      .offset(offset)
+      .query(naturalLanguageQuery)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    options = options.newBuilder().build();
 
     IBMDiscoveryV1Models.LogQueryResponse response = discovery.queryLog(options);
 
@@ -2387,27 +2460,25 @@ private class IBMDiscoveryV1Test {
 
     String environmentId = 'environment_id';
     String collectionId = 'collection_id';
-    String headerKey = 'Test-Header';
-    String headerValue = 'test_value';
     IBMDiscoveryV1Models.TokenDictRule firstTokenDictRule = new IBMDiscoveryV1Models.TokenDictRule();
     IBMDiscoveryV1Models.TokenDictRule secondTokenDictRule = new IBMDiscoveryV1Models.TokenDictRule();
     List<IBMDiscoveryV1Models.TokenDictRule> tokenDictRuleList = new List<IBMDiscoveryV1Models.TokenDictRule>();
     tokenDictRuleList.add(firstTokenDictRule);
 
     IBMDiscoveryV1Models.CreateTokenizationDictionaryOptions createOptions = new IBMDiscoveryV1Models.CreateTokenizationDictionaryOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .tokenizationRules(tokenDictRuleList)
-        .addTokenizationRules(secondTokenDictRule)
-        .addHeader(headerKey, headerValue)
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .tokenizationRules(tokenDictRuleList)
+      .addTokenizationRules(secondTokenDictRule)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    createOptions = createOptions.newBuilder().build();
 
     tokenDictRuleList.add(secondTokenDictRule);
 
     System.assertEquals(environmentId, createOptions.environmentId());
     System.assertEquals(collectionId, createOptions.collectionId());
     System.assertEquals(tokenDictRuleList, createOptions.tokenizationRules());
-    System.assertEquals(headerValue, createOptions.requestHeaders().get(headerKey));
 
     Test.stopTest(); 
   }
@@ -2417,17 +2488,15 @@ private class IBMDiscoveryV1Test {
 
     String environmentId = 'environment_id';
     String collectionId = 'collection_id';
-    String headerKey = 'Test-Header';
-    String headerValue = 'test_value';
     IBMDiscoveryV1Models.GetTokenizationDictionaryStatusOptions getOptions = new IBMDiscoveryV1Models.GetTokenizationDictionaryStatusOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .addHeader(headerKey, headerValue)
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    getOptions = getOptions.newBuilder().build();
 
     System.assertEquals(environmentId, getOptions.environmentId());
     System.assertEquals(collectionId, getOptions.collectionId());
-    System.assertEquals(headerValue, getOptions.requestHeaders().get(headerKey));
 
     Test.stopTest();
   }
@@ -2437,17 +2506,15 @@ private class IBMDiscoveryV1Test {
 
     String environmentId = 'environment_id';
     String collectionId = 'collection_id';
-    String headerKey = 'Test-Header';
-    String headerValue = 'test_value';
     IBMDiscoveryV1Models.DeleteTokenizationDictionaryOptions deleteOptions = new IBMDiscoveryV1Models.DeleteTokenizationDictionaryOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .addHeader(headerKey, headerValue)
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    deleteOptions = deleteOptions.newBuilder().build();
 
     System.assertEquals(environmentId, deleteOptions.environmentId());
     System.assertEquals(collectionId, deleteOptions.collectionId());
-    System.assertEquals(headerValue, deleteOptions.requestHeaders().get(headerKey));
 
     Test.stopTest();
   }
@@ -2465,10 +2532,12 @@ private class IBMDiscoveryV1Test {
     String environmentId = 'environment_id';
     String collectionId = 'collection_id';
     IBMDiscoveryV1Models.CreateTokenizationDictionaryOptions createOptions = new IBMDiscoveryV1Models.CreateTokenizationDictionaryOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .tokenizationRules(new List<IBMDiscoveryV1Models.TokenDictRule> { new IBMDiscoveryV1Models.TokenDictRule() })
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .tokenizationRules(new List<IBMDiscoveryV1Models.TokenDictRule> { new IBMDiscoveryV1Models.TokenDictRule() })
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    createOptions = createOptions.newBuilder().build();
     IBMDiscoveryV1Models.TokenDictStatusResponse response = discovery.createTokenizationDictionary(createOptions);
 
     System.assertEquals('active', response.getStatus());
@@ -2490,9 +2559,11 @@ private class IBMDiscoveryV1Test {
     String environmentId = 'environment_id';
     String collectionId = 'collection_id';
     IBMDiscoveryV1Models.GetTokenizationDictionaryStatusOptions getOptions = new IBMDiscoveryV1Models.GetTokenizationDictionaryStatusOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    getOptions = getOptions.newBuilder().build();
     IBMDiscoveryV1Models.TokenDictStatusResponse response = discovery.getTokenizationDictionaryStatus(getOptions);
 
     System.assertEquals('active', response.getStatus());
@@ -2514,9 +2585,11 @@ private class IBMDiscoveryV1Test {
     String environmentId = 'environment_id';
     String collectionId = 'collection_id';
     IBMDiscoveryV1Models.DeleteTokenizationDictionaryOptions deleteOptions = new IBMDiscoveryV1Models.DeleteTokenizationDictionaryOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    deleteOptions = deleteOptions.newBuilder().build();
     discovery.deleteTokenizationDictionary(deleteOptions);
 
     Test.stopTest();
@@ -2534,11 +2607,12 @@ private class IBMDiscoveryV1Test {
       .build();
 
     IBMDiscoveryV1Models.CreateStopwordListOptions createStopwordListOptions = new IBMDiscoveryV1Models.CreateStopwordListOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .stopwordFile(testfile)
-        .stopwordFilename(testFilename)
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .stopwordFile(testfile)
+      .stopwordFilename(testFilename)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
     createStopwordListOptions = createStopwordListOptions.newBuilder().build();
 
     System.assertEquals(environmentId, createStopwordListOptions.environmentId());
@@ -2568,11 +2642,13 @@ private class IBMDiscoveryV1Test {
       .build();
 
     IBMDiscoveryV1Models.CreateStopwordListOptions createStopwordListOptions = new IBMDiscoveryV1Models.CreateStopwordListOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .stopwordFile(testfile)
-        .stopwordFilename(testFilename)
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .stopwordFile(testfile)
+      .stopwordFilename(testFilename)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    createStopwordListOptions = createStopwordListOptions.newBuilder().build();
     IBMDiscoveryV1Models.TokenDictStatusResponse response = discovery.createStopwordList(createStopwordListOptions);
 
     System.assertEquals('active', response.getStatus());
@@ -2588,9 +2664,10 @@ private class IBMDiscoveryV1Test {
     String collectionId = 'collection_id';
 
     IBMDiscoveryV1Models.DeleteStopwordListOptions deleteStopwordListOptions = new IBMDiscoveryV1Models.DeleteStopwordListOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
     deleteStopwordListOptions = deleteStopwordListOptions.newBuilder().build();
 
     System.assertEquals(environmentId, deleteStopwordListOptions.environmentId());
@@ -2613,9 +2690,11 @@ private class IBMDiscoveryV1Test {
     String collectionId = 'collection_id';
 
     IBMDiscoveryV1Models.DeleteStopwordListOptions deleteStopwordListOptions = new IBMDiscoveryV1Models.DeleteStopwordListOptionsBuilder()
-        .environmentId(environmentId)
-        .collectionId(collectionId)
-        .build();
+      .environmentId(environmentId)
+      .collectionId(collectionId)
+      .addHeader(HEADER_KEY, HEADER_VAL)
+      .build();
+    deleteStopwordListOptions = deleteStopwordListOptions.newBuilder().build();
     discovery.deleteStopwordList(deleteStopwordListOptions);
 
     Test.stopTest();
@@ -2630,6 +2709,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetStopwordListStatusOptions getStopwordListStatusOptions = new IBMDiscoveryV1Models.GetStopwordListStatusOptionsBuilder()
         .environmentId(environmentId)
         .collectionId(collectionId)
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
     getStopwordListStatusOptions = getStopwordListStatusOptions.newBuilder().build();
 
@@ -2655,6 +2735,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetStopwordListStatusOptions getStopwordListStatusOptions = new IBMDiscoveryV1Models.GetStopwordListStatusOptionsBuilder()
         .environmentId(environmentId)
         .collectionId(collectionId)
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
     IBMDiscoveryV1Models.TokenDictStatusResponse response = discovery.getStopwordListStatus(getStopwordListStatusOptions);
 
@@ -2703,6 +2784,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.CreateGatewayOptions createGatewayOptions = new IBMDiscoveryV1Models.CreateGatewayOptionsBuilder()
         .environmentId(environmentId)
         .name(name)
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
     IBMDiscoveryV1Models.Gateway response = discovery.createGateway(createGatewayOptions);
 
@@ -2749,6 +2831,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.DeleteGatewayOptions deleteGatewayOptions = new IBMDiscoveryV1Models.DeleteGatewayOptionsBuilder()
         .environmentId(environmentId)
         .gatewayId(gatewayId)
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
     discovery.deleteGateway(deleteGatewayOptions);
 
@@ -2794,6 +2877,7 @@ private class IBMDiscoveryV1Test {
     IBMDiscoveryV1Models.GetGatewayOptions getGatewayOptions = new IBMDiscoveryV1Models.GetGatewayOptionsBuilder()
         .environmentId(environmentId)
         .gatewayId(gatewayId)
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
     IBMDiscoveryV1Models.Gateway response = discovery.getGateway(getGatewayOptions);
 
@@ -2841,6 +2925,7 @@ private class IBMDiscoveryV1Test {
 
     IBMDiscoveryV1Models.ListGatewaysOptions listGatewaysOptions = new IBMDiscoveryV1Models.ListGatewaysOptionsBuilder()
         .environmentId(environmentId)
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
     IBMDiscoveryV1Models.GatewayList response = discovery.listGateways(listGatewaysOptions);
 
@@ -2854,6 +2939,7 @@ private class IBMDiscoveryV1Test {
   }
 
   static testMethod void testSourceOptionsWebCrawl() {
+    Test.startTest();
     String url = 'url';
     String crawlSpeed = 'crawl_speed';
     Long maximumHops = 1L;
@@ -2878,9 +2964,11 @@ private class IBMDiscoveryV1Test {
     System.assertEquals(requestTimeout, sourceOptionsWebCrawl.getRequestTimeout());
     System.assert(sourceOptionsWebCrawl.getOverrideRobotsTxt());
     System.assertEquals(blacklist, sourceOptionsWebCrawl.getBlacklist());
+    Test.stopTest();
   }
 
   static testMethod void testSourceOptionsBuckets() {
+    Test.startTest();
     String name = 'name';
     Long testLimit = 9000L;
 
@@ -2890,9 +2978,11 @@ private class IBMDiscoveryV1Test {
 
     System.assertEquals(name, sourceOptionsBuckets.getName());
     System.assertEquals(testLimit, sourceOptionsBuckets.getXlimit());
+    Test.stopTest();
   }
 
   static testMethod void testSourceOptions() {
+    Test.startTest();
     String folderOwnerUserId = 'folder_owner_user_id';
     String folderId = 'folder_id';
     Long testLimit = 10L;
@@ -2950,6 +3040,7 @@ private class IBMDiscoveryV1Test {
     System.assertEquals(bucketName, sourceOptions.getBuckets().get(0).getName());
     System.assertEquals(testLimit, sourceOptions.getBuckets().get(0).getXlimit());
     System.assert(sourceOptions.getCrawlAllBuckets());
+    Test.stopTest();
   }
 
   static testMethod void testSourceStatus() {

--- a/force-app/main/default/classes/IBMLanguageTranslatorV3Test.cls
+++ b/force-app/main/default/classes/IBMLanguageTranslatorV3Test.cls
@@ -1,5 +1,6 @@
 @isTest
 private class IBMLanguageTranslatorV3Test {
+  private static String version;
   private static String headerKey;
   private static String headerVal;
   private static String documentId;
@@ -17,6 +18,7 @@ private class IBMLanguageTranslatorV3Test {
   private static String status;
 
   static {
+    version = '2018-05-01';
     headerKey = 'Test-Header';
     headerVal = 'test_value';
     documentId = 'id';
@@ -34,6 +36,31 @@ private class IBMLanguageTranslatorV3Test {
     status = 'available';
   }
 
+  static testMethod void testVersionConstructor() {
+    Test.startTest();
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version, 'username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version, config);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
   /**
    *  Test translate
    */
@@ -45,7 +72,7 @@ private class IBMLanguageTranslatorV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01', iamOptions);
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version, iamOptions);
     String modelId = '3e7dfdbe-f757-4150-afee-458e71eb93fb';
     String source = 'en';
     String target = 'es';
@@ -58,6 +85,7 @@ private class IBMLanguageTranslatorV3Test {
       .addText('World')
       .addHeader(headerKey, headerVal)
       .build();
+    translateOptions = translateOptions.newBuilder().build();
     IBMLanguageTranslatorV3Models.TranslationResult translate =
       service.translate(translateOptions);
     System.assertEquals(translate.getWordCount(), 1);
@@ -78,12 +106,13 @@ private class IBMLanguageTranslatorV3Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01');
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version);
     IBMLanguageTranslatorV3Models.IdentifyOptions identifyOptions =
       new IBMLanguageTranslatorV3Models.IdentifyOptionsBuilder()
       .text('sample')
       .addHeader(headerKey, headerVal)
       .build();
+    identifyOptions = identifyOptions.newBuilder().build();
     IBMLanguageTranslatorV3Models.IdentifiedLanguages identify =
       service.identify(identifyOptions);
     Test.stopTest();
@@ -97,11 +126,12 @@ private class IBMLanguageTranslatorV3Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01');
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version);
     IBMLanguageTranslatorV3Models.ListIdentifiableLanguagesOptions listIdentifiableLanguagesOptions =
       new IBMLanguageTranslatorV3Models.ListIdentifiableLanguagesOptionsBuilder()
       .addHeader(headerKey, headerVal)
       .build();
+    listIdentifiableLanguagesOptions = listIdentifiableLanguagesOptions.newBuilder().build();
     IBMLanguageTranslatorV3Models.IdentifiableLanguages listIdentifiableLanguages =
       service.listIdentifiableLanguages(listIdentifiableLanguagesOptions);
 
@@ -128,7 +158,7 @@ private class IBMLanguageTranslatorV3Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01');
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version);
     // Forced Glossary
     Attachment forcedGlossaryAttachment = new Attachment(Body = Blob.valueOf('glossary'),
       Name='glossary.txt',
@@ -153,6 +183,7 @@ private class IBMLanguageTranslatorV3Test {
       .parallelCorpus(parallelCorpus)
       .addHeader(headerKey, headerVal)
       .build();
+    createModelOptions = createModelOptions.newBuilder().build();
     IBMLanguageTranslatorV3Models.TranslationModel TranslationModel =
       service.createModel(createModelOptions);
     System.assertEquals(TranslationModel.getModelId(), '3e7dfdbe-f757-4150-afee-458e71eb93fb');
@@ -190,12 +221,13 @@ private class IBMLanguageTranslatorV3Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01');
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version);
     IBMLanguageTranslatorV3Models.DeleteModelOptions deleteModelOptions =
       new IBMLanguageTranslatorV3Models.DeleteModelOptionsBuilder()
       .modelId('3e7dfdbe-f757-4150-afee-458e71eb93fb')
       .addHeader(headerKey, headerVal)
       .build();
+    deleteModelOptions = deleteModelOptions.newBuilder().build();
     service.deleteModel(deleteModelOptions);
     IBMLanguageTranslatorV3Models.DeleteModelOptionsBuilder newDeleteModelOptionsBuilder1 =
       deleteModelOptions.newBuilder();
@@ -212,12 +244,13 @@ private class IBMLanguageTranslatorV3Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01');
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version);
     IBMLanguageTranslatorV3Models.GetModelOptions getModelOptions =
       new IBMLanguageTranslatorV3Models.GetModelOptionsBuilder()
       .modelId('3e7dfdbe-f757-4150-afee-458e71eb93fb')
       .addHeader(headerKey, headerVal)
       .build();
+    getModelOptions = getModelOptions.newBuilder().build();
     IBMLanguageTranslatorV3Models.TranslationModel getModel =
       service.getModel(getModelOptions);
     IBMLanguageTranslatorV3Models.GetModelOptionsBuilder newGetModelOptionsBuilder1 =
@@ -235,7 +268,7 @@ private class IBMLanguageTranslatorV3Test {
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01');
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version);
     IBMLanguageTranslatorV3Models.ListModelsOptions listModelsOptions =
       new IBMLanguageTranslatorV3Models.ListModelsOptionsBuilder()
       .source('en')
@@ -243,6 +276,7 @@ private class IBMLanguageTranslatorV3Test {
       .defaultModels(false)
       .addHeader(headerKey, headerVal)
       .build();
+    listModelsOptions = listModelsOptions.newBuilder().build();
     IBMLanguageTranslatorV3Models.TranslationModels listModels =
       service.listModels(listModelsOptions);
     IBMLanguageTranslatorV3Models.ListModelsOptionsBuilder newListModelsOptionsBuilder =
@@ -347,7 +381,7 @@ private class IBMLanguageTranslatorV3Test {
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
 
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01', new IBMWatsonNoauthConfig());
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version, new IBMWatsonNoauthConfig());
 
     Attachment documentAttachment = new Attachment(Body = Blob.valueOf('words'),
       Name='document.txt',
@@ -360,7 +394,9 @@ private class IBMLanguageTranslatorV3Test {
     IBMLanguageTranslatorV3Models.TranslateDocumentOptions options = new IBMLanguageTranslatorV3Models.TranslateDocumentOptionsBuilder()
       .file(document)
       .filename(filename)
+      .addHeader(headerKey, headerVal)
       .build();
+    options = options.newBuilder().build();
     IBMLanguageTranslatorV3Models.DocumentStatus response = service.translateDocument(options);
 
     System.assertEquals(documentId, response.getDocumentId());
@@ -384,9 +420,12 @@ private class IBMLanguageTranslatorV3Test {
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
 
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01', new IBMWatsonNoauthConfig());
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version, new IBMWatsonNoauthConfig());
 
-    IBMLanguageTranslatorV3Models.ListDocumentsOptions options = new IBMLanguageTranslatorV3Models.ListDocumentsOptionsBuilder().build();
+    IBMLanguageTranslatorV3Models.ListDocumentsOptions options = new IBMLanguageTranslatorV3Models.ListDocumentsOptionsBuilder()
+      .addHeader(headerKey, headerVal)
+      .build();
+    options = options.newBuilder().build();
     IBMLanguageTranslatorV3Models.DocumentList response = service.listDocuments(options);
 
     System.assert(response.getDocuments().size() > 0);
@@ -400,11 +439,13 @@ private class IBMLanguageTranslatorV3Test {
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
 
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01', new IBMWatsonNoauthConfig());
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version, new IBMWatsonNoauthConfig());
 
     IBMLanguageTranslatorV3Models.GetDocumentStatusOptions options = new IBMLanguageTranslatorV3Models.GetDocumentStatusOptionsBuilder()
       .documentId(documentId)
+      .addHeader(headerKey, headerVal)
       .build();
+    options = options.newBuilder().build();
     IBMLanguageTranslatorV3Models.DocumentStatus response = service.getDocumentStatus(options);
 
     System.assert(response != null);
@@ -418,11 +459,13 @@ private class IBMLanguageTranslatorV3Test {
     Test.setMock(HttpCalloutMock.class, mockResponse);
     Test.startTest();
 
-    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3('2018-05-01', new IBMWatsonNoauthConfig());
+    IBMLanguageTranslatorV3 service = new IBMLanguageTranslatorV3(version, new IBMWatsonNoauthConfig());
 
     IBMLanguageTranslatorV3Models.DeleteDocumentOptions options = new IBMLanguageTranslatorV3Models.DeleteDocumentOptionsBuilder()
       .documentId(documentId)
+      .addHeader(headerKey, headerVal)
       .build();
+    options = options.newBuilder().build();
     service.deleteDocument(options);
 
     Test.stopTest();

--- a/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageClassifierV1Test.cls
@@ -1,5 +1,37 @@
 @isTest
 private class IBMNaturalLanguageClassifierV1Test {
+  private static String HEADER_KEY;
+  private static String HEADER_VAL;
+
+  static {
+    HEADER_KEY = 'Header-Key';
+    HEADER_VAL = 'header_val';
+  }
+
+  static testMethod void testEmptyConstructor() {
+    Test.startTest();
+    IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1();
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1('username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1(config);
+    System.assert(service != null);
+    Test.stopTest();
+  }
 
   /**
    *  Test phrase to classify.
@@ -22,8 +54,9 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1Models.ClassifyOptions classifyOptions = new IBMNaturalLanguageClassifierV1Models.ClassifyOptionsBuilder()
       .classifierId(classifier_id_serialized_name)
       .text(text_serialized_name)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    classifyOptions = classifyOptions.newBuilder().build();
     IBMNaturalLanguageClassifierV1Models.Classification classification = service.classify(classifyOptions);
     System.assertEquals(classification.getClassifierId(), classifier_id_serialized_name);
     System.assertEquals(classification.getUrl(), IBMWatsonMockResponses.IBMNaturalLanguageClassifierClassifyURL);
@@ -69,8 +102,9 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptions classifyOptions = new IBMNaturalLanguageClassifierV1Models.ClassifyCollectionOptionsBuilder()
       .classifierId(classifierId)
       .collection(inputCollection)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    classifyOptions = classifyOptions.newBuilder().build();
     IBMNaturalLanguageClassifierV1Models.ClassificationCollection classification = service.classifyCollection(classifyOptions);
     System.assertEquals(classification.getClassifierId(), classifierId);
     System.assertEquals(classification.getUrl(), 'https://gateway.watsonplatform.net/natural-language-classifier/api/v1/classifiers/' + classifierId);
@@ -113,8 +147,9 @@ private class IBMNaturalLanguageClassifierV1Test {
       new IBMNaturalLanguageClassifierV1Models.CreateClassifierOptionsBuilder()
       .metadata(training_metadata_serialized_name)
       .trainingData(training_data_serialized_name)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
+    createClassifierOptions = createClassifierOptions.newBuilder().build();
     IBMNaturalLanguageClassifierV1Models.Classifier Classifier = service.createClassifier(createClassifierOptions);
     System.assertEquals(Classifier.getName(), 'My Classifier');
     System.assertEquals(Classifier.getUrl(), IBMWatsonMockResponses.IBMNaturalLanguageClassifierClassifyBaseURL);
@@ -146,7 +181,7 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptions deleteClassifierOptions =
       new IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptionsBuilder()
       .classifierId(classifier_id_serialized_name)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     service.deleteClassifier(deleteClassifierOptions);
     IBMNaturalLanguageClassifierV1Models.DeleteClassifierOptionsBuilder DeleteClassifierOptionsBuilder =
@@ -167,7 +202,7 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1Models.GetClassifierOptions getClassifierOption =
       new IBMNaturalLanguageClassifierV1Models.GetClassifierOptionsBuilder()
       .classifierId(classifier_id_serialized_name)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     IBMNaturalLanguageClassifierV1Models.Classifier Classifier = service.getClassifier(getClassifierOption);
     System.assertEquals(Classifier.getName(), 'My Classifier');
@@ -191,7 +226,7 @@ private class IBMNaturalLanguageClassifierV1Test {
     IBMNaturalLanguageClassifierV1 service = new IBMNaturalLanguageClassifierV1();
     IBMNaturalLanguageClassifierV1Models.ListClassifiersOptions listClassifiersOptions =
       new IBMNaturalLanguageClassifierV1Models.ListClassifiersOptionsBuilder()
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     IBMNaturalLanguageClassifierV1Models.ClassifierList ClassifierList = service.listClassifiers(listClassifiersOptions);
     List<IBMNaturalLanguageClassifierV1Models.Classifier> Classifiers = ClassifierList.getClassifiers();

--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Test.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Test.cls
@@ -1,5 +1,8 @@
 @isTest
 private class IBMNaturalLanguageUnderstandingV1Test {
+  private static String VERSION;
+  private static String HEADER_KEY;
+  private static String HEADER_VAL;
   private static String TEXT;
   private static Long LIMIT_VAL;
   private static String MODEL;
@@ -7,11 +10,39 @@ private class IBMNaturalLanguageUnderstandingV1Test {
   private static Long LOCATION;
 
   static {
+    VERSION = '2017-02-27';
+    HEADER_KEY = 'Header-Key';
+    HEADER_VAL = 'header_val';
     TEXT = 'text';
     LIMIT_VAL = 200L;
     MODEL = 'model';
     CONFIDENCE = 0.5;
     LOCATION = 0L;
+  }
+
+  static testMethod void testVersionConstructor() {
+    Test.startTest();
+    IBMNaturalLanguageUnderstandingV1 service = new IBMNaturalLanguageUnderstandingV1(VERSION);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMNaturalLanguageUnderstandingV1 service = new IBMNaturalLanguageUnderstandingV1(VERSION, 'username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMNaturalLanguageUnderstandingV1 service = new IBMNaturalLanguageUnderstandingV1(VERSION, config);
+    System.assert(service != null);
+    Test.stopTest();
   }
 
   static testMethod void testCategoriesOptions() {
@@ -88,8 +119,10 @@ private class IBMNaturalLanguageUnderstandingV1Test {
       .xlimit(12L)
       .explanation(true)
       .build();
+    categories = categories.newBuilder().build();
     IBMNaturalLanguageUnderstandingV1Models.MetadataOptions metadata = new IBMNaturalLanguageUnderstandingV1Models.MetadataOptions();
     IBMNaturalLanguageUnderstandingV1Models.SyntaxOptions syntax = new IBMNaturalLanguageUnderstandingV1Models.SyntaxOptionsBuilder().build();
+    syntax = syntax.newBuilder().build();
     IBMNaturalLanguageUnderstandingV1Models.Features features = new IBMNaturalLanguageUnderstandingV1Models.FeaturesBuilder()
       .concepts(concepts)
       .emotion(emotion)
@@ -115,7 +148,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
       .returnAnalyzedText(true)
       .language('en')
       .limitTextCharacters(100)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -191,6 +224,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
   }
 
   static testMethod void testSytntaxOptions() {
+    Test.startTest();
     IBMNaturalLanguageUnderstandingV1Models.SyntaxOptionsTokens token = new IBMNaturalLanguageUnderstandingV1Models.SyntaxOptionsTokens();
     token.setLemma(true);
     token.setPartOfSpeech(true);
@@ -203,9 +237,11 @@ private class IBMNaturalLanguageUnderstandingV1Test {
     System.assert(options.sentences());
     System.assert(options.tokens().getLemma());
     System.assert(options.tokens().getPartOfSpeech());
+    Test.stopTest();
   }
 
   static testMethod void testModel() {
+    Test.startTest();
     String status = 'status';
     String modelId = 'model_id';
     String language = 'spanish';
@@ -233,6 +269,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
     System.assertEquals(version, model.getVersion());
     System.assertEquals(versionDescription, model.getVersionDescription());
     System.assertEquals(created, model.getCreated());
+    Test.stopTest();
   }
 
   static testMethod void testAnalysisResultsAttributes() {
@@ -373,7 +410,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
     naturalLanguageUnderstanding.setEndPoint('https://gateway.watsonplatform.net/natural-language-understanding/api');
     naturalLanguageUnderstanding.setUsernameAndPassword('username', 'password');
     IBMNaturalLanguageUnderstandingV1Models.ListModelsOptions options = new IBMNaturalLanguageUnderstandingV1Models.ListModelsOptionsBuilder()
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -396,7 +433,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
     naturalLanguageUnderstanding.setEndPoint('https://gateway.watsonplatform.net/natural-language-understanding/api');
     IBMNaturalLanguageUnderstandingV1Models.DeleteModelOptions options = new IBMNaturalLanguageUnderstandingV1Models.DeleteModelOptionsBuilder()
       .modelId('test')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -414,7 +451,7 @@ private class IBMNaturalLanguageUnderstandingV1Test {
       naturalLanguageUnderstanding.setEndPoint('https://gateway.watsonplatform.net/natural-language-understanding/api');
       IBMNaturalLanguageUnderstandingV1Models.DeleteModelOptions options = new IBMNaturalLanguageUnderstandingV1Models.DeleteModelOptionsBuilder()
         .modelId('test')
-        .addHeader('Test-Header', 'test_value')
+        .addHeader(HEADER_KEY, HEADER_VAL)
         .build();
       naturalLanguageUnderstanding.deleteModel(options);
     }

--- a/force-app/main/default/classes/IBMPersonalityInsightsV3Test.cls
+++ b/force-app/main/default/classes/IBMPersonalityInsightsV3Test.cls
@@ -1,5 +1,39 @@
 @isTest
 private class IBMPersonalityInsightsV3Test {
+  private static String VERSION;
+  private static String HEADER_KEY;
+  private static String HEADER_VAL;
+
+  static {
+    VERSION = '2017-09-01';
+    HEADER_KEY = 'Header-Key';
+    HEADER_VAL = 'header_val';
+  }
+
+  static testMethod void testVersionConstructor() {
+    Test.startTest();
+    IBMPersonalityInsightsV3 service = new IBMPersonalityInsightsV3(VERSION);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMPersonalityInsightsV3 service = new IBMPersonalityInsightsV3(VERSION, 'username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMPersonalityInsightsV3 service = new IBMPersonalityInsightsV3(VERSION, config);
+    System.assert(service != null);
+    Test.stopTest();
+  }
   /**
    * Generates a personality profile based on input text.
    *
@@ -12,9 +46,9 @@ private class IBMPersonalityInsightsV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMPersonalityInsightsV3 personalityInsights = new IBMPersonalityInsightsV3('2017-09-01', iamOptions);
+    IBMPersonalityInsightsV3 personalityInsights = new IBMPersonalityInsightsV3(VERSION, iamOptions);
     personalityInsights.setEndPoint('https://gateway.watsonplatform.net/personality-insights/api');
-    IBMPersonalityInsightsV3Models.ContentItem contentItem=new IBMPersonalityInsightsV3Models.ContentItemBuilder()
+    IBMPersonalityInsightsV3Models.ContentItem contentItem = new IBMPersonalityInsightsV3Models.ContentItemBuilder()
       .content('text/plain')
       .id('test')
       .created(1)
@@ -27,12 +61,12 @@ private class IBMPersonalityInsightsV3Test {
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     contentItem = contentItem.newBuilder().build();
-    IBMPersonalityInsightsV3Models.Content content=new IBMPersonalityInsightsV3Models.ContentBuilder()
+    IBMPersonalityInsightsV3Models.Content content = new IBMPersonalityInsightsV3Models.ContentBuilder()
       .addContentItems(contentItem)
       .contentItems(new List<IBMPersonalityInsightsV3Models.ContentItem>{contentItem})
       .build();
     // or you can use following
-    content=new IBMPersonalityInsightsV3Models.ContentBuilder(new List<IBMPersonalityInsightsV3Models.ContentItem>{contentItem})
+    content = new IBMPersonalityInsightsV3Models.ContentBuilder(new List<IBMPersonalityInsightsV3Models.ContentItem>{contentItem})
       .addContentItems(contentItem)
       .contentItems(new List<IBMPersonalityInsightsV3Models.ContentItem>{contentItem})
       .build();
@@ -46,7 +80,7 @@ private class IBMPersonalityInsightsV3Test {
       .content(content)
       .html('<html><body>test</body></html>')
       .text('test')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();

--- a/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
+++ b/force-app/main/default/classes/IBMSpeechToTextV1Test.cls
@@ -106,6 +106,31 @@ private class IBMSpeechToTextV1Test {
     updated = '2019-10-11T19:16:58.547Z';
   }
 
+  static testMethod void testEmptyConstructor() {
+    Test.startTest();
+    IBMSpeechToTextV1 service = new IBMSpeechToTextV1();
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMSpeechToTextV1 service = new IBMSpeechToTextV1('username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMSpeechToTextV1 service = new IBMSpeechToTextV1(config);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
   static testMethod void getModelTest() {
     String body = IBMWatsonMockResponses.speechToTextGetModel();
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
@@ -118,7 +143,7 @@ private class IBMSpeechToTextV1Test {
     speechToText.setEndPoint(URL);
     IBMSpeechToTextV1Models.GetModelOptions getModelOptions = new IBMSpeechToTextV1Models.GetModelOptionsBuilder('en-US_NarrowbandModel')
       .modelId('en-US_NarrowbandModel')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.SpeechModel speechModel = speechToText.getModel(getModelOptions);
     System.assertEquals(speechModel.getName(), 'en-US_NarrowbandModel');
@@ -144,7 +169,7 @@ private class IBMSpeechToTextV1Test {
       speechToText.setUsernameAndPassword(username, password);
     }
     IBMSpeechToTextV1Models.ListModelsOptions listModelsOptions = new IBMSpeechToTextV1Models.ListModelsOptionsBuilder()
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.SpeechModels speechModels = speechToText.listModels(listModelsOptions);
     System.assertEquals(speechModels.getModels()[0].getName(), 'en-US_NarrowbandModel');
@@ -192,7 +217,7 @@ private class IBMSpeechToTextV1Test {
       .smartFormatting(true)
       .speakerLabels(true)
       .baseModelVersion('version')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.RecognitionJob createJob = speechToText.createJob(createJobOptions);
     System.assertEquals(createJob.getUrl(), 'string');
@@ -237,7 +262,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.CheckJobOptionsBuilder CheckJobOptionsBuilder = new IBMSpeechToTextV1Models.CheckJobOptionsBuilder();
     IBMSpeechToTextV1Models.CheckJobOptions checkJobOptions = new IBMSpeechToTextV1Models.CheckJobOptionsBuilder('56d09f2c-e020-11e7-9ee3-33bf91161141')
       .id('56d09f2c-e020-11e7-9ee3-33bf91161141')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     checkJobOptions = checkJobOptions.newBuilder().build();
     IBMSpeechToTextV1Models.RecognitionJob checkJob = speechToText.checkJob(checkJobOptions);
@@ -256,7 +281,7 @@ private class IBMSpeechToTextV1Test {
       speechToText.setUsernameAndPassword(username, password);
     }
     IBMSpeechToTextV1Models.CheckJobsOptions checkJobsOptions = new IBMSpeechToTextV1Models.CheckJobsOptionsBuilder()
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     checkJobsOptions = checkJobsOptions.newBuilder().build();
     IBMSpeechToTextV1Models.RecognitionJobs checkJobs = speechToText.checkJobs(checkJobsOptions);
@@ -276,7 +301,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.DeleteJobOptions deleteJobOptions = new IBMSpeechToTextV1Models.DeleteJobOptionsBuilder('56d09f2c-e020-11e7-9ee3-33bf91161141')
       .id('56d09f2c-e020-11e7-9ee3-33bf91161141')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.deleteJob(deleteJobOptions);
     deleteJobOptions = deleteJobOptions.newBuilder().build();
@@ -296,7 +321,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.RegisterCallbackOptions registerCallbackOptions = new IBMSpeechToTextV1Models.RegisterCallbackOptionsBuilder(callbackBaseURL)
       .callbackUrl(callbackBaseURL)
       .userSecret('UserSecretTest')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.RegisterStatus registerCallback = speechToText.registerCallback(registerCallbackOptions);
     System.assertEquals(registerCallback.getStatus(), 'created');
@@ -316,7 +341,7 @@ private class IBMSpeechToTextV1Test {
       speechToText.setUsernameAndPassword(username, password);
     }
     IBMSpeechToTextV1Models.UnregisterCallbackOptions unregisterCallbackOptions = new IBMSpeechToTextV1Models.UnregisterCallbackOptionsBuilder(callbackBaseURL)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     unregisterCallbackOptions = unregisterCallbackOptions.newBuilder().build();
     speechToText.unregisterCallback(unregisterCallbackOptions);
@@ -340,8 +365,9 @@ private class IBMSpeechToTextV1Test {
       .baseModelName(baseModelName)
       .dialect('en-US')
       .description('model description')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
+    createLanguageModelOptions = createLanguageModelOptions.newBuilder().build();
     IBMSpeechToTextV1Models.LanguageModel languageModel = speechToText.createLanguageModel(createLanguageModelOptions);
     System.assertEquals(languageModel.getCustomizationId(), '74f4807e-b5ff-4866-824e-6bba1a84fe96');
     System.assertEquals(languageModel.getOwner(), '952e2069-9ece-48d8-96c9-0206b4473819');
@@ -376,7 +402,7 @@ private class IBMSpeechToTextV1Test {
       .word('tornado')
       .soundsLike(new List<String>{'tornado', 'hurricane'})
       .displayAs('tornado')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.addWord(addWordOptions);
     addWordOptions = addWordOptions.newBuilder().build();
@@ -401,7 +427,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.AddWordsOptions addWordsOptions = new IBMSpeechToTextV1Models.AddWordsOptionsBuilder()
       .customizationId(customizationId)
       .words(new List<IBMSpeechToTextV1Models.CustomWord>{ customWord })
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.addWords(addWordsOptions);
     addWordsOptions = addWordsOptions.newBuilder().build();
@@ -427,7 +453,7 @@ private class IBMSpeechToTextV1Test {
       .name(name)
       .baseModelName(baseModelName)
       .description('test')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.AcousticModel AcousticModel = speechToText.createAcousticModel(createAcousticModelOptions);
     createAcousticModelOptions = createAcousticModelOptions.newBuilder().build();
@@ -446,7 +472,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.DeleteLanguageModelOptions deleteLanguageModelOptions = new IBMSpeechToTextV1Models.DeleteLanguageModelOptionsBuilder('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
       .customizationId('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.deleteLanguageModel(deleteLanguageModelOptions);
     deleteLanguageModelOptions = deleteLanguageModelOptions.newBuilder().build();
@@ -478,7 +504,7 @@ private class IBMSpeechToTextV1Test {
       .audioName(audioName)
       .containedContentType('audio/mp3')
       .allowOverwrite(false)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.addAudio(addAudioOptions);
     addAudioOptions = addAudioOptions.newBuilder().build();
@@ -497,7 +523,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.GetLanguageModelOptions getLanguageModelOptions = new IBMSpeechToTextV1Models.GetLanguageModelOptionsBuilder('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
       .customizationId('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.LanguageModel languageModel = speechToText.getLanguageModel(getLanguageModelOptions);
     System.assertEquals(languageModel.getCustomizationId(), 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5');
@@ -528,7 +554,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.ListLanguageModelsOptions listLanguageModelsOptions = new IBMSpeechToTextV1Models.ListLanguageModelsOptionsBuilder()
       .language('en-US')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.LanguageModels languageModels = speechToText.listLanguageModels(listLanguageModelsOptions);
     System.assertEquals(languageModels.getCustomizations()[0].getCustomizationId(), 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5');
@@ -548,7 +574,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.ResetLanguageModelOptions resetLanguageModelOptions = new IBMSpeechToTextV1Models.ResetLanguageModelOptionsBuilder('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
       .customizationId('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.resetLanguageModel(resetLanguageModelOptions);
     resetLanguageModelOptions = resetLanguageModelOptions.newBuilder().build();
@@ -567,7 +593,9 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.TrainLanguageModelOptions trainLanguageModelOptions = new IBMSpeechToTextV1Models.TrainLanguageModelOptionsBuilder()
       .customizationId(customizationId)
+      .addHeader(headerKey, headerVal)
       .build();
+    trainLanguageModelOptions = trainLanguageModelOptions.newBuilder().build();
     IBMSpeechToTextV1Models.TrainingResponse response = speechToText.trainLanguageModel(trainLanguageModelOptions);
 
     Test.stopTest();
@@ -585,7 +613,9 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.TrainAcousticModelOptions options = new IBMSpeechToTextV1Models.TrainAcousticModelOptionsBuilder()
       .customizationId(customizationId)
+      .addHeader(headerKey, headerVal)
       .build();
+    options = options.newBuilder().build();
     IBMSpeechToTextV1Models.TrainingResponse response = speechToText.trainAcousticModel(options);
 
     Test.stopTest();
@@ -604,8 +634,9 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.UpgradeLanguageModelOptions upgradeLanguageModelOptions = new IBMSpeechToTextV1Models.UpgradeLanguageModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
+    upgradeLanguageModelOptions = upgradeLanguageModelOptions.newBuilder().build();
     speechToText.upgradeLanguageModel(upgradeLanguageModelOptions);
     Test.stopTest();
   }
@@ -633,7 +664,7 @@ private class IBMSpeechToTextV1Test {
       .corpusName(corpusName)
       .allowOverwrite(true)
       .corpusFile(corpusFile)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.addCorpus(addCorpusOptions);
     addCorpusOptions = addCorpusOptions.newBuilder().build();
@@ -655,7 +686,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.DeleteCorpusOptions deleteCorpusOptions = new IBMSpeechToTextV1Models.DeleteCorpusOptionsBuilder(customizationId, corpusName)
       .customizationId(customizationId)
       .corpusName(corpusName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.deleteCorpus(deleteCorpusOptions);
     deleteCorpusOptions = deleteCorpusOptions.newBuilder().build();
@@ -677,7 +708,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.GetCorpusOptions getCorpusOptions = new IBMSpeechToTextV1Models.GetCorpusOptionsBuilder(customizationId, corpusName)
       .customizationId(customizationId)
       .corpusName(corpusName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.Corpus corpus = speechToText.getCorpus(getCorpusOptions);
     System.assertEquals(corpus.getError(), 'none');
@@ -701,7 +732,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.ListCorporaOptions listCorporaOptions = new IBMSpeechToTextV1Models.ListCorporaOptionsBuilder('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
       .customizationId('d0bdc477-59e6-4e45-86f3-1a9a39664eb5')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.Corpora corpora = speechToText.listCorpora(listCorporaOptions);
     System.assertEquals(corpora.getCorpora()[0].getName(), 'custom_corpus');
@@ -724,7 +755,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.DeleteWordOptions deleteWordOptions = new IBMSpeechToTextV1Models.DeleteWordOptionsBuilder(customizationId, wordName)
       .customizationId(customizationId)
       .wordName(wordName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.deleteWord(deleteWordOptions);
     deleteWordOptions = deleteWordOptions.newBuilder().build();
@@ -746,7 +777,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.GetWordOptions getWordOptions = new IBMSpeechToTextV1Models.GetWordOptionsBuilder(customizationId, wordName)
       .customizationId(customizationId)
       .wordName(wordName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.Word wordResult =  speechToText.getWord(getWordOptions);
     System.assertEquals(wordResult.getDisplayAs(), 'words matter');
@@ -776,7 +807,7 @@ private class IBMSpeechToTextV1Test {
       .customizationId(customizationId)
       .wordType(wordType)
       .xsort(sortField)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.Words wordList = speechToText.listWords(listWordsOptions);
     System.assertEquals(wordList.getWords()[0].getDisplayAs(), 'words matter');
@@ -797,7 +828,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.DeleteAcousticModelOptions deleteAcousticModelOptions = new IBMSpeechToTextV1Models.DeleteAcousticModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.deleteAcousticModel(deleteAcousticModelOptions);
     deleteAcousticModelOptions = deleteAcousticModelOptions.newBuilder().build();
@@ -817,7 +848,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.GetAcousticModelOptions getAcousticModelOptions = new IBMSpeechToTextV1Models.GetAcousticModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.AcousticModel acousticModel = speechToText.getAcousticModel(getAcousticModelOptions);
     System.assertEquals(acousticModel.getCustomizationId(), '825485d7-af3f-44e7-b1ea-76130dec8a61');
@@ -845,7 +876,7 @@ private class IBMSpeechToTextV1Test {
       .customizationId(customizationId)
       .customLanguageModelId(customLanguageModelId)
       .force(true)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
       upgradeAcousticModelOptions = upgradeAcousticModelOptions.newBuilder().build();
 
@@ -873,7 +904,9 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.UpgradeAcousticModelOptions upgradeAcousticModelOptions = new IBMSpeechToTextV1Models.UpgradeAcousticModelOptionsBuilder()
       .customizationId(customizationId)
       .customLanguageModelId(customLanguageModelId)
+      .addHeader(headerKey, headerVal)
       .build();
+    upgradeAcousticModelOptions = upgradeAcousticModelOptions.newBuilder().build();
     speechToText.upgradeAcousticModel(upgradeAcousticModelOptions);
     Test.stopTest();
   }
@@ -890,7 +923,7 @@ private class IBMSpeechToTextV1Test {
     }
     IBMSpeechToTextV1Models.ListAcousticModelsOptions listAcousticModelsOptions = new IBMSpeechToTextV1Models.ListAcousticModelsOptionsBuilder()
       .language('en-US')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.AcousticModels acousticModels = speechToText.listAcousticModels(listAcousticModelsOptions);
     System.assertEquals(acousticModels.getCustomizations()[0].getCustomizationId(), '825485d7-af3f-44e7-b1ea-76130dec8a61');
@@ -911,7 +944,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.ResetAcousticModelOptions resetAcousticModelOptions = new IBMSpeechToTextV1Models.ResetAcousticModelOptionsBuilder(customizationId)
       .customizationId(customizationId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.resetAcousticModel(resetAcousticModelOptions);
     resetAcousticModelOptions = resetAcousticModelOptions.newBuilder().build();
@@ -933,7 +966,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.DeleteAudioOptions deleteAudioOptions = new IBMSpeechToTextV1Models.DeleteAudioOptionsBuilder(customizationId, audioName)
       .customizationId(customizationId)
       .audioName(audioName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     speechToText.deleteAudio(deleteAudioOptions);
     deleteAudioOptions = deleteAudioOptions.newBuilder().build();
@@ -955,7 +988,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.GetAudioOptions getAudioOptions = new IBMSpeechToTextV1Models.GetAudioOptionsBuilder(customizationId, audioName)
       .customizationId(customizationId)
       .audioName(audioName)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.AudioListing audioListing = speechToText.getAudio(getAudioOptions);
 //    System.assertEquals(audioListing.getTotalMinutesOfAudio(),0);
@@ -988,7 +1021,7 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'd0bdc477-59e6-4e45-86f3-1a9a39664eb5';
     IBMSpeechToTextV1Models.ListAudioOptions listAudioOptions = new IBMSpeechToTextV1Models.ListAudioOptionsBuilder(customizationId)
       .customizationId(customizationId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.AudioResources AudioResources = speechToText.listAudio(listAudioOptions);
     listAudioOptions = listAudioOptions.newBuilder().build();
@@ -1015,6 +1048,7 @@ private class IBMSpeechToTextV1Test {
     IBMSpeechToTextV1Models.RecognizeOptions recognizeOptions = new IBMSpeechToTextV1Models.RecognizeOptionsBuilder()
       .audio(audio)
       .contentType(fileContentType)
+      .addHeader(headerKey, headerVal)
       .build();
     IBMSpeechToTextV1Models.SpeechRecognitionResults speechResults = speechToText.recognize(recognizeOptions);
     System.assertEquals(speechResults.getResults()[0].getWordAlternatives()[0].getStartTime(),0.14);
@@ -1065,7 +1099,7 @@ private class IBMSpeechToTextV1Test {
     String customerId = 'salesforce_sdk_test_id';
     IBMSpeechToTextV1Models.DeleteUserDataOptions deleteOptions = new IBMSpeechToTextV1Models.DeleteUserDataOptionsBuilder()
       .customerId(customerId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(headerKey, headerVal)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -1086,12 +1120,14 @@ private class IBMSpeechToTextV1Test {
     String contentType = 'application/srgs';
 
     IBMSpeechToTextV1Models.AddGrammarOptions addGrammarOptions = new IBMSpeechToTextV1Models.AddGrammarOptionsBuilder()
-        .customizationId(customizationId)
-        .grammarName(grammarName)
-        .grammarFile(testfile)
-        .contentType(contentType)
-        .allowOverwrite(true)
-        .build();
+      .customizationId(customizationId)
+      .grammarName(grammarName)
+      .grammarFile(testfile)
+      .contentType(contentType)
+      .allowOverwrite(true)
+      .addHeader(headerKey, headerVal)
+      .build();
+    addGrammarOptions = addGrammarOptions.newBuilder().build();
 
     System.assertEquals(customizationId, addGrammarOptions.customizationId());
     System.assertEquals(grammarName, addGrammarOptions.grammarName());
@@ -1124,11 +1160,12 @@ private class IBMSpeechToTextV1Test {
     String contentType = 'application/srgs';
 
     IBMSpeechToTextV1Models.AddGrammarOptions addGrammarOptions = new IBMSpeechToTextV1Models.AddGrammarOptionsBuilder()
-        .customizationId(customizationId)
-        .grammarName(grammarName)
-        .grammarFile(testfile)
-        .contentType(contentType)
-        .build();
+      .customizationId(customizationId)
+      .grammarName(grammarName)
+      .grammarFile(testfile)
+      .contentType(contentType)
+      .addHeader(headerKey, headerVal)
+      .build();
     speechToText.addGrammar(addGrammarOptions);
 
     Test.stopTest();
@@ -1140,8 +1177,9 @@ private class IBMSpeechToTextV1Test {
     String customizationId = 'id';
 
     IBMSpeechToTextV1Models.ListGrammarsOptions listGrammarsOptions = new IBMSpeechToTextV1Models.ListGrammarsOptionsBuilder()
-        .customizationId(customizationId)
-        .build();
+      .customizationId(customizationId)
+      .build();
+    listGrammarsOptions = listGrammarsOptions.newBuilder().build();
 
     System.assertEquals(customizationId, listGrammarsOptions.customizationId());
 
@@ -1164,8 +1202,9 @@ private class IBMSpeechToTextV1Test {
     String status = 'analyzed';
 
     IBMSpeechToTextV1Models.ListGrammarsOptions listGrammarsOptions = new IBMSpeechToTextV1Models.ListGrammarsOptionsBuilder()
-        .customizationId(customizationId)
-        .build();
+      .customizationId(customizationId)
+      .addHeader(headerKey, headerVal)
+      .build();
     IBMSpeechToTextV1Models.Grammars response = speechToText.listGrammars(listGrammarsOptions);
 
     System.assertEquals(outOfVocabularyWords, response.getGrammars().get(0).getOutOfVocabularyWords());
@@ -1183,9 +1222,10 @@ private class IBMSpeechToTextV1Test {
     String grammarName = 'grammar_name';
 
     IBMSpeechToTextV1Models.GetGrammarOptions getGrammarOptions = new IBMSpeechToTextV1Models.GetGrammarOptionsBuilder()
-        .customizationId(customizationId)
-        .grammarName(grammarName)
-        .build();
+      .customizationId(customizationId)
+      .grammarName(grammarName)
+      .build();
+    getGrammarOptions = getGrammarOptions.newBuilder().build();
 
     System.assertEquals(customizationId, getGrammarOptions.customizationId());
     System.assertEquals(grammarName, getGrammarOptions.grammarName());
@@ -1209,9 +1249,10 @@ private class IBMSpeechToTextV1Test {
     String status = 'analyzed';
 
     IBMSpeechToTextV1Models.GetGrammarOptions getGrammarOptions = new IBMSpeechToTextV1Models.GetGrammarOptionsBuilder()
-        .customizationId(customizationId)
-        .grammarName(grammarName)
-        .build();
+      .customizationId(customizationId)
+      .grammarName(grammarName)
+      .addHeader(headerKey, headerVal)
+      .build();
     IBMSpeechToTextV1Models.Grammar response = speechToText.getGrammar(getGrammarOptions);
 
     System.assertEquals(outOfVocabularyWords, response.getOutOfVocabularyWords());
@@ -1229,9 +1270,10 @@ private class IBMSpeechToTextV1Test {
     String grammarName = 'grammar_name';
 
     IBMSpeechToTextV1Models.DeleteGrammarOptions deleteGrammarOptions = new IBMSpeechToTextV1Models.DeleteGrammarOptionsBuilder()
-        .customizationId(customizationId)
-        .grammarName(grammarName)
-        .build();
+      .customizationId(customizationId)
+      .grammarName(grammarName)
+      .build();
+    deleteGrammarOptions = deleteGrammarOptions.newBuilder().build();
 
     System.assertEquals(customizationId, deleteGrammarOptions.customizationId());
     System.assertEquals(grammarName, deleteGrammarOptions.grammarName());
@@ -1256,9 +1298,10 @@ private class IBMSpeechToTextV1Test {
     String grammarName = 'grammar_name';
 
     IBMSpeechToTextV1Models.DeleteGrammarOptions deleteGrammarOptions = new IBMSpeechToTextV1Models.DeleteGrammarOptionsBuilder()
-        .customizationId(customizationId)
-        .grammarName(grammarName)
-        .build();
+      .customizationId(customizationId)
+      .grammarName(grammarName)
+      .addHeader(headerKey, headerVal)
+      .build();
     speechToText.deleteGrammar(deleteGrammarOptions);
 
     Test.stopTest();

--- a/force-app/main/default/classes/IBMTextToSpeechV1Test.cls
+++ b/force-app/main/default/classes/IBMTextToSpeechV1Test.cls
@@ -3,6 +3,40 @@ private class IBMTextToSpeechV1Test {
   private static String URL = 'https://stream.watsonplatform.net/text-to-speech/api';
   private static String username = 'username';
   private static String password = 'password';
+
+  private static String HEADER_KEY;
+  private static String HEADER_VAL;
+
+  static {
+    HEADER_KEY = 'Header-Key';
+    HEADER_VAL = 'header_val';
+  }
+
+  static testMethod void testEmptyConstructor() {
+    Test.startTest();
+    IBMTextToSpeechV1 service = new IBMTextToSpeechV1();
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMTextToSpeechV1 service = new IBMTextToSpeechV1('username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMTextToSpeechV1 service = new IBMTextToSpeechV1(config);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
   /**
    * Creates a new custom voice model.
    *
@@ -21,7 +55,7 @@ private class IBMTextToSpeechV1Test {
       .name('I love Apples not oranges')
       .language('de-DE')
       .description('Salesforce is making it easier for developers to use IBM Watson\'s artificial intelligence engine within the firm\'s customer relationship management software, which could lead to some exciting new technology for advisers.')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -57,7 +91,7 @@ private class IBMTextToSpeechV1Test {
     IBMTextToSpeechV1Models.GetVoiceOptions options = new IBMTextToSpeechV1Models.GetVoiceOptionsBuilder()
       .customizationId('customizationId')
       .voice('en-US_AllisonVoice')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -90,7 +124,7 @@ private class IBMTextToSpeechV1Test {
       textToSpeech.setUsernameAndPassword(username, password);
     }
     IBMTextToSpeechV1Models.ListVoicesOptions options = new IBMTextToSpeechV1Models.ListVoicesOptionsBuilder()
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -116,7 +150,7 @@ private class IBMTextToSpeechV1Test {
     }
     IBMTextToSpeechV1Models.DeleteVoiceModelOptions options = new IBMTextToSpeechV1Models.DeleteVoiceModelOptionsBuilder()
       .customizationId('customizationId')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -140,7 +174,7 @@ private class IBMTextToSpeechV1Test {
     }
     IBMTextToSpeechV1Models.GetVoiceModelOptions options = new IBMTextToSpeechV1Models.GetVoiceModelOptionsBuilder()
       .customizationId('customizationId')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -165,7 +199,7 @@ private class IBMTextToSpeechV1Test {
       textToSpeech.setUsernameAndPassword(username, password);
     }
     IBMTextToSpeechV1Models.ListVoiceModelsOptions options = new IBMTextToSpeechV1Models.ListVoiceModelsOptionsBuilder()
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -195,7 +229,7 @@ private class IBMTextToSpeechV1Test {
     IBMTextToSpeechV1Models.UpdateVoiceModelOptions options = new IBMTextToSpeechV1Models.UpdateVoiceModelOptionsBuilder()
       .customizationId('customizationId')
       .addWords(word)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -226,7 +260,7 @@ private class IBMTextToSpeechV1Test {
       .translation('de-DE')
       .partOfSpeech('Josi')
       .translation(translation)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -257,7 +291,7 @@ private class IBMTextToSpeechV1Test {
       .customizationId('customizationId')
       .addWords(word)
       .words(words)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -282,7 +316,7 @@ private class IBMTextToSpeechV1Test {
     IBMTextToSpeechV1Models.DeleteWordOptions options = new IBMTextToSpeechV1Models.DeleteWordOptionsBuilder()
       .customizationId('customizationId')
       .word('World')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -307,7 +341,7 @@ private class IBMTextToSpeechV1Test {
     IBMTextToSpeechV1Models.GetWordOptions options = new IBMTextToSpeechV1Models.GetWordOptionsBuilder()
       .customizationId('customizationId')
       .word('World')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -334,7 +368,7 @@ private class IBMTextToSpeechV1Test {
     }
     IBMTextToSpeechV1Models.ListWordsOptions options = new IBMTextToSpeechV1Models.ListWordsOptionsBuilder()
       .customizationId('customizationId')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -363,7 +397,7 @@ private class IBMTextToSpeechV1Test {
       .voice('de-DE_DieterVoice')
       .format('ipa')
       .customizationId('customizationId')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -389,7 +423,7 @@ private class IBMTextToSpeechV1Test {
     String customerId = 'salesforce_sdk_test_id';
     IBMTextToSpeechV1Models.DeleteUserDataOptions deleteOptions = new IBMTextToSpeechV1Models.DeleteUserDataOptionsBuilder()
       .customerId(customerId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();
@@ -397,33 +431,4 @@ private class IBMTextToSpeechV1Test {
 
     Test.stopTest();
   }
-
-   /**
-   * Streaming speech synthesis of the text in the body parameter.
-   *
-
-  static testMethod void testSynthesize() {
-    String body = IBMWatsonMockResponses.profile();
-    IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
-    Test.setMock(HttpCalloutMock.class, mockResponse);
-    Test.startTest();
-    IBMTextToSpeechV1 textToSpeech = new IBMTextToSpeechV1();
-    if (username != null && password != null) {
-      textToSpeech.setEndPoint(URL);
-      textToSpeech.setUsernameAndPassword(username, password);
-    }
-    IBMTextToSpeechV1Models.SynthesizeOptions options = new IBMTextToSpeechV1Models.SynthesizeOptionsBuilder()
-      .accept('audio/mp3')
-      .Accept('audio/mp3')
-      .voice('de-DE_DieterVoice')
-      .customizationId('customizationId')
-      .text('Hello World')
-      .build();
-    Blob resp =
-      textToSpeech.synthesize(options);
-    System.debug('IBMTextToSpeechV1FTest.testListWords(): ' + resp);
-    Attachment att=new Attachment(Name='test.mp3', parentId='0011I000005Owfk',Body=resp);
-    insert att;
-    Test.stopTest();
-  }*/
 }

--- a/force-app/main/default/classes/IBMToneAnalyzerV3Test.cls
+++ b/force-app/main/default/classes/IBMToneAnalyzerV3Test.cls
@@ -1,5 +1,40 @@
 @isTest
 private class IBMToneAnalyzerV3Test {
+  private static String VERSION;
+  private static String HEADER_KEY;
+  private static String HEADER_VAL;
+
+  static {
+    VERSION = '2017-09-21';
+    HEADER_KEY = 'Header-Key';
+    HEADER_VAL = 'header_val';
+  }
+
+  static testMethod void testVersionConstructor() {
+    Test.startTest();
+    IBMToneAnalyzerV3 service = new IBMToneAnalyzerV3(VERSION);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testBasicConstructor() {
+    Test.startTest();
+    IBMToneAnalyzerV3 service = new IBMToneAnalyzerV3(VERSION, 'username', 'password');
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMToneAnalyzerV3 service = new IBMToneAnalyzerV3(VERSION, config);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
   /**
    *  Test Analyze general purpose tone.
    *
@@ -12,7 +47,7 @@ private class IBMToneAnalyzerV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMToneAnalyzerV3 toneAnalyzer = new IBMToneAnalyzerV3('2017-09-21', iamOptions);
+    IBMToneAnalyzerV3 toneAnalyzer = new IBMToneAnalyzerV3(VERSION, iamOptions);
     toneAnalyzer.setEndPoint('https://gateway.watsonplatform.net/tone-analyzer/api');
     IBMToneAnalyzerV3Models.ToneInput toneInput = new IBMToneAnalyzerV3Models.ToneInputBuilder()
       .text('We have a better product. We can do better selling by having more campaigns')
@@ -28,7 +63,7 @@ private class IBMToneAnalyzerV3Test {
     .contentLanguage('en')
     .acceptLanguage('en')
     .toneInput(toneInput)
-    .addHeader('Test-Header', 'test_value')
+    .addHeader(HEADER_KEY, HEADER_VAL)
     .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -67,7 +102,7 @@ private class IBMToneAnalyzerV3Test {
       .addUtterances(utterance)
       .acceptLanguage('en')
       .contentLanguage('en')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();

--- a/force-app/main/default/classes/IBMVisualRecognitionV3Test.cls
+++ b/force-app/main/default/classes/IBMVisualRecognitionV3Test.cls
@@ -1,8 +1,33 @@
 @isTest
 private class IBMVisualRecognitionV3Test {
-  // Make sure the named credentials below is defined
-  private static String NAMED_CREDENTIALS = 'callout:watson_visual_recognition_v3';
-  private static String API_KEY = '80bc2e663293e8d13564c260cdb4cbf891b606c0';
+  private static String VERSION;
+  private static String HEADER_KEY;
+  private static String HEADER_VAL;
+
+  static {
+    VERSION = '2016-05-20';
+    HEADER_KEY = 'Header-Key';
+    HEADER_VAL = 'header_val';
+  }
+
+  static testMethod void testVersionConstructor() {
+    Test.startTest();
+    IBMVisualRecognitionV3 service = new IBMVisualRecognitionV3(VERSION);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
+  static testMethod void testConfigConstructor() {
+    Test.startTest();
+    IBMWatsonAuthenticatorConfig config = new IBMWatsonBasicAuthConfig.Builder()
+      .username('username')
+      .password('password')
+      .build();
+    IBMVisualRecognitionV3 service = new IBMVisualRecognitionV3(VERSION, config);
+    System.assert(service != null);
+    Test.stopTest();
+  }
+
   static testMethod void testClassify() {
     String body = IBMWatsonMockResponses.classifiedImages();
     IBMWatsonMockHttpResponse mockResponse = new IBMWatsonMockHttpResponse(200, 'Success', body, null);
@@ -11,11 +36,11 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3(VERSION, iamOptions);
     visualRecognition.setEndPoint('https://gateway-a.watsonplatform.net/visual-recognition/api');
     IBMVisualRecognitionV3Models.ClassifyOptions options = new IBMVisualRecognitionV3Models.ClassifyOptionsBuilder()
       .url('http://www.indya101.com/gallery/Actors_TV/Sumeet_Sachdev/2011/12/27/Sumeet_Sachdevjpg_3_arnem.jpg')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -47,7 +72,7 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3(VERSION, iamOptions);
     Attachment att = new Attachment(Body=Blob.valueOf('test string'),
       Name='test.txt',
       Description='test description',
@@ -60,7 +85,7 @@ private class IBMVisualRecognitionV3Test {
       .imagesFile(testfile)
       .imagesFilename(att.Name)
       .imagesFileContentType(att.ContentType)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -82,8 +107,7 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
-    visualRecognition.setEndPoint(NAMED_CREDENTIALS);
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3(VERSION, iamOptions);
     Attachment att = new Attachment(Body=Blob.valueOf('test string'),
       Name='test.txt',
       Description='test description',
@@ -99,7 +123,7 @@ private class IBMVisualRecognitionV3Test {
       .imagesFilename(att.Name)
       .imagesFileContentType(att.ContentType)
       .acceptLanguage('es')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -133,8 +157,7 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
-    visualRecognition.setEndPoint(NAMED_CREDENTIALS);
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3(VERSION, iamOptions);
     Attachment att = new Attachment(Body=Blob.valueOf('test string'),
       Name='test.txt',
       Description='test description',
@@ -155,7 +178,7 @@ private class IBMVisualRecognitionV3Test {
       .addPositiveExamples('other_test', testfile)
       .negativeExamples(testfile)
       .negativeExamplesFilename('test')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -180,8 +203,7 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
-    visualRecognition.setEndPoint(NAMED_CREDENTIALS);
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3(VERSION, iamOptions);
     Attachment att = new Attachment(Body=Blob.valueOf('test string'),
       Name='test.txt',
       Description='test description',
@@ -194,7 +216,7 @@ private class IBMVisualRecognitionV3Test {
       .build();
     IBMVisualRecognitionV3Models.GetClassifierOptions options = new IBMVisualRecognitionV3Models.GetClassifierOptionsBuilder('classifierId')
       .classifierId('classifierId')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -214,8 +236,7 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
-    visualRecognition.setEndPoint(NAMED_CREDENTIALS);
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3(VERSION, iamOptions);
     Attachment att = new Attachment(Body=Blob.valueOf('test string'),
       Name='test.txt',
       Description='test description',
@@ -236,7 +257,7 @@ private class IBMVisualRecognitionV3Test {
       .addPositiveExamples('other_test', testfile)
       .negativeExamples(testfile)
       .negativeExamplesFilename('test')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -256,8 +277,7 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
-    visualRecognition.setEndPoint(NAMED_CREDENTIALS);
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3(VERSION, iamOptions);
     Attachment att = new Attachment(Body=Blob.valueOf('test string'),
       Name='test.txt',
       Description='test description',
@@ -270,7 +290,7 @@ private class IBMVisualRecognitionV3Test {
       .build();
     IBMVisualRecognitionV3Models.DeleteClassifierOptions options = new IBMVisualRecognitionV3Models.DeleteClassifierOptionsBuilder('classifierId')
       .classifierId('classifierId')
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -289,11 +309,10 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
-    visualRecognition.setEndPoint(NAMED_CREDENTIALS);
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3(VERSION, iamOptions);
     IBMVisualRecognitionV3Models.ListClassifiersOptions options = new IBMVisualRecognitionV3Models.ListClassifiersOptionsBuilder()
       .verbose(true)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     options = options.newBuilder().build();
@@ -315,13 +334,12 @@ private class IBMVisualRecognitionV3Test {
     IBMWatsonIAMOptions iamOptions = new IBMWatsonIAMOptions.Builder()
       .apiKey('apikey')
       .build();
-    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3('2016-05-20', iamOptions);
-    visualRecognition.setEndPoint(NAMED_CREDENTIALS);
+    IBMVisualRecognitionV3 visualRecognition = new IBMVisualRecognitionV3(VERSION, iamOptions);
 
     String customerId = 'salesforce_sdk_test_id';
     IBMVisualRecognitionV3Models.DeleteUserDataOptions deleteOptions = new IBMVisualRecognitionV3Models.DeleteUserDataOptionsBuilder()
       .customerId(customerId)
-      .addHeader('Test-Header', 'test_value')
+      .addHeader(HEADER_KEY, HEADER_VAL)
       .build();
     //you can add more attributes using following builder method. This step is not necessary
     deleteOptions = deleteOptions.newBuilder().build();


### PR DESCRIPTION
Fixes #197 

Salesforce has a requirement that all code deployed to a user's organization must have a total code coverage of >= 75% to be deployed to production. This number had dipped in the SDK, and it was preventing the linked user from being able to deploy to production, specifically with Assistant and Natural Language Understanding.

This PR just goes through the test classes and bumps up the coverage. After the changes, I'm seeing **81%** coverage with the whole SDK deployed and **79%** coverage with Assistant v1, Assistant v2, Natural Language Understanding, and the core deployed.