### PR TITLE
Add mistakenly-removed parameter in NLU

### DIFF
--- a/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
+++ b/force-app/main/default/classes/IBMNaturalLanguageUnderstandingV1Models.cls
@@ -1077,6 +1077,7 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class CategoriesOptions extends IBMWatsonGenericModel {
     private Boolean explanation;
     private Long xLimit;
+    private String model;
 
     /**
      * Gets the explanation.
@@ -1100,10 +1101,26 @@ public class IBMNaturalLanguageUnderstandingV1Models {
     public Long xLimit() {
       return xLimit;
     }
+
+    /**
+     * Gets the model.
+     *
+     * Enter a [custom
+     * model](https://cloud.ibm.com/docs/services/natural-language-understanding?topic=natural-language-understanding-customizing)
+     * ID to override the standard categories model.
+     *
+     * @return the model
+     * @deprecated the model parameter is no longer supported by the Natural Language Understanding service and will
+     * be removed in the next major release
+     */
+    public String model() {
+      return model;
+    }
   
     private CategoriesOptions(CategoriesOptionsBuilder builder) {
       this.explanation = builder.explanation;
       this.xLimit = builder.xLimit;
+      this.model = builder.model;
     }
 
     /**
@@ -1138,10 +1155,12 @@ public class IBMNaturalLanguageUnderstandingV1Models {
   public class CategoriesOptionsBuilder {
     private Boolean explanation;
     private Long xLimit;
+    private String model;
 
     private CategoriesOptionsBuilder(CategoriesOptions categoriesOptions) {
       this.explanation = categoriesOptions.explanation;
       this.xLimit = categoriesOptions.xLimit;
+      this.model = categoriesOptions.model;
     }
 
     /**
@@ -1178,6 +1197,19 @@ public class IBMNaturalLanguageUnderstandingV1Models {
      */
     public CategoriesOptionsBuilder xLimit(Long xLimit) {
       this.xLimit = xLimit;
+      return this;
+    }
+
+    /**
+     * Set the model.
+     *
+     * @param model the model
+     * @return the CategoriesOptions builder
+     * @deprecated the model parameter is no longer supported by the Natural Language Understanding service and will
+     * be removed in the next major release
+     */
+    public CategoriesOptionsBuilder model(String model) {
+      this.model = model;
       return this;
     }
   }


### PR DESCRIPTION
This PR adds back the `model` parameter in `CategoriesOptions`, which was mistakenly removed. This parameter _is_ deprecated though, as it's no longer supported in the service.