### PR TITLE
Remove base64 encoding when building multipart/form-data

### DIFF
--- a/force-app/main/default/classes/IBMWatsonClient.cls
+++ b/force-app/main/default/classes/IBMWatsonClient.cls
@@ -32,9 +32,9 @@ public class IBMWatsonClient {
     if (request.getMethod().equals('POST') || request.getMethod().equals('PUT')) {
       if (request.getBody() instanceof IBMWatsonMultipartBody) {
         // form-multipart request will be send as Base64 request
-        String form64 = ((IBMWatsonMultipartBody)request.getBody()).form64();
-        httpRequest.setBodyAsBlob(EncodingUtil.base64Decode(form64));
-        httpRequest.setHeader('Content-Length', String.valueof(form64.length()));
+        String multipartBody = ((IBMWatsonMultipartBody)request.getBody()).multipartBody();
+        httpRequest.setBodyAsBlob(Blob.valueOf(multipartBody));
+        httpRequest.setHeader('Content-Length', String.valueof(multipartBody.length()));
       } else if (request.getBody().contentType.toString().contains(IBMWatsonHttpMediaType.APPLICATION_JSON)) {
         httpRequest.setBody(IBMWatsonJSONUtil.serialize(request.getBody().content));
       } else {

--- a/force-app/main/default/classes/IBMWatsonMultipartBody.cls
+++ b/force-app/main/default/classes/IBMWatsonMultipartBody.cls
@@ -19,7 +19,7 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
   private IBMWatsonMediaType originalType;
   private IBMWatsonMediaType contentType;
   private List<Part> parts;
-  private String form64;
+  private String multipartBody;
   private Blob formBlob;
   private Map<String, String> headers;
   private long contentLength = -1L;
@@ -27,11 +27,11 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
   IBMWatsonMultipartBody(String boundary, IBMWatsonMediaType mediaType, List<Part> parts) {
     this.boundary = boundary;
     this.originalType = mediaType;
-    this.contentType = IBMWatsonMediaType.parse(mediaType + '; boundary=' + EncodingUtil.urlEncode(boundary, 'UTF-8'));
+    this.contentType = IBMWatsonMediaType.parse(mediaType + '; boundary=' + boundary);
     this.parts = parts;
     this.headers = new Map<String, String>();
     this.contentLength = 0;
-    writeForm64(parts);
+    writeMultipartBody(parts);
   }
 
   public IBMWatsonMediaType contentType() {
@@ -42,17 +42,17 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
     return formBlob;
   }
 
-  public String form64() {
-    return form64;
+  public String multipartBody() {
+    return multipartBody;
   }
 
   public long contentLength() {
     return contentLength;
   }
 
-  private long writeForm64(List<Part> parts) {
-    headers.put('Content-Type', 'multipart/form-data; boundary="' + boundary + '"');
-    form64 = '';
+  private long writeMultipartBody(List<Part> parts) {
+    headers.put('Content-Type', 'multipart/form-data; boundary=' + boundary);
+    multipartBody = '';
     for (Integer i = 0; i < parts.size(); i++) {
       Part p = parts[i];
       Boolean isEndingPart = (i == parts.size() - 1);
@@ -60,14 +60,14 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
         String fileName = p.body().name;
         String mimeType = p.body.bodyContentType().toString();
         String file64Body = EncodingUtil.base64Encode(p.body().blobContent);
-        form64 += writeBlobBody(p.headers().get('Content-Disposition'), file64Body, mimeType, isEndingPart);
+        multipartBody += writeBlobBody(p.headers().get('Content-Disposition'), file64Body, mimeType, isEndingPart);
       } else {
-        form64 += writeBoundary();
-        form64 += writeBodyParameter(p.headers().get('Content-Disposition'), p.body().content, isEndingPart);
+        multipartBody += writeBoundary();
+        multipartBody += writeBodyParameter(p.headers().get('Content-Disposition'), p.body().content, isEndingPart);
       }
     }
 
-    return form64.length();
+    return multipartBody.length();
   }
 
   /**
@@ -93,23 +93,14 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
   public String writeBodyParameter(String key, String value, Boolean isEndingPart) {
     String contentDisposition = 'Content-Disposition: ' + key;
     String contentDispositionCrLf = contentDisposition + CRLF + CRLF;
-    Blob contentDispositionCrLfBlob = blob.valueOf(contentDispositionCrLf);
-    String contentDispositionCrLf64 = EncodingUtil.base64Encode(contentDispositionCrLfBlob);
-    String content = safelyPad(contentDisposition, contentDispositionCrLf64, CRLF + CRLF);
-    String valueCrLf = value + CRLF;
-    Blob valueCrLfBlob = blob.valueOf(valueCrLf);
-    String valueCrLf64 = EncodingUtil.base64Encode(valueCrLfBlob);
+    String content = contentDispositionCrLf;
 
-    content += safelyPad(value, valueCrLf64, CRLF);
+    String valueCrLf = value + CRLF;
+    content += valueCrLf;
+
     if (isEndingPart == true) {
       String footer = '--' + this.boundary + '--';
-      Blob footerBlob = blob.valueOf(footer);
-      String footerEncoded = EncodingUtil.base64Encode(footerBlob);
-      while (footerEncoded.endsWith('=')) {
-        footer += ' ';
-        footerEncoded = EncodingUtil.base64Encode(blob.valueOf(footer));
-      }
-      content += safelyPad(footer, footerEncoded, CRLF);
+      content = content + footer;
     }
     return content;
   }
@@ -165,15 +156,7 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
   }
 
   public String writeBoundary() {
-    String value = '--' + boundary;
-    String valueCrlf = value + CRLF;
-    Blob valueBlob = blob.valueOf(valueCrlf);
-    String boundaryEncoded = EncodingUtil.base64Encode(valueBlob);
-    while (boundaryEncoded.endsWith('=')) {
-      valueCrlf += ' ';
-      boundaryEncoded = EncodingUtil.base64Encode(blob.valueOf(valueCrlf));
-    }
-    return boundaryEncoded;
+    return '--' + this.boundary + CRLF;
   }
 
   public Map<String, String> getAllHeaders() {
@@ -257,7 +240,7 @@ public class IBMWatsonMultipartBody extends IBMWatsonRequestBody {
   private static String generateRandomBoundaryString() {
     Blob b = Crypto.GenerateAESKey(128);
     String h = EncodingUtil.ConvertTohex(b);
-    String boundaryString = h.substring(0, 8);
+    String boundaryString = h.substring(0, 16);
     return boundaryString;
   }
 

--- a/force-app/main/default/classes/IBMWatsonServiceTest.cls
+++ b/force-app/main/default/classes/IBMWatsonServiceTest.cls
@@ -363,11 +363,10 @@ private class IBMWatsonServiceTest {
       .addPart(new Map<String, String>{'test' => 'test', 'Content-Disposition'=>'Content-Disposition'}, IBMWatsonRequestBody.create())
       .addFormDataPart('key', 'value')
       .build();
-    System.assertEquals(IBMWatsonMultipartBody.safelyPad('test', 'test=test=', 'test'), EncodingUtil.base64Encode(blob.valueOf('test test')));
-    System.assertEquals(multipartBody.writeBodyParameter('test', 'test', false), 'Q29udGVudC1EaXNwb3NpdGlvbjogdGVzdCANCg0KdGVzdA0K');
+    System.assertEquals('Content-Disposition: test\r\n\r\ntest\r\n', multipartBody.writeBodyParameter('test', 'test', false));
     System.assertEquals(multipartBody.parts().size(), 2);
     System.assert(multipartBody.getAllHeaders().get('Content-Type').contains('multipart/form-data; boundary'));
-    System.assert(multipartBody.form64().contains(multipartBody.writeBoundary()));
+    System.assert(multipartBody.multipartBody().contains(multipartBody.writeBoundary()));
     Test.stopTest();
   }
 


### PR DESCRIPTION
This PR fixes an issue when trying to use the `threshold` parameter in the `classify()` endpoint in Visual Recognition. The service would previously respond with an error complaining about the supplied `threshold` value.

After some debugging with someone from the Visual Recognition team, we found that the value was being sent as a string with a trailing space, which was the issue. In looking through the code to build up the form data, I saw a lot of logic adding trailing spaces to play well with base 64 encoding, which was previously being done for every piece of the multipart form body. [This class](https://github.com/MetaMind/apex-utils/blob/master/HttpFormBuilder.apex) seems to be the initial inspiration for the logic. Since Apex doesn't really have support for this built in, I saw this referenced a lot of Salesforce forums.

In playing around with things, I realized I could send the request just fine by removing the encoding, since trying to just do something like not adding the trailing spaces would result in weird data when going from encoding -> decoding. I was initially a bit worried about what this might mean to remove the encoding, but I took a look at [OkHttp](https://github.com/square/okhttp), which we use for the Java SDK, and they don't seem to do any sort of encoding for their multipart/form-data requests. Since it's a popular library, I'm going on the assumption that this is okay in this SDK.

I left the current little bit of encoding that's done when sending something like a file. I might have to revisit, but I wanted to get this fix out in the meantime since it was reported as blocking a customer.

<img width="1625" alt="Screen Shot 2019-08-30 at 4 21 40 PM" src="https://user-images.githubusercontent.com/8710772/64049274-49ec1700-cb42-11e9-80aa-1b4af77df63d.png">
